### PR TITLE
fix: restore automatic Jira worklog sync and tolerate legacy NULL ticketurl

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -47,7 +47,6 @@ services:
             - '../src/Service/Integration/Jira/JiraTicketService.php'
             - '../src/Service/Integration/Jira/JiraAuthenticationService.php'
             - '../src/Service/Integration/Jira/JiraIntegrationService.php'
-            - '../src/EventSubscriber/EntryEventSubscriber.php'
 
     # Controllers are tagged automatically
     App\Controller\:

--- a/src/Entity/TicketSystem.php
+++ b/src/Entity/TicketSystem.php
@@ -55,9 +55,9 @@ class TicketSystem extends Base
     protected $url;
 
     /**
-     * @var string $ticketUrl
+     * @var string|null $ticketUrl
      */
-    #[ORM\Column(name: 'ticketurl', type: 'string', length: 255, nullable: false)]
+    #[ORM\Column(name: 'ticketurl', type: 'string', length: 255, nullable: true)]
     protected $ticketUrl;
 
     /**
@@ -187,7 +187,7 @@ class TicketSystem extends Base
      *
      * @return $this
      */
-    public function setTicketUrl(string $ticketUrl): static
+    public function setTicketUrl(?string $ticketUrl): static
     {
         $this->ticketUrl = $ticketUrl;
 
@@ -196,10 +196,13 @@ class TicketSystem extends Base
 
     /**
      * Get url pointing to a ticket.
+     *
+     * The database column is nullable (legacy rows): normalize NULL to an
+     * empty string for the string-building callers.
      */
     public function getTicketUrl(): string
     {
-        return $this->ticketUrl;
+        return $this->ticketUrl ?? '';
     }
 
     /**

--- a/src/EventSubscriber/EntryEventSubscriber.php
+++ b/src/EventSubscriber/EntryEventSubscriber.php
@@ -12,10 +12,12 @@ namespace App\EventSubscriber;
 use App\Entity\Entry;
 use App\Entity\Project;
 use App\Entity\TicketSystem;
+use App\Entity\User;
 use App\Enum\TicketSystemType;
 use App\Event\EntryEvent;
 use App\Service\Cache\QueryCacheService;
-use App\Service\Integration\Jira\JiraIntegrationService;
+use App\Service\Integration\Jira\JiraOAuthApiFactory;
+use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -25,11 +27,17 @@ use function in_array;
 
 /**
  * Handles entry-related events.
+ *
+ * Worklog synchronization deliberately uses the legacy JiraOAuthApiService
+ * (via JiraOAuthApiFactory): it is the only Jira integration path wired into
+ * the service container; the newer JiraIntegrationService stack stays
+ * excluded until token encryption is production-ready.
  */
 class EntryEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly JiraIntegrationService $jiraIntegrationService,
+        private readonly JiraOAuthApiFactory $jiraOAuthApiFactory,
+        private readonly ManagerRegistry $managerRegistry,
         private readonly QueryCacheService $queryCacheService,
         private readonly ?LoggerInterface $logger = null,
     ) {
@@ -52,20 +60,12 @@ class EntryEventSubscriber implements EventSubscriberInterface
 
         $this->logger?->info('Entry created');
 
-        // Invalidate cache for user entries
-        $user = $entry->getUser();
-        $userId = $user?->getId();
-        if (null !== $userId) {
-            $this->queryCacheService->invalidateEntity(
-                Entry::class,
-                $userId,
-            );
-        }
+        $this->invalidateUserEntryCache($entry);
 
         // Check if automatic JIRA sync is needed
         if ($this->shouldAutoSync($entry)) {
             try {
-                $this->jiraIntegrationService->saveWorklog($entry);
+                $this->syncWorklog($entry);
                 $this->logger?->info('Entry auto-synced to JIRA');
             } catch (Exception $e) {
                 $this->logger?->error('Auto-sync to JIRA failed', ['exception' => $e]);
@@ -79,20 +79,14 @@ class EntryEventSubscriber implements EventSubscriberInterface
 
         $this->logger?->info('Entry updated');
 
-        // Invalidate cache
-        $user = $entry->getUser();
-        $userId = $user?->getId();
-        if (null !== $userId) {
-            $this->queryCacheService->invalidateEntity(
-                Entry::class,
-                $userId,
-            );
-        }
+        $this->invalidateUserEntryCache($entry);
 
-        // Update JIRA if already synced
-        if ($entry->getSyncedToTicketsystem() && null !== $entry->getWorklogId()) {
+        // Sync on every update (v4 parity): updateEntryJiraWorkLog creates a
+        // new worklog or updates the existing one based on the worklog id,
+        // so entries that were never synced are caught up on their next save.
+        if ($this->shouldAutoSync($entry)) {
             try {
-                $this->jiraIntegrationService->saveWorklog($entry);
+                $this->syncWorklog($entry);
                 $this->logger?->info('JIRA worklog updated');
             } catch (Exception $e) {
                 $this->logger?->warning('JIRA worklog update failed', ['exception' => $e]);
@@ -106,20 +100,12 @@ class EntryEventSubscriber implements EventSubscriberInterface
 
         $this->logger?->info('Entry deleted');
 
-        // Invalidate cache
-        $user = $entry->getUser();
-        $userId = $user?->getId();
-        if (null !== $userId) {
-            $this->queryCacheService->invalidateEntity(
-                Entry::class,
-                $userId,
-            );
-        }
+        $this->invalidateUserEntryCache($entry);
 
         // Delete from JIRA if synced
         if ($entry->getSyncedToTicketsystem() && null !== $entry->getWorklogId()) {
             try {
-                $this->jiraIntegrationService->deleteWorklog($entry);
+                $this->deleteWorklog($entry);
                 $this->logger?->info('JIRA worklog deleted');
             } catch (Exception $e) {
                 $this->logger?->warning('JIRA worklog deletion failed', ['exception' => $e]);
@@ -149,6 +135,49 @@ class EntryEventSubscriber implements EventSubscriberInterface
         // Could trigger notification or retry logic here
     }
 
+    private function invalidateUserEntryCache(Entry $entry): void
+    {
+        $user = $entry->getUser();
+        $userId = $user?->getId();
+        if (null !== $userId) {
+            $this->queryCacheService->invalidateEntity(
+                Entry::class,
+                $userId,
+            );
+        }
+    }
+
+    private function syncWorklog(Entry $entry): void
+    {
+        $user = $entry->getUser();
+        $ticketSystem = $entry->getProject()?->getTicketSystem();
+        if (!$user instanceof User || !$ticketSystem instanceof TicketSystem) {
+            return;
+        }
+
+        $this->jiraOAuthApiFactory->create($user, $ticketSystem)
+            ->updateEntryJiraWorkLog($entry);
+
+        // updateEntryJiraWorkLog sets the worklog id and the synced flag on
+        // the already-persisted entity; flush them or the next sync would
+        // create a duplicate worklog.
+        $this->managerRegistry->getManager()->flush();
+    }
+
+    private function deleteWorklog(Entry $entry): void
+    {
+        $user = $entry->getUser();
+        $ticketSystem = $entry->getProject()?->getTicketSystem();
+        if (!$user instanceof User || !$ticketSystem instanceof TicketSystem) {
+            return;
+        }
+
+        $this->jiraOAuthApiFactory->create($user, $ticketSystem)
+            ->deleteEntryJiraWorkLog($entry);
+
+        $this->managerRegistry->getManager()->flush();
+    }
+
     private function shouldAutoSync(Entry $entry): bool
     {
         // Check if project has auto-sync enabled
@@ -159,6 +188,11 @@ class EntryEventSubscriber implements EventSubscriberInterface
 
         $ticketSystem = $project->getTicketSystem();
         if (!$ticketSystem instanceof TicketSystem) {
+            return false;
+        }
+
+        // The Jira client acts on behalf of the entry's user
+        if (!$entry->getUser() instanceof User) {
             return false;
         }
 

--- a/tests/EventSubscriber/EntryEventSubscriberTest.php
+++ b/tests/EventSubscriber/EntryEventSubscriberTest.php
@@ -12,11 +12,15 @@ use App\Enum\TicketSystemType;
 use App\Event\EntryEvent;
 use App\EventSubscriber\EntryEventSubscriber;
 use App\Service\Cache\QueryCacheService;
-use App\Service\Integration\Jira\JiraIntegrationService;
+use App\Service\Integration\Jira\JiraOAuthApiFactory;
+use App\Service\Integration\Jira\JiraOAuthApiService;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
 use Exception;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -27,22 +31,77 @@ use Psr\Log\LoggerInterface;
 #[AllowMockObjectsWithoutExpectations]
 final class EntryEventSubscriberTest extends TestCase
 {
-    private JiraIntegrationService&MockObject $jiraIntegrationService;
+    private JiraOAuthApiFactory&MockObject $jiraOAuthApiFactory;
+    private JiraOAuthApiService&MockObject $jiraOAuthApiService;
+    private ManagerRegistry&MockObject $managerRegistry;
+    private ObjectManager&MockObject $objectManager;
     private QueryCacheService&MockObject $queryCacheService;
     private LoggerInterface&MockObject $logger;
     private EntryEventSubscriber $subscriber;
 
     protected function setUp(): void
     {
-        $this->jiraIntegrationService = $this->createMock(JiraIntegrationService::class);
+        $this->jiraOAuthApiFactory = $this->createMock(JiraOAuthApiFactory::class);
+        $this->jiraOAuthApiService = $this->createMock(JiraOAuthApiService::class);
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->objectManager = $this->createMock(ObjectManager::class);
+        $this->managerRegistry->method('getManager')->willReturn($this->objectManager);
         $this->queryCacheService = $this->createMock(QueryCacheService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->subscriber = new EntryEventSubscriber(
-            $this->jiraIntegrationService,
+            $this->jiraOAuthApiFactory,
+            $this->managerRegistry,
             $this->queryCacheService,
             $this->logger,
         );
+    }
+
+    /**
+     * Creates an entry stub whose user/project/ticket-system graph satisfies
+     * the subscriber's auto-sync conditions (unless overridden).
+     *
+     * @return array{Entry&Stub, User&Stub, TicketSystem&Stub}
+     */
+    private function createSyncableEntry(
+        bool $bookTime = true,
+        TicketSystemType $type = TicketSystemType::JIRA,
+        string $ticket = 'ABC-123',
+        bool $synced = false,
+        ?int $worklogId = null,
+    ): array {
+        $ticketSystem = self::createStub(TicketSystem::class);
+        $ticketSystem->method('getBookTime')->willReturn($bookTime);
+        $ticketSystem->method('getType')->willReturn($type);
+
+        $project = self::createStub(Project::class);
+        $project->method('getTicketSystem')->willReturn($ticketSystem);
+
+        $user = self::createStub(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $entry = self::createStub(Entry::class);
+        $entry->method('getUser')->willReturn($user);
+        $entry->method('getProject')->willReturn($project);
+        $entry->method('getTicket')->willReturn($ticket);
+        $entry->method('getSyncedToTicketsystem')->willReturn($synced);
+        $entry->method('getWorklogId')->willReturn($worklogId);
+
+        return [$entry, $user, $ticketSystem];
+    }
+
+    private function expectJiraApiCreatedFor(User&Stub $user, TicketSystem&Stub $ticketSystem): void
+    {
+        $this->jiraOAuthApiFactory->expects(self::once())
+            ->method('create')
+            ->with($user, $ticketSystem)
+            ->willReturn($this->jiraOAuthApiService);
+    }
+
+    private function expectNoJiraApi(): void
+    {
+        $this->jiraOAuthApiFactory->expects(self::never())
+            ->method('create');
     }
 
     public function testGetSubscribedEventsReturnsCorrectEvents(): void
@@ -94,24 +153,16 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryCreatedAutoSyncsToJiraWhenConditionsMet(): void
     {
-        $ticketSystem = self::createStub(TicketSystem::class);
-        $ticketSystem->method('getBookTime')->willReturn(true);
-        $ticketSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+        [$entry, $user, $ticketSystem] = $this->createSyncableEntry();
 
-        $project = self::createStub(Project::class);
-        $project->method('getTicketSystem')->willReturn($ticketSystem);
+        $this->expectJiraApiCreatedFor($user, $ticketSystem);
 
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getProject')->willReturn($project);
-        $entry->method('getTicket')->willReturn('ABC-123');
-
-        $this->jiraIntegrationService->expects(self::once())
-            ->method('saveWorklog')
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
             ->with($entry);
+
+        $this->objectManager->expects(self::once())
+            ->method('flush');
 
         $this->logger->expects(self::exactly(2))
             ->method('info');
@@ -129,8 +180,7 @@ final class EntryEventSubscriberTest extends TestCase
         $entry->method('getUser')->willReturn($user);
         $entry->method('getProject')->willReturn(null);
 
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryCreated($event);
@@ -148,8 +198,7 @@ final class EntryEventSubscriberTest extends TestCase
         $entry->method('getUser')->willReturn($user);
         $entry->method('getProject')->willReturn($project);
 
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryCreated($event);
@@ -157,22 +206,9 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryCreatedDoesNotSyncWhenBookTimeDisabled(): void
     {
-        $ticketSystem = self::createStub(TicketSystem::class);
-        $ticketSystem->method('getBookTime')->willReturn(false);
-        $ticketSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+        [$entry] = $this->createSyncableEntry(bookTime: false);
 
-        $project = self::createStub(Project::class);
-        $project->method('getTicketSystem')->willReturn($ticketSystem);
-
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getProject')->willReturn($project);
-
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryCreated($event);
@@ -180,22 +216,9 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryCreatedDoesNotSyncWhenNotJiraTicketSystem(): void
     {
-        $ticketSystem = self::createStub(TicketSystem::class);
-        $ticketSystem->method('getBookTime')->willReturn(true);
-        $ticketSystem->method('getType')->willReturn(TicketSystemType::OTRS);
+        [$entry] = $this->createSyncableEntry(type: TicketSystemType::OTRS);
 
-        $project = self::createStub(Project::class);
-        $project->method('getTicketSystem')->willReturn($ticketSystem);
-
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getProject')->willReturn($project);
-
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryCreated($event);
@@ -203,23 +226,9 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryCreatedDoesNotSyncWhenEmptyTicket(): void
     {
-        $ticketSystem = self::createStub(TicketSystem::class);
-        $ticketSystem->method('getBookTime')->willReturn(true);
-        $ticketSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+        [$entry] = $this->createSyncableEntry(ticket: '');
 
-        $project = self::createStub(Project::class);
-        $project->method('getTicketSystem')->willReturn($ticketSystem);
-
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getProject')->willReturn($project);
-        $entry->method('getTicket')->willReturn('');
-
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryCreated($event);
@@ -227,23 +236,9 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryCreatedDoesNotSyncWhenZeroTicket(): void
     {
-        $ticketSystem = self::createStub(TicketSystem::class);
-        $ticketSystem->method('getBookTime')->willReturn(true);
-        $ticketSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+        [$entry] = $this->createSyncableEntry(ticket: '0');
 
-        $project = self::createStub(Project::class);
-        $project->method('getTicketSystem')->willReturn($ticketSystem);
-
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getProject')->willReturn($project);
-        $entry->method('getTicket')->willReturn('0');
-
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryCreated($event);
@@ -251,24 +246,13 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryCreatedLogsErrorOnJiraSyncFailure(): void
     {
-        $ticketSystem = self::createStub(TicketSystem::class);
-        $ticketSystem->method('getBookTime')->willReturn(true);
-        $ticketSystem->method('getType')->willReturn(TicketSystemType::JIRA);
-
-        $project = self::createStub(Project::class);
-        $project->method('getTicketSystem')->willReturn($ticketSystem);
-
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getProject')->willReturn($project);
-        $entry->method('getTicket')->willReturn('ABC-123');
+        [$entry] = $this->createSyncableEntry();
 
         $exception = new Exception('Jira API error');
-        $this->jiraIntegrationService->expects(self::once())
-            ->method('saveWorklog')
+        $this->jiraOAuthApiFactory->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
             ->willThrowException($exception);
 
         $this->logger->expects(self::once())
@@ -296,19 +280,18 @@ final class EntryEventSubscriberTest extends TestCase
         $this->subscriber->onEntryUpdated($event);
     }
 
-    public function testOnEntryUpdatedSyncsToJiraWhenAlreadySynced(): void
+    public function testOnEntryUpdatedSyncsWhenAutoSyncConditionsMet(): void
     {
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
+        [$entry, $user, $ticketSystem] = $this->createSyncableEntry(synced: true, worklogId: 12345);
 
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(true);
-        $entry->method('getWorklogId')->willReturn(12345);
+        $this->expectJiraApiCreatedFor($user, $ticketSystem);
 
-        $this->jiraIntegrationService->expects(self::once())
-            ->method('saveWorklog')
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
             ->with($entry);
+
+        $this->objectManager->expects(self::once())
+            ->method('flush');
 
         $this->logger->expects(self::exactly(2))
             ->method('info');
@@ -317,34 +300,35 @@ final class EntryEventSubscriberTest extends TestCase
         $this->subscriber->onEntryUpdated($event);
     }
 
-    public function testOnEntryUpdatedDoesNotSyncWhenNotPreviouslySynced(): void
+    public function testOnEntryUpdatedSyncsWhenNotPreviouslySynced(): void
     {
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
+        // Catch-up behavior: entries that were never synced (e.g. saved while
+        // sync was unavailable) are synced on their next update.
+        [$entry, $user, $ticketSystem] = $this->createSyncableEntry();
 
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(false);
+        $this->expectJiraApiCreatedFor($user, $ticketSystem);
 
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
+            ->with($entry);
+
+        $this->objectManager->expects(self::once())
+            ->method('flush');
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryUpdated($event);
     }
 
-    public function testOnEntryUpdatedDoesNotSyncWhenNoWorklogId(): void
+    public function testOnEntryUpdatedDoesNotSyncWhenNoProject(): void
     {
         $user = self::createStub(User::class);
         $user->method('getId')->willReturn(1);
 
         $entry = self::createStub(Entry::class);
         $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(true);
-        $entry->method('getWorklogId')->willReturn(null);
+        $entry->method('getProject')->willReturn(null);
 
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('saveWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryUpdated($event);
@@ -352,17 +336,13 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryUpdatedLogsWarningOnJiraFailure(): void
     {
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(true);
-        $entry->method('getWorklogId')->willReturn(12345);
+        [$entry] = $this->createSyncableEntry();
 
         $exception = new Exception('Jira API error');
-        $this->jiraIntegrationService->expects(self::once())
-            ->method('saveWorklog')
+        $this->jiraOAuthApiFactory->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
             ->willThrowException($exception);
 
         $this->logger->expects(self::once())
@@ -392,17 +372,16 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryDeletedDeletesWorklogFromJira(): void
     {
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
+        [$entry, $user, $ticketSystem] = $this->createSyncableEntry(synced: true, worklogId: 12345);
 
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(true);
-        $entry->method('getWorklogId')->willReturn(12345);
+        $this->expectJiraApiCreatedFor($user, $ticketSystem);
 
-        $this->jiraIntegrationService->expects(self::once())
-            ->method('deleteWorklog')
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('deleteEntryJiraWorkLog')
             ->with($entry);
+
+        $this->objectManager->expects(self::once())
+            ->method('flush');
 
         $this->logger->expects(self::exactly(2))
             ->method('info');
@@ -413,15 +392,9 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryDeletedDoesNotDeleteWhenNotSynced(): void
     {
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
+        [$entry] = $this->createSyncableEntry();
 
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(false);
-
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('deleteWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryDeleted($event);
@@ -429,16 +402,9 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryDeletedDoesNotDeleteWhenNoWorklogId(): void
     {
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
+        [$entry] = $this->createSyncableEntry(synced: true);
 
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(true);
-        $entry->method('getWorklogId')->willReturn(null);
-
-        $this->jiraIntegrationService->expects(self::never())
-            ->method('deleteWorklog');
+        $this->expectNoJiraApi();
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryDeleted($event);
@@ -446,17 +412,13 @@ final class EntryEventSubscriberTest extends TestCase
 
     public function testOnEntryDeletedLogsWarningOnFailure(): void
     {
-        $user = self::createStub(User::class);
-        $user->method('getId')->willReturn(1);
-
-        $entry = self::createStub(Entry::class);
-        $entry->method('getUser')->willReturn($user);
-        $entry->method('getSyncedToTicketsystem')->willReturn(true);
-        $entry->method('getWorklogId')->willReturn(12345);
+        [$entry] = $this->createSyncableEntry(synced: true, worklogId: 12345);
 
         $exception = new Exception('Jira API error');
-        $this->jiraIntegrationService->expects(self::once())
-            ->method('deleteWorklog')
+        $this->jiraOAuthApiFactory->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('deleteEntryJiraWorkLog')
             ->willThrowException($exception);
 
         $this->logger->expects(self::once())
@@ -523,7 +485,8 @@ final class EntryEventSubscriberTest extends TestCase
     public function testConstructorWithoutLogger(): void
     {
         $subscriber = new EntryEventSubscriber(
-            $this->jiraIntegrationService,
+            $this->jiraOAuthApiFactory,
+            $this->managerRegistry,
             $this->queryCacheService,
         );
 


### PR DESCRIPTION
## Summary

Production test of v5 (internal deployment, NRS-4188) surfaced two regressions against v4; both are fixed here.

### 1. Automatic Jira worklog sync was dead code

Saving/deleting an entry dispatches `EntryEvent`, but the only subscriber (`EntryEventSubscriber`) was excluded from the service container together with the unfinished `JiraIntegrationService` stack (`config/services.yaml`) — entries were saved but never synced to Jira, silently. In v4 every save booked the worklog inline.

Fix: rewire the subscriber to the legacy `JiraOAuthApiService` via `JiraOAuthApiFactory` — the only Jira path wired into the container, already used by `SyncJiraEntriesAction`, `ExportService` and `SubticketSyncService` — and re-enable it in DI. The encrypted-token stack stays excluded.

Behavior notes:
- `onEntryUpdated` now syncs whenever auto-sync conditions are met (v4 parity) instead of only when previously synced; `updateEntryJiraWorkLog` decides create-vs-update by worklog id, so never-synced entries catch up on their next save.
- The entity manager is flushed after sync so worklog id + synced flag persist (otherwise the next sync would create a duplicate worklog).

### 2. `GET /getTicketSystems` → HTTP 500 on legacy data

`ticket_systems.ticketurl` is nullable in the production schema (NULL rows exist), but the entity declared `nullable: false` and `getTicketUrl(): string` — every hydration+read threw `TypeError`. Mapping aligned with reality, getter normalizes NULL to `''` (v4 behavior).

## Known limitations (unchanged scope)

- Users without an OAuth token get a logged error instead of the v4 OAuth-dance trigger on save — token acquisition flow is a separate issue.
- Moving an entry to a different ticket leaves the old worklog in the previous ticket (v4 had delete-on-ticket-change; can follow up).
- The legacy-NULL vs strict-getter pattern may exist on other entities — worth a systematic audit against the production schema.

## Test plan

- `EntryEventSubscriberTest` adapted/extended: 26 tests / 78 assertions green, including the new catch-up-on-update semantics.
- Full suite via `make test` (docker, db_unittest + ldap-dev): 1922 tests, 5629 assertions, green.
- PHPStan level 10 (full), PHP-CS-Fixer, Rector, PHPat, `lint:container`, `composer validate`, `composer audit`: all clean.
- Verified test fixtures keep `book_time=0`, so re-enabling the subscriber cannot make CI tests call Jira.
- Production deployment of this branch's image will be verified on tt.netresearch.de (NRS-4188): re-save of an unsynced entry must create the worklog.
