### PR TITLE
TIM-130: Use new Jira API to search for tickets

### DIFF
--- a/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
+++ b/src/Netresearch/TimeTrackerBundle/Helper/JiraOAuthApi.php
@@ -441,7 +441,7 @@ class JiraOAuthApi
     {
         // we use POST to support very large queries
         return $this->post(
-            "search/",
+            "search/jql",
             [
                 'jql'        => $jql,
                 'fields'     => $fields,


### PR DESCRIPTION
The old ticket search API has been removed.
https://developer.atlassian.com/changelog/#CHANGE-2046

We switch from
"/rest/api/latest/search/" to
"/rest/api/latest/search/jql"