### PR TITLE
TIM-111: Fix local build on MacOS

### DIFF
--- a/tests/prepare-test-sql.sh
+++ b/tests/prepare-test-sql.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #   run this script to duplicate the database structure
 #   the duplicate is used to create a test env.
+#   command runs on linux and mac
 
-cp ../sql/full.sql ../sql/unittest/001_testtables.sql
-sed -i '1s/^/USE unittest;\n/' ../sql/unittest/001_testtables.sql
+sed '1s/^/USE unittest;\n/' ../sql/full.sql > ../sql/unittest/001_testtables.sql


### PR DESCRIPTION
Previous sed command throws error on a mac:
> sed: 1: "../sql/unittest/001_tes ...": invalid command code .