### PR TITLE
chore: remove GD extension from Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,10 @@ jobs:
           # Create directories with proper permissions for non-root container user
           mkdir -p vendor var/cache var/log bin
           chmod -R 777 vendor var bin
-          # --ignore-platform-req=php needed until laminas-ldap adds PHP 8.5 support
-          # See: https://github.com/laminas/laminas-ldap/issues/62
-          docker compose run --rm app-tools composer install --no-interaction --prefer-dist --ignore-platform-req=php
+          # --ignore-platform-req needed for:
+          # - php: laminas-ldap PHP 8.5 support (https://github.com/laminas/laminas-ldap/issues/62)
+          # - ext-gd: PHPSpreadsheet requires GD but we only use data export
+          docker compose run --rm app-tools composer install --no-interaction --prefer-dist --ignore-platform-req=php --ignore-platform-req=ext-gd
 
       - name: Validate composer.json
         env:
@@ -106,7 +107,7 @@ jobs:
           COMPOSE_PROFILES: dev
         run: |
           # Image already built by bake - just install deps and start services
-          docker compose run --rm app-dev composer install --ignore-platform-req=php
+          docker compose run --rm app-dev composer install --ignore-platform-req=php --ignore-platform-req=ext-gd
           docker compose run --rm app-dev npm install --legacy-peer-deps
           docker compose up -d
           docker compose exec -T db_unittest mariadb-admin ping -h 127.0.0.1 -uroot -pglobal123 --wait --connect-timeout=60

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,10 @@ sh:
 install: composer-install npm-install
 
 composer-install:
-	# --ignore-platform-req=php needed until laminas-ldap adds PHP 8.5 support
-	# See: https://github.com/laminas/laminas-ldap/issues/62
-	docker compose run --rm app-dev composer install --ignore-platform-req=php
+	# --ignore-platform-req needed for:
+	# - php: laminas-ldap PHP 8.5 support (https://github.com/laminas/laminas-ldap/issues/62)
+	# - ext-gd: PHPSpreadsheet requires GD but we only use data export
+	docker compose run --rm app-dev composer install --ignore-platform-req=php --ignore-platform-req=ext-gd
 
 composer-update:
 	docker compose run --rm app-dev composer update


### PR DESCRIPTION
## Summary
- Remove GD extension from Docker image (saves ~9MB)
- PHPSpreadsheet requires GD but only for charts/images - we only use data export
- Add `--ignore-platform-req=ext-gd` to all composer install commands

## Background
PHPSpreadsheet [decided to keep GD required](https://github.com/PHPOffice/PhpSpreadsheet/pull/3766) even though it's only needed for:
- `MemoryDrawing.php` - embedding images
- Chart rendering

Since TimeTracker only uses XLSX export for data (no charts or images), we can safely ignore the platform requirement.

## Changes
- **Dockerfile**: Removed GD and its dependencies (libpng-dev, libjpeg62-turbo-dev, libfreetype6-dev)
- **Dockerfile**: Added comments explaining the GD omission
- **CI workflow**: Added `--ignore-platform-req=ext-gd` to composer commands
- **Makefile**: Added `--ignore-platform-req=ext-gd` to composer-install target

## Image Size Impact
- Before: 976MB
- After: 967MB
- Saved: ~9MB

Related to #210