### PR TITLE
docker-compose fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM runtime AS builder
 RUN apt-get update -y
 RUN apt-get install -y git unzip curl
 # install composer
-RUN curl -sS https://getcomposer.org/installer | php
+RUN curl -sS https://getcomposer.org/installer | php -- --1
 RUN mv composer.phar /usr/local/bin/composer
 
 COPY . /var/www/html

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-date": "*",
         "ext-json": "*",
         "ext-ldap": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9f9627a088b014f048d30169279345d",
+    "content-hash": "eb2475e57e3b7278197587e2dfe0ec0c",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -584,6 +584,7 @@
                 "cache",
                 "caching"
             ],
+            "abandoned": true,
             "time": "2019-11-29T11:22:01+00:00"
         },
         {
@@ -1239,6 +1240,7 @@
                 "reflection",
                 "static"
             ],
+            "abandoned": "roave/better-reflection",
             "time": "2020-01-08T19:53:19+00:00"
         },
         {
@@ -3166,6 +3168,7 @@
                 "configuration",
                 "distribution"
             ],
+            "abandoned": true,
             "time": "2019-06-18T15:43:58+00:00"
         },
         {
@@ -3293,7 +3296,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "abandoned": true,
+            "abandoned": "symfony/maker-bundle",
             "time": "2017-12-07T15:36:41+00:00"
         },
         {
@@ -3342,6 +3345,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
+            "abandoned": "https://github.com/fabpot/local-php-security-checker",
             "time": "2019-11-01T13:20:14+00:00"
         },
         {
@@ -4671,6 +4675,7 @@
                 "i18n",
                 "text"
             ],
+            "abandoned": true,
             "time": "2013-10-18T19:37:15+00:00"
         },
         {
@@ -5457,6 +5462,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -6271,7 +6277,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-date": "*",
         "ext-json": "*",
         "ext-ldap": "*",
@@ -6282,5 +6288,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
     volumes:
       - app-cache:/var/www/html/app/cache
       - app-logs:/var/www/html/app/logs
-      - ./app/config/parameters.yml:/var/www/html/app/config/parameters.yml
+      - type: bind
+        source: ./app/config/parameters.yml
+        target: /var/www/html/app/config/parameters.yml
     links:
       - db:db
     restart: always
@@ -19,7 +21,7 @@ services:
   httpd:
     image: nginx:alpine
     volumes:
-      - app-pub:/var/www/html/web
+      - ./web:/var/www/html/web
       - ./nginx-conf.d-default.conf:/etc/nginx/conf.d/default.conf
     links:
       - app:phpfpm


### PR DESCRIPTION
"docker-compose up" currently fails because

1. composer.lock is not up to date with composer.json
2. composer2 gets installed, which is not able to install the timetracker dependencies:

```
$ composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - ocramius/package-versions is locked to version 1.5.1 and an update of this package was not requested.
    - ocramius/package-versions 1.5.1 requires composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
  Problem 2
    - ocramius/package-versions 1.5.1 requires composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
    - ocramius/proxy-manager 2.6.1 requires ocramius/package-versions ^1.5.1 -> satisfiable by ocramius/package-versions[1.5.1].
    - ocramius/proxy-manager is locked to version 2.6.1 and an update of this package was not requested.

ocramius/package-versions only provides support for Composer 2 in 1.8+, which requires PHP 7.4.
If you can not upgrade PHP you can require composer/package-versions-deprecated to resolve this with PHP 7.0+.

You are using Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report a plugin-issue to ask them to support Composer 2.
```