### PR TITLE
TIM-18: Add optional "billable" field to monthly .xlsx export

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -35,3 +35,5 @@ parameters:
     app_monthly_overview_url: "https://stats.timetracker.nr/?user="
     app_title:                "Netresearch TimeTracker"
     app_header_url:           "https://acme.org/corpnav/"
+
+    app_show_billable_field_in_export: false

--- a/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
+++ b/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
@@ -423,13 +423,15 @@ class JiraOAuthApi
      */
     public function searchTicket($jql, $fields, $limit = 1)
     {
-        $query = http_build_query([
-            'jql'        => $jql,
-            'fields'     => $fields,
-            'maxResults' => $limit,
-        ]);
-
-        return $this->get("search/?" . $query);
+        //we use POST to support very large queries
+        return $this->post(
+            "search/",
+            [
+                'jql'        => $jql,
+                'fields'     => $fields,
+                'maxResults' => $limit,
+            ]
+        );
     }
 
     /**

--- a/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
+++ b/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
@@ -132,7 +132,7 @@ _export:
         days: \d+
 
 _controllingExport:
-    path: /controlling/export/{userid}/{year}/{month}/{project}/{customer}
+    path: /controlling/export/{userid}/{year}/{month}/{project}/{customer}/{billable}
     defaults:
       _controller: NetresearchTimeTrackerBundle:Controlling:export
       userid: 0
@@ -140,6 +140,7 @@ _controllingExport:
       month: 0
       project: 0
       customer: 0
+      billable: 0
     requirements: { year: \d+, userid: \d+}
 
 check_status:

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Controlling.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Controlling.js
@@ -27,7 +27,7 @@ Ext.define('Netresearch.widget.Controlling', {
     _monthTitle: 'Month',
     _exportTitle: 'Export',
     _tabTitle: 'Controlling',
-
+    _billableTitle: 'limit export to billable entries',
 
     initComponent: function() {
         this.on('render', this.refreshStores, this);
@@ -130,6 +130,13 @@ Ext.define('Netresearch.widget.Controlling', {
                 displayField: 'displayname',
                 valueField: 'value',
                 value: curMonth
+            }, {
+                id:'cnt-billable',
+                xtype: 'checkbox',
+                fieldLabel: this._billableTitle,
+                name: 'billable',
+                trueText: '1',
+                falseText: '0'
             }],
             buttons: [{
                 text: this._exportTitle,
@@ -140,7 +147,8 @@ Ext.define('Netresearch.widget.Controlling', {
                     var month = parseInt(Ext.getCmp("cnt-month").value) || 0;
                     var project = Ext.getCmp("cnt-project").value;
                     var customer = Ext.getCmp("cnt-customer").value;
-                    this.exportEntries(user, year, month, project, customer);
+                    var billable = +Ext.getCmp("cnt-billable").value;
+                    this.exportEntries(user, year, month, project, customer, billable);
                 }
             }]
         });
@@ -165,7 +173,7 @@ Ext.define('Netresearch.widget.Controlling', {
         this.callParent();
     },
 
-    exportEntries: function(user, year, month, project, customer) {
+    exportEntries: function(user, year, month, project, customer, billable) {
         if ((undefined == user) || (null == user) || ('' == user) || (1 > user)) {
             user = 0;
         }
@@ -181,7 +189,8 @@ Ext.define('Netresearch.widget.Controlling', {
             + year + '/'
             + month + '/'
             + project + '/'
-            + customer
+            + customer + '/'
+            + billable;
     },
 
     refreshStores: function () {
@@ -201,6 +210,7 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
         _yearTitle: 'Jahr',
         _monthTitle: 'Monat',
         _exportTitle: 'Exportieren',
-        _tabTitle: 'Abrechnung'
+        _tabTitle: 'Abrechnung',
+        _billableTitle: 'nur abrechenbare Einträge exportieren'
     });
 }


### PR DESCRIPTION
For some projects, we use a Jira issue label "billable" to declare those tickets whose times we can put on a bill to our customers.

A new (optional) configuration value `app_show_billable_field_in_export` is introduced which enables fetching of the "billable" label from jira, and adds it value in the .xlsx export file.

The monthly statement .xlsx export form gets a new checkbox "limit export to billable entries".
If this is set, only timetracker entries for tickets with the "billable" label are exported.