### PR TITLE
chore: ignore local AI agent and IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-/.cursor/mcp.json
+/.cursor/
+/.claude/
+/.repowise/
+/.mcp.json
 /.idea
 /.buildpath
 /.project


### PR DESCRIPTION
## Summary

Add `.cursor/`, `.claude/`, `.repowise/`, and `.mcp.json` to `.gitignore`. These hold per-developer agent configuration and MCP server state and should never be committed.

The previous entry `/.cursor/mcp.json` is replaced by ignoring the whole `/.cursor/` directory.

## Test plan

- [x] `git check-ignore -v` confirms all four paths match the new patterns
- [x] `git status` no longer shows them as untracked in a fresh worktree