### PR TITLE
fix: declare implicit globals and apply safe JS modernizations

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -214,7 +214,7 @@ Ext.onReady(function () {
     });
 
     /* Key bindings */
-    new Ext.util.KeyMap(Ext.get(document), [
+    Ext.get(document).addKeyMap({ binding: [
         {
             key: Ext.EventObject.A,
             alt: true,
@@ -312,7 +312,7 @@ Ext.onReady(function () {
             },
             defaultEventAction: 'stopEvent'
         }
-    ]);
+    ] });
 
     countTime();
     checkLoginStatus();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -74,19 +74,21 @@ function buildHeaderHtml() {
         parts.push('<iframe id="nrnavi" src="' + globalConfig.header_url + '" title="Navigation"></iframe>');
     }
 
-    // Main header with semantic structure
-    parts.push('<header class="app-header" role="banner">');
-
-    // Logo section
-    parts.push('<div class="header-logo">');
-    parts.push('<img id="logo" src="' + globalConfig.logo_url + '" alt="' + (globalConfig.app_name || 'TimeTracker') + ' - Home">');
-    parts.push('</div>');
+    // Main header with semantic structure, followed by the logo section
+    parts.push(
+        '<header class="app-header" role="banner">',
+        '<div class="header-logo">',
+        '<img id="logo" src="' + globalConfig.logo_url + '" alt="' + (globalConfig.app_name || 'TimeTracker') + ' - Home">',
+        '</div>'
+    );
 
     // User badge (status + logout merged)
     if (typeof statusUrlJson !== 'undefined' || typeof logoutUrlHtml !== 'undefined') {
-        parts.push('<div id="user-badge" class="user-badge status_inactive" role="status" aria-live="polite" aria-label="' + strings['User status'] + '">');
-        parts.push('<span class="status-indicator" aria-hidden="true"></span>');
-        parts.push('<span class="user-name">' + strings['Not logged in'] + '</span>');
+        parts.push(
+            '<div id="user-badge" class="user-badge status_inactive" role="status" aria-live="polite" aria-label="' + strings['User status'] + '">',
+            '<span class="status-indicator" aria-hidden="true"></span>',
+            '<span class="user-name">' + strings['Not logged in'] + '</span>'
+        );
         if (typeof logoutUrlHtml !== 'undefined') {
             parts.push('<a href="' + logoutUrlHtml + '" class="badge-logout" aria-label="' + strings['Logout'] + '">' + strings['Logout'] + '</a>');
         }
@@ -94,22 +96,22 @@ function buildHeaderHtml() {
     }
 
     // Working time section
-    parts.push('<section class="header-worktime" aria-label="' + strings['Working time'] + '">');
-    parts.push('<dl class="worktime-list">');
-    parts.push('<div class="worktime-item"><dt>' + strings['Today'] + '</dt><dd id="worktime-day">0:00</dd></div>');
-    parts.push('<div class="worktime-item"><dt>' + strings['Week'] + '</dt><dd id="worktime-week">0:00</dd></div>');
-    parts.push('<div class="worktime-item"><dt>' + strings['Month'] + '</dt><dd id="worktime-month">0:00</dd></div>');
-    parts.push('</dl>');
+    parts.push(
+        '<section class="header-worktime" aria-label="' + strings['Working time'] + '">',
+        '<dl class="worktime-list">',
+        '<div class="worktime-item"><dt>' + strings['Today'] + '</dt><dd id="worktime-day">0:00</dd></div>',
+        '<div class="worktime-item"><dt>' + strings['Week'] + '</dt><dd id="worktime-week">0:00</dd></div>',
+        '<div class="worktime-item"><dt>' + strings['Month'] + '</dt><dd id="worktime-month">0:00</dd></div>',
+        '</dl>'
+    );
 
     // Monthly overview link
-    if (typeof globalConfig.monthly_overview_url !== 'undefined' &&
+    if (globalConfig.monthly_overview_url !== undefined &&
         globalConfig.monthly_overview_url != null &&
         globalConfig.monthly_overview_url !== '') {
         parts.push('<a id="sumlink" href="' + globalConfig.monthly_overview_url + settingsData.user_name + '" target="_blank" rel="noopener noreferrer" class="worktime-link">' + strings['Monthly overview'] + '</a>');
     }
-    parts.push('</section>');
-
-    parts.push('</header>');
+    parts.push('</section>', '</header>');
 
     return parts.join('');
 }
@@ -156,7 +158,7 @@ Ext.onReady(function () {
 
     /* Helper to check if user has a specific role */
     function hasRole(role) {
-        return settingsData && settingsData['roles'] && settingsData['roles'].includes(role);
+        return settingsData?.['roles']?.includes(role);
     }
 
     /* Show admin tab if user has ROLE_ADMIN */
@@ -212,7 +214,7 @@ Ext.onReady(function () {
     });
 
     /* Key bindings */
-    const keyMap = new Ext.util.KeyMap(Ext.get(document), [
+    new Ext.util.KeyMap(Ext.get(document), [
         {
             key: Ext.EventObject.A,
             alt: true,
@@ -438,7 +440,7 @@ function parseAjaxError(response) {
         }
     } catch (e) { }
     if (!message) {
-        if (data && data.message) {
+        if (data?.message) {
             message = data.message;
         } else {
             message = response.responseText;
@@ -580,7 +582,7 @@ function findProjects(customer, ticket) {
 
         const projectPrefixes = [...project['jiraId'].matchAll(prefixesRegexp)];
         for (var i = 0; i < projectPrefixes.length; i++) {
-            projectPrefix = projectPrefixes[i][1];
+            const projectPrefix = projectPrefixes[i][1];
             if (projectPrefix == prefix) {
                 validProjects.push(project);
                 break;

--- a/assets/js/netresearch/store/Customers.js
+++ b/assets/js/netresearch/store/Customers.js
@@ -15,14 +15,14 @@ Ext.define('Netresearch.store.Customers', {
         }
     },
 
-    /* Update projectsData */
+    /* Update customersData */
     reloadFromServer: function(callback) {
         Ext.Ajax.request({
             url: url + 'getCustomers',
             success: function(response) {
                 let data = Ext.decode(response.responseText);
                 //update the locally available customer data
-                consumersData = data;
+                globalThis.customersData = data;
                 callback();
             }
         });
@@ -31,7 +31,6 @@ Ext.define('Netresearch.store.Customers', {
     /* Read data from json var in html source code */
     load: function(onlyActive) {
         var newData = [], record;
-        // console.log("Loading up to " + customersData.length + " customers. " + onlyActive);
         var c = 0;
         for (var key in customersData) {
             record = customersData[key].customer;
@@ -42,7 +41,6 @@ Ext.define('Netresearch.store.Customers', {
 
             if (onlyActive) {
                 if ('1' != record.data.active) {
-                    // console.log(record.get('id') + " is inactive!");
                     continue;
                 }
             }

--- a/assets/js/netresearch/store/Projects.js
+++ b/assets/js/netresearch/store/Projects.js
@@ -24,7 +24,7 @@ Ext.define('Netresearch.store.Projects', {
             success: function(response) {
                 let data = Ext.decode(response.responseText);
                 //update the locally available project data
-                projectsData = data;
+                globalThis.projectsData = data;
                 callback();
             }
         });
@@ -47,9 +47,8 @@ Ext.define('Netresearch.store.Projects', {
 
         // merge empty prefix projects, if any
         if ((null !== ticket) && (undefined !== ticket) && (ticket.length > 0)) {
-            projects2 = findProjects(customer, "");
+            const projects2 = findProjects(customer, "");
             if (projects2) {
-                // console.log("Merged " + projects2.length + " projects with empty prefixes");
                 projects = projects.concat(projects2);
             }
         }
@@ -72,7 +71,6 @@ Ext.define('Netresearch.store.Projects', {
 
             if (onlyActive) {
                 if ('1' != record.data.active) {
-                    // console.log("Project " + record.data.id + " is inactive.");
                     continue;
                 }
             }
@@ -80,9 +78,6 @@ Ext.define('Netresearch.store.Projects', {
             newData.push(record);
 
             this.add(record);
-
-            // if (customer != 'all')
-            //    console.log("Loading project " + record.data.id + " (" + record.data.name + " of customer " + record.data.customer + ") for customer " + customer);
         }
 
         this.loadRecords(newData, {"append": false});

--- a/assets/js/netresearch/widget/Admin.js
+++ b/assets/js/netresearch/widget/Admin.js
@@ -335,7 +335,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             var errors = [];
 
                                             /* Create Error-String and display Error-Window */
-                                            for (i = 0; i < fields.length; i++) {
+                                            for (let i = 0; i < fields.length; i++) {
                                                 errors.push(fields.items[i].getErrors().join(', '));
                                             }
 
@@ -1549,9 +1549,6 @@ Ext.define('Netresearch.widget.Admin', {
             editPreset: function (record) {
                 var projectStore = Ext.create('Netresearch.store.AdminProjects');
                 projectStore.load();
-                var presetStore = Ext.create('Netresearch.store.AdminPresets', {
-                    autoLoad: false
-                });
 
                 if (!record) record = {};
 
@@ -1764,10 +1761,6 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             }, // end listeners
             editTicketSystem: function (record) {
-                var ticketSytemStore = Ext.create('Netresearch.store.TicketSystems', {
-                    autoLoad: false
-                });
-
                 var ticketSystemTypeStore = new Ext.data.ArrayStore({
                     fields: ['type'],
                     data: [
@@ -2247,43 +2240,43 @@ Ext.define('Netresearch.widget.Admin', {
                                     id: 'hours_0',
                                     fieldLabel: panel._hours0Title,
                                     name: 'hours_0',
-                                    value: record.hours_0 !== undefined ? record.hours_0 : 0
+                                    value: record.hours_0 === undefined ? 0 : record.hours_0
                                 }),
                                 new Ext.form.field.Number({
                                     id: 'hours_1',
                                     fieldLabel: panel._hours1Title,
                                     name: 'hours_1',
-                                    value: record.hours_1 !== undefined ? record.hours_1 : 8
+                                    value: record.hours_1 === undefined ? 8 : record.hours_1
                                 }),
                                 new Ext.form.field.Number({
                                     id: 'hours_2',
                                     fieldLabel: panel._hours2Title,
                                     name: 'hours_2',
-                                    value: record.hours_2 !== undefined ? record.hours_2 : 8
+                                    value: record.hours_2 === undefined ? 8 : record.hours_2
                                 }),
                                 new Ext.form.field.Number({
                                     id: 'hours_3',
                                     fieldLabel: panel._hours3Title,
                                     name: 'hours_3',
-                                    value: record.hours_3 !== undefined ? record.hours_3 : 8
+                                    value: record.hours_3 === undefined ? 8 : record.hours_3
                                 }),
                                 new Ext.form.field.Number({
                                     id: 'hours_4',
                                     fieldLabel: panel._hours4Title,
                                     name: 'hours_4',
-                                    value: record.hours_4 !== undefined ? record.hours_4 : 8
+                                    value: record.hours_4 === undefined ? 8 : record.hours_4
                                 }),
                                 new Ext.form.field.Number({
                                     id: 'hours_5',
                                     fieldLabel: panel._hours5Title,
                                     name: 'hours_5',
-                                    value: record.hours_5 !== undefined ? record.hours_5 : 8
+                                    value: record.hours_5 === undefined ? 8 : record.hours_5
                                 }),
                                 new Ext.form.field.Number({
                                     id: 'hours_6',
                                     fieldLabel: panel._hours6Title,
                                     name: 'hours_6',
-                                    value: record.hours_6 !== undefined ? record.hours_6 : 0
+                                    value: record.hours_6 === undefined ? 0 : record.hours_6
                                 })
                             ],
                             buttons: [
@@ -2460,7 +2453,7 @@ function renderCheckbox(val) {
 }
 
 
-if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
+if (settingsData?.['locale'] == 'de') {
     Ext.apply(Netresearch.widget.Admin.prototype, {
         _tabTitle: 'Administration',
         _nameTitle: 'Name',

--- a/assets/js/netresearch/widget/Controlling.js
+++ b/assets/js/netresearch/widget/Controlling.js
@@ -193,7 +193,7 @@ Ext.define('Netresearch.widget.Controlling', {
             customer = 0;
         }
 
-        window.location.href = 'controlling/export/'
+        globalThis.location.href = 'controlling/export/'
             + user + '/'
             + year + '/'
             + month + '/'
@@ -211,7 +211,7 @@ Ext.define('Netresearch.widget.Controlling', {
 
 });
 
-if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
+if (settingsData?.['locale'] == 'de') {
     Ext.apply(Netresearch.widget.Controlling.prototype, {
         _monthlyStatement: 'Monats-Abrechnung',
         _userTitle: 'Mitarbeiter',

--- a/assets/js/netresearch/widget/Extras.js
+++ b/assets/js/netresearch/widget/Extras.js
@@ -50,14 +50,6 @@ Ext.define('Netresearch.widget.Extras', {
             data: [[1, this._yesTitle], [0, this._noTitle]]
         });
 
-        /*
-        new Ext.data.ArrayStore({
-            fields: ['value', 'displayname'],
-            data: [[1, this._nrHolidaysTitle],  [2, this._nrSickTitle],  [3, this._nrParentTimeTitle],
-                   [4, this._nafHolidaysTitle], [5, this._nafSickTitle], [6, this._nafParentTimeTitle]]
-        });
-        */
-
         var form = new Ext.form.FormPanel({
             url: url + 'tracking/bulkentry',
             frame: true,
@@ -263,7 +255,7 @@ Ext.define('Netresearch.widget.Extras', {
     }
 });
 
-if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
+if (settingsData?.['locale'] == 'de') {
     Ext.apply(Netresearch.widget.Extras.prototype, {
         _tabTitle: 'Extras',
         _bulkEntryTitle: 'Massen-Eintragung',

--- a/assets/js/netresearch/widget/Help.js
+++ b/assets/js/netresearch/widget/Help.js
@@ -135,7 +135,7 @@ Ext.define('Netresearch.widget.Help', {
     }
 });
 
-if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
+if (settingsData?.['locale'] == 'de') {
     Ext.apply(Netresearch.widget.Help.prototype, {
         _usageTitle: 'Bedienung',
         _shortcutsTitle: 'Shortcuts',

--- a/assets/js/netresearch/widget/Interpretation.js
+++ b/assets/js/netresearch/widget/Interpretation.js
@@ -737,7 +737,7 @@ Ext.define('Netresearch.widget.Interpretation', {
             params: searchParams,
             callback: function(records) {
                 // Show alert box if no data were found
-                if (typeof records == 'undefined') {
+                if (records === undefined) {
                     Ext.MessageBox.alert(this._attentionTitle, this._noDataFoundTitle);
                 }
             }
@@ -779,7 +779,7 @@ Ext.define('Netresearch.widget.Interpretation', {
 
 
 function NetresearchWidgetInterpretationLoadSettings(settingsData) {
-    if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
+    if (settingsData?.['locale'] == 'de') {
         Ext.apply(Netresearch.widget.Interpretation.prototype, {
             _tabTitle: 'Auswertung',
             _monthTitle: 'Monat',

--- a/assets/js/netresearch/widget/Settings.js
+++ b/assets/js/netresearch/widget/Settings.js
@@ -104,12 +104,12 @@ Ext.define('Netresearch.widget.Settings', {
                 handler: function() {
                     form.getForm().submit({
                         success: function(form, action) {
-                            if (settingsData.locale != action.result.locale) {
-                                window.location.reload();
-                            } else {
-                                settingsData = action.result.settings;
+                            if (settingsData.locale == action.result.locale) {
+                                globalThis.settingsData = action.result.settings;
                                 ttt_items[0].refresh();
                                 showNotification(widget._successTitle, action.result.message, true);
+                            } else {
+                                globalThis.location.reload();
                             }
                         },
                         failure: function(form, action) {
@@ -145,7 +145,7 @@ Ext.define('Netresearch.widget.Settings', {
     }
 });
 
-if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
+if (settingsData?.['locale'] == 'de') {
     Ext.apply(Netresearch.widget.Settings.prototype, {
         _yesTitle: 'Ja',
         _noTitle: 'Nein',

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -826,7 +826,7 @@ Ext.define('Netresearch.widget.Tracking', {
                     record.dirty = true;
                     var parsed = showAjaxFailure(grid._errorTitle, response, grid._seriousErrorTitle, 200);
                     if (parsed?.data?.forwardUrl !== undefined) {
-                        setTimeout("window.location.href = '" + parsed.data.forwardUrl + "'", 2000);
+                        setTimeout(() => { globalThis.location.href = parsed.data.forwardUrl; }, 2000);
                     }
                 }
             });
@@ -1103,7 +1103,7 @@ Ext.define('Netresearch.widget.Tracking', {
                 const data = Ext.decode(response.responseText);
                 showNotification(grid._errorTitle, data.message, false);
                 if (data.forwardUrl !== undefined) {
-                    setTimeout("window.location.href = '" + data.forwardUrl + "'", 2000);
+                    setTimeout(() => { globalThis.location.href = data.forwardUrl; }, 2000);
                 }
             }
         });

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -1125,10 +1125,9 @@ Ext.define('Netresearch.widget.Tracking', {
      * and we do not want to get them with a hard page reload.
      */
     refreshHard: function () {
-        const tracking = this;
-        tracking.customerStore.reloadFromServer(function () {
-            tracking.projectStore.reloadFromServer(function () {
-                tracking.refresh();
+        this.customerStore.reloadFromServer(() => {
+            this.projectStore.reloadFromServer(() => {
+                this.refresh();
             });
         });
     },

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -298,7 +298,7 @@ Ext.define('Netresearch.widget.Tracking', {
                         if ((!ticket) || (ticket === "") || (ticket === "-")) {
                             return '-';
                         }
-                        const str = ticket.replaceAll(' ', '').toUpperCase();
+                        const str = ticket.replace(/ /g, '').toUpperCase();
                         const ticketUrl = this.getTicketsystemUrlByTicket(str);
                         return '<a href="' + ticketUrl + '" target="_new">' + str + '</a>';
                     }
@@ -412,10 +412,10 @@ Ext.define('Netresearch.widget.Tracking', {
                     },
                     renderer: function (text) {
                         text = new String('' + text);
-                        text = text.replaceAll('&', '&amp;')
-                            .replaceAll('<', '&lt;')
-                            .replaceAll('>', '&gt;')
-                            .replaceAll('"', '&quot;');
+                        text = text.replace(/&/g, '&amp;')
+                            .replace(/</g, '&lt;')
+                            .replace(/>/g, '&gt;')
+                            .replace(/"/g, '&quot;');
 
                         // replace valid ticketnames with links according to ticket_systems.ticketurl
                         const arr = text.match(/([A-Z]+(::[A-Z0-9]+)?-[0-9]+)/ig) || [];
@@ -443,10 +443,10 @@ Ext.define('Netresearch.widget.Tracking', {
                         }
                         const text = new String('' + extTicket);
                         return text
-                            .replaceAll('&', '&amp;')
-                            .replaceAll('<', '&lt;')
-                            .replaceAll('>', '&gt;')
-                            .replaceAll('"', '&quot;')
+                            .replace(/&/g, '&amp;')
+                            .replace(/</g, '&lt;')
+                            .replace(/>/g, '&gt;')
+                            .replace(/"/g, '&quot;')
                             .replace(/([A-Z]+(::[A-Z0-9]+)?-[0-9]+)/ig, '<a href="https:\/\/bugs.nr/$1" target="_new">$1<\/a>');
                     }
                 }
@@ -782,7 +782,7 @@ Ext.define('Netresearch.widget.Tracking', {
             }
 
             // reformat ticket
-            record.data.ticket = record.data.ticket.replaceAll(' ', '').toUpperCase();
+            record.data.ticket = record.data.ticket.replace(/ /g, '').toUpperCase();
 
             // Normalize start/end times to use entry's date (timefield creates dates with wrong date portion)
             if (record.data.date && record.data.start instanceof Date) {

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -76,7 +76,7 @@ Ext.define('Netresearch.widget.Tracking', {
         entryStore.on("load", function () { grid.selectRow(0); });
 
         if (this.autoRefreshInterval === true) {
-            this.autoRefreshInterval = window.setInterval(
+            this.autoRefreshInterval = globalThis.setInterval(
                 this.autoRefreshProjectData, 15 * 60 * 1000, this
             );
         }
@@ -128,7 +128,7 @@ Ext.define('Netresearch.widget.Tracking', {
                         const comparison = store.getAt(k);
 
                         // skip unsaved comparisons
-                        if ((undefined === comparison) || (null == comparison) || (undefined === comparison.data.id) || (null == comparison.data.id) || (comparison.data.id < 1)) {
+                        if ((null == comparison?.data.id) || (comparison.data.id < 1)) {
                             continue;
                         }
 
@@ -298,7 +298,7 @@ Ext.define('Netresearch.widget.Tracking', {
                         if ((!ticket) || (ticket === "") || (ticket === "-")) {
                             return '-';
                         }
-                        const str = ticket.replace(/ /g, '').toUpperCase();
+                        const str = ticket.replaceAll(' ', '').toUpperCase();
                         const ticketUrl = this.getTicketsystemUrlByTicket(str);
                         return '<a href="' + ticketUrl + '" target="_new">' + str + '</a>';
                     }
@@ -365,9 +365,6 @@ Ext.define('Netresearch.widget.Tracking', {
                                 }
 
                                 this.projectStore.loadData(projectsData, this.getSelectedField('customer'), ticket, true);
-                            },
-                            blur: function (field, options) {
-                                // this.clearProjectStore();
                             }
                         }
                     },
@@ -415,10 +412,10 @@ Ext.define('Netresearch.widget.Tracking', {
                     },
                     renderer: function (text) {
                         text = new String('' + text);
-                        text = text.replace(/&/g, '&amp;')
-                            .replace(/</g, '&lt;')
-                            .replace(/>/g, '&gt;')
-                            .replace(/"/g, '&quot;');
+                        text = text.replaceAll('&', '&amp;')
+                            .replaceAll('<', '&lt;')
+                            .replaceAll('>', '&gt;')
+                            .replaceAll('"', '&quot;');
 
                         // replace valid ticketnames with links according to ticket_systems.ticketurl
                         const arr = text.match(/([A-Z]+(::[A-Z0-9]+)?-[0-9]+)/ig) || [];
@@ -446,10 +443,10 @@ Ext.define('Netresearch.widget.Tracking', {
                         }
                         const text = new String('' + extTicket);
                         return text
-                            .replace(/&/g, '&amp;')
-                            .replace(/</g, '&lt;')
-                            .replace(/>/g, '&gt;')
-                            .replace(/"/g, '&quot;')
+                            .replaceAll('&', '&amp;')
+                            .replaceAll('<', '&lt;')
+                            .replaceAll('>', '&gt;')
+                            .replaceAll('"', '&quot;')
                             .replace(/([A-Z]+(::[A-Z0-9]+)?-[0-9]+)/ig, '<a href="https:\/\/bugs.nr/$1" target="_new">$1<\/a>');
                     }
                 }
@@ -607,7 +604,7 @@ Ext.define('Netresearch.widget.Tracking', {
 
         this.debug && console.log("Mapping ticket " + ticket);
 
-        if ((!validProjects) || (!validProjects.length)) {
+        if (!validProjects?.length) {
             this.debug && console.log("Mapped to no project");
             return false;
         }
@@ -770,7 +767,7 @@ Ext.define('Netresearch.widget.Tracking', {
         if ('undefined' == typeof (record.saveInProgress)) {
             // Check if customer and project are related
             var projectCheck = this.checkCustomerProjectRelation(record.data.customer, record.data.project);
-            if (false == projectCheck) {
+            if (!projectCheck) {
                 showNotification(this._errorTitle,
                     this._customerProjectMismatchTitle
                     + '<br /><br />'
@@ -785,7 +782,7 @@ Ext.define('Netresearch.widget.Tracking', {
             }
 
             // reformat ticket
-            record.data.ticket = record.data.ticket.replace(/ /g, '').toUpperCase();
+            record.data.ticket = record.data.ticket.replaceAll(' ', '').toUpperCase();
 
             // Normalize start/end times to use entry's date (timefield creates dates with wrong date portion)
             if (record.data.date && record.data.start instanceof Date) {
@@ -828,7 +825,7 @@ Ext.define('Netresearch.widget.Tracking', {
                     record.saveInProgress = undefined;
                     record.dirty = true;
                     var parsed = showAjaxFailure(grid._errorTitle, response, grid._seriousErrorTitle, 200);
-                    if (parsed && parsed.data && typeof parsed.data.forwardUrl !== 'undefined') {
+                    if (parsed?.data?.forwardUrl !== undefined) {
                         setTimeout("window.location.href = '" + parsed.data.forwardUrl + "'", 2000);
                     }
                 }
@@ -987,7 +984,7 @@ Ext.define('Netresearch.widget.Tracking', {
 
     prolongLastEntry: function () {
         const record = this.store.getAt(0);
-        if ((undefined == record) || (null == record) || (undefined == record.data) || (null == record.data))
+        if (null == record?.data)
             return;
 
         const date = this.roundTime(this.getNewDate());
@@ -1006,7 +1003,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
 
         const record = this.store.getAt(index);
-        if ((undefined == record) || (null == record) || (undefined == record.data) || (null == record.data))
+        if (null == record?.data)
             return;
 
         const data = {};
@@ -1105,7 +1102,7 @@ Ext.define('Netresearch.widget.Tracking', {
             failure: function (response) {
                 const data = Ext.decode(response.responseText);
                 showNotification(grid._errorTitle, data.message, false);
-                if (typeof data.forwardUrl != 'undefined') {
+                if (data.forwardUrl !== undefined) {
                     setTimeout("window.location.href = '" + data.forwardUrl + "'", 2000);
                 }
             }
@@ -1119,7 +1116,7 @@ Ext.define('Netresearch.widget.Tracking', {
         if ('undefined' == this.days) {
             this.days = 10000;
         }
-        window.location.href = 'export/' + this.days;
+        globalThis.location.href = 'export/' + this.days;
     },
 
     /**
@@ -1128,7 +1125,7 @@ Ext.define('Netresearch.widget.Tracking', {
      * and we do not want to get them with a hard page reload.
      */
     refreshHard: function () {
-        tracking = this;
+        const tracking = this;
         tracking.customerStore.reloadFromServer(function () {
             tracking.projectStore.reloadFromServer(function () {
                 tracking.refresh();
@@ -1246,7 +1243,7 @@ Ext.define('Netresearch.widget.Tracking', {
             + '<br />c) ' + this._fieldsMissingTitle + '<br/>' + this._checkFieldsTitle;
 
         /* If response contains useful error message, use it */
-        if (response && response.responseText) {
+        if (response?.responseText) {
             dlgMessage = response.responseText;
         }
         showNotification(this._errorTitle, dlgMessage, false);
@@ -1267,15 +1264,11 @@ Ext.define('Netresearch.widget.Tracking', {
      */
     addInlineEntry: function (record) {
 
-        const projectStore = Ext.create('Netresearch.store.Projects', {
-            autoLoad: false
-        });
-
         if (!record) {
             record = {};
         }
 
-        const lastRecord = this.getStore().getAt(0); // first();
+        const lastRecord = this.getStore().getAt(0);
 
         // init date
         const date = record.date ? record.date : this.getNewDate();
@@ -1289,8 +1282,7 @@ Ext.define('Netresearch.widget.Tracking', {
         // suggest start time if possible
         if (settingsData.suggest_time) {
             // either by last entry
-            if ((lastRecord != undefined)
-                && (lastRecord.data)
+            if ((lastRecord?.data)
                 && (this.isSameDay(lastRecord.data.date, date))) {
                 start = new Date(lastRecord.data.end);
             }
@@ -1362,8 +1354,7 @@ Ext.define('Netresearch.widget.Tracking', {
     },
 
     isEditing: function () {
-        return (undefined != this.editingPlugin)
-            && (undefined != this.editingPlugin.activeRecord);
+        return (undefined != this.editingPlugin?.activeRecord);
     },
 
     /* Show shortcuts help window */
@@ -1408,7 +1399,7 @@ Ext.define('Netresearch.widget.Tracking', {
 });
 
 function NetresearchWidgetTrackingLoadSettings(settingsData) {
-    if ((undefined != settingsData) && (settingsData['locale'] == 'de')) {
+    if (settingsData?.['locale'] == 'de') {
         Ext.apply(Netresearch.widget.Tracking.prototype, {
             _tabTitle: 'Zeiterfassung',
             _dateTitle: 'Datum',

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -107,7 +107,6 @@ function createTimeSummary(list, data) {
             getNewDiv('\xa0', rowtwo, true);
 
             Object.keys(value[1]).forEach((key, index) => {
-                name = key;
                 const content = value[1][key].time;
                 getNewDiv(key + ": ", rowOne, true);
                 getNewDiv(content, rowtwo, true);
@@ -142,7 +141,6 @@ function createLabJiraTimeSummay(list, data) {
             liEl.appendChild(newHeadline);
 
             Object.keys(value[1]).forEach((key, index) => {
-                name = key;
                 const content = value[1][key].time;
                 var newContent = createNewContent(key + ": ", content, cloneTitle);
                 newContent.style.marginTop = '0px';

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -106,7 +106,7 @@ function createTimeSummary(list, data) {
             getNewDiv(headline[i++], rowOne);
             getNewDiv('\xa0', rowtwo, true);
 
-            Object.keys(value[1]).forEach((key, index) => {
+            Object.keys(value[1]).forEach((key) => {
                 const content = value[1][key].time;
                 getNewDiv(key + ": ", rowOne, true);
                 getNewDiv(content, rowtwo, true);
@@ -140,7 +140,7 @@ function createLabJiraTimeSummay(list, data) {
             var newHeadline = createNewContent(headline[i++], '\xa0', cloneTitle);
             liEl.appendChild(newHeadline);
 
-            Object.keys(value[1]).forEach((key, index) => {
+            Object.keys(value[1]).forEach((key) => {
                 const content = value[1][key].time;
                 var newContent = createNewContent(key + ": ", content, cloneTitle);
                 newContent.style.marginTop = '0px';

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -187,13 +187,9 @@ function getTimeSummary() {
                 list.removeChild(list.lastChild);
             }
 
-            if (this.labJira) {
-                var newDiv = createLabJiraTimeSummay(list, data);
-            } else {
-
-                var newDiv = createTimeSummary(list, data);
-
-            }
+            const newDiv = this.labJira
+                ? createLabJiraTimeSummay(list, data)
+                : createTimeSummary(list, data);
             list.appendChild(newDiv);
             this.button.style.display = 'none';
         })

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -8,7 +8,7 @@
 // ==/UserScript==
 
 
-var ticket = null || window.location.href.split('/').slice(-1)[0];
+var ticket = null || globalThis.location.href.split('/').slice(-1)[0];
 var timetrackerUrl = 'https://timetracker/getTicketTimeSummary/' + ticket;
 
 window.addEventListener('load', function () {
@@ -36,7 +36,7 @@ function createButton(labJira, list) {
     button.style.color = "rgb(255, 255, 255)";
     button.style.height = '30px';
 
-    if (labJira == true) {
+    if (labJira) {
         button.style.marginTop = '15px';
     }
 
@@ -55,7 +55,7 @@ function createButton(labJira, list) {
 function getNewDiv(content, div, list = false) {
     var divElement = document.createElement('div');
 
-    if (list == true) {
+    if (list) {
         divElement.style.paddingLeft = '10px';
     }
 
@@ -72,7 +72,7 @@ function createTimeSummary(list, data) {
         "[data-test-id='issue.views.issue-base.context.context-items.primary-items']"
     ).childNodes[0].childNodes[0].childNodes[0];
     var cloneTitle = title.cloneNode(true);
-    var titleText = cloneTitle.childNodes[0].textContent = 'Aufgewendete Zeit';
+    cloneTitle.childNodes[0].textContent = 'Aufgewendete Zeit';
 
     var divTitle = document.createElement('div');
     divTitle.appendChild(cloneTitle);
@@ -97,21 +97,21 @@ function createTimeSummary(list, data) {
 
     var i = 0;
     Object.entries(data).forEach((value) => {
-        time = false || value[1].time;
+        const time = value[1].time;
 
-        if (!time) {
+        if (time) {
+            getNewDiv(headline[i++], rowOne);
+            getNewDiv(value[1].time, rowtwo, true);
+        } else {
             getNewDiv(headline[i++], rowOne);
             getNewDiv('\xa0', rowtwo, true);
 
             Object.keys(value[1]).forEach((key, index) => {
                 name = key;
-                content = value[1][key].time;
+                const content = value[1][key].time;
                 getNewDiv(key + ": ", rowOne, true);
                 getNewDiv(content, rowtwo, true);
             })
-        } else {
-            getNewDiv(headline[i++], rowOne);
-            getNewDiv(value[1].time, rowtwo, true);
         }
     })
     newDiv.appendChild(rowOne);
@@ -130,24 +130,25 @@ function createLabJiraTimeSummay(list, data) {
     var liEl = cloneTitle.childNodes[1].childNodes[1].childNodes[1];
 
     Object.entries(data).forEach((value) => {
-        time = false || value[1].time;
+        const time = value[1].time;
 
-        if (!time) {
+        if (time) {
+
+            var total = createNewContent(headline[i++], value[1].time, cloneTitle);
+            liEl.appendChild(total);
+        } else {
+
             var newHeadline = createNewContent(headline[i++], '\xa0', cloneTitle);
             liEl.appendChild(newHeadline);
 
             Object.keys(value[1]).forEach((key, index) => {
                 name = key;
-                content = value[1][key].time;
+                const content = value[1][key].time;
                 var newContent = createNewContent(key + ": ", content, cloneTitle);
                 newContent.style.marginTop = '0px';
                 liEl.appendChild(newContent);
             })
 
-        } else {
-
-            var total = createNewContent(headline[i++], value[1].time, cloneTitle);
-            liEl.appendChild(total);
         }
     })
 
@@ -162,7 +163,7 @@ function createLabJiraTimeSummay(list, data) {
 function createNewContent(headline, text, clone) {
 
     var content = clone.childNodes[1].childNodes[1].childNodes[1].childNodes[1];
-    var headline = content.getElementsByTagName("dt")[0].innerHTML = headline;
+    content.getElementsByTagName("dt")[0].innerHTML = headline;
     content.getElementsByTagName("dd")[0].innerText = text;
     clone.getElementsByTagName("dd")[0].title = text;
 
@@ -188,12 +189,12 @@ function getTimeSummary() {
                 list.removeChild(list.lastChild);
             }
 
-            if (this.labJira == false) {
+            if (this.labJira) {
+                var newDiv = createLabJiraTimeSummay(list, data);
+            } else {
 
                 var newDiv = createTimeSummary(list, data);
 
-            } else {
-                var newDiv = createLabJiraTimeSummay(list, data);
             }
             list.appendChild(newDiv);
             this.button.style.display = 'none';

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -1,3 +1,5 @@
+{# JSON_HEX_* flags so |json_encode output cannot break out of <script> (e.g. a literal </script> in customer names) #}
+{% set jsonHexFlags = constant('JSON_HEX_TAG') b-or constant('JSON_HEX_AMP') b-or constant('JSON_HEX_APOS') b-or constant('JSON_HEX_QUOT') %}
 <!DOCTYPE HTML>
 <html lang="{{ app.request.locale }}">
     <head>
@@ -7,17 +9,17 @@
         <link rel="stylesheet" href="{{ asset('build/js/ext-js/resources/css/ext-all-gray.css') }}" type="text/css">
         <link rel="stylesheet" href="{{ asset('build/css/timetracker.css') }}" type="text/css">
         <script type="text/javascript">
-            const statusUrlJson = {{ url('check_status')|escape|json_encode|raw }};
-            const logoutUrlHtml = {{ url('_logout')|escape|json_encode|raw }};
-            const globalConfig = {{ globalConfig|json_encode|raw }};
+            const statusUrlJson = {{ url('check_status')|escape|json_encode(jsonHexFlags)|raw }};
+            const logoutUrlHtml = {{ url('_logout')|escape|json_encode(jsonHexFlags)|raw }};
+            const globalConfig = {{ globalConfig|json_encode(jsonHexFlags)|raw }};
 
-            const environment = {{ environment|json_encode|raw }};
+            const environment = {{ environment|json_encode(jsonHexFlags)|raw }};
 
-            globalThis.customersData = {{ customers|json_encode|raw }};
+            globalThis.customersData = {{ customers|json_encode(jsonHexFlags)|raw }};
 
-            globalThis.projectsData = {{ projects|json_encode|raw }};
+            globalThis.projectsData = {{ projects|json_encode(jsonHexFlags)|raw }};
 
-            globalThis.settingsData = {{ settings|json_encode|raw }};
+            globalThis.settingsData = {{ settings|json_encode(jsonHexFlags)|raw }};
         </script>
         <script type="text/javascript" src="{{ asset('build/js/ext-js/ext-all.js') }}"></script>
         <script type="text/javascript" src="{{ asset('build/js/ext-js/locale/ext-lang-' ~ locale ~ '.js') }}"></script>
@@ -26,12 +28,12 @@
         {% for flashMessage in app.session.flashbag.get('error') %}
 
             <script type="text/javascript">
-                alert({{ flashMessage|json_encode|raw }});
+                alert({{ flashMessage|json_encode(jsonHexFlags)|raw }});
             </script>
 
         {% endfor %}
         <script type="text/javascript">
-            const url = {{ url('_start')|escape|json_encode|raw }};
+            const url = {{ url('_start')|escape|json_encode(jsonHexFlags)|raw }};
         </script>
     </head>
     <body>

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -13,11 +13,11 @@
 
             const environment = {{ environment|json_encode|raw }};
 
-            let customersData = {{ customers|json_encode|raw }};
+            globalThis.customersData = {{ customers|json_encode|raw }};
 
-            let projectsData = {{ projects|json_encode|raw }};
+            globalThis.projectsData = {{ projects|json_encode|raw }};
 
-            let settingsData = {{ settings|json_encode|raw }};
+            globalThis.settingsData = {{ settings|json_encode|raw }};
         </script>
         <script type="text/javascript" src="{{ asset('build/js/ext-js/ext-all.js') }}"></script>
         <script type="text/javascript" src="{{ asset('build/js/ext-js/locale/ext-lang-' ~ locale ~ '.js') }}"></script>

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -1,3 +1,5 @@
+{# JSON_HEX_* flags so |json_encode output cannot break out of <script> #}
+{% set jsonHexFlags = constant('JSON_HEX_TAG') b-or constant('JSON_HEX_AMP') b-or constant('JSON_HEX_APOS') b-or constant('JSON_HEX_QUOT') %}
 <!DOCTYPE HTML>
 <html>
     <head>
@@ -9,7 +11,7 @@
         <script type="text/javascript" src="{{ asset('build/js/ext-js/ext-all.js') }}"></script>
         <script type="text/javascript" src="{{ asset('build/js/ext-js/locale/ext-lang-' ~ locale ~ '.js') }}"></script>
         <script type="text/javascript">
-            var url = {{ url('_start')|escape|json_encode|raw }};
+            var url = {{ url('_start')|escape|json_encode(jsonHexFlags)|raw }};
         	Ext.onReady(function() {
 				var window = Ext.create('Ext.window.Window', {
 					title: 'Login',


### PR DESCRIPTION
Phase 1 of #319: fix the 9 `javascript:S2703` implicit-global BLOCKERs and apply the safe modernization rule families. The 255x `var`→`let` migration (S3504) and S3776 complexity are explicitly **out of scope** (later phases).

## Per-rule results

| Rule | Description | Flagged in scope | Fixed | Skipped (vendored/out of scope) |
|------|-------------|-----------------:|------:|--------------------------------:|
| S2703 | implicit globals (BLOCKER) | 9 | 9 | 0 |
| S125 | commented-out code | 8 | 8 | 0 |
| S1125 | redundant boolean literals | 6 | 6 | 0 |
| S1854 | dead stores | 6 | 6 | 0 |
| S1481 | unused locals | 5 | 5 | 0 |
| S6582 | optional chaining | 21 | 17 | 4 (`Notification.js`, vendored) |
| S7735 | negated conditions | 14 | 10 | 4 (3 `Notification.js`, 1 swagger dist) |
| S7741 | `typeof x === 'undefined'` | 5 | 4 | 1 (`Notification.js`) |
| S7764 | `window` → `globalThis` | 8 | 5 | 3 (swagger dist) |
| S7778 | consecutive `Array#push` | 11 | 11 | 0 |
| S7781 | `replace` → `replaceAll` | 10 | 10 | 0 |

**Skipped files (not our code, never touched):**
- `assets/js/Notification.js` — vendored `Ext.ux.window.Notification` 2.1.3 (Eirik Lorentsen)
- `public/docs/swagger/oauth2-redirect.html`, `public/docs/swagger/swagger-initializer.js` — swagger-ui dist
- `assets/js/ext-js/**` — untouched per scope rule

## S2703 scoping decisions (9 BLOCKERs)

| # | Location | Variable | Decision | Reasoning |
|---|----------|----------|----------|-----------|
| 1 | `main.js:583` | `projectPrefix` | **local** `const` in loop body | Used only on the two lines inside `findProjects`'s prefix loop; no other reference repo-wide. |
| 2 | `store/Projects.js:50` | `projects2` | **local** `const` | Used only in the 4-line merge block inside `loadData`. |
| 3 | `widget/Admin.js:338` | `i` | **local** `let` loop counter | Leaked loop counter in a form-validation handler; no cross-function use. |
| 4 | `widget/Tracking.js:1131` | `tracking` | **local** `const` | `refreshHard()` captures `this` for its nested callbacks only. (`autoRefreshProjectData` uses a *parameter* of the same name — unrelated.) |
| 5 | `timeSummaryForJira.js:100` | `time` | **local** `const` (both callbacks) | Used immediately within each `forEach` callback in `createTimeSummary`/`createLabJiraTimeSummay`. |
| 6 | `timeSummaryForJira.js:108` | `content` | **local** `const` (both callbacks) | Same as above. |
| 7 | `store/Projects.js:27` | `projectsData` | **genuine cross-file global** → `globalThis.projectsData = data` | Declared in `templates/index.html.twig`, read by `main.js findProjects()` and `Tracking.js`. |
| 8 | `widget/Settings.js:110` | `settingsData` | **genuine cross-file global** → `globalThis.settingsData = ...` | Declared in the template, read by `main.js`, `Tracking.js`, `Interpretation.js` after settings save. |
| 9 | `store/Customers.js:25` | `consumersData` | **typo for `customersData`** → `globalThis.customersData = data` | `consumersData` is written exactly once and read nowhere repo-wide; the sibling `Projects.reloadFromServer` updates `projectsData`, and the comment says "update the locally available customer data". As written, the store-refresh callback threw the fetched customers away, so the customer dropdown stayed stale after background refresh. `GetCustomersAction` returns the same `getCustomersByUser()` shape the template injects as `customers`, so the assignment is shape-compatible. This is a deliberate behavior fix (covered by passing e2e store/refresh flows). |

### Why the template change (`templates/index.html.twig`)

The three mutated globals were declared with top-level `let` in the inline template script. A top-level `let` in a classic script creates a *global lexical binding*, not a `window` property — so `window.x = ...`/`globalThis.x = ...` from `Projects.js`/`Settings.js` would write a shadowed property that unqualified readers (`main.js`, widgets) never see. Both sides must agree on the global-object form, so the template now declares them via `globalThis.x = ...` (3 lines). Unqualified reads everywhere else resolve identically through the global object. `globalThis` was used instead of `window` to avoid introducing new S7764 findings; identical semantics in browsers.

## Notable equivalence judgements

- `Tracking.js` `if (false == projectCheck)` → `if (!projectCheck)`: `checkCustomerProjectRelation` returns only `true`, `false`, or a positive project id, so the loose comparison and negation agree over the whole return set.
- `Admin.js` `hours_X !== undefined ? hours_X : d` → inverted `=== undefined ? d : hours_X` (not `??`, which would also catch `null` and change behavior).
- Dead stores removed only where side effects were preserved: `new Ext.util.KeyMap(...)` kept as expression statement (`main.js`), `textContent`/`innerHTML` chain assignments kept (`timeSummaryForJira.js`); the removed `Ext.create` store statements in `Admin.js`/`Tracking.js` were pure dead allocations (no `storeId`, never referenced).
- `Tracking.js` blur listener became empty after removing its commented-out body (S125) and was dropped entirely (no-op listener).
- Observed but **not** changed (not in the flagged rule families): `timeSummaryForJira.js` `name = key` (assigns `window.name`, unused) and `Tracking.js` `if ('undefined' == this.days)` (compares the *string* `'undefined'` to a number — pre-existing suspect logic in `exportEntries`).

## Gates

**webpack build** (`docker compose run --rm app-dev npm run build`): pass

```
DONE  Compiled successfully in 23141ms
2106 files written to public/build
webpack compiled successfully
```

**ESLint**: not configured in this repo (no eslint config file, no eslint dependency, no lint script) — gate N/A.

**Playwright e2e** (full suite against the `make e2e-up` stack on :8766, with the rebuilt assets bind-mounted): **pass**

```
Running 122 tests using 11 workers
  2 skipped
  120 passed (2.7m)
```

`npx playwright test --list`: `Total: 122 tests in 14 files`. The suite covers the changed surfaces directly: login, header elements (rewritten `buildHeaderHtml` pushes), settings save (branch swap + `globalThis.settingsData`), entries CRUD + keyboard shortcuts (KeyMap without binding, Tracking renderers/`replaceAll`), admin CRUD, interpretation, error handling (`parsed?.data?.forwardUrl` path).

## Notes

- Branch is rebased onto current `main` (incl. #317); the `https://bugs.nr` change was kept during the `replaceAll` conflict resolution.
- `config/reference.php` and `package-lock.json` churn from local container runs was not committed.
