### PR TITLE
v4: Add support for per-ticket projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,7 +200,7 @@ Using OAuth to transmit work logs to Jira ticket system
    - After new Application is created click on action "edit" (the little pencil at the right to your new application)
       - Select "Incoming Authentication"
       - Consumer Key:
-           timetracker (or chose any other name you like)
+           timetracker (It must be unique among all application links!)
       - Consumer Name:
            TimeTracker (or chose any other name you like)
       - Public Key:

--- a/sql/004_ticketproject.sql
+++ b/sql/004_ticketproject.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `projects` ADD COLUMN `jira_ticket` VARCHAR(63) NULL AFTER `jira_id`;

--- a/sql/004_ticketproject.sql
+++ b/sql/004_ticketproject.sql
@@ -1,1 +1,3 @@
 ALTER TABLE `projects` ADD COLUMN `jira_ticket` VARCHAR(63) NULL AFTER `jira_id`;
+ALTER TABLE `projects` ADD COLUMN `subtickets` TEXT DEFAULT '' AFTER `internal_jira_ticket_system`;
+

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -174,6 +174,7 @@ CREATE TABLE `projects` (
   `additional_information_from_external` tinyint(1) NOT NULL,
   `internal_jira_project_key` VARCHAR(50) NULL,
   `internal_jira_ticket_system` INTEGER(11) NULL,
+  `subtickets` TEXT DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `customer_id` (`customer_id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -158,6 +158,7 @@ CREATE TABLE `projects` (
   `customer_id` int(11) DEFAULT NULL,
   `name` varchar(127) NOT NULL,
   `jira_id` varchar(63) DEFAULT NULL,
+  `jira_ticket` VARCHAR(63) NULL,
   `ticket_system` int(11) NULL DEFAULT NULL,
   `active` tinyint(1) NOT NULL,
   `global` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/src/Netresearch/TimeTrackerBundle/Command/TtSyncSubticketsCommand.php
+++ b/src/Netresearch/TimeTrackerBundle/Command/TtSyncSubticketsCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Netresearch\TimeTrackerBundle\Command;
+
+use Netresearch\TimeTrackerBundle\Services\SubticketSyncService;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class TtSyncSubticketsCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('tt:sync-subtickets')
+            ->setDescription('Update project subtickets from Jira')
+            ->addArgument('project', InputArgument::OPTIONAL, 'Single project to update')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $projectId = $input->getArgument('project');
+
+        $projectRepo = $this->getContainer()->get('doctrine')
+            ->getRepository('NetresearchTimeTrackerBundle:Project');
+        if ($projectId) {
+            $project = $projectRepo->find($projectId);
+            if (!$project) {
+                $io->error('Project does not exist');
+                return 1;
+            }
+            $projects = [$project];
+        } else {
+            $projects = $projectRepo->createQueryBuilder('p')
+                ->where('p.ticketSystem IS NOT NULL')
+                ->getQuery()
+                ->getResult();
+        }
+
+        $stss = new SubticketSyncService($this->getContainer());
+
+        $output->writeln(
+            'Found ' . count($projects) . ' projects with ticket system',
+            OutputInterface::VERBOSITY_VERBOSE
+        );
+        foreach ($projects as $project) {
+            $output->writeln(
+                'Syncing ' . $project->getId() . ' ' . $project->getName(),
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+            $subtickets = $stss->syncProjectSubtickets($project);
+
+            $output->writeln(
+                ' ' . count($subtickets) . ' subtickets found',
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+            if (count($subtickets)) {
+                $output->writeln(
+                    ' ' . implode(',', $subtickets),
+                    OutputInterface::VERBOSITY_VERY_VERBOSE
+                );
+            }
+        }
+
+        return 0;
+    }
+
+}

--- a/src/Netresearch/TimeTrackerBundle/Controller/AdminController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/AdminController.php
@@ -259,14 +259,16 @@ class AdminController extends BaseController
 
         $data = array($project->getId(), $name, $project->getCustomer()->getId(), $jiraId);
 
-        try {
-            $stss = new SubticketSyncService($this->container);
-            $subtickets = $stss->syncProjectSubtickets($project->getId());
-        } catch (\Exception $e) {
-            //we do not let it fail because creating a new project
-            // would lead to inconsistencies in the frontend
-            // ("project with that name exists already")
-            $data['message'] = $e->getMessage();
+        if ($ticketSystem) {
+            try {
+                $stss = new SubticketSyncService($this->container);
+                $subtickets = $stss->syncProjectSubtickets($project->getId());
+            } catch (\Exception $e) {
+                //we do not let it fail because creating a new project
+                // would lead to inconsistencies in the frontend
+                // ("project with that name exists already")
+                $data['message'] = $e->getMessage();
+            }
         }
 
         return new JsonResponse($data);

--- a/src/Netresearch/TimeTrackerBundle/Controller/AdminController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/AdminController.php
@@ -173,6 +173,7 @@ class AdminController extends BaseController
             : null;
 
         $jiraId       = strtoupper($request->get('jiraId'));
+        $jiraTicket   = strtoupper($request->get('jiraTicket'));
         $active       = $request->get('active') ? $request->get('active') : 0;
         $global       = $request->get('global') ? $request->get('global') : 0;
         $estimation   = TimeHelper::readable2minutes($request->get('estimation') ? $request->get('estimation') : '0m');
@@ -238,6 +239,7 @@ class AdminController extends BaseController
             ->setName($name)
             ->setTicketSystem($ticketSystem)
             ->setJiraId($jiraId)
+            ->setJiraTicket($jiraTicket)
             ->setActive($active)
             ->setGlobal($global)
             ->setEstimation($estimation)

--- a/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
@@ -339,12 +339,12 @@ class CrudController extends BaseController
 
         } catch (JiraApiUnauthorizedException $e) {
             // Invalid JIRA token
-            return new Error($e->getMessage(), 403, $e->getRedirectUrl());
+            return new Error($e->getMessage(), 403, $e->getRedirectUrl(), $e);
 
         } catch (\Exception $e) {
-            return new Error($this->get('translator')->trans($e->getMessage()), 406);
+            return new Error($this->get('translator')->trans($e->getMessage()), 406, null, $e);
         } catch (\Throwable $exception) {
-            return new Error($exception->getMessage(), 503);
+            return new Error($exception->getMessage(), 503, null, $e);
         }
     }
 

--- a/src/Netresearch/TimeTrackerBundle/Controller/DefaultController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/DefaultController.php
@@ -401,6 +401,32 @@ class DefaultController extends BaseController
     }
 
     /**
+     * Return projects grouped by customer ID.
+     *
+     * Needed for frontend tracking autocompletion.
+     */
+    public function getProjectStructureAction(Request $request)
+    {
+        if (!$this->checkLogin($request)) {
+            return $this->login($request);
+        }
+
+        $userId = (int) $this->getUserId($request);
+        $doctrine = $this->getDoctrine();
+
+        // Send customers to the frontend for caching
+        $customers = $doctrine
+            ->getRepository('NetresearchTimeTrackerBundle:Customer')
+            ->getCustomersByUser($userId);
+
+        /* @var $projectRepo \Netresearch\TimeTrackerBundle\Repository\ProjectRepository */
+        $projectRepo = $doctrine->getRepository('NetresearchTimeTrackerBundle:Project');
+        $projectStructure = $projectRepo->getProjectStructure($userId, $customers);
+
+        return new JsonResponse($projectStructure);
+    }
+
+    /**
      * @return Response
      */
     public function getActivitiesAction(Request $request)

--- a/src/Netresearch/TimeTrackerBundle/Entity/Project.php
+++ b/src/Netresearch/TimeTrackerBundle/Entity/Project.php
@@ -53,6 +53,11 @@ class Project extends Base
     protected $jiraId;
 
     /**
+     * @ORM\Column(type="string", name="jira_ticket")
+     */
+    protected $jiraTicket;
+
+    /**
      * @ORM\ManyToOne(targetEntity="TicketSystem", inversedBy="projects")
      * @ORM\JoinColumn(name="ticket_system", referencedColumnName="id")
      */
@@ -350,6 +355,20 @@ class Project extends Base
     public function setJiraId($jiraId)
     {
         $this->jiraId = $jiraId;
+        return $this;
+    }
+
+    public function getJiraTicket()
+    {
+        return $this->jiraTicket;
+    }
+
+    public function setJiraTicket($jiraTicket)
+    {
+        if ($jiraTicket === '') {
+            $jiraTicket = null;
+        }
+        $this->jiraTicket = $jiraTicket;
         return $this;
     }
 

--- a/src/Netresearch/TimeTrackerBundle/Entity/Project.php
+++ b/src/Netresearch/TimeTrackerBundle/Entity/Project.php
@@ -58,6 +58,15 @@ class Project extends Base
     protected $jiraTicket;
 
     /**
+     * Ticket numbers that are subtickets of $jiraTicket
+     * Gets calculated automatically.
+     * Comma-separated string.
+     *
+     * @ORM\Column(type="string", name="subtickets")
+     */
+    protected $subtickets;
+
+    /**
      * @ORM\ManyToOne(targetEntity="TicketSystem", inversedBy="projects")
      * @ORM\JoinColumn(name="ticket_system", referencedColumnName="id")
      */
@@ -369,6 +378,23 @@ class Project extends Base
             $jiraTicket = null;
         }
         $this->jiraTicket = $jiraTicket;
+        return $this;
+    }
+
+    public function getSubtickets()
+    {
+        if ($this->subtickets == '') {
+            return [];
+        }
+        return explode(',', $this->subtickets);
+    }
+
+    public function setSubtickets($subtickets)
+    {
+        if (is_array($subtickets)) {
+            $subtickets = implode(',', $subtickets);
+        }
+        $this->subtickets = $subtickets;
         return $this;
     }
 

--- a/src/Netresearch/TimeTrackerBundle/Helper/JiraApiException.php
+++ b/src/Netresearch/TimeTrackerBundle/Helper/JiraApiException.php
@@ -21,11 +21,11 @@ class JiraApiException extends \Exception
      * @param $code
      * @param null $redirectUrl
      */
-    public function __construct($message, $code, $redirectUrl = null)
+    public function __construct($message, $code, $redirectUrl = null, \Throwable $previous = null)
     {
         $this->redirectUrl = $redirectUrl;
         $message = 'JiraApi: '. $message;
-        parent::__construct($message, $code, null);
+        parent::__construct($message, $code, $previous);
     }
 
     /**

--- a/src/Netresearch/TimeTrackerBundle/Helper/JiraApiUnauthorizedException.php
+++ b/src/Netresearch/TimeTrackerBundle/Helper/JiraApiUnauthorizedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Netresearch\TimeTrackerBundle\Helper;
+
+/**
+ * The user needs to authorize in Jira first and get an OAuth token
+ */
+class JiraApiUnauthorizedException extends JiraApiException
+{
+}

--- a/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
+++ b/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
@@ -449,6 +449,38 @@ class JiraOAuthApi
     }
 
     /**
+     * Get an array of ticket numbers that are subtickets of the given issue
+     *
+     * @return array
+     */
+    public function getSubtickets($sTicket)
+    {
+        if (!$this->doesTicketExist($sTicket)) {
+            return [];
+        }
+
+        $ticket = $this->get('issue/' . $sTicket);
+
+        $subtickets = [];
+        foreach ($ticket->fields->subtasks as $subtask) {
+            $subtickets[] = $subtask->key;
+        }
+
+        if ($ticket->fields->issuetype->id == 10002) {
+            //Epic
+            $epicSubs = $this->searchTicket('"Epic Link" = ' . $sTicket, ['key', 'subtasks'], 100);
+            foreach ($epicSubs->issues as $epicSubtask) {
+                $subtickets[] = $epicSubtask->key;
+                foreach ($epicSubtask->fields->subtasks as $subtask) {
+                    $subtickets[] = $subtask->key;
+                }
+            }
+        }
+
+        return $subtickets;
+    }
+
+    /**
      * Checks existence of a work log entry in Jira
      *
      * @param string  $sTicket

--- a/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
+++ b/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
@@ -558,7 +558,7 @@ class JiraOAuthApi
             if ($e->getCode() === 401) {
                 $oauthAuthUrl = $this->fetchOAuthRequestToken();
                 $message = 'Jira: 401 - Unauthorized. Please authorize: ' . $oauthAuthUrl;
-                throw new JiraApiException($message, $e->getCode(), $oauthAuthUrl);
+                throw new JiraApiUnauthorizedException($message, $e->getCode(), $oauthAuthUrl);
             } elseif ($e->getCode() === 404) {
                 $message = 'Jira: 404 - Resource is not available: (' . $url . ')';
                 throw new JiraApiInvalidResourceException($message);

--- a/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
+++ b/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
@@ -170,6 +170,10 @@ deleteProject:
     path: /project/delete
     defaults: { _controller: NetresearchTimeTrackerBundle:Admin:deleteProject }
 
+syncAllProjectSubtickets:
+    path: /projects/syncsubtickets
+    defaults: { _controller: NetresearchTimeTrackerBundle:Admin:syncAllProjectSubtickets }
+
 syncProjectSubtickets:
     path: /projects/{project}/syncsubtickets
     defaults: { _controller: NetresearchTimeTrackerBundle:Admin:syncProjectSubtickets }

--- a/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
+++ b/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
@@ -166,6 +166,10 @@ deleteProject:
     path: /project/delete
     defaults: { _controller: NetresearchTimeTrackerBundle:Admin:deleteProject }
 
+syncProjectSubtickets:
+    path: /projects/{project}/syncsubtickets
+    defaults: { _controller: NetresearchTimeTrackerBundle:Admin:syncProjectSubtickets }
+
 saveCustomer:
     path: /customer/save
     defaults: { _controller: NetresearchTimeTrackerBundle:Admin:saveCustomer }

--- a/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
+++ b/src/Netresearch/TimeTrackerBundle/Resources/config/routing.yml
@@ -96,6 +96,10 @@ _getAllProjects:
     path:  /getAllProjects
     defaults: { _controller: NetresearchTimeTrackerBundle:Default:getAllProjects }
 
+_getProjectStructure:
+    path:  /getProjectStructure
+    defaults: { _controller: NetresearchTimeTrackerBundle:Default:getProjectStructure }
+
 _getActivities:
     path:  /getActivities
     defaults: { _controller: NetresearchTimeTrackerBundle:Default:getActivities }

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/main.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/main.js
@@ -78,9 +78,11 @@ Ext.onDocumentReady(function() {
     // Setup state manager
     Ext.state.Manager.setProvider(Ext.create('Ext.state.CookieProvider'));
 
-    const trackingWidget = Ext.create('Netresearch.widget.Tracking',
-        { itemId: 'tracking', plugins: [cellEditing] }
-    );
+    const trackingWidget = Ext.create('Netresearch.widget.Tracking', {
+        itemId: 'tracking',
+        plugins: [cellEditing],
+        autoRefreshInterval: true
+    });
 
     const interpretationWidget = Ext.create('Netresearch.widget.Interpretation', { itemId: 'interpretation' });
     const extrasWidget = Ext.create('Netresearch.widget.Extras', { itemId: 'extras'});

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/main.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/main.js
@@ -399,6 +399,22 @@ function findProjects(customer, ticket)
     let validProjects = [];
     let project;
 
+    //find project by exact ticket number
+    for (let projectKey in projects) {
+        project = projects[projectKey];
+        if (null == project['jiraTicket']) {
+            continue;
+        }
+        for (let i = 0; i < project['subtickets'].length; i++) {
+            if (project['subtickets'][i] == ticket) {
+                validProjects.push(project);
+            }
+        }
+    }
+    if (validProjects.length > 0) {
+        return validProjects;
+    }
+
     //find project by ticket prefix
     const prefixesRegexp = /(?:[ ,]+)?(?<prefix>[A-Za-z][A-Za-z0-9]*)(?:[ ,]+)?/g;
     for (let key in projects) {

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/model/Project.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/model/Project.js
@@ -6,6 +6,7 @@ Ext.define('Netresearch.model.Project', {
         {name: 'customer', type: 'integer'},
         {name: 'ticket_system', type: 'integer'},
         {name: 'jiraId', type: 'string'},
+        {name: 'jiraTicket', type: 'string'},
         {name: 'active', type: 'boolean'},
         {name: 'additionalInformationFromExternal', type: 'boolean'},
         {name: 'global', type: 'boolean'},

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/model/Project.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/model/Project.js
@@ -7,6 +7,7 @@ Ext.define('Netresearch.model.Project', {
         {name: 'ticket_system', type: 'integer'},
         {name: 'jiraId', type: 'string'},
         {name: 'jiraTicket', type: 'string'},
+        {name: 'subtickets', type: 'array'},
         {name: 'active', type: 'boolean'},
         {name: 'additionalInformationFromExternal', type: 'boolean'},
         {name: 'global', type: 'boolean'},

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/store/Customers.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/store/Customers.js
@@ -51,7 +51,7 @@ Ext.define('Netresearch.store.Customers', {
             this.add(record);
             c++;
         }
-        console.log("Loaded " + c + " customers.");
+
         this.loadRecords(newData, {"append": false});
     }
 });

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/store/Customers.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/store/Customers.js
@@ -1,10 +1,10 @@
 Ext.define('Netresearch.store.Customers', {
 	extend: 'Ext.data.Store',
-	
+
 	requires: [
    	    'Netresearch.model.Customer'
    	],
-	
+
     autoLoad: false,
     model: 'Netresearch.model.Customer',
     proxy: {
@@ -14,6 +14,20 @@ Ext.define('Netresearch.store.Customers', {
             record: 'customer'
         }
     },
+
+    /* Update projectsData */
+    reloadFromServer: function(callback) {
+        Ext.Ajax.request({
+            url: url + 'getCustomers',
+            success: function(response) {
+                let data = Ext.decode(response.responseText);
+                //update the locally available customer data
+                consumersData = data;
+                callback();
+            }
+        });
+    },
+
     /* Read data from json var in html source code */
     load: function(onlyActive) {
         var newData = [], record;

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/store/Projects.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/store/Projects.js
@@ -17,6 +17,19 @@ Ext.define('Netresearch.store.Projects', {
         }
     },
 
+    /* Update projectsData */
+    reloadFromServer: function(callback) {
+        Ext.Ajax.request({
+            url: url + 'getProjectStructure',
+            success: function(response) {
+                let data = Ext.decode(response.responseText);
+                //update the locally available project data
+                projectsData = data;
+                callback();
+            }
+        });
+    },
+
     /* Read data from json var in html source code */
     load: function(options) {
         return this.loadData(projectsData, null, null, false);

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
@@ -45,6 +45,7 @@ Ext.define('Netresearch.widget.Admin', {
     _addProjectTitle: 'Add project',
     _editProjectTitle: 'Edit project',
     _projectSubticketsTitle: 'Known subtickets',
+    _projectSubticketsSyncTitle: 'Sync subtickets',
     _forAllCustomersTitle: 'for all customers',
     _userNameTitle: 'User name',
     _abbreviationTitle: 'Abbr',
@@ -576,14 +577,6 @@ Ext.define('Netresearch.widget.Admin', {
                     var contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
-                                text: panel._projectSubticketsTitle,
-                                iconCls: 'icon-info',
-                                scope: this,
-                                handler: function() {
-                                    this.showProjectSubtickets(record.data);
-                                }
-                            },
-                            {
                                 text: panel._editTitle,
                                 iconCls: 'icon-edit',
                                 scope: this,
@@ -597,6 +590,25 @@ Ext.define('Netresearch.widget.Admin', {
                                 scope: this,
                                 handler: function() {
                                     this.deleteProject(record.data);
+                                }
+                            },
+                            {
+                                xtype: 'menuseparator'
+                            },
+                            {
+                                text: panel._projectSubticketsTitle,
+                                iconCls: 'icon-info',
+                                scope: this,
+                                handler: function() {
+                                    this.showProjectSubtickets(record.data);
+                                }
+                            },
+                            {
+                                text: panel._projectSubticketsSyncTitle,
+                                iconCls: 'icon-refresh',
+                                scope: this,
+                                handler: function() {
+                                    this.syncProjectSubtickets(record.data);
                                 }
                             }
                         ]
@@ -807,6 +819,10 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function(response) {
+                                                let data = Ext.decode(response.responseText);
+                                                if (data.message) {
+                                                    showNotification(panel._errorTitle, data.message, false);
+                                                }
                                                 window.close();
                                             },
                                             failure: function(response) {
@@ -845,7 +861,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: function(response) {
                                 var data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -857,6 +873,22 @@ Ext.define('Netresearch.widget.Admin', {
                     project['jiraTicket'] + "<br/>\n"
                     + project['subtickets']
                 );
+            },
+            syncProjectSubtickets: function(project) {
+                var grid = this;
+                Ext.Ajax.request({
+                    method: 'POST',
+                    url: url + 'projects/' + project.id + '/syncsubtickets',
+                    scope: this,
+                    success: function(response) {
+                        grid.refresh();
+                        grid.showProjectSubtickets(project);
+                    },
+                    failure: function(response) {
+                        var data = Ext.decode(response.responseText);
+                        showNotification(panel._errorTitle, data.message, false);
+                    }
+                });
             },
             refresh: function() {
                 this.customerStore.load();
@@ -2431,6 +2463,7 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
         _addProjectTitle: 'Neues Projekt',
         _editProjectTitle: 'Projekt bearbeiten',
         _projectSubticketsTitle: 'Bekannte Untertickets',
+        _projectSubticketsSyncTitle: 'Untertickets synchronisieren',
         _forAllCustomersTitle: 'für alle Kunden',
         _userNameTitle: 'Username',
         _abbreviationTitle: 'Kürzel',
@@ -2469,7 +2502,7 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
         _privateKeyTitle: 'Private Key',
         _errorsTitle: 'Fehler',
         _errorTitle: 'Fehler',
-        _successTitle: 'Success',
+        _successTitle: 'Erfolg',
         _estimationTitle: 'Geschätzte Dauer',
         _internalJiraProjectKey: 'internal JIRA Projekt Key',
         _offerTitle: 'Angebot',

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
@@ -36,6 +36,7 @@ Ext.define('Netresearch.widget.Admin', {
     _seriousErrorTitle: 'A serious error occurred. Find more details in Firebug or the Chrome Developer Tools.',
     _customerTitle: 'Customer',
     _ticketPrefixTitle: 'Ticket prefix',
+    _ticketPrefixTitleHelp: 'Multiple may be separated with commas',
     _ticketSystemTitle: 'Ticket system',
     _internalJiraTicketSystem: 'internal JIRA Ticket-System',
     _projectTitle: 'Project',
@@ -666,6 +667,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 }),
                                 {
                                     fieldLabel: panel._ticketPrefixTitle,
+                                    afterSubTpl: panel._ticketPrefixTitleHelp,
                                     name: 'jiraId',
                                     anchor: '100%',
                                     value: record.jiraId ? record.jiraId : ''
@@ -2386,6 +2388,7 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
         _seriousErrorTitle: ' Ein schwerer Fehler ist aufgetreten. Mehr Details gibts im Firebug/in den Chrome Developer Tools.',
         _customerTitle: 'Kunde',
         _ticketPrefixTitle: 'Ticket-Präfix',
+        _ticketPrefixTitleHelp: 'Mehrere können kommasepariert angegeben werden',
         _ticketSystemTitle: 'Ticket-System',
         _internalJiraTicketSystem: 'internal JIRA Ticket-System',
         _projectTitle: 'Projekt',

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
@@ -37,6 +37,8 @@ Ext.define('Netresearch.widget.Admin', {
     _customerTitle: 'Customer',
     _ticketPrefixTitle: 'Ticket prefix',
     _ticketPrefixTitleHelp: 'Multiple may be separated with commas',
+    _ticketNumberTitle: 'Ticket number',
+    _ticketNumberTitleHelp: 'Instead of the ticket prefix. Tasks in Epics and subtasks are taken into account. Separate multiple with a comma.',
     _ticketSystemTitle: 'Ticket system',
     _internalJiraTicketSystem: 'internal JIRA Ticket-System',
     _projectTitle: 'Project',
@@ -440,6 +442,14 @@ Ext.define('Netresearch.widget.Admin', {
                     }
                 },
                 {
+                    header: this._ticketNumberTitle,
+                    dataIndex: 'jiraTicket',
+                    flex: 1,
+                    field: {
+                        xtype: 'textfield'
+                    }
+                },
+                {
                     header: this._ticketSystemTitle,
                     dataIndex: 'ticket_system',
                     flex: 1,
@@ -671,6 +681,13 @@ Ext.define('Netresearch.widget.Admin', {
                                     name: 'jiraId',
                                     anchor: '100%',
                                     value: record.jiraId ? record.jiraId : ''
+                                },
+                                {
+                                    fieldLabel: panel._ticketNumberTitle,
+                                    afterSubTpl: panel._ticketNumberTitleHelp,
+                                    name: 'jiraTicket',
+                                    anchor: '100%',
+                                    value: record.jiraTicket ? record.jiraTicket : ''
                                 },
                                 new Ext.form.field.Checkbox({
                                     fieldLabel: panel._additionalInformationFromExternal,
@@ -2389,6 +2406,8 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
         _customerTitle: 'Kunde',
         _ticketPrefixTitle: 'Ticket-Präfix',
         _ticketPrefixTitleHelp: 'Mehrere können kommasepariert angegeben werden',
+        _ticketNumberTitle: 'Ticketnummer',
+        _ticketNumberTitleHelp: 'Anstelle des Ticket-Präfix. Aufgaben in Epics und Unteraufgaben werden mit reingezählt. Mehrere mit Komma trennen.',
         _ticketSystemTitle: 'Ticket-System',
         _internalJiraTicketSystem: 'internal JIRA Ticket-System',
         _projectTitle: 'Projekt',

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
@@ -44,6 +44,7 @@ Ext.define('Netresearch.widget.Admin', {
     _projectTitle: 'Project',
     _addProjectTitle: 'Add project',
     _editProjectTitle: 'Edit project',
+    _projectSubticketsTitle: 'Known subtickets',
     _forAllCustomersTitle: 'for all customers',
     _userNameTitle: 'User name',
     _abbreviationTitle: 'Abbr',
@@ -575,13 +576,22 @@ Ext.define('Netresearch.widget.Admin', {
                     var contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
+                                text: panel._projectSubticketsTitle,
+                                iconCls: 'icon-info',
+                                scope: this,
+                                handler: function() {
+                                    this.showProjectSubtickets(record.data);
+                                }
+                            },
+                            {
                                 text: panel._editTitle,
                                 iconCls: 'icon-edit',
                                 scope: this,
                                 handler: function() {
                                     this.editProject(record.data);
                                 }
-                            }, {
+                            },
+                            {
                                 text: panel._deleteTitle,
                                 iconCls: 'icon-delete',
                                 scope: this,
@@ -840,6 +850,13 @@ Ext.define('Netresearch.widget.Admin', {
                         });
                     }
                 });
+            },
+            showProjectSubtickets: function(project) {
+                Ext.Msg.alert(
+                    panel._projectSubticketsTitle + ': ' + project['name'],
+                    project['jiraTicket'] + "<br/>\n"
+                    + project['subtickets']
+                );
             },
             refresh: function() {
                 this.customerStore.load();
@@ -2413,6 +2430,7 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
         _projectTitle: 'Projekt',
         _addProjectTitle: 'Neues Projekt',
         _editProjectTitle: 'Projekt bearbeiten',
+        _projectSubticketsTitle: 'Bekannte Untertickets',
         _forAllCustomersTitle: 'für alle Kunden',
         _userNameTitle: 'Username',
         _abbreviationTitle: 'Kürzel',

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Admin.js
@@ -46,6 +46,7 @@ Ext.define('Netresearch.widget.Admin', {
     _editProjectTitle: 'Edit project',
     _projectSubticketsTitle: 'Known subtickets',
     _projectSubticketsSyncTitle: 'Sync subtickets',
+    _subticketSyncFinishedTitle: 'Subtickets have been synchronized from Jira.',
     _forAllCustomersTitle: 'for all customers',
     _userNameTitle: 'User name',
     _abbreviationTitle: 'Abbr',
@@ -567,6 +568,13 @@ Ext.define('Netresearch.widget.Admin', {
                     handler: function() {
                         projectGrid.refresh();
                     }
+                }, {
+                    text: this._projectSubticketsSyncTitle,
+                    iconCls: 'icon-refresh',
+                    scope: this,
+                    handler: function() {
+                        projectGrid.syncAllProjectSubtickets();
+                    }
                 }
             ],
             listeners: {
@@ -883,6 +891,22 @@ Ext.define('Netresearch.widget.Admin', {
                     success: function(response) {
                         grid.refresh();
                         grid.showProjectSubtickets(project);
+                    },
+                    failure: function(response) {
+                        var data = Ext.decode(response.responseText);
+                        showNotification(panel._errorTitle, data.message, false);
+                    }
+                });
+            },
+            syncAllProjectSubtickets: function() {
+                var grid = this;
+                Ext.Ajax.request({
+                    method: 'POST',
+                    url: url + 'projects/syncsubtickets',
+                    scope: this,
+                    success: function(response) {
+                        grid.refresh();
+                        showNotification(panel._successTitle, panel._subticketSyncFinishedTitle, true);
                     },
                     failure: function(response) {
                         var data = Ext.decode(response.responseText);
@@ -2464,6 +2488,7 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
         _editProjectTitle: 'Projekt bearbeiten',
         _projectSubticketsTitle: 'Bekannte Untertickets',
         _projectSubticketsSyncTitle: 'Untertickets synchronisieren',
+        _subticketSyncFinishedTitle: 'Untertickets wurden von Jira synchronisiert.',
         _forAllCustomersTitle: 'für alle Kunden',
         _userNameTitle: 'Username',
         _abbreviationTitle: 'Kürzel',

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Tracking.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Tracking.js
@@ -11,6 +11,8 @@ Ext.define('Netresearch.widget.Tracking', {
         'Ext.ux.window.Notification'
     ],
 
+    debug: false,
+
     /* Create stores */
     customerStore: Ext.create('Netresearch.store.Customers'),
     projectStore: Ext.create('Netresearch.store.Projects'),
@@ -593,10 +595,10 @@ Ext.define('Netresearch.widget.Tracking', {
     mapTicketToProject: function(ticket) {
         const validProjects = findProjects(null, ticket);
 
-        console.log("Mapping ticket " + ticket);
+        this.debug && console.log("Mapping ticket " + ticket);
 
         if ((!validProjects) || (!validProjects.length)) {
-            console.log("Mapped to no project");
+            this.debug && console.log("Mapped to no project");
             return false;
         }
 
@@ -605,7 +607,7 @@ Ext.define('Netresearch.widget.Tracking', {
         let sure = true;
 
         if (validProjects.length == 1) {
-            console.log("Mapped to customer " + customer + " and project " + " (sure, single)");
+            this.debug && console.log("Mapped to customer " + customer + " and project " + " (sure, single)");
             return { customer: parseInt(customer), id: parseInt(id), sure: sure };
         }
 
@@ -626,7 +628,7 @@ Ext.define('Netresearch.widget.Tracking', {
             }
         }
 
-        console.log("Mapped to customer " + customer + " and project " + id + (sure ? " (sure)" : " (unsure)"));
+        this.debug && console.log("Mapped to customer " + customer + " and project " + id + (sure ? " (sure)" : " (unsure)"));
         return { customer: parseInt(customer), id: parseInt(id), sure: sure };
     },
 
@@ -1446,4 +1448,3 @@ if ((undefined != settingsData) && (settingsData['locale'] == 'ru')) {
     });
 }
 */
-

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Tracking.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Tracking.js
@@ -12,6 +12,7 @@ Ext.define('Netresearch.widget.Tracking', {
     ],
 
     debug: false,
+    autoRefreshInterval: false,
 
     /* Create stores */
     customerStore: Ext.create('Netresearch.store.Customers'),
@@ -74,6 +75,12 @@ Ext.define('Netresearch.widget.Tracking', {
         const entryStore = Ext.create('Netresearch.store.Entries');
         const grid = this;
         entryStore.on("load", function() { grid.selectRow(0); });
+
+        if (this.autoRefreshInterval === true) {
+            this.autoRefreshInterval = window.setInterval(
+                this.autoRefreshProjectData, 15 * 60 * 1000, this
+            );
+        }
 
         const config = {
             title: this._tabTitle,
@@ -1111,18 +1118,32 @@ Ext.define('Netresearch.widget.Tracking', {
         });
     },
 
+    /**
+     * Reload project data, then refresh store data.
+     * Used for automatic background refreshes to make subtickets available.
+     */
+    autoRefreshProjectData: function(tracking) {
+        tracking.customerStore.reloadFromServer(function () {
+            tracking.projectStore.reloadFromServer(function () {
+                tracking.refresh(false);
+            });
+        });
+    },
+
     /*
      * Refresh stores
      */
-    refresh: function() {
+    refresh: function(reloadView = true) {
         this.clearProjectStore();
         this.customerStore.load();
         this.activityStore.load();
         this.userStore.load();
         this.ticketSystemStore.load();
-        this.getStore().load();
 
-        this.getView().refresh();
+        if (reloadView) {
+            this.getStore().load();
+            this.getView().refresh();
+        }
         countTime();
     },
 

--- a/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Tracking.js
+++ b/src/Netresearch/TimeTrackerBundle/Resources/public/js/netresearch/widget/Tracking.js
@@ -460,7 +460,7 @@ Ext.define('Netresearch.widget.Tracking', {
                     tooltip: 'Shortcut (Alt + r)',
                     scope: this,
                     handler: function() {
-                        this.refresh();
+                        this.refreshHard();
                     }
                 }, {
                     text: this._exportTitle,
@@ -1095,6 +1095,20 @@ Ext.define('Netresearch.widget.Tracking', {
             this.days = 10000;
         }
         window.location.href = 'export/' + this.days;
+    },
+
+    /**
+     * Reload project data, then refresh
+     * Useful when project data/settings changed in the background,
+     * and we do not want to get them with a hard page reload.
+     */
+    refreshHard: function() {
+        tracking = this;
+        tracking.customerStore.reloadFromServer(function () {
+            tracking.projectStore.reloadFromServer(function () {
+                tracking.refresh();
+            });
+        });
     },
 
     /*

--- a/src/Netresearch/TimeTrackerBundle/Resources/views/Default/index.html.twig
+++ b/src/Netresearch/TimeTrackerBundle/Resources/views/Default/index.html.twig
@@ -12,9 +12,9 @@
 
             const environment = {{ environment|json_encode|raw }};
 
-            const customersData = {{ customers|json_encode|raw }};
+            let customersData = {{ customers|json_encode|raw }};
 
-            const projectsData = {{ projects|json_encode|raw }};
+            let projectsData = {{ projects|json_encode|raw }};
 
             let settingsData = {{ settings|json_encode|raw }};
         </script>

--- a/src/Netresearch/TimeTrackerBundle/Response/Error.php
+++ b/src/Netresearch/TimeTrackerBundle/Response/Error.php
@@ -20,14 +20,33 @@ class Error extends JsonResponse
      * @param integer     $statusCode
      * @param string|null $forwardUrl
      */
-    public function __construct($errorMessage, $statusCode, $forwardUrl = null)
-    {
+    public function __construct(
+        $errorMessage, $statusCode, $forwardUrl = null, \Throwable $exception = null
+    ) {
         $message = ['message' => $errorMessage];
 
         if ($forwardUrl) {
             $message['forwardUrl'] = $forwardUrl;
         }
+        if (ini_get('display_errors')) {
+            $message['exception'] = $this->getExceptionAsArray($exception);
+        }
 
         parent::__construct($message, $statusCode);
+    }
+
+    protected function getExceptionAsArray(\Throwable $exception = null)
+    {
+        if ($exception === null) {
+            return null;
+        }
+        return [
+            'message' => $exception->getMessage(),
+            'code'    => $exception->getCode(),
+            'file'    => $exception->getFile(),
+            'line'    => $exception->getLine(),
+            'trace'   => $exception->getTrace(),
+            'previous' => $this->getExceptionAsArray($exception->getPrevious()),
+        ];
     }
 }

--- a/src/Netresearch/TimeTrackerBundle/Response/Error.php
+++ b/src/Netresearch/TimeTrackerBundle/Response/Error.php
@@ -32,7 +32,7 @@ class Error extends JsonResponse
             $message['exception'] = $this->getExceptionAsArray($exception);
         }
 
-        parent::__construct($message, $statusCode);
+        parent::__construct($message, $statusCode > 0 ? $statusCode : 400);
     }
 
     protected function getExceptionAsArray(\Throwable $exception = null)

--- a/src/Netresearch/TimeTrackerBundle/Services/SubticketSyncService.php
+++ b/src/Netresearch/TimeTrackerBundle/Services/SubticketSyncService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Netresearch\TimeTrackerBundle\Services;
+
+use Netresearch\TimeTrackerBundle\Entity\Project;
+use Netresearch\TimeTrackerBundle\Helper\JiraOAuthApi;
+use Psr\Container\ContainerInterface;
+
+class SubticketSyncService
+{
+    protected ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Fetch subtickets from Jira and update the project record's "subtickets" field.
+     *
+     * The project lead user's Jira tokens are used for access.
+     *
+     * @return array Array of subticket keys
+     *
+     * @throws \Exception When something goes wrong.
+     *                    Exception codes are sensible HTTP status codes
+     */
+    public function syncProjectSubtickets($projectOrProjectId)
+    {
+        if ($projectOrProjectId instanceof Project) {
+            $project = $projectOrProjectId;
+        } else {
+            $project = $this->getDoctrine()
+                ->getRepository('NetresearchTimeTrackerBundle:Project')
+                ->find($projectOrProjectId);
+        }
+        if (!$project) {
+            throw new \Exception('Project does not exist', 404);
+        }
+
+        $ticketSystem = $project->getTicketSystem();
+        if (!$ticketSystem) {
+            throw new \Exception('No ticket system configured for project', 400);
+        }
+
+        $mainTickets = $project->getJiraTicket();
+        if ($mainTickets === null) {
+            if ($project->getSubtickets() != '') {
+                $project->setSubtickets([]);
+
+                $em = $this->getDoctrine()->getManager();
+                $em->persist($project);
+                $em->flush();
+            }
+            return [];
+        }
+
+        $userWithJiraAccess = $project->getProjectLead();
+        if (!$userWithJiraAccess) {
+            throw new \Exception('Project has no lead user', 400);
+        }
+        $token = $userWithJiraAccess->getTicketSystemAccessToken($ticketSystem);
+        if (!$token) {
+            throw new \Exception('Project user has no token for ticket system', 400);
+        }
+
+        $jiraOAuthApi = new JiraOAuthApi(
+            $userWithJiraAccess, $ticketSystem,
+            $this->getDoctrine(), $this->container->get('router')
+        );
+
+        $mainTickets = array_map('trim', explode(',', $mainTickets));
+        $allSubtickets = [];
+        foreach ($mainTickets as $mainTicket) {
+            //we want to make it easy to find matching tickets,
+            // so we put the main ticket in the subticket list as well
+            $allSubtickets[] = $mainTicket;
+            $allSubtickets = array_merge(
+                $allSubtickets, $jiraOAuthApi->getSubtickets($mainTicket)
+            );
+        }
+        natcasesort($allSubtickets);
+
+        $project->setSubtickets($allSubtickets);
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($project);
+        $em->flush();
+
+        return $allSubtickets;
+    }
+
+    protected function getDoctrine()
+    {
+        return $this->container->get('doctrine');
+    }
+}

--- a/web/api.yml
+++ b/web/api.yml
@@ -1956,6 +1956,12 @@ components:
       properties:
         message:
           type: string
+        forwardUrl:
+          type: string
+          description: Optional URL to redirect to (e.g. Jira OAuth)
+        exception:
+          type: object
+          description: Only when debugging is enabled
 
     ForbiddenResponse:
       type: object

--- a/web/api.yml
+++ b/web/api.yml
@@ -1392,6 +1392,32 @@ paths:
                 description: id, name, customer, jiraId
                 example: [1,"TestProject",1,"TIM"]
 
+  /projects/{projectId}/syncsubtickets:
+    post:
+      summary: Synchronize subticket information from Jira into TimeTracker
+      tags: Project
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            example: 23
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectSubticketSyncResponse'
+        400:
+          description: Some error occured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+
   /settings/save:
     post:
       summary: Update settings
@@ -2068,6 +2094,18 @@ components:
       required:
         - name
         - customer
+
+    ProjectSubticketSyncResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        subtickets:
+          type: array
+          items:
+            type: string
+            example: "TEST-23"
+
 
     SuccessResponse:
       type: object

--- a/web/api.yml
+++ b/web/api.yml
@@ -1392,6 +1392,24 @@ paths:
                 description: id, name, customer, jiraId
                 example: [1,"TestProject",1,"TIM"]
 
+  /projects/syncsubtickets:
+    post:
+      summary: Synchronize subticket information from Jira into TimeTracker for all projects
+      tags: Project
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        400:
+          description: Some error occured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /projects/{projectId}/syncsubtickets:
     post:
       summary: Synchronize subticket information from Jira into TimeTracker

--- a/web/api.yml
+++ b/web/api.yml
@@ -2011,6 +2011,9 @@ components:
           type: string
           example: "TIM-12"
           description: Specific ticket key this project is meant for, instead of a whole "jiraId". See "subtickets" property. May contain multiple issue keys separated by a comma.
+        subtickets:
+          type: array
+          description: List of ticket keys that are considered to be children of the jiraTicket, e.g. child issues and issues within an epic. Includes the jiraTicket key itself.
         ticket_system:
           type: string
           example: TestTicketSystem

--- a/web/api.yml
+++ b/web/api.yml
@@ -2007,6 +2007,10 @@ components:
           type: string
           example: "TIM"
           description: Ticket prefix with only capital letters
+        jiraTicket:
+          type: string
+          example: "TIM-12"
+          description: Specific ticket key this project is meant for, instead of a whole "jiraId". See "subtickets" property. May contain multiple issue keys separated by a comma.
         ticket_system:
           type: string
           example: TestTicketSystem


### PR DESCRIPTION
This allows "small" projects to be tied to a ticket number instead of a Jira ticket prefix.
Subtasks and tickets within epics are seen as subtickets, and the project is automatically selected when using such ticket numbers.

Example:
- TT project "Hack" with Jira prefix "HACK"
- TT project "Hack Monday" with Jira ticket "HACK-23"

When booking onto "HACK-14", project "Hack" will automatically be chosen.
When booking onto "HACK-23" or a subticket, "Hack Monday" project will be chosen.

Based on PR #76 - merge that first.