### PR TITLE
Do not allow search engines to index timetracker

### DIFF
--- a/src/Netresearch/TimeTrackerBundle/Resources/views/Default/login.html.twig
+++ b/src/Netresearch/TimeTrackerBundle/Resources/views/Default/login.html.twig
@@ -2,6 +2,7 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>{{ apptitle }}</title>
+        <meta name="robots" content="noindex,nofollow" />
         <link rel="stylesheet" href="{{ asset('bundles/netresearchtimetracker/js/ext-js/resources/css/ext-all-gray.css') }}" type="text/css">
         <link rel="stylesheet" href="{{ asset('bundles/netresearchtimetracker/css/timetracker.css') }}" type="text/css">
         <script type="text/javascript" src="{{ asset('bundles/netresearchtimetracker/js/ext-js/ext-all.js') }}"></script>

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,4 +1,7 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
-User-agent: *
+user-agent: *
+allow: /$
+allow: /login$
+disallow: /


### PR DESCRIPTION
When the login is already in the index, or has been linked to,
then a "disallow" in robots.txt does not help.
There needs to be a "noindex" directive in the page itself :(