### PR TITLE
TIM-54: Prevent LibreOffice error when loading exported .xlsx file

### DIFF
--- a/src/Netresearch/TimeTrackerBundle/Controller/ControllingController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/ControllingController.php
@@ -14,6 +14,7 @@
 
 namespace Netresearch\TimeTrackerBundle\Controller;
 
+use Netresearch\TimeTrackerBundle\Helper\LOReadFilter;
 use Netresearch\TimeTrackerBundle\Model\Response;
 
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -84,7 +85,9 @@ class ControllingController extends BaseController
         );
 
         //$spreadsheet = new Spreadsheet();
-        $spreadsheet = \PhpOffice\PhpSpreadsheet\IOFactory::load(
+        $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader('Xlsx');
+        $reader->setReadFilter(new LOReadFilter());
+        $spreadsheet = $reader->load(
             $this->container->getParameter('kernel.root_dir')
             . '/../web/template.xlsx'
         );

--- a/src/Netresearch/TimeTrackerBundle/Helper/LOReadFilter.php
+++ b/src/Netresearch/TimeTrackerBundle/Helper/LOReadFilter.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Netresearch Timetracker
+ *
+ * PHP version 5
+ *
+ * @category   Netresearch
+ * @package    Timetracker
+ * @subpackage Controller
+ * @author     Various Artists <info@netresearch.de>
+ * @license    http://www.gnu.org/licenses/agpl-3.0.html GNU AGPl 3
+ * @link       http://www.netresearch.de
+ */
+
+namespace Netresearch\TimeTrackerBundle\Helper;
+
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+
+/**
+ * Workaround for phpoffice/phpspreadsheet bug #667
+ * > The data could not be loaded completely because the maximum
+ * > number of columns per sheet was exceeded.
+ *
+ * https://github.com/PHPOffice/PhpSpreadsheet/issues/667
+ *
+ * @author Christian Weiske <weiske@mogic.com>
+ */
+class LOReadFilter implements \PhpOffice\PhpSpreadsheet\Reader\IReadFilter
+{
+    public function readCell($column, $row, $worksheetName = '') {
+        if (Coordinate::columnIndexFromString($column) > 1024) {
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
"Die Daten konnten nicht vollständig geladen werden, da die maximale Anzahl an Spalten pro Tabelle überschritten wurde"
or
"The data could not be loaded completely because the maximum number of columns per sheet was exceeded."