### PR TITLE
fix: remove invalid remember_me configuration in test environment

### DIFF
--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -11,7 +11,7 @@ security:
                 default_target_path: /
             # Set form_login as the entry point for redirects
             entry_point: form_login
-            remember_me: false
+            # Note: remember_me disabled by omission in test environment
             logout:
                 path: _logout
                 target: _login


### PR DESCRIPTION
## Summary
- Fixes UnsetKeyException in Symfony test environment
- Removes invalid `remember_me: false` configuration that causes CI failures

## Problem
Symfony's security configuration does not accept `false` as a value for the `remember_me` option. It must either be configured with proper settings or omitted entirely to disable it.

## Solution  
Removed the invalid `remember_me: false` line and replaced it with a comment explaining that remember_me is disabled by omission in the test environment.

## Test plan
- [x] CI pipeline should no longer fail with UnsetKeyException
- [x] Test suite runs successfully without remember_me configuration errors
- [x] Security configuration validates correctly in test environment

🤖 Generated with [Claude Code](https://claude.ai/code)