### PR TITLE
chore: rector fix, SonarCloud new-code findings and analysis scope

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,7 @@
+# SonarCloud AutoScan analysis scope
+#
+# Vendored third-party code and generated/fixture SQL are not ours to fix;
+# excluding them removes ~200 nonsensical security hotspots (regex
+# backtracking warnings inside the bundled legacy ExtJS builds) and
+# duplicate-literal noise from schema/fixture dumps.
+sonar.exclusions=assets/js/ext-js/**,sql/**,public/build/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,16 +219,18 @@ ENV APP_ENV=test
 # =============================================================================
 FROM base AS production
 
-# Copy only what's needed from deps stage
-COPY --from=deps --chown=app:app /var/www/html/vendor /var/www/html/vendor
-COPY --from=deps --chown=app:app /var/www/html/public /var/www/html/public
-COPY --from=deps --chown=app:app /var/www/html/config /var/www/html/config
-COPY --from=deps --chown=app:app /var/www/html/bin /var/www/html/bin
-COPY --from=deps --chown=app:app /var/www/html/src /var/www/html/src
-COPY --from=deps --chown=app:app /var/www/html/templates /var/www/html/templates
-COPY --from=deps --chown=app:app /var/www/html/translations /var/www/html/translations
+# Copy only what's needed from deps stage. Application code and assets are
+# root-owned and read-only for the runtime user (docker:S6504); only var/
+# must stay writable (cache, logs).
+COPY --from=deps /var/www/html/vendor /var/www/html/vendor
+COPY --from=deps /var/www/html/public /var/www/html/public
+COPY --from=deps /var/www/html/config /var/www/html/config
+COPY --from=deps /var/www/html/bin /var/www/html/bin
+COPY --from=deps /var/www/html/src /var/www/html/src
+COPY --from=deps /var/www/html/templates /var/www/html/templates
+COPY --from=deps /var/www/html/translations /var/www/html/translations
 COPY --from=deps /var/www/html/migrations /var/www/html/migrations
-COPY --from=deps --chown=app:app /var/www/html/sql /var/www/html/sql
+COPY --from=deps /var/www/html/sql /var/www/html/sql
 COPY --from=deps --chown=app:app /var/www/html/var /var/www/html/var
 
 # Copy healthcheck script

--- a/src/Controller/Tracking/BaseTrackingController.php
+++ b/src/Controller/Tracking/BaseTrackingController.php
@@ -77,7 +77,10 @@ abstract class BaseTrackingController extends BaseController
 
             $start = $entry->getStart();
             $previousEnd = $previous->getEnd();
-            if (!$start instanceof DateTime || !$previousEnd instanceof DateTime) {
+            if (!$start instanceof DateTime) {
+                continue;
+            }
+            if (!$previousEnd instanceof DateTime) {
                 continue;
             }
 

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -37,7 +37,9 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 use Throwable;
 
+use function array_map;
 use function assert;
+use function in_array;
 use function sprintf;
 
 final class SaveEntryAction extends BaseTrackingController
@@ -316,16 +318,12 @@ final class SaveEntryAction extends BaseTrackingController
         }
 
         $ticketPrefix = (string) $this->ticketService->getPrefix($ticket);
-        foreach (explode(',', $jiraId) as $allowedPrefix) {
-            if (trim($allowedPrefix) === $ticketPrefix) {
-                return null;
-            }
-        }
+        $allowedPrefixes = array_map(trim(...), explode(',', $jiraId));
+        $prefixMatches = in_array($ticketPrefix, $allowedPrefixes, true)
+            || $project->matchesInternalJiraProject($ticketPrefix);
 
-        if ($project->matchesInternalJiraProject($ticketPrefix)) {
-            return null;
-        }
-
-        return new Error('Given ticket does not have a valid prefix.', Response::HTTP_BAD_REQUEST);
+        return $prefixMatches
+            ? null
+            : new Error('Given ticket does not have a valid prefix.', Response::HTTP_BAD_REQUEST);
     }
 }

--- a/src/EventSubscriber/EntryEventSubscriber.php
+++ b/src/EventSubscriber/EntryEventSubscriber.php
@@ -15,6 +15,7 @@ use App\Entity\TicketSystem;
 use App\Entity\User;
 use App\Enum\TicketSystemType;
 use App\Event\EntryEvent;
+use App\Exception\Integration\Jira\JiraApiException;
 use App\Service\Cache\QueryCacheService;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use Doctrine\Persistence\ManagerRegistry;
@@ -307,7 +308,7 @@ class EntryEventSubscriber implements EventSubscriberInterface
         }
 
         if (!is_object($issue) || !property_exists($issue, 'key') || !is_string($issue->key) || '' === $issue->key) {
-            throw new Exception('Unexpected response from Jira when resolving the internal ticket');
+            throw new JiraApiException('Unexpected response from Jira when resolving the internal ticket', 500);
         }
 
         $entry->setInternalJiraTicketOriginalKey($externalTicket);

--- a/tests/Controller/SaveEntryClassesAndNormalizationTest.php
+++ b/tests/Controller/SaveEntryClassesAndNormalizationTest.php
@@ -24,6 +24,9 @@ use Tests\AbstractWebTestCase;
  */
 final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
 {
+    private const string NINE = '09:00:00';
+    private const string TEN = '10:00:00';
+
     /**
      * @param array<string, string|int> $overrides
      *
@@ -60,7 +63,7 @@ final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
     {
         $this->logInSession('unittest');
 
-        $result = $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
+        $result = $this->saveEntry($this->saveParameters(['start' => self::NINE, 'end' => self::TEN]));
 
         self::assertSame(EntryClass::DAYBREAK->value, $result['class']);
     }
@@ -69,8 +72,8 @@ final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
     {
         $this->logInSession('unittest');
 
-        $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
-        $result = $this->saveEntry($this->saveParameters(['start' => '10:00:00', 'end' => '10:30:00']));
+        $this->saveEntry($this->saveParameters(['start' => self::NINE, 'end' => self::TEN]));
+        $result = $this->saveEntry($this->saveParameters(['start' => self::TEN, 'end' => '10:30:00']));
 
         self::assertSame(EntryClass::PLAIN->value, $result['class']);
     }
@@ -79,7 +82,7 @@ final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
     {
         $this->logInSession('unittest');
 
-        $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
+        $this->saveEntry($this->saveParameters(['start' => self::NINE, 'end' => self::TEN]));
         $result = $this->saveEntry($this->saveParameters(['start' => '10:30:00', 'end' => '11:00:00']));
 
         self::assertSame(EntryClass::PAUSE->value, $result['class']);
@@ -89,7 +92,7 @@ final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
     {
         $this->logInSession('unittest');
 
-        $this->saveEntry($this->saveParameters(['start' => '09:00:00', 'end' => '10:00:00']));
+        $this->saveEntry($this->saveParameters(['start' => self::NINE, 'end' => self::TEN]));
         $result = $this->saveEntry($this->saveParameters(['start' => '09:30:00', 'end' => '10:30:00']));
 
         self::assertSame(EntryClass::OVERLAP->value, $result['class']);
@@ -102,8 +105,8 @@ final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
         // fixture project 1 has jira_id 'SA'; lower-case input must pass the
         // prefix validation and be stored normalized (v4 parity)
         $result = $this->saveEntry($this->saveParameters([
-            'start' => '09:00:00',
-            'end' => '10:00:00',
+            'start' => self::NINE,
+            'end' => self::TEN,
             'ticket' => 'sa-123',
         ]));
 
@@ -115,8 +118,8 @@ final class SaveEntryClassesAndNormalizationTest extends AbstractWebTestCase
         $this->logInSession('unittest');
 
         $result = $this->saveEntry($this->saveParameters([
-            'start' => '09:00:00',
-            'end' => '10:00:00',
+            'start' => self::NINE,
+            'end' => self::TEN,
             'ticket' => 'SA-77',
             'extTicket' => 'EXT-77',
         ]));

--- a/tests/EventSubscriber/EntryEventSubscriberTest.php
+++ b/tests/EventSubscriber/EntryEventSubscriberTest.php
@@ -615,6 +615,32 @@ final class EntryEventSubscriberTest extends TestCase
         self::assertSame('DHLSUP-123456', $entry->getInternalJiraTicketOriginalKey());
     }
 
+    public function testInternalTicketSystemMalformedJiraResponseIsCaughtAndLogged(): void
+    {
+        [$entry] = $this->createInternalProjectEntry('DHLSUP-8');
+
+        $this->jiraOAuthApiFactory->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+
+        // malformed response: issue without a usable key
+        $this->jiraOAuthApiService->method('searchTicket')
+            ->willReturn((object) ['issues' => [(object) ['key' => '']]]);
+
+        $this->jiraOAuthApiService->expects(self::never())
+            ->method('updateEntryJiraWorkLog');
+
+        $this->logger->expects(self::once())
+            ->method('error')
+            ->with('Auto-sync to JIRA failed', self::anything());
+
+        $event = new EntryEvent($entry);
+        $this->subscriber->onEntryCreated($event);
+
+        // entry stays unmapped
+        self::assertSame('DHLSUP-8', $entry->getTicket());
+        self::assertNull($entry->getInternalJiraTicketOriginalKey());
+    }
+
     public function testInternalTicketSystemSkippedWhenInternalSystemNotBookable(): void
     {
         $internalTicketSystem = self::createStub(TicketSystem::class);


### PR DESCRIPTION
Addresses the reported Rector finding and the SonarCloud backlog at its highest-leverage points:

| Change | Effect |
| --- | --- |
| Rector `ChangeOrIfContinueToMultiContinueRector` applied | `rector --dry-run` clean again |
| php:S112 / S1142 / S1192 fixes | the new-code findings introduced by this week's fixes are gone (dedicated `JiraApiException`, 3-return validator, test constants) |
| docker:S6504 ×12 fixed at source | production image code/assets now root-owned read-only; only `var/` writable. **Verified:** image builds, `cache:warmup` succeeds as user `app`, container `healthy` |
| `.sonarcloud.properties` exclusions | removes ~204/229 hotspots (vendored legacy ExtJS builds) + fixture-SQL noise from analysis — not actionable in this repo |

**Not code-fixable** (needs SonarCloud UI review as *safe*): `docker:S4507` xdebug in the **dev** stage (intentional), deps-stage COPY ownership (build-only, never ships).

**Remaining backlog** (~150 src/ issues: S1142 returns, S112 generic exceptions, S3776 cognitive complexity, S116 naming — legacy-era debt) is a structured refactoring program, proposed as follow-up per-rule PRs.

**Test plan:** full suite 1943 green (`make test`), PHPStan level 10, CS-Fixer, Rector dry-run clean; hardened image runtime-verified.