### PR TITLE
chore(deps): bump phpoffice/phpspreadsheet 5.4.0 → 5.7.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1808,16 +1808,16 @@
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "682f1098a8fddbaf43edac2306a691c7ad508ec5"
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/682f1098a8fddbaf43edac2306a691c7ad508ec5",
-                "reference": "682f1098a8fddbaf43edac2306a691c7ad508ec5",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
                 "shasum": ""
             },
             "require": {
@@ -1874,7 +1874,7 @@
             ],
             "support": {
                 "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
-                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.1"
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.2"
             },
             "funding": [
                 {
@@ -1882,7 +1882,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-10T09:58:31+00:00"
+            "time": "2026-04-11T18:38:28+00:00"
         },
         {
             "name": "markbaker/complex",
@@ -2096,16 +2096,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.4.0",
+            "version": "5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "48f2fe37d64c2dece0ef71fb2ac55497566782af"
+                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/48f2fe37d64c2dece0ef71fb2ac55497566782af",
-                "reference": "48f2fe37d64c2dece0ef71fb2ac55497566782af",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
+                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
                 "shasum": ""
             },
             "require": {
@@ -2199,9 +2199,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.4.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.7.0"
             },
-            "time": "2026-01-11T04:52:00+00:00"
+            "time": "2026-04-20T02:42:17+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -5240,16 +5240,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -5299,7 +5299,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5319,7 +5319,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -12549,16 +12549,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.2",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
                 "shasum": ""
             },
             "require": {
@@ -12605,9 +12605,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
             },
-            "time": "2026-01-13T14:02:24+00:00"
+            "time": "2026-04-11T10:33:05+00:00"
         }
     ],
     "aliases": [],
@@ -12629,5 +12629,5 @@
     "platform-overrides": {
         "php": "8.5"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/Util/PhpSpreadsheet/LOReadFilterTest.php
+++ b/tests/Util/PhpSpreadsheet/LOReadFilterTest.php
@@ -113,7 +113,7 @@ final class LOReadFilterTest extends TestCase
         );
 
         self::assertFalse(
-            $this->filter->readCell('ZZZ', 1, 'AnySheet'),
+            $this->filter->readCell('XFD', 1, 'AnySheet'),
             'Column beyond limit should still be rejected regardless of worksheet name',
         );
     }
@@ -177,8 +177,7 @@ final class LOReadFilterTest extends TestCase
             'Column AMK' => ['AMK', 1025],   // Column 1025 - first beyond limit
             'Column AML' => ['AML', 1026],   // Column 1026
             'Column ANZ' => ['ANZ', 1078],   // Random column beyond limit
-            'Column ZZZ' => ['ZZZ', 18278],  // Very high column (max for 3 chars)
-            'Column XFD' => ['XFD', 16384],  // Excel's maximum column
+            'Column XFD' => ['XFD', 16384],  // Excel's maximum column (PhpSpreadsheet rejects anything beyond)
         ];
     }
 


### PR DESCRIPTION
## Summary

Resolves five open Dependabot alerts on `composer.lock` for `phpoffice/phpspreadsheet`:

| Alert | Severity | CVE | Issue |
|---|---|---|---|
| [#96](https://github.com/netresearch/timetracker/security/dependabot/96) | High | CVE-2026-34084 | SSRF/RCE in `IOFactory::load` when `$filename` is user-controlled |
| [#97](https://github.com/netresearch/timetracker/security/dependabot/97) | High | CVE-2026-40863 | CPU DoS via unbounded row index in SpreadsheetML XML reader |
| [#98](https://github.com/netresearch/timetracker/security/dependabot/98) | High | CVE-2026-40902 | CPU DoS via unbounded row number in XLSX row dimensions |
| [#94](https://github.com/netresearch/timetracker/security/dependabot/94) | Medium | CVE-2026-35453 | XSS via `NumberFormat` `@` text substitution (HTML writer) |
| [#95](https://github.com/netresearch/timetracker/security/dependabot/95) | Medium | CVE-2026-40296 | XSS via `@` text placeholder bypass of `htmlspecialchars` (HTML writer) |

Bump stays within existing `^5.0` constraint in `composer.json`.

### Application impact assessment

- **CVE-2026-34084 (SSRF/RCE):** not exploitable on `main` — `src/Controller/Controlling/ExportAction.php:115` uses `IOFactory::createReader('Xlsx')` with a hardcoded reader type, never `IOFactory::load($userPath)`. Bumping removes the foot-gun for future code.
- **DoS / XSS CVEs:** the export pipeline produces XLSX via PhpSpreadsheet, so the writer-side issues were applicable.

### Test fixture update

`Coordinate::columnIndexFromString()` now hard-rejects column references beyond `XFD` (16384, the Excel format limit). The previous `LOReadFilterTest` data provider included `ZZZ` (resolves to 18278), which is unreachable in real spreadsheets — PhpSpreadsheet itself never iterates past `XFD`. Replaced with `XFD` as the boundary case. Production `LOReadFilter` is unchanged.

## Test plan

- [x] `composer update phpoffice/phpspreadsheet --with-dependencies` → bumped to 5.7.0
- [x] Export-related PHPUnit suite (Service / Repository / Dto / Util / Controller): **85 tests, 163 assertions, 0 failures**
- [ ] Full CI suite (handled by GHA on this PR)
- [ ] Manual smoke: open an exported XLSX in LibreOffice (column-limit workaround behavior unchanged)