### PR TITLE
fix: install procps and ship migrations in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -218,6 +218,13 @@ ENV APP_ENV=test
 # =============================================================================
 FROM base AS production
 
+# Install procps (provides pgrep, required by the healthcheck script)
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends procps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy only what's needed from deps stage
 COPY --from=deps --chown=app:app /var/www/html/vendor /var/www/html/vendor
 COPY --from=deps --chown=app:app /var/www/html/public /var/www/html/public
@@ -226,6 +233,7 @@ COPY --from=deps --chown=app:app /var/www/html/bin /var/www/html/bin
 COPY --from=deps --chown=app:app /var/www/html/src /var/www/html/src
 COPY --from=deps --chown=app:app /var/www/html/templates /var/www/html/templates
 COPY --from=deps --chown=app:app /var/www/html/translations /var/www/html/translations
+COPY --from=deps /var/www/html/migrations /var/www/html/migrations
 COPY --from=deps --chown=app:app /var/www/html/sql /var/www/html/sql
 COPY --from=deps --chown=app:app /var/www/html/var /var/www/html/var
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
         libjpeg62-turbo-dev \
         libfreetype6-dev \
         libicu-dev \
+        procps \
         unzip \
         zlib1g-dev \
     && docker-php-ext-configure gd --with-jpeg --with-freetype \
@@ -217,13 +218,6 @@ ENV APP_ENV=test
 # PRODUCTION - Minimal secure image
 # =============================================================================
 FROM base AS production
-
-# Install procps (provides pgrep, required by the healthcheck script)
-RUN set -ex \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends procps \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 # Copy only what's needed from deps stage
 COPY --from=deps --chown=app:app /var/www/html/vendor /var/www/html/vendor


### PR DESCRIPTION
Fixes #310, fixes #311 — found during the v5 production rollout (NRS-4188).

| Defect | Fix |
| --- | --- |
| HEALTHCHECK calls `pgrep` but procps is not installed → containers permanently *unhealthy* | install procps in the production stage |
| `migrations/` not copied into the production image → `doctrine:migrations:migrate` fails, operators must bind-mount | copy `migrations/` (root-owned, read-only for the runtime user — addresses Sonar docker:S6504) |

**Verification** (local `production`-target bake build):
```
command -v pgrep              → /usr/bin/pgrep
ls -ld /var/www/html/migrations → drwxr-xr-x root root  (read-only for app)
cat migrations/Version…php as user app → READ-OK
docker inspect …Health.Status → healthy   (was: permanently unhealthy)
```

After this lands, the `--no-healthcheck` workaround and the migrations bind-mount on utility3.nr can be dropped.