### PR TITLE
fix: add array type to FORMULA_TRIGGER_CHARACTERS const

### DIFF
--- a/src/Extension/TwigCsvEscapingExtension.php
+++ b/src/Extension/TwigCsvEscapingExtension.php
@@ -31,7 +31,7 @@ class TwigCsvEscapingExtension
      * Characters that spreadsheet applications interpret as a formula trigger
      * when they appear at the start of a cell (OWASP CSV injection).
      */
-    private const FORMULA_TRIGGER_CHARACTERS = ['=', '+', '-', '@', "\t", "\r", "\n"];
+    private const array FORMULA_TRIGGER_CHARACTERS = ['=', '+', '-', '@', "\t", "\r", "\n"];
 
     #[AsTwigFilter(name: 'csv_escape')]
     public function csvEscape(string $string): string


### PR DESCRIPTION
Repairs the Rector dry-run gate on `main`, broken since #324 merged.

#324 added `FORMULA_TRIGGER_CHARACTERS` without a native const type; `AddTypeToConstRector` requires one. Both PRs were green individually — the combination broke main (semantic merge conflict).

One-line change, exactly the diff Rector itself proposes.