### PR TITLE
ci: restore semver image tag publishing via bake metadata inheritance

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+            type=raw,value=production,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -71,14 +71,24 @@ target "_common" {
 # BUILD TARGETS
 # =============================================================================
 
-# Production image
-target "app" {
-  inherits = ["_common"]
-  target   = "production"
+# Tag/label provider for the "app" target.
+#
+# In CI this stub is REPLACED by the bake file that docker/metadata-action
+# generates (the workflow passes it via `files:`), so pushes get the full
+# metadata tag set (semver from git tags, branch name, sha, production,
+# latest). For local `docker buildx bake` runs the stub supplies the
+# defaults that compose.yml expects.
+target "docker-metadata-action" {
   tags = [
     "${REGISTRY}/${IMAGE_NAME}:${TAG}",
     "${REGISTRY}/${IMAGE_NAME}:production",
   ]
+}
+
+# Production image
+target "app" {
+  inherits = ["_common", "docker-metadata-action"]
+  target   = "production"
   labels = {
     "org.opencontainers.image.title"       = "Netresearch TimeTracker"
     "org.opencontainers.image.description" = "Time tracking application"


### PR DESCRIPTION
Since the bake-action migration (eb76c8c7, 2026-01-18) the docker/metadata-action tags were silently dropped — the `app` bake target never inherited the `docker-metadata-action` target, so every build pushed only `latest`/`production` and a release tag produced **no versioned image** (ghcr `main`/`nightly` stale since January).

**Fix:** stub `docker-metadata-action` target in `docker-bake.hcl` (keeps local-bake defaults; replaced by the generated bake file in CI) + `app` inherits it; `production`/`latest` added as raw metadata tags on the default branch so daily main builds keep rolling them.

**Verified** via `docker buildx bake --print`: local → `latest`+`production`; with simulated metadata file → `5.0.0`/`5.0`/`5`/`latest`.

Prerequisite for the v5.0.0 release (versioned image tags for the deployment playbook).