### PR TITLE
fix: restore v4 entry-save behaviors (internal ticket mirroring, day classes, normalization)

### DIFF
--- a/src/Controller/Tracking/BaseTrackingController.php
+++ b/src/Controller/Tracking/BaseTrackingController.php
@@ -59,65 +59,40 @@ abstract class BaseTrackingController extends BaseController
             return;
         }
 
-        $normalizedEntries = [];
-        foreach ($entries as $entry) {
-            // No need for instanceof check - findByDay always returns Entry[]
-            $normalizedEntries[] = [
-                'id' => (int) $entry->getId(),
-                'start' => $entry->getStart(),
-                'end' => $entry->getEnd(),
-            ];
+        // v4 semantics: the class describes the transition BEFORE an entry.
+        // The first entry of a day always marks the day break; every further
+        // entry is a pause (gap to the previous entry), an overlap (starts
+        // before the previous one ended) or plain (seamless continuation).
+        $firstEntry = $entries[0];
+        if (EntryClass::DAYBREAK !== $firstEntry->getClass()) {
+            $firstEntry->setClass(EntryClass::DAYBREAK);
+            $objectManager->persist($firstEntry);
+            $objectManager->flush();
         }
 
-        if (0 === count($normalizedEntries)) {
-            return;
-        }
+        $counter = count($entries);
+        for ($i = 1; $i < $counter; ++$i) {
+            $entry = $entries[$i];
+            $previous = $entries[$i - 1];
 
-        // Sort by start time - no isset check needed, structure is guaranteed
-        usort(
-            $normalizedEntries,
-            static fn (array $a, array $b): int => $a['start'] <=> $b['start'],
-        );
-        // Calculate overlaps
-        $counter = count($normalizedEntries);
-
-        // Calculate overlaps
-        for ($i = 0; $i < $counter; ++$i) {
-            for ($j = $i + 1; $j < count($normalizedEntries); ++$j) {
-                if ($normalizedEntries[$i]['end'] > $normalizedEntries[$j]['start']) {
-                    // Mark both as overlapping
-                    $this->addEntryClass($normalizedEntries[$i]['id'], EntryClass::OVERLAP);
-                    $this->addEntryClass($normalizedEntries[$j]['id'], EntryClass::OVERLAP);
-                }
+            $start = $entry->getStart();
+            $previousEnd = $previous->getEnd();
+            if (!$start instanceof DateTime || !$previousEnd instanceof DateTime) {
+                continue;
             }
-        }
 
-        // Calculate pauses and day breaks
-        for ($i = 0; $i < count($normalizedEntries) - 1; ++$i) {
-            $current = $normalizedEntries[$i];
-            $next = $normalizedEntries[$i + 1];
-
-            $pauseMinutes = ($next['start']->getTimestamp() - $current['end']->getTimestamp()) / 60;
-
-            if ($pauseMinutes > 0) {
-                if ($pauseMinutes >= 60) {  // 1 hour or more
-                    $this->addEntryClass($current['id'], EntryClass::DAYBREAK);
-                } else {
-                    $this->addEntryClass($current['id'], EntryClass::PAUSE);
-                }
+            $entryClass = EntryClass::PLAIN;
+            if ($start->format('H:i') > $previousEnd->format('H:i')) {
+                $entryClass = EntryClass::PAUSE;
+            } elseif ($start->format('H:i') < $previousEnd->format('H:i')) {
+                $entryClass = EntryClass::OVERLAP;
             }
-        }
-    }
 
-    /**
-     * Add a rendering class to an entry.
-     */
-    private function addEntryClass(int $entryId, EntryClass $entryClass): void
-    {
-        $entry = $this->managerRegistry->getRepository(Entry::class)->find($entryId);
-        if ($entry instanceof Entry) {
-            $entry->addClass($entryClass);
-            $this->managerRegistry->getManager()->flush();
+            if ($entryClass !== $entry->getClass()) {
+                $entry->setClass($entryClass);
+                $objectManager->persist($entry);
+                $objectManager->flush();
+            }
         }
     }
 

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -281,6 +281,12 @@ final class SaveEntryAction extends BaseTrackingController
                 $data['result']['ticket'] = $entry->getTicket();
             }
 
+            // The UI round-trips the original external ticket key of
+            // mirrored entries from this field (v4: part of toArray())
+            if ($entry->hasInternalJiraTicketOriginalKey()) {
+                $data['result']['extTicket'] = $entry->getInternalJiraTicketOriginalKey();
+            }
+
             if ('' !== $entrySaveDto->description && '0' !== $entrySaveDto->description) {
                 $data['result']['description'] = $entry->getDescription();
             }

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -15,7 +15,6 @@ use App\Entity\Customer;
 use App\Entity\Entry;
 use App\Entity\Project;
 use App\Entity\User;
-use App\Enum\EntryClass;
 use App\Event\EntryEvent;
 use App\Model\JsonResponse;
 use App\Model\Response;
@@ -116,9 +115,12 @@ final class SaveEntryAction extends BaseTrackingController
 
         $entryId = $entrySaveDto->id;
 
+        // v4 parity: tickets are stored upper-cased and trimmed
+        $ticket = strtoupper(trim($entrySaveDto->ticket));
+
         // Should we check if the ticket belongs to the project
-        if ('' !== $entrySaveDto->ticket && '0' !== $entrySaveDto->ticket) {
-            $prefixError = $this->validateTicketPrefix($project, $entrySaveDto->ticket);
+        if ('' !== $ticket && '0' !== $ticket) {
+            $prefixError = $this->validateTicketPrefix($project, $ticket);
             if ($prefixError instanceof Error) {
                 return $prefixError;
             }
@@ -142,11 +144,14 @@ final class SaveEntryAction extends BaseTrackingController
             $entry = new Entry();
         }
 
+        // pre-mutation snapshot for the event subscriber (worklog cleanup on
+        // ticket changes) and the day-class recalculation of a moved entry
+        $previousEntry = $isNewEntry ? null : clone $entry;
+
         $entry->setUser($user);
         $entry->setCustomer($customer);
         $entry->setProject($project);
         $entry->setActivity($activity);
-        $entry->setClass(EntryClass::DAYBREAK);
 
         // Use DTO methods for date/time parsing (supports multiple formats)
         $dayDate = $entrySaveDto->getDateAsDateTime();
@@ -177,9 +182,15 @@ final class SaveEntryAction extends BaseTrackingController
             $entry->setDescription($entrySaveDto->description);
         }
 
-        if ('' !== $entrySaveDto->ticket && '0' !== $entrySaveDto->ticket) {
-            $entry->setTicket($entrySaveDto->ticket);
+        if ('' !== $ticket && '0' !== $ticket) {
+            $entry->setTicket($ticket);
         }
+
+        // v4 parity: the UI round-trips the original external ticket key of
+        // mirrored entries in "extTicket" (see internal Jira ticket system)
+        $entry->setInternalJiraTicketOriginalKey(
+            '' !== $entrySaveDto->extTicket ? $entrySaveDto->extTicket : null,
+        );
 
         if (!$project->getActive()) {
             return new Error('Project is no longer active.', Response::HTTP_BAD_REQUEST);
@@ -211,7 +222,24 @@ final class SaveEntryAction extends BaseTrackingController
             // Dispatch entry event for Jira sync and cache invalidation
             if ($this->eventDispatcher instanceof EventDispatcherInterface) {
                 $eventName = $isNewEntry ? EntryEvent::CREATED : EntryEvent::UPDATED;
-                $this->eventDispatcher->dispatch(new EntryEvent($entry), $eventName);
+                $this->eventDispatcher->dispatch(
+                    new EntryEvent($entry, ['previous' => $previousEntry]),
+                    $eventName,
+                );
+            }
+
+            // v4 parity: recalculate the day-break/pause/overlap rendering
+            // classes of the affected day(s)
+            $entryDay = $entry->getDay();
+            if ($entryDay instanceof DateTime) {
+                $this->calculateClasses($user->getId() ?? 0, $entryDay->format('Y-m-d'));
+
+                $previousDay = $previousEntry?->getDay();
+                if ($previousDay instanceof DateTime
+                    && $previousDay->format('Y-m-d') !== $entryDay->format('Y-m-d')
+                ) {
+                    $this->calculateClasses($user->getId() ?? 0, $previousDay->format('Y-m-d'));
+                }
             }
 
             // Return JSON response matching test expectations

--- a/src/Dto/EntrySaveDto.php
+++ b/src/Dto/EntrySaveDto.php
@@ -53,6 +53,8 @@ final readonly class EntrySaveDto
         public ?int $customer = null,
         #[Assert\Positive(message: 'Activity ID must be positive')]
         public ?int $activity = null,
+        #[Assert\Length(max: 50, maxMessage: 'Ticket cannot be longer than 50 characters')]
+        #[Assert\Regex(pattern: '/^[A-Z0-9\-_]*$/i', message: 'Invalid ticket format')]
         public string $extTicket = '',
     ) {
     }

--- a/src/EventSubscriber/EntryEventSubscriber.php
+++ b/src/EventSubscriber/EntryEventSubscriber.php
@@ -283,7 +283,7 @@ class EntryEventSubscriber implements EventSubscriberInterface
 
         $searchResult = $api->searchTicket(
             sprintf(
-                'project = %s AND summary ~ %s',
+                'project = %s AND summary ~ "%s"',
                 $project->getInternalJiraProjectKey() ?? '',
                 $externalTicket,
             ),
@@ -298,7 +298,11 @@ class EntryEventSubscriber implements EventSubscriberInterface
         if (count($issues) > 0) {
             $issue = reset($issues);
         } else {
-            // issue does not exist in the internal Jira, create it
+            // issue does not exist in the internal Jira, create it - with
+            // the EXTERNAL key as its summary (relevant when an already
+            // mirrored entry is edited and the mirror issue vanished: the
+            // entry's ticket holds the internal key at this point)
+            $entry->setTicket($externalTicket);
             $issue = $api->createTicket($entry);
         }
 

--- a/src/EventSubscriber/EntryEventSubscriber.php
+++ b/src/EventSubscriber/EntryEventSubscriber.php
@@ -23,7 +23,12 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Throwable;
 
+use function count;
 use function in_array;
+use function is_array;
+use function is_object;
+use function is_string;
+use function sprintf;
 
 /**
  * Handles entry-related events.
@@ -32,6 +37,12 @@ use function in_array;
  * (via JiraOAuthApiFactory): it is the only Jira integration path wired into
  * the service container; the newer JiraIntegrationService stack stays
  * excluded until token encryption is production-ready.
+ *
+ * Projects with an internal Jira project key get the v4 "internal ticket
+ * system" behavior: time booked on an external ticket is mirrored to an
+ * issue in the internal Jira (found by summary, created on demand), the
+ * entry's ticket is rewritten to the internal issue key and the external
+ * key is preserved in internalJiraTicketOriginalKey ("ext. ticket").
  */
 class EntryEventSubscriber implements EventSubscriberInterface
 {
@@ -65,7 +76,7 @@ class EntryEventSubscriber implements EventSubscriberInterface
         // Check if automatic JIRA sync is needed
         if ($this->shouldAutoSync($entry)) {
             try {
-                $this->syncWorklog($entry);
+                $this->syncWorklog($entry, $this->getPreviousEntry($entryEvent));
                 $this->logger?->info('Entry auto-synced to JIRA');
             } catch (Exception $e) {
                 $this->logger?->error('Auto-sync to JIRA failed', ['exception' => $e]);
@@ -86,7 +97,7 @@ class EntryEventSubscriber implements EventSubscriberInterface
         // so entries that were never synced are caught up on their next save.
         if ($this->shouldAutoSync($entry)) {
             try {
-                $this->syncWorklog($entry);
+                $this->syncWorklog($entry, $this->getPreviousEntry($entryEvent));
                 $this->logger?->info('JIRA worklog updated');
             } catch (Exception $e) {
                 $this->logger?->warning('JIRA worklog update failed', ['exception' => $e]);
@@ -147,28 +158,59 @@ class EntryEventSubscriber implements EventSubscriberInterface
         }
     }
 
-    private function syncWorklog(Entry $entry): void
+    /**
+     * The pre-mutation snapshot of an updated entry, if the dispatcher
+     * provided one (used for v4-parity worklog cleanup on ticket changes).
+     */
+    private function getPreviousEntry(EntryEvent $entryEvent): ?Entry
+    {
+        $previous = $entryEvent->getContext()['previous'] ?? null;
+
+        return $previous instanceof Entry ? $previous : null;
+    }
+
+    private function syncWorklog(Entry $entry, ?Entry $previousEntry = null): void
     {
         $user = $entry->getUser();
-        $ticketSystem = $entry->getProject()?->getTicketSystem();
-        if (!$user instanceof User || !$ticketSystem instanceof TicketSystem) {
+        $project = $entry->getProject();
+        if (!$user instanceof User || !$project instanceof Project) {
             return;
         }
 
-        $this->jiraOAuthApiFactory->create($user, $ticketSystem)
-            ->updateEntryJiraWorkLog($entry);
+        // v4 "internal ticket system": mirror the external ticket into the
+        // internal Jira and book the worklog there.
+        if ($project->hasInternalJiraProjectKey()) {
+            $internalTicketSystem = $this->findInternalTicketSystem($project);
+            if ($internalTicketSystem instanceof TicketSystem && $this->canBookOn($internalTicketSystem)) {
+                $this->remapEntryToInternalTicket($entry, $project, $user, $internalTicketSystem);
+                $this->bookWorklog($entry, null, $user, $internalTicketSystem);
+            }
+        }
 
-        // updateEntryJiraWorkLog sets the worklog id and the synced flag on
-        // the already-persisted entity; flush them or the next sync would
-        // create a duplicate worklog.
-        $this->managerRegistry->getManager()->flush();
+        // Regular path: the project's own ticket system decides via its
+        // book_time/type flags (v4 ran both paths; for internal-key projects
+        // the own system usually has booking disabled).
+        $ownTicketSystem = $project->getTicketSystem();
+        if ($ownTicketSystem instanceof TicketSystem && $this->canBookOn($ownTicketSystem)) {
+            $this->bookWorklog($entry, $previousEntry, $user, $ownTicketSystem);
+        }
     }
 
     private function deleteWorklog(Entry $entry): void
     {
         $user = $entry->getUser();
-        $ticketSystem = $entry->getProject()?->getTicketSystem();
-        if (!$user instanceof User || !$ticketSystem instanceof TicketSystem) {
+        $project = $entry->getProject();
+        if (!$user instanceof User || !$project instanceof Project) {
+            return;
+        }
+
+        // v4 parity: entries of internal-key projects have their worklog in
+        // the internal Jira, not in the project's own ticket system.
+        $ticketSystem = $project->hasInternalJiraProjectKey()
+            ? $this->findInternalTicketSystem($project)
+            : $project->getTicketSystem();
+
+        if (!$ticketSystem instanceof TicketSystem || !$this->canBookOn($ticketSystem)) {
             return;
         }
 
@@ -180,14 +222,8 @@ class EntryEventSubscriber implements EventSubscriberInterface
 
     private function shouldAutoSync(Entry $entry): bool
     {
-        // Check if project has auto-sync enabled
         $project = $entry->getProject();
         if (!$project instanceof Project) {
-            return false;
-        }
-
-        $ticketSystem = $project->getTicketSystem();
-        if (!$ticketSystem instanceof TicketSystem) {
             return false;
         }
 
@@ -196,9 +232,111 @@ class EntryEventSubscriber implements EventSubscriberInterface
             return false;
         }
 
-        // Check if ticket system has auto-sync enabled
+        if (in_array($entry->getTicket(), ['', '0'], true)) {
+            return false;
+        }
+
+        // At least one bookable target must exist; the per-system gates in
+        // syncWorklog() make the final call.
+        return $project->getTicketSystem() instanceof TicketSystem
+            || $project->hasInternalJiraProjectKey();
+    }
+
+    private function canBookOn(TicketSystem $ticketSystem): bool
+    {
         return $ticketSystem->getBookTime()
-               && TicketSystemType::JIRA === $ticketSystem->getType()
-               && !in_array($entry->getTicket(), ['', '0'], true);
+            && TicketSystemType::JIRA === $ticketSystem->getType();
+    }
+
+    private function findInternalTicketSystem(Project $project): ?TicketSystem
+    {
+        $internalTicketSystemId = (int) $project->getInternalJiraTicketSystem();
+        if (0 === $internalTicketSystemId) {
+            return null;
+        }
+
+        $ticketSystem = $this->managerRegistry
+            ->getRepository(TicketSystem::class)
+            ->find($internalTicketSystemId);
+
+        return $ticketSystem instanceof TicketSystem ? $ticketSystem : null;
+    }
+
+    /**
+     * Finds (by summary) or creates the mirror issue in the internal Jira
+     * project and rewrites the entry to it, keeping the external ticket in
+     * internalJiraTicketOriginalKey (v4: CrudController::handleInternalJiraTicketSystem).
+     */
+    private function remapEntryToInternalTicket(
+        Entry $entry,
+        Project $project,
+        User $user,
+        TicketSystem $internalTicketSystem,
+    ): void {
+        // when an already-mirrored entry is edited, the internal issue must
+        // be looked up by the original external key
+        $externalTicket = $entry->hasInternalJiraTicketOriginalKey()
+            ? (string) $entry->getInternalJiraTicketOriginalKey()
+            : $entry->getTicket();
+
+        $api = $this->jiraOAuthApiFactory->create($user, $internalTicketSystem);
+
+        $searchResult = $api->searchTicket(
+            sprintf(
+                'project = %s AND summary ~ %s',
+                $project->getInternalJiraProjectKey() ?? '',
+                $externalTicket,
+            ),
+            ['key', 'summary'],
+            1,
+        );
+
+        $issues = is_object($searchResult) && property_exists($searchResult, 'issues') && is_array($searchResult->issues)
+            ? $searchResult->issues
+            : [];
+
+        if (count($issues) > 0) {
+            $issue = reset($issues);
+        } else {
+            // issue does not exist in the internal Jira, create it
+            $issue = $api->createTicket($entry);
+        }
+
+        if (!is_object($issue) || !property_exists($issue, 'key') || !is_string($issue->key) || '' === $issue->key) {
+            throw new Exception('Unexpected response from Jira when resolving the internal ticket');
+        }
+
+        $entry->setInternalJiraTicketOriginalKey($externalTicket);
+        $entry->setTicket($issue->key);
+
+        $this->managerRegistry->getManager()->flush();
+    }
+
+    private function bookWorklog(Entry $entry, ?Entry $previousEntry, User $user, TicketSystem $ticketSystem): void
+    {
+        if (in_array($entry->getTicket(), ['', '0'], true)) {
+            return;
+        }
+
+        $api = $this->jiraOAuthApiFactory->create($user, $ticketSystem);
+
+        // v4 parity (CrudController::shouldTicketBeDeleted): when the ticket
+        // changed, the worklog on the previous ticket is removed; a new one
+        // is created below.
+        if ($previousEntry instanceof Entry
+            && $previousEntry->getTicket() !== $entry->getTicket()
+            && $entry->getInternalJiraTicketOriginalKey() !== $entry->getTicket()
+            && null !== $previousEntry->getWorklogId()
+        ) {
+            $api->deleteEntryJiraWorkLog($previousEntry);
+            $entry->setWorklogId(null);
+        }
+
+        $api->updateEntryJiraWorkLog($entry);
+
+        // updateEntryJiraWorkLog sets the worklog id and the synced flag on
+        // the already-persisted entity; flush them or the next sync would
+        // create a duplicate worklog.
+        $this->managerRegistry->getManager()->flush();
     }
 }

--- a/tests/Controller/SaveEntryClassesAndNormalizationTest.php
+++ b/tests/Controller/SaveEntryClassesAndNormalizationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Entry;
+use App\Enum\EntryClass;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+/**
+ * Day-class recalculation (day break / pause / overlap, see #305) and
+ * v4-parity ticket normalization on /tracking/save.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
+{
+    /**
+     * @param array<string, string|int> $overrides
+     *
+     * @return array<string, string|int>
+     */
+    private function saveParameters(array $overrides = []): array
+    {
+        return $overrides + [
+            'date' => '2024-03-11',
+            'project_id' => 1,
+            'customer_id' => 1,
+            'activity_id' => 1,
+        ];
+    }
+
+    /**
+     * @param array<string, string|int> $parameters
+     *
+     * @return array<mixed>
+     */
+    private function saveEntry(array $parameters): array
+    {
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $parameters, [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(200);
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('result', $data);
+        self::assertIsArray($data['result']);
+
+        return $data['result'];
+    }
+
+    public function testFirstEntryOfDayGetsDaybreakClass(): void
+    {
+        $this->logInSession('unittest');
+
+        $result = $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
+
+        self::assertSame(EntryClass::DAYBREAK->value, $result['class']);
+    }
+
+    public function testSeamlessFollowUpEntryGetsPlainClass(): void
+    {
+        $this->logInSession('unittest');
+
+        $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
+        $result = $this->saveEntry($this->saveParameters(['start' => '10:00:00', 'end' => '10:30:00']));
+
+        self::assertSame(EntryClass::PLAIN->value, $result['class']);
+    }
+
+    public function testEntryAfterGapGetsPauseClass(): void
+    {
+        $this->logInSession('unittest');
+
+        $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
+        $result = $this->saveEntry($this->saveParameters(['start' => '10:30:00', 'end' => '11:00:00']));
+
+        self::assertSame(EntryClass::PAUSE->value, $result['class']);
+    }
+
+    public function testOverlappingEntryGetsOverlapClass(): void
+    {
+        $this->logInSession('unittest');
+
+        $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
+        $result = $this->saveEntry($this->saveParameters(['start' => '09:30:00', 'end' => '10:30:00']));
+
+        self::assertSame(EntryClass::OVERLAP->value, $result['class']);
+    }
+
+    public function testTicketIsUpperCasedAndTrimmedOnSave(): void
+    {
+        $this->logInSession('unittest');
+
+        // fixture project 1 has jira_id 'SA'; lower-case input must pass the
+        // prefix validation and be stored normalized (v4 parity)
+        $result = $this->saveEntry($this->saveParameters([
+            'start' => '09:00:00',
+            'end' => '10:00:00',
+            'ticket' => 'sa-123',
+        ]));
+
+        self::assertSame('SA-123', $result['ticket']);
+    }
+
+    public function testExtTicketIsPersistedAsInternalJiraTicketOriginalKey(): void
+    {
+        $this->logInSession('unittest');
+
+        $result = $this->saveEntry($this->saveParameters([
+            'start' => '09:00:00',
+            'end' => '10:00:00',
+            'ticket' => 'SA-77',
+            'extTicket' => 'EXT-77',
+        ]));
+
+        $entryId = $result['id'];
+        self::assertIsInt($entryId);
+
+        $container = $this->client->getContainer();
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
+        $doctrine = $container->get('doctrine');
+        $entry = $doctrine->getManager()->getRepository(Entry::class)->find($entryId);
+
+        self::assertInstanceOf(Entry::class, $entry);
+        self::assertSame('EXT-77', $entry->getInternalJiraTicketOriginalKey());
+    }
+}

--- a/tests/EventSubscriber/EntryEventSubscriberTest.php
+++ b/tests/EventSubscriber/EntryEventSubscriberTest.php
@@ -16,6 +16,7 @@ use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use App\Service\Integration\Jira\JiraOAuthApiService;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Exception;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -500,5 +501,187 @@ final class EntryEventSubscriberTest extends TestCase
 
         // No exception thrown = success
         $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * Builds a REAL entry on a project with an internal Jira ticket system
+     * (the "internal ticket system" feature, see GH discussion in NRS-4188).
+     *
+     * @return array{Entry, User&Stub, TicketSystem&Stub}
+     */
+    private function createInternalProjectEntry(string $ticket, ?string $originalKey = null): array
+    {
+        $internalTicketSystem = self::createStub(TicketSystem::class);
+        $internalTicketSystem->method('getBookTime')->willReturn(true);
+        $internalTicketSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+
+        $project = self::createStub(Project::class);
+        $project->method('hasInternalJiraProjectKey')->willReturn(true);
+        $project->method('getInternalJiraProjectKey')->willReturn('OPSDHL');
+        $project->method('getInternalJiraTicketSystem')->willReturn('9');
+        $project->method('getTicketSystem')->willReturn(null);
+
+        $user = self::createStub(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $ticketSystemRepository = $this->createMock(ObjectRepository::class);
+        $ticketSystemRepository->method('find')->willReturn($internalTicketSystem);
+        $this->managerRegistry->method('getRepository')
+            ->willReturn($ticketSystemRepository);
+
+        $entry = new Entry();
+        $entry->setUser($user);
+        $entry->setProject($project);
+        $entry->setTicket($ticket);
+        if (null !== $originalKey) {
+            $entry->setInternalJiraTicketOriginalKey($originalKey);
+        }
+
+        return [$entry, $user, $internalTicketSystem];
+    }
+
+    public function testInternalTicketSystemRemapsToExistingInternalIssue(): void
+    {
+        [$entry, $user, $internalTicketSystem] = $this->createInternalProjectEntry('DHLSUP-123456');
+
+        $this->jiraOAuthApiFactory->expects(self::atLeastOnce())
+            ->method('create')
+            ->with($user, $internalTicketSystem)
+            ->willReturn($this->jiraOAuthApiService);
+
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('searchTicket')
+            ->with('project = OPSDHL AND summary ~ DHLSUP-123456', ['key', 'summary'], 1)
+            ->willReturn((object) ['issues' => [(object) ['key' => 'OPSDHL-75']]]);
+
+        $this->jiraOAuthApiService->expects(self::never())
+            ->method('createTicket');
+
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
+            ->with($entry);
+
+        $event = new EntryEvent($entry);
+        $this->subscriber->onEntryCreated($event);
+
+        self::assertSame('OPSDHL-75', $entry->getTicket());
+        self::assertSame('DHLSUP-123456', $entry->getInternalJiraTicketOriginalKey());
+    }
+
+    public function testInternalTicketSystemCreatesMissingInternalIssue(): void
+    {
+        [$entry] = $this->createInternalProjectEntry('DHLSUP-7');
+
+        $this->jiraOAuthApiFactory->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+
+        $this->jiraOAuthApiService->method('searchTicket')
+            ->willReturn((object) ['issues' => []]);
+
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('createTicket')
+            ->with($entry)
+            ->willReturn((object) ['key' => 'OPSDHL-99']);
+
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
+            ->with($entry);
+
+        $event = new EntryEvent($entry);
+        $this->subscriber->onEntryCreated($event);
+
+        self::assertSame('OPSDHL-99', $entry->getTicket());
+        self::assertSame('DHLSUP-7', $entry->getInternalJiraTicketOriginalKey());
+    }
+
+    public function testInternalTicketSystemUsesOriginalKeyForMirroredEntries(): void
+    {
+        // an already-mirrored entry carries the internal key as its ticket
+        // and the external key in internalJiraTicketOriginalKey
+        [$entry] = $this->createInternalProjectEntry('OPSDHL-75', 'DHLSUP-123456');
+
+        $this->jiraOAuthApiFactory->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('searchTicket')
+            ->with('project = OPSDHL AND summary ~ DHLSUP-123456', ['key', 'summary'], 1)
+            ->willReturn((object) ['issues' => [(object) ['key' => 'OPSDHL-75']]]);
+
+        $event = new EntryEvent($entry);
+        $this->subscriber->onEntryUpdated($event);
+
+        self::assertSame('OPSDHL-75', $entry->getTicket());
+        self::assertSame('DHLSUP-123456', $entry->getInternalJiraTicketOriginalKey());
+    }
+
+    public function testInternalTicketSystemSkippedWhenInternalSystemNotBookable(): void
+    {
+        $internalTicketSystem = self::createStub(TicketSystem::class);
+        $internalTicketSystem->method('getBookTime')->willReturn(false);
+
+        $project = self::createStub(Project::class);
+        $project->method('hasInternalJiraProjectKey')->willReturn(true);
+        $project->method('getInternalJiraTicketSystem')->willReturn('9');
+        $project->method('getTicketSystem')->willReturn(null);
+
+        $user = self::createStub(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $ticketSystemRepository = $this->createMock(ObjectRepository::class);
+        $ticketSystemRepository->method('find')->willReturn($internalTicketSystem);
+        $this->managerRegistry->method('getRepository')->willReturn($ticketSystemRepository);
+
+        $entry = new Entry();
+        $entry->setUser($user);
+        $entry->setProject($project);
+        $entry->setTicket('DHLSUP-1');
+
+        $this->jiraOAuthApiFactory->expects(self::never())
+            ->method('create');
+
+        $event = new EntryEvent($entry);
+        $this->subscriber->onEntryCreated($event);
+
+        self::assertSame('DHLSUP-1', $entry->getTicket());
+    }
+
+    public function testOnEntryUpdatedDeletesPreviousWorklogWhenTicketChanged(): void
+    {
+        $ticketSystem = self::createStub(TicketSystem::class);
+        $ticketSystem->method('getBookTime')->willReturn(true);
+        $ticketSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+
+        $project = self::createStub(Project::class);
+        $project->method('getTicketSystem')->willReturn($ticketSystem);
+
+        $user = self::createStub(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $entry = new Entry();
+        $entry->setUser($user);
+        $entry->setProject($project);
+        $entry->setTicket('ABC-2');
+        $entry->setWorklogId(555);
+
+        $previousEntry = new Entry();
+        $previousEntry->setTicket('ABC-1');
+        $previousEntry->setWorklogId(555);
+
+        $this->jiraOAuthApiFactory->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('deleteEntryJiraWorkLog')
+            ->with($previousEntry);
+
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('updateEntryJiraWorkLog')
+            ->with($entry);
+
+        $event = new EntryEvent($entry, ['previous' => $previousEntry]);
+        $this->subscriber->onEntryUpdated($event);
+
+        self::assertNull($entry->getWorklogId());
     }
 }

--- a/tests/EventSubscriber/EntryEventSubscriberTest.php
+++ b/tests/EventSubscriber/EntryEventSubscriberTest.php
@@ -551,7 +551,7 @@ final class EntryEventSubscriberTest extends TestCase
 
         $this->jiraOAuthApiService->expects(self::once())
             ->method('searchTicket')
-            ->with('project = OPSDHL AND summary ~ DHLSUP-123456', ['key', 'summary'], 1)
+            ->with('project = OPSDHL AND summary ~ "DHLSUP-123456"', ['key', 'summary'], 1)
             ->willReturn((object) ['issues' => [(object) ['key' => 'OPSDHL-75']]]);
 
         $this->jiraOAuthApiService->expects(self::never())
@@ -605,7 +605,7 @@ final class EntryEventSubscriberTest extends TestCase
 
         $this->jiraOAuthApiService->expects(self::once())
             ->method('searchTicket')
-            ->with('project = OPSDHL AND summary ~ DHLSUP-123456', ['key', 'summary'], 1)
+            ->with('project = OPSDHL AND summary ~ "DHLSUP-123456"', ['key', 'summary'], 1)
             ->willReturn((object) ['issues' => [(object) ['key' => 'OPSDHL-75']]]);
 
         $event = new EntryEvent($entry);


### PR DESCRIPTION
## Summary

Restores three v4 entry-save behaviors lost in the v5 rewrite. Found during the v5 production rollout (NRS-4188).

### 1. Internal Jira ticket system — Fixes #313

The external-ticket mirroring workflow (2017 "Tag der Abrechnung" feature): on projects with **internal JIRA Project Key** + **internal JIRA Ticket-System**, time booked on an external ticket is mirrored to an internal Jira issue (looked up by summary, created on demand), the worklog lands there, the entry's ticket is rewritten to the internal key and the external key is kept as "ext. ticket" (`internal_jira_ticket_original_key`).

All v5 building blocks existed (`searchTicket`/`createTicket`, entity field, `EntrySaveDto::extTicket`) but were never wired. `EntryEventSubscriber` now implements the v4 `handleInternalJiraTicketSystem` semantics (incl. effective-ticket-system selection for worklog deletion of mirrored entries), `SaveEntryAction` round-trips `extTicket` again, and a pre-mutation snapshot in the entry event restores the v4 `shouldTicketBeDeleted` cleanup (worklog removed from the old ticket when an entry moves).

### 2. Day rendering classes — Fixes #305

v5 stamped `EntryClass::DAYBREAK` on **every** save and never called the (incorrectly ported) recalculation → green day-separator above every row. `calculateClasses` now implements the v4 semantics (first entry of day = DAYBREAK; later entries PAUSE/OVERLAP/PLAIN by transition) and runs after save for the affected day(s).

### 3. Ticket normalization

`strtoupper(trim($ticket))` on save (v4 parity) — lower-case input passes prefix validation and is stored canonically.

## Test plan

- `EntryEventSubscriberTest`: 31 tests / 108 assertions — incl. new coverage: remap to existing internal issue, create-on-miss, original-key lookup for mirrored entries, non-bookable internal system skipped, previous-worklog cleanup on ticket change.
- New `SaveEntryClassesAndNormalizationTest` (docker, real DB): DAYBREAK/PLAIN/PAUSE/OVERLAP transitions, lower-case normalization, extTicket persistence — 6 tests / 43 assertions.
- Full suite via `make test`: 1938 tests green (one non-reproducible order-dependent flake observed once, green on two consecutive full runs).
- PHPStan level 10, CS-Fixer, container lint: clean.

## Notes

- v4's save-time `doesTicketExist` check (rejecting non-existent tickets for non-mirrored projects, incl. the OAuth-dance trigger) is still missing in v5 — out of scope here, can be a follow-up.
- Production data: entries saved under v5.0.0 carry `class=DAYBREAK`; days touched after deployment self-heal via recalculation.
