### PR TITLE
fix: restore v4 ticket-prefix validation on entry save

### DIFF
--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -24,6 +24,7 @@ use App\Repository\CustomerRepository;
 use App\Repository\EntryRepository;
 use App\Repository\ProjectRepository;
 use App\Response\Error;
+use App\Service\Util\TicketService;
 use BadMethodCallException;
 use DateTime;
 use DateTimeInterface;
@@ -44,10 +45,18 @@ final class SaveEntryAction extends BaseTrackingController
 {
     private ?EventDispatcherInterface $eventDispatcher = null;
 
+    private TicketService $ticketService;
+
     #[Required]
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
     {
         $this->eventDispatcher = $eventDispatcher;
+    }
+
+    #[Required]
+    public function setTicketService(TicketService $ticketService): void
+    {
+        $this->ticketService = $ticketService;
     }
 
     /**
@@ -109,17 +118,9 @@ final class SaveEntryAction extends BaseTrackingController
 
         // Should we check if the ticket belongs to the project
         if ('' !== $entrySaveDto->ticket && '0' !== $entrySaveDto->ticket) {
-            // Use project's jira_id as the expected prefix if it exists
-            $prefix = $project->getJiraId();
-
-            if (null !== $prefix && '' !== $prefix) {
-                if (!str_starts_with($entrySaveDto->ticket, $prefix)) {
-                    return new Error('Given ticket does not have a valid prefix.', Response::HTTP_BAD_REQUEST);
-                }
-
-                if (!str_contains($entrySaveDto->ticket, '-')) {
-                    return new Error('Given ticket does not have a valid format.', Response::HTTP_BAD_REQUEST);
-                }
+            $prefixError = $this->validateTicketPrefix($project, $entrySaveDto->ticket);
+            if ($prefixError instanceof Error) {
+                return $prefixError;
             }
         }
 
@@ -260,5 +261,37 @@ final class SaveEntryAction extends BaseTrackingController
         } catch (Throwable $throwable) {
             return new Error('Could not save entry: ' . $throwable->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * TTT-199: check if the ticket prefix matches the project's Jira ID.
+     *
+     * v4 parity: the project's jira_id is a comma-separated list of allowed
+     * prefixes (entries are trimmed before comparison), and the project's
+     * internal Jira project key is accepted as an alternative match.
+     */
+    private function validateTicketPrefix(Project $project, string $ticket): ?Error
+    {
+        $jiraId = $project->getJiraId();
+        if (null === $jiraId || '' === $jiraId) {
+            return null;
+        }
+
+        if (!$this->ticketService->checkFormat($ticket)) {
+            return new Error('Given ticket does not have a valid format.', Response::HTTP_BAD_REQUEST);
+        }
+
+        $ticketPrefix = (string) $this->ticketService->getPrefix($ticket);
+        foreach (explode(',', $jiraId) as $allowedPrefix) {
+            if (trim($allowedPrefix) === $ticketPrefix) {
+                return null;
+            }
+        }
+
+        if ($project->matchesInternalJiraProject($ticketPrefix)) {
+            return null;
+        }
+
+        return new Error('Given ticket does not have a valid prefix.', Response::HTTP_BAD_REQUEST);
     }
 }

--- a/tests/Controller/SaveEntryTicketPrefixTest.php
+++ b/tests/Controller/SaveEntryTicketPrefixTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Project;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+/**
+ * Ticket-prefix validation on /tracking/save (v4 parity, see #306).
+ *
+ * The project's jira_id is a comma-separated list of allowed prefixes
+ * (entries trimmed before comparison); the project's internal Jira project
+ * key is accepted as an alternative match; prefixes must match exactly,
+ * not merely be a string prefix of the ticket.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class SaveEntryTicketPrefixTest extends AbstractWebTestCase
+{
+    /**
+     * @param array<string, string|int> $overrides
+     *
+     * @return array<string, string|int>
+     */
+    private function saveParameters(array $overrides = []): array
+    {
+        return $overrides + [
+            'start' => '09:00:00',
+            'end' => '10:00:00',
+            'date' => '2024-01-02',
+            'project_id' => 1,
+            'customer_id' => 1,
+            'activity_id' => 1,
+        ];
+    }
+
+    private function configureProjectOne(?string $jiraId, ?string $internalKey = null, ?string $internalTicketSystem = null): void
+    {
+        $container = $this->client->getContainer();
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
+        $doctrine = $container->get('doctrine');
+        $em = $doctrine->getManager();
+        $project = $em->getRepository(Project::class)->find(1);
+        self::assertInstanceOf(Project::class, $project);
+
+        $project->setJiraId($jiraId);
+        if (null !== $internalKey) {
+            $project->setInternalJiraProjectKey($internalKey);
+        }
+        if (null !== $internalTicketSystem) {
+            $project->setInternalJiraTicketSystem($internalTicketSystem);
+        }
+
+        $em->persist($project);
+        $em->flush();
+    }
+
+    public function testTicketMatchingSingleJiraIdIsAccepted(): void
+    {
+        $this->logInSession('unittest');
+
+        // Fixture project 1 has jira_id 'SA'
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'SA-123']), [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(200);
+    }
+
+    public function testTicketMatchingLaterPrefixInCommaListIsAccepted(): void
+    {
+        $this->logInSession('unittest');
+        $this->configureProjectOne('SA, DHLSUP');
+
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'DHLSUP-123456']), [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(200);
+    }
+
+    public function testTicketMatchingInternalJiraProjectKeyIsAccepted(): void
+    {
+        $this->logInSession('unittest');
+        $this->configureProjectOne('SA', 'OPSDHL', '1');
+
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'OPSDHL-77']), [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(200);
+    }
+
+    public function testTicketWithUnknownPrefixIsRejected(): void
+    {
+        $this->logInSession('unittest');
+
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'WRONG-123']), [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(400);
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('message', $data);
+        self::assertSame('Given ticket does not have a valid prefix.', $data['message']);
+    }
+
+    public function testTicketPrefixMustMatchExactlyNotMerelyStartWith(): void
+    {
+        $this->logInSession('unittest');
+
+        // 'SAX-1' starts with the configured prefix 'SA' as a string, but the
+        // Jira project key differs - must be rejected (regression guard for
+        // the str_starts_with() implementation).
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'SAX-1']), [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(400);
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('message', $data);
+        self::assertSame('Given ticket does not have a valid prefix.', $data['message']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #306 — "Given ticket does not have a valid prefix" when booking time on tickets that v4 accepted.

v5 replaced the v4 entry-save ticket validation (TTT-199) with a bare `str_starts_with($ticket, $project->getJiraId())`, which broke three behaviors and weakened a fourth:

| Case | v4 | v5 before this PR |
| --- | --- | --- |
| `jira_id` comma list (`"NRNR,NRMARKETING"`) | each trimmed entry matched | never matches → booking with ticket impossible (4 active production projects affected) |
| internal Jira project key | accepted as alternative match | ignored (`matchesInternalJiraProject` unused) |
| whitespace in list entries | trimmed | raw comparison |
| `SAX-1` on `jira_id "SA"` | rejected (key mismatch) | **wrongly accepted** (string-prefix ≠ key match) |

## Fix

`SaveEntryAction::validateTicketPrefix()` reintroduces the v4 semantics using the existing `TicketService` (same `TICKET_REGEXP` as v4's `TicketHelper`): strict format check, exact prefix equality against the trimmed comma-list, internal Jira project key as alternative.

## Test plan

- New `SaveEntryTicketPrefixTest` (5 controller tests): single prefix, later comma-list entry (incl. trim), internal-key match, unknown prefix rejected, `SAX-1`-on-`SA` rejected.
- Full suite green via `make test`: 1927 tests, 5643 assertions.
- PHPStan level 10, CS-Fixer, Rector clean.
