### PR TITLE
fix: correct package name in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "fix-timetracker-audit",
+  "name": "timetracker",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fix-timetracker-audit",
+      "name": "timetracker",
       "license": "UNLICENSED",
       "devDependencies": {
         "@babel/core": "^7.26.0",


### PR DESCRIPTION
## Summary
- Fix `package-lock.json` name from `fix-timetracker-audit` (branch name) to `timetracker`
- Caused by `npm audit fix` using the working directory name as package name
- Addresses review comments on PR #274

## Test plan
- [ ] Verify package-lock.json has correct name