### PR TITLE
TIM-60: Fix autocompletion for projects with numbers in ticket prefix (main)

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -376,7 +376,7 @@ function findProjects(customer, ticket)
 
     // Support 2nd-trial mode: find projects without defined prefix
     let prefix = "";
-    const regexp = /([ ,]+)?([A-Za-z]+)([ ,]+)?/;
+    const regexp = /([ ,]+)?([A-Za-z][A-Za-z0-9]*)([ ,]+)?/;
 
     if (ticket == "") {
         prefix = "";


### PR DESCRIPTION
So that "PROJ" and "PROJ1" are not seen as the same ticket prefix.

Related: #65 