### PR TITLE
Implement #28: Make trusted proxies configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,8 +71,8 @@ PL (Project leader)
   ticket systems and activities in **Administration** tab
 
 
-Installation
-============
+Installation and set up
+=======================
 
 Requirements
 ------------
@@ -122,6 +122,26 @@ Setup - with prebuilt docker images
 #. Put the provided app/config/parameters.yml.dist from this repo as paramters.yml into the above created folder
 #. Check and adapt the copied confoguration files to your needs
 #. Run docker-compose up -d
+
+
+Trusted proxies
+---------------
+
+To work behind a proxy Symfony needs to know which proxies are allowed to trust.
+
+There are two ENV variables which can be set to modify the proxy behavior of the
+app:
+
+TRUSTED_PROXY_LIST
+  The variable expects a valid JSON encoded list of IPs or IP ranges::
+
+    TRUSTED_PROXY_LIST=["192.0.0.1","10.0.0.0\/8"]
+
+TRUSTED_PROXY_ALL
+  The variable expects a boolean 1/0 to indicate if the application
+  should handle each address in ``$_SERVER[REMOTE_ADDR]`` as a trusted proxy::
+
+    TRUSTED_PROXY_ALL=1
 
 
 Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     links:
       - db:db
     restart: always
+    environment:
+      - TRUSTED_PROXY_ALL
+      - TRUSTED_PROXY_LIST
+
 
   httpd:
     image: nginx:alpine

--- a/web/app.php
+++ b/web/app.php
@@ -10,6 +10,21 @@ $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();
 $kernel = new AppCache($kernel);
 $request = Request::createFromGlobals();
+
+# feat #28: trust a defined list of proxy
+if (!empty($_SERVER['TRUSTED_PROXY_LIST']) && null !== json_decode($_SERVER['TRUSTED_PROXY_LIST'])) {
+    Request::setTrustedProxies(
+        json_decode($_SERVER['TRUSTED_PROXY_LIST'])
+    );
+}
+
+# feat #28: trust all remote addresses
+if (!empty($_SERVER['TRUSTED_PROXY_ALL']) && true === (bool) $_SERVER['TRUSTED_PROXY_ALL']) {
+    Request::setTrustedProxies(
+        ['127.0.0.1', $request->server->get('REMOTE_ADDR')]
+    );
+}
+
 $response = $kernel->handle($request);
 $response->send();
 


### PR DESCRIPTION
Add some check to the app controler for supporting symfony beeing behind a proxy, introduced ENV variables TRUSTED_PROXY_ALL and TRUSTED_PROXY_LIST for configurable behavior - solve problem with empty entry list due to untrusted proxy requests