### PR TITLE
fix: protect CSV export against formula injection

### DIFF
--- a/src/Extension/TwigCsvEscapingExtension.php
+++ b/src/Extension/TwigCsvEscapingExtension.php
@@ -31,7 +31,7 @@ class TwigCsvEscapingExtension
      * Characters that spreadsheet applications interpret as a formula trigger
      * when they appear at the start of a cell (OWASP CSV injection).
      */
-    private const FORMULA_TRIGGER_CHARACTERS = ['=', '+', '-', '@', "\t", "\r"];
+    private const FORMULA_TRIGGER_CHARACTERS = ['=', '+', '-', '@', "\t", "\r", "\n"];
 
     #[AsTwigFilter(name: 'csv_escape')]
     public function csvEscape(string $string): string

--- a/src/Extension/TwigCsvEscapingExtension.php
+++ b/src/Extension/TwigCsvEscapingExtension.php
@@ -15,6 +15,8 @@ namespace App\Extension;
 
 use Twig\Attribute\AsTwigFilter;
 
+use function in_array;
+
 /**
  * Class TwigCsvEscapingExtension.
  */
@@ -25,9 +27,24 @@ class TwigCsvEscapingExtension
         return 'csv_escaper';
     }
 
+    /**
+     * Characters that spreadsheet applications interpret as a formula trigger
+     * when they appear at the start of a cell (OWASP CSV injection).
+     */
+    private const FORMULA_TRIGGER_CHARACTERS = ['=', '+', '-', '@', "\t", "\r"];
+
     #[AsTwigFilter(name: 'csv_escape')]
     public function csvEscape(string $string): string
     {
-        return str_replace('"', '""', $string);
+        $escaped = str_replace('"', '""', $string);
+
+        // Neutralize formula injection: prefix dangerous leading characters
+        // with a single quote so Excel/LibreOffice treat the cell as text.
+        // See https://owasp.org/www-community/attacks/CSV_Injection
+        if ('' !== $escaped && in_array($escaped[0], self::FORMULA_TRIGGER_CHARACTERS, true)) {
+            return "'" . $escaped;
+        }
+
+        return $escaped;
     }
 }

--- a/tests/Extension/TwigCsvEscapingExtensionTest.php
+++ b/tests/Extension/TwigCsvEscapingExtensionTest.php
@@ -11,6 +11,7 @@ namespace Tests\Extension;
 
 use App\Extension\TwigCsvEscapingExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -66,5 +67,39 @@ final class TwigCsvEscapingExtensionTest extends TestCase
     public function testCsvEscapeHandlesMultipleQuotesInSequence(): void
     {
         self::assertSame('a""""b', $this->extension->csvEscape('a""b'));
+    }
+
+    // ==================== formula injection tests ====================
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function provideFormulaTriggerCases(): array
+    {
+        return [
+            'equals sign' => ['=1+2', "'=1+2"],
+            'plus sign' => ['+SUM(A1:A2)', "'+SUM(A1:A2)"],
+            'minus sign' => ['-2+3', "'-2+3"],
+            'at sign' => ['@cmd', "'@cmd"],
+            'tab' => ["\t=1+2", "'\t=1+2"],
+            'carriage return' => ["\r=1+2", "'\r=1+2"],
+        ];
+    }
+
+    #[DataProvider('provideFormulaTriggerCases')]
+    public function testCsvEscapePrefixesFormulaTriggerCharacters(string $input, string $expected): void
+    {
+        self::assertSame($expected, $this->extension->csvEscape($input));
+    }
+
+    public function testCsvEscapeCombinesFormulaPrefixWithQuoteDoubling(): void
+    {
+        self::assertSame("'=HYPERLINK(\"\"https://evil.example\"\")", $this->extension->csvEscape('=HYPERLINK("https://evil.example")'));
+    }
+
+    public function testCsvEscapeLeavesFormulaCharactersInsideStringUnchanged(): void
+    {
+        self::assertSame('a=b', $this->extension->csvEscape('a=b'));
+        self::assertSame('1 + 2', $this->extension->csvEscape('1 + 2'));
     }
 }

--- a/tests/Extension/TwigCsvEscapingExtensionTest.php
+++ b/tests/Extension/TwigCsvEscapingExtensionTest.php
@@ -83,6 +83,7 @@ final class TwigCsvEscapingExtensionTest extends TestCase
             'at sign' => ['@cmd', "'@cmd"],
             'tab' => ["\t=1+2", "'\t=1+2"],
             'carriage return' => ["\r=1+2", "'\r=1+2"],
+            'line feed' => ["\n=1+2", "'\n=1+2"],
         ];
     }
 

--- a/tests/Traits/TestDataTrait.php
+++ b/tests/Traits/TestDataTrait.php
@@ -20,6 +20,10 @@ use function function_exists;
 use function is_file;
 use function trim;
 
+use const MYSQLI_REPORT_ERROR;
+use const MYSQLI_REPORT_OFF;
+use const MYSQLI_REPORT_STRICT;
+
 /**
  * Test data management trait.
  *


### PR DESCRIPTION
## Summary

`TwigCsvEscapingExtension::csvEscape()` only doubled quotes. Cell values starting with `=`, `+`, `-`, `@`, TAB or CR were interpreted as formulas by Excel/LibreOffice when the exported CSV is opened — classic CSV/formula injection ([OWASP: CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection)). Entry descriptions and external Jira data (summaries, labels, reporters) are user/third-party controlled and end up in the export.

Per OWASP guidance, `csvEscape()` now prefixes values starting with one of these characters with a single quote (`'`) so spreadsheet applications treat the cell as text. Quote doubling is kept; since the prefix is applied to the value (before the template wraps it in `"..."`), it lands inside the quoted CSV cell.

## Behavior change (heads-up)

Users will see a visible leading `'` in affected spreadsheet cells when opening the export. In particular, the `-` prefix can annoy users whose entries legitimately start with a dash or look like negative numbers (e.g. `-2h pairing`) — per OWASP, `-` must be neutralized anyway because Excel evaluates `-2+3` as a formula. Tradeoff accepted: a visible `'` beats silent formula execution.

## Changes

- `src/Extension/TwigCsvEscapingExtension.php`: prefix `'` when the (quote-escaped) value starts with `=`, `+`, `-`, `@`, TAB or CR; keep `"` doubling.
- `tests/Extension/TwigCsvEscapingExtensionTest.php`: cover each dangerous prefix, combination of dangerous prefix + quote doubling, and formula characters mid-string remaining untouched (plain text, quote doubling and empty string were already covered).
- `tests/Traits/TestDataTrait.php` (separate commit): pre-existing php-cs-fixer finding on `main` (missing `use const MYSQLI_REPORT_*` imports), fixed to keep the full php-cs-fixer gate green.

No caller/controller test asserts exported CSV row bodies — `DefaultControllerTest::testExportCsvAction` only asserts the header line, which is unaffected; no assertions needed updating.

## Test plan / gates

- `php -d memory_limit=1G bin/phpstan analyse --no-progress` (full): `[OK] No errors`
- `PHP_CS_FIXER_IGNORE_ENV=1 bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run` (full): clean (`"files":[]`)
- Full PHPUnit in docker (`db_unittest` + `ldap-dev`, `APP_ENV=test`): `OK, but some tests were skipped! Tests: 1952, Assertions: 5758, Skipped: 1` (the skip is pre-existing and unrelated)

Fixes #318
