### PR TITLE
fix: meet WCAG minimal contrast in timetracker.css

### DIFF
--- a/assets/styles/timetracker.css
+++ b/assets/styles/timetracker.css
@@ -86,7 +86,7 @@
 }
 
 .user-badge.status_active {
-    background-color: #ebf5eb;
+    background-color: #c1cbc1;
     color: #333;
 }
 
@@ -96,8 +96,8 @@
 }
 
 .user-badge.status_inactive {
-    background-color: #f9ebeb;
-    color: #555;
+    background-color: #cfc1c1;
+    color: #444;
 }
 
 .user-badge.status_inactive .status-indicator {
@@ -117,9 +117,9 @@
 
 .user-badge .badge-logout:hover,
 .user-badge .badge-logout:focus {
-    background-color: #f7e6e6;
+    background-color: #cfbdbd;
     border-color: #B00000;
-    color: #B00000;
+    color: #8F0000;
 }
 
 .user-badge .badge-logout:focus {

--- a/assets/styles/timetracker.css
+++ b/assets/styles/timetracker.css
@@ -6,7 +6,7 @@
     position: absolute;
     top: -40px;
     left: 0;
-    background: #00889A;
+    background: #00707F;
     color: #fff;
     padding: 8px 16px;
     z-index: 10000;
@@ -86,7 +86,7 @@
 }
 
 .user-badge.status_active {
-    background-color: rgba(0, 128, 0, 0.08);
+    background-color: #ebf5eb;
     color: #333;
 }
 
@@ -96,8 +96,8 @@
 }
 
 .user-badge.status_inactive {
-    background-color: rgba(176, 0, 0, 0.08);
-    color: #666;
+    background-color: #f9ebeb;
+    color: #555;
 }
 
 .user-badge.status_inactive .status-indicator {
@@ -117,7 +117,7 @@
 
 .user-badge .badge-logout:hover,
 .user-badge .badge-logout:focus {
-    background-color: rgba(176, 0, 0, 0.1);
+    background-color: #f7e6e6;
     border-color: #B00000;
     color: #B00000;
 }


### PR DESCRIPTION
Fixes #321 — the four `css:S7924` findings.

| Site | Before | After | Why |
| --- | --- | --- | --- |
| `.skip-link` | `#00889A` bg / white text (4.2:1) | `#00707F` (5.8:1) | AA for normal text, stays in the teal family |
| `.user-badge.status_active` | `rgba(0,128,0,.08)` | `#c1cbc1` | exact solid equivalent over the **actual** `#D2D2D2` header background — pixel-identical, computable for contrast checkers |
| `.user-badge.status_inactive` | `rgba(176,0,0,.08)` / `#666` | `#cfc1c1` / `#444` | solid equivalent over #D2D2D2 + darker text for AA |
| `.badge-logout:hover/:focus` | `rgba(176,0,0,.1)` / `#B00000` | `#cfbdbd` / `#8F0000` | solid equivalent + darker text for ≥4.5:1 |

First revision composited over white; review correctly pointed at the gray header — recomputed in 802621a6. Webpack build green.