### PR TITLE
refactor: resolve SonarCloud S1192/S112/S4144 findings in src, config and public

### DIFF
--- a/config/quality/phpat.php
+++ b/config/quality/phpat.php
@@ -13,22 +13,34 @@ use PHPat\Test\PHPat;
 
 final class ArchitectureTest
 {
+    private const string NAMESPACE_ENTITY = 'App\Entity';
+
+    private const string NAMESPACE_SERVICE = 'App\Service';
+
+    private const string NAMESPACE_ENUM = 'App\Enum';
+
+    private const string NAMESPACE_REPOSITORY = 'App\Repository';
+
+    private const string CLASSNAME_DATETIME = 'DateTime*';
+
+    private const string CLASSNAME_EXCEPTION = '*Exception';
+
     public function test_controllers_should_only_depend_on_business_logic(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace('App\Controller'))
             ->canOnly()->dependOn()
             ->classes(
-                Selector::inNamespace('App\Entity'),
-                Selector::inNamespace('App\Service'),
+                Selector::inNamespace(self::NAMESPACE_ENTITY),
+                Selector::inNamespace(self::NAMESPACE_SERVICE),
                 Selector::inNamespace('App\Dto'),
-                Selector::inNamespace('App\Enum'),
+                Selector::inNamespace(self::NAMESPACE_ENUM),
                 Selector::inNamespace('App\Event'),
                 Selector::inNamespace('Symfony'),
                 Selector::inNamespace('Doctrine'),
                 Selector::inNamespace('Sensio'),
-                Selector::classname('DateTime*', true),
-                Selector::classname('*Exception', true),
+                Selector::classname(self::CLASSNAME_DATETIME, true),
+                Selector::classname(self::CLASSNAME_EXCEPTION, true),
             )
             ->because('Controllers should only depend on business logic and framework components');
     }
@@ -36,14 +48,14 @@ final class ArchitectureTest
     public function test_entities_should_be_pure_data_models(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('App\Entity'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_ENTITY))
             ->canOnly()->dependOn()
             ->classes(
-                Selector::inNamespace('App\Enum'),
+                Selector::inNamespace(self::NAMESPACE_ENUM),
                 Selector::inNamespace('Doctrine'),
                 Selector::inNamespace('Symfony\Component\Validator'),
                 Selector::classname('DateTimeInterface'),
-                Selector::classname('DateTime*', true),
+                Selector::classname(self::CLASSNAME_DATETIME, true),
             )
             ->because('Entities should be pure data models with minimal dependencies');
     }
@@ -51,21 +63,21 @@ final class ArchitectureTest
     public function test_services_can_orchestrate_business_logic(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('App\Service'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_SERVICE))
             ->canOnly()->dependOn()
             ->classes(
-                Selector::inNamespace('App\Entity'),
-                Selector::inNamespace('App\Repository'),
+                Selector::inNamespace(self::NAMESPACE_ENTITY),
+                Selector::inNamespace(self::NAMESPACE_REPOSITORY),
                 Selector::inNamespace('App\Dto'),
-                Selector::inNamespace('App\Enum'),
+                Selector::inNamespace(self::NAMESPACE_ENUM),
                 Selector::inNamespace('App\Event'),
-                Selector::inNamespace('App\Service'),
+                Selector::inNamespace(self::NAMESPACE_SERVICE),
                 Selector::inNamespace('Symfony'),
                 Selector::inNamespace('Doctrine'),
                 Selector::inNamespace('Psr'),
                 Selector::inNamespace('GuzzleHttp'),
-                Selector::classname('DateTime*', true),
-                Selector::classname('*Exception', true),
+                Selector::classname(self::CLASSNAME_DATETIME, true),
+                Selector::classname(self::CLASSNAME_EXCEPTION, true),
             )
             ->because('Services should handle business logic and orchestration');
     }
@@ -73,15 +85,15 @@ final class ArchitectureTest
     public function test_repositories_should_only_handle_data_access(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('App\Repository'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_REPOSITORY))
             ->canOnly()->dependOn()
             ->classes(
-                Selector::inNamespace('App\Entity'),
-                Selector::inNamespace('App\Enum'),
+                Selector::inNamespace(self::NAMESPACE_ENTITY),
+                Selector::inNamespace(self::NAMESPACE_ENUM),
                 Selector::inNamespace('Doctrine'),
                 Selector::inNamespace('Symfony\Component\Security'),
-                Selector::classname('DateTime*', true),
-                Selector::classname('*Exception', true),
+                Selector::classname(self::CLASSNAME_DATETIME, true),
+                Selector::classname(self::CLASSNAME_EXCEPTION, true),
             )
             ->because('Repositories should only handle data access');
     }
@@ -91,7 +103,7 @@ final class ArchitectureTest
         return PHPat::rule()
             ->classes(Selector::inNamespace('App\Controller'))
             ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace('App\Repository'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_REPOSITORY))
             ->because('Controllers should use Services, not Repositories directly');
     }
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,8 @@
 parameters:
     locale: 'en'
     secret: '%env(APP_SECRET)%'
+    # APP_ENCRYPTION_KEY with fallback to APP_SECRET (via the secret parameter)
+    app.encryption_key: '%env(default:secret:APP_ENCRYPTION_KEY)%'
     app_title: '%env(APP_TITLE)%'
     app_locale: '%env(APP_LOCALE)%'
     app_logo_url: '%env(default:app_logo_url_default:APP_LOGO_URL)%'

--- a/public/coverage.php
+++ b/public/coverage.php
@@ -22,6 +22,9 @@ declare(strict_types=1);
 // Coverage storage directory
 define('COVERAGE_DIR', dirname(__DIR__) . '/var/coverage/e2e');
 
+// Glob pattern matching all collected coverage files
+define('COVERAGE_FILE_PATTERN', COVERAGE_DIR . '/*.json');
+
 /**
  * Check if coverage is enabled via environment variable.
  */
@@ -134,7 +137,7 @@ function handleCoverageRequest(): void
 
     switch ($action) {
         case 'status':
-            $files = is_dir(COVERAGE_DIR) ? (glob(COVERAGE_DIR . '/*.json') ?: []) : [];
+            $files = is_dir(COVERAGE_DIR) ? (glob(COVERAGE_FILE_PATTERN) ?: []) : [];
             echo json_encode([
                 'enabled' => function_exists('xdebug_start_code_coverage'),
                 'xdebug_mode' => ini_get('xdebug.mode'),
@@ -171,7 +174,7 @@ function generateCoverageReport(string $format): void
 
     // Merge all coverage files
     $mergedCoverage = [];
-    $files = glob(COVERAGE_DIR . '/*.json') ?: [];
+    $files = glob(COVERAGE_FILE_PATTERN) ?: [];
 
     foreach ($files as $file) {
         $content = @file_get_contents($file);
@@ -294,7 +297,7 @@ function clearCoverageData(): void
         return;
     }
 
-    $files = glob(COVERAGE_DIR . '/*.json') ?: [];
+    $files = glob(COVERAGE_FILE_PATTERN) ?: [];
     foreach ($files as $file) {
         if (!@unlink($file)) {
             error_log('Coverage: Failed to delete file ' . $file);

--- a/src/Controller/Admin/DeleteActivityAction.php
+++ b/src/Controller/Admin/DeleteActivityAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\Activity;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -41,7 +41,7 @@ final class DeleteActivityAction extends BaseController
                 $em->remove($activity);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/DeleteContractAction.php
+++ b/src/Controller/Admin/DeleteContractAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\Contract;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -41,7 +41,7 @@ final class DeleteContractAction extends BaseController
                 $em->remove($contract);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/DeleteCustomerAction.php
+++ b/src/Controller/Admin/DeleteCustomerAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\Customer;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -40,7 +40,7 @@ final class DeleteCustomerAction extends BaseController
                 $em->remove($customer);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/DeletePresetAction.php
+++ b/src/Controller/Admin/DeletePresetAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\Preset;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -40,7 +40,7 @@ final class DeletePresetAction extends BaseController
                 $em->remove($preset);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/DeleteProjectAction.php
+++ b/src/Controller/Admin/DeleteProjectAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\Project;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -40,7 +40,7 @@ final class DeleteProjectAction extends BaseController
                 $em->remove($project);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/DeleteTeamAction.php
+++ b/src/Controller/Admin/DeleteTeamAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\Team;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -40,7 +40,7 @@ final class DeleteTeamAction extends BaseController
                 $em->remove($team);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/DeleteTicketSystemAction.php
+++ b/src/Controller/Admin/DeleteTicketSystemAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\TicketSystem;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -40,7 +40,7 @@ final class DeleteTicketSystemAction extends BaseController
                 $em->remove($ticketSystem);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/DeleteUserAction.php
+++ b/src/Controller/Admin/DeleteUserAction.php
@@ -12,11 +12,11 @@ namespace App\Controller\Admin;
 use App\Controller\BaseController;
 use App\Dto\IdDto;
 use App\Entity\User;
+use App\Exception\EntityAlreadyDeletedException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
 use Exception;
-use RuntimeException;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -38,7 +38,7 @@ final class DeleteUserAction extends BaseController
                 $em->remove($user);
                 $em->flush();
             } else {
-                throw new RuntimeException('Already deleted');
+                throw new EntityAlreadyDeletedException('Already deleted');
             }
         } catch (Exception $exception) {
             $reason = '';

--- a/src/Controller/Admin/SavePresetAction.php
+++ b/src/Controller/Admin/SavePresetAction.php
@@ -15,6 +15,7 @@ use App\Entity\Activity;
 use App\Entity\Customer;
 use App\Entity\Preset;
 use App\Entity\Project;
+use App\Exception\IncompletePresetException;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
@@ -67,7 +68,7 @@ final class SavePresetAction extends BaseController
 
         try {
             if (!$customer instanceof Customer || !$project instanceof Project || !$activity instanceof Activity) {
-                throw new Exception('Please choose a customer, a project and an activity.');
+                throw new IncompletePresetException('Please choose a customer, a project and an activity.');
             }
 
             // Map scalar fields (name, description)

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -38,6 +38,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+use function sprintf;
+
 use const E_USER_DEPRECATED;
 
 /**
@@ -77,6 +79,14 @@ class BaseController extends AbstractController
     }
 
     /**
+     * Triggers a deprecation notice for the given method.
+     */
+    private function triggerMethodDeprecation(string $method, string $advice): void
+    {
+        @trigger_error(sprintf('Method %s is deprecated, %s', $method, $advice), E_USER_DEPRECATED);
+    }
+
+    /**
      * Check if user is logged in using Symfony Security.
      *
      * @throws Exception
@@ -84,7 +94,7 @@ class BaseController extends AbstractController
     #[Deprecated(message: "Use isGranted('IS_AUTHENTICATED_FULLY') directly")]
     protected function isLoggedIn(Request $request): bool
     {
-        @trigger_error('Method ' . __METHOD__ . ' is deprecated, use isGranted(\'IS_AUTHENTICATED_FULLY\') directly', E_USER_DEPRECATED);
+        $this->triggerMethodDeprecation(__METHOD__, "use isGranted('IS_AUTHENTICATED_FULLY') directly");
 
         return $this->isGranted('IS_AUTHENTICATED_FULLY');
     }
@@ -131,7 +141,7 @@ class BaseController extends AbstractController
     #[Deprecated(message: 'Use Security expressions with #[Security] attribute instead')]
     protected function hasUserType(Request $request, UserType $userType): bool
     {
-        @trigger_error('Method ' . __METHOD__ . ' is deprecated, use #[Security] attribute with expressions instead', E_USER_DEPRECATED);
+        $this->triggerMethodDeprecation(__METHOD__, 'use #[Security] attribute with expressions instead');
 
         $currentUser = $this->getUser();
         if ($currentUser instanceof User) {
@@ -147,7 +157,7 @@ class BaseController extends AbstractController
     #[Deprecated(message: "Use #[Security(\"is_granted('ROLE_ADMIN') or (is_granted('ROLE_USER') and user.getType() == 'PL')\")] instead")]
     protected function isPl(Request $request): bool
     {
-        @trigger_error('Method ' . __METHOD__ . ' is deprecated, use #[Security] attribute with user type check instead', E_USER_DEPRECATED);
+        $this->triggerMethodDeprecation(__METHOD__, 'use #[Security] attribute with user type check instead');
 
         return $this->hasUserType($request, UserType::PL);
     }
@@ -158,7 +168,7 @@ class BaseController extends AbstractController
     #[Deprecated(message: "Use #[Security(\"is_granted('ROLE_USER') and user.getType() == 'DEV')\")] instead")]
     protected function isDEV(Request $request): bool
     {
-        @trigger_error('Method ' . __METHOD__ . ' is deprecated, use #[Security] attribute with user type check instead', E_USER_DEPRECATED);
+        $this->triggerMethodDeprecation(__METHOD__, 'use #[Security] attribute with user type check instead');
 
         return $this->hasUserType($request, UserType::DEV);
     }
@@ -179,7 +189,7 @@ class BaseController extends AbstractController
     #[Deprecated(message: "Use isGranted('IS_AUTHENTICATED_FULLY') directly")]
     protected function checkLogin(Request $request): bool
     {
-        @trigger_error('Method ' . __METHOD__ . ' is deprecated, use isGranted(\'IS_AUTHENTICATED_FULLY\') directly', E_USER_DEPRECATED);
+        $this->triggerMethodDeprecation(__METHOD__, "use isGranted('IS_AUTHENTICATED_FULLY') directly");
 
         return $this->isGranted('IS_AUTHENTICATED_FULLY');
     }

--- a/src/Controller/Interpretation/BaseInterpretationController.php
+++ b/src/Controller/Interpretation/BaseInterpretationController.php
@@ -14,10 +14,11 @@ use App\Dto\InterpretationFiltersDto;
 use App\Entity\Entry;
 use App\Entity\User;
 use App\Enum\UserType;
+use App\Exception\InvalidDateFormatException;
+use App\Exception\MissingSearchCriteriaException;
 use App\Repository\EntryRepository;
 use DateInterval;
 use DateTime;
-use Exception;
 use Symfony\Component\HttpFoundation\Request;
 
 use function assert;
@@ -61,7 +62,8 @@ abstract class BaseInterpretationController extends BaseController
     /**
      * Get entries by request parameter.
      *
-     * @throws Exception
+     * @throws InvalidDateFormatException     when the year/month filter cannot be parsed
+     * @throws MissingSearchCriteriaException when no usable filter criteria are given
      *
      * @return list<Entry>
      */
@@ -78,7 +80,7 @@ abstract class BaseInterpretationController extends BaseController
                 $datestart = $year . '-' . $month . '-01';
                 $dateend = DateTime::createFromFormat('Y-m-d', $datestart);
                 if (false === $dateend) {
-                    throw new Exception('Invalid date');
+                    throw new InvalidDateFormatException('Invalid date');
                 }
 
                 $dateend->add(new DateInterval('P1M'));
@@ -87,7 +89,7 @@ abstract class BaseInterpretationController extends BaseController
                 $datestart = $year . '-01-01';
                 $dateend = DateTime::createFromFormat('Y-m-d', $datestart);
                 if (false === $dateend) {
-                    throw new Exception('Invalid date');
+                    throw new InvalidDateFormatException('Invalid date');
                 }
 
                 $dateend->add(new DateInterval('P1Y'));
@@ -99,7 +101,7 @@ abstract class BaseInterpretationController extends BaseController
         }
 
         if (null === $arParams['customer'] && null === $arParams['project'] && null === $arParams['user'] && null === $arParams['ticket']) {
-            throw new Exception($this->translate('You need to specify at least customer, project, ticket, user or month and year.'));
+            throw new MissingSearchCriteriaException($this->translate('You need to specify at least customer, project, ticket, user or month and year.'));
         }
 
         $objectRepository = $this->managerRegistry->getRepository(Entry::class);

--- a/src/Controller/Tracking/BaseTrackingController.php
+++ b/src/Controller/Tracking/BaseTrackingController.php
@@ -12,6 +12,7 @@ namespace App\Controller\Tracking;
 use App\Controller\BaseController;
 use App\Entity\Entry;
 use App\Enum\EntryClass;
+use App\Exception\InvalidEntryTimeException;
 use App\Repository\EntryRepository;
 use DateInterval;
 use DateTime;
@@ -134,7 +135,7 @@ abstract class BaseTrackingController extends BaseController
     /**
      * Validates entry date and time values.
      *
-     * @throws Exception when validation fails
+     * @throws InvalidEntryTimeException when validation fails
      */
     protected function validateEntryDateTime(Entry $entry): void
     {
@@ -142,18 +143,18 @@ abstract class BaseTrackingController extends BaseController
         $end = $entry->getEnd();
 
         if (!$start instanceof DateTime || !$end instanceof DateTime) {
-            throw new Exception('Entry must have valid start and end times');
+            throw new InvalidEntryTimeException('Entry must have valid start and end times');
         }
 
         if ($start >= $end) {
-            throw new Exception('Entry start time must be before end time');
+            throw new InvalidEntryTimeException('Entry start time must be before end time');
         }
 
         new DateInterval('PT23H59M');
         $dateInterval = $start->diff($end);
 
         if ($dateInterval->days > 0 || $dateInterval->h > 23) {
-            throw new Exception('Entry duration cannot exceed 24 hours');
+            throw new InvalidEntryTimeException('Entry duration cannot exceed 24 hours');
         }
     }
 

--- a/src/Controller/Tracking/BaseTrackingController.php
+++ b/src/Controller/Tracking/BaseTrackingController.php
@@ -14,7 +14,6 @@ use App\Entity\Entry;
 use App\Enum\EntryClass;
 use App\Exception\InvalidEntryTimeException;
 use App\Repository\EntryRepository;
-use DateInterval;
 use DateTime;
 use Exception;
 use Psr\Log\LoggerInterface;
@@ -150,7 +149,6 @@ abstract class BaseTrackingController extends BaseController
             throw new InvalidEntryTimeException('Entry start time must be before end time');
         }
 
-        new DateInterval('PT23H59M');
         $dateInterval = $start->diff($end);
 
         if ($dateInterval->days > 0 || $dateInterval->h > 23) {

--- a/src/Controller/Tracking/BulkEntryAction.php
+++ b/src/Controller/Tracking/BulkEntryAction.php
@@ -19,6 +19,7 @@ use App\Entity\Project;
 use App\Entity\User;
 use App\Enum\EntryClass;
 use App\Event\EntryEvent;
+use App\Exception\PresetNotFoundException;
 use App\Model\Response;
 use DateInterval;
 use DateTime;
@@ -93,7 +94,7 @@ final class BulkEntryAction extends BaseTrackingController
 
             $preset = $doctrine->getRepository(Preset::class)->find($bulkEntryDto->preset);
             if (!$preset instanceof Preset) {
-                throw new Exception('Preset not found');
+                throw new PresetNotFoundException('Preset not found');
             }
 
             $user = $currentUser;

--- a/src/Dto/EntrySaveDto.php
+++ b/src/Dto/EntrySaveDto.php
@@ -24,6 +24,8 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[Map(target: Entry::class)]
 final readonly class EntrySaveDto
 {
+    private const string FORMAT_ISO_DATETIME = 'Y-m-d\TH:i:s';
+
     public function __construct(
         public ?int $id = null,
         #[Assert\NotBlank(message: 'Date is required')]
@@ -94,7 +96,7 @@ final readonly class EntrySaveDto
         }
 
         // Try ISO 8601 format first (from ExtJS: 2026-01-14T00:00:00)
-        $date = DateTime::createFromFormat('Y-m-d\TH:i:s', $this->date);
+        $date = DateTime::createFromFormat(self::FORMAT_ISO_DATETIME, $this->date);
         if (false !== $date) {
             return $date;
         }
@@ -124,7 +126,7 @@ final readonly class EntrySaveDto
         }
 
         // Try ISO 8601 format first (from ExtJS: 2026-01-14T08:00:00)
-        $time = DateTime::createFromFormat('Y-m-d\TH:i:s', $this->start);
+        $time = DateTime::createFromFormat(self::FORMAT_ISO_DATETIME, $this->start);
         if (false !== $time) {
             return $time;
         }
@@ -160,7 +162,7 @@ final readonly class EntrySaveDto
         }
 
         // Try ISO 8601 format first (from ExtJS: 2026-01-14T16:00:00)
-        $time = DateTime::createFromFormat('Y-m-d\TH:i:s', $this->end);
+        $time = DateTime::createFromFormat(self::FORMAT_ISO_DATETIME, $this->end);
         if (false !== $time) {
             return $time;
         }

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -172,13 +172,13 @@ class Customer extends Base
     /**
      * Add projects.
      *
+     * Legacy alias kept for backward compatibility; delegates to addProject().
+     *
      * @return $this
      */
     public function addProjects(Project $project): static
     {
-        $this->projects[] = $project;
-
-        return $this;
+        return $this->addProject($project);
     }
 
     /**
@@ -237,6 +237,8 @@ class Customer extends Base
 
     /**
      * Add projects.
+     *
+     * @return $this
      */
     public function addProject(Project $project): static
     {

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -236,7 +236,7 @@ class Customer extends Base
     }
 
     /**
-     * Add projects.
+     * Add a project.
      *
      * @return $this
      */

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Enum\EntryClass;
+use App\Exception\InvalidEntryTimeException;
 use App\Model\Base;
 use App\Repository\EntryRepository;
 use DateTime;
@@ -171,14 +172,14 @@ class Entry extends Base
     protected $externalReporter = '';
 
     /**
-     * @throws Exception
+     * @throws InvalidEntryTimeException
      *
      * @return $this
      */
     public function validateDuration(): static
     {
         if ($this->end->getTimestamp() <= $this->start->getTimestamp()) {
-            throw new Exception('Duration must be greater than 0!');
+            throw new InvalidEntryTimeException('Duration must be greater than 0!');
         }
 
         return $this;

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -542,9 +542,7 @@ class Entry extends Base
      */
     public function addClass(EntryClass $entryClass): static
     {
-        $this->class = $entryClass;
-
-        return $this;
+        return $this->setClass($entryClass);
     }
 
     /**

--- a/src/EventSubscriber/AccessDeniedSubscriber.php
+++ b/src/EventSubscriber/AccessDeniedSubscriber.php
@@ -22,6 +22,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 final readonly class AccessDeniedSubscriber implements EventSubscriberInterface
 {
+    private const string MIME_TYPE_JSON = 'application/json';
+
     public function __construct(
         private Security $security,
         private RouterInterface $router,
@@ -85,14 +87,14 @@ final readonly class AccessDeniedSubscriber implements EventSubscriberInterface
         $pathInfo = $request->getPathInfo();
 
         // If explicitly requesting HTML, let Symfony render error403.html.twig
-        $prefersHtml = str_contains($acceptHeader, 'text/html') && !str_contains($acceptHeader, 'application/json');
+        $prefersHtml = str_contains($acceptHeader, 'text/html') && !str_contains($acceptHeader, self::MIME_TYPE_JSON);
         if ($prefersHtml) {
             return;
         }
 
         // Check if request expects JSON response (headers or API-like paths)
-        $isJsonRequest = str_contains($acceptHeader, 'application/json')
-            || str_contains($contentType, 'application/json')
+        $isJsonRequest = str_contains($acceptHeader, self::MIME_TYPE_JSON)
+            || str_contains($contentType, self::MIME_TYPE_JSON)
             || 'XMLHttpRequest' === $request->headers->get('X-Requested-With')
             || str_starts_with($pathInfo, '/get')
             || str_starts_with($pathInfo, '/getAll')

--- a/src/EventSubscriber/ExceptionSubscriber.php
+++ b/src/EventSubscriber/ExceptionSubscriber.php
@@ -26,6 +26,8 @@ use Throwable;
  */
 class ExceptionSubscriber implements EventSubscriberInterface
 {
+    private const string ERROR_INTERNAL_SERVER = 'Internal server error';
+
     public function __construct(
         private readonly LoggerInterface $logger = new NullLogger(),
         private readonly string $environment = 'prod',
@@ -113,7 +115,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
         // Handle generic exceptions (only show details in dev mode)
         if ('dev' === $this->environment) {
             return new JsonResponse([
-                'error' => 'Internal server error',
+                'error' => self::ERROR_INTERNAL_SERVER,
                 'message' => $throwable->getMessage(),
                 'exception' => $throwable::class,
                 'file' => $throwable->getFile(),
@@ -124,7 +126,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
 
         // Production mode - hide internal details
         return new JsonResponse([
-            'error' => 'Internal server error',
+            'error' => self::ERROR_INTERNAL_SERVER,
             'message' => 'An unexpected error occurred. Please try again later.',
         ], Response::HTTP_INTERNAL_SERVER_ERROR);
     }
@@ -141,7 +143,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
             409 => 'Conflict',
             422 => 'Unprocessable entity',
             429 => 'Too many requests',
-            500 => 'Internal server error',
+            500 => self::ERROR_INTERNAL_SERVER,
             502 => 'Bad gateway',
             503 => 'Service unavailable',
             default => 'Error',

--- a/src/Exception/EntityAlreadyDeletedException.php
+++ b/src/Exception/EntityAlreadyDeletedException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when a delete action targets an entity that no longer exists.
+ */
+final class EntityAlreadyDeletedException extends RuntimeException
+{
+}

--- a/src/Exception/IncompletePresetException.php
+++ b/src/Exception/IncompletePresetException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+/**
+ * Thrown when a preset is saved without the required customer, project and activity relations.
+ */
+final class IncompletePresetException extends Exception
+{
+}

--- a/src/Exception/InvalidDateFormatException.php
+++ b/src/Exception/InvalidDateFormatException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+/**
+ * Thrown when a date string cannot be parsed in the expected format.
+ */
+final class InvalidDateFormatException extends Exception
+{
+}

--- a/src/Exception/InvalidEntryTimeException.php
+++ b/src/Exception/InvalidEntryTimeException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+/**
+ * Thrown when a time tracking entry has invalid start, end or duration values.
+ */
+final class InvalidEntryTimeException extends Exception
+{
+}

--- a/src/Exception/InvalidPaginationException.php
+++ b/src/Exception/InvalidPaginationException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+/**
+ * Thrown when pagination parameters are out of range.
+ */
+final class InvalidPaginationException extends Exception
+{
+}

--- a/src/Exception/Ldap/LdapAuthenticationException.php
+++ b/src/Exception/Ldap/LdapAuthenticationException.php
@@ -9,11 +9,16 @@ declare(strict_types=1);
 
 namespace App\Exception\Ldap;
 
-use Exception;
+use RuntimeException;
 
 /**
  * Thrown when LDAP authentication fails or the LDAP response cannot be processed.
+ *
+ * Extends RuntimeException so the one pre-refactoring throw site that used
+ * RuntimeException (LdapClientService::login()) keeps its catch contract;
+ * sites that previously threw plain Exception remain catchable as Exception
+ * since RuntimeException extends it.
  */
-final class LdapAuthenticationException extends Exception
+final class LdapAuthenticationException extends RuntimeException
 {
 }

--- a/src/Exception/Ldap/LdapAuthenticationException.php
+++ b/src/Exception/Ldap/LdapAuthenticationException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception\Ldap;
+
+use Exception;
+
+/**
+ * Thrown when LDAP authentication fails or the LDAP response cannot be processed.
+ */
+final class LdapAuthenticationException extends Exception
+{
+}

--- a/src/Exception/Ldap/LdapConnectionException.php
+++ b/src/Exception/Ldap/LdapConnectionException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception\Ldap;
+
+use Exception;
+
+/**
+ * Thrown when a connection to the LDAP server cannot be established.
+ */
+final class LdapConnectionException extends Exception
+{
+}

--- a/src/Exception/MissingSearchCriteriaException.php
+++ b/src/Exception/MissingSearchCriteriaException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+/**
+ * Thrown when an interpretation query is missing the minimum required filter criteria.
+ */
+final class MissingSearchCriteriaException extends Exception
+{
+}

--- a/src/Exception/PresetNotFoundException.php
+++ b/src/Exception/PresetNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+/**
+ * Thrown when a referenced preset does not exist.
+ */
+final class PresetNotFoundException extends Exception
+{
+}

--- a/src/Exception/SubticketSyncException.php
+++ b/src/Exception/SubticketSyncException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+/**
+ * Thrown when project subtickets cannot be synchronized from the ticket system.
+ *
+ * Exception codes are sensible HTTP status codes.
+ */
+final class SubticketSyncException extends Exception
+{
+}

--- a/src/Exception/TokenEncryptionException.php
+++ b/src/Exception/TokenEncryptionException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when token encryption or decryption fails.
+ */
+final class TokenEncryptionException extends RuntimeException
+{
+}

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -42,6 +42,22 @@ use function sprintf;
  */
 class EntryRepository extends ServiceEntityRepository
 {
+    private const string WHERE_USER = 'e.user = :user';
+
+    private const string WHERE_DAY = 'e.day = :day';
+
+    private const string WHERE_ACTIVITY = 'e.activity = :activity';
+
+    private const string WHERE_PROJECT = 'e.project = :project';
+
+    private const string WHERE_CUSTOMER = 'e.customer = :customer';
+
+    private const string WHERE_DAY_UNTIL_END_OF_MONTH = 'e.day <= :endOfMonth';
+
+    private const string WHERE_FIELD_TEMPLATE = 'e.%s = :%s';
+
+    private const string FIELD_PLACEHOLDER = '{field}';
+
     public function __construct(
         ManagerRegistry $registry,
         private readonly TimeCalculationService $timeCalculationService,
@@ -68,8 +84,8 @@ class EntryRepository extends ServiceEntityRepository
     public function getEntriesForDay(User $user, string $day): array
     {
         $result = $this->createQueryBuilder('e')
-            ->where('e.user = :user')
-            ->andWhere('e.day = :day')
+            ->where(self::WHERE_USER)
+            ->andWhere(self::WHERE_DAY)
             ->setParameter('user', $user)
             ->setParameter('day', $day)
             ->getQuery()
@@ -89,7 +105,7 @@ class EntryRepository extends ServiceEntityRepository
     public function getEntriesForMonth(User $user, string $startDate, string $endDate): array
     {
         $result = $this->createQueryBuilder('e')
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->andWhere('e.day >= :startDate')
             ->andWhere('e.day <= :endDate')
             ->setParameter('user', $user)
@@ -113,7 +129,7 @@ class EntryRepository extends ServiceEntityRepository
     {
         return (int) $this->createQueryBuilder('e')
             ->select('COUNT(e.id)')
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->setParameter('user', $user)
             ->getQuery()
             ->getSingleScalarResult();
@@ -126,7 +142,7 @@ class EntryRepository extends ServiceEntityRepository
     {
         $this->createQueryBuilder('e')
             ->delete()
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->setParameter('user', $user)
             ->getQuery()
             ->execute();
@@ -139,7 +155,7 @@ class EntryRepository extends ServiceEntityRepository
     {
         $this->createQueryBuilder('e')
             ->delete()
-            ->where('e.activity = :activity')
+            ->where(self::WHERE_ACTIVITY)
             ->setParameter('activity', $activity)
             ->getQuery()
             ->execute();
@@ -152,7 +168,7 @@ class EntryRepository extends ServiceEntityRepository
     {
         $this->createQueryBuilder('e')
             ->delete()
-            ->where('e.project = :project')
+            ->where(self::WHERE_PROJECT)
             ->setParameter('project', $project)
             ->getQuery()
             ->execute();
@@ -165,7 +181,7 @@ class EntryRepository extends ServiceEntityRepository
     {
         $this->createQueryBuilder('e')
             ->delete()
-            ->where('e.customer = :customer')
+            ->where(self::WHERE_CUSTOMER)
             ->setParameter('customer', $customer)
             ->getQuery()
             ->execute();
@@ -185,7 +201,7 @@ class EntryRepository extends ServiceEntityRepository
             ->leftJoin('e.activity', 'a');
 
         foreach ($conditions as $field => $value) {
-            $queryBuilder->andWhere(sprintf('e.%s = :%s', $field, $field))
+            $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
                 ->setParameter($field, $value);
         }
 
@@ -228,7 +244,7 @@ class EntryRepository extends ServiceEntityRepository
             ->select('SUM(e.duration)');
 
         foreach ($conditions as $field => $value) {
-            $queryBuilder->andWhere(sprintf('e.%s = :%s', $field, $field))
+            $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
                 ->setParameter($field, $value);
         }
 
@@ -246,7 +262,7 @@ class EntryRepository extends ServiceEntityRepository
             ->select('1');
 
         foreach ($conditions as $field => $value) {
-            $queryBuilder->andWhere(sprintf('e.%s = :%s', $field, $field))
+            $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
                 ->setParameter($field, $value);
         }
 
@@ -368,8 +384,8 @@ class EntryRepository extends ServiceEntityRepository
 
         // Get database-agnostic date/time formatting functions
         $formats = $this->getDateTimeFormats();
-        $startTimeFormat = str_replace('{field}', 'start', $formats['timeFormat']);
-        $endTimeFormat = str_replace('{field}', 'end', $formats['timeFormat']);
+        $startTimeFormat = str_replace(self::FIELD_PLACEHOLDER, 'start', $formats['timeFormat']);
+        $endTimeFormat = str_replace(self::FIELD_PLACEHOLDER, 'end', $formats['timeFormat']);
 
         $sql = [];
         $sql['select'] = "SELECT e.id,
@@ -452,7 +468,7 @@ class EntryRepository extends ServiceEntityRepository
                     $queryBuilder->andWhere(sprintf('e.%s %s :%s', $fieldName, $operator, $field))
                         ->setParameter($field, $value);
                 } else {
-                    $queryBuilder->andWhere(sprintf('e.%s = :%s', $field, $field))
+                    $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
                         ->setParameter($field, $value);
                 }
             }
@@ -512,7 +528,7 @@ class EntryRepository extends ServiceEntityRepository
                     $queryBuilder->andWhere(sprintf('e.%s %s :%s', $fieldName, $operator, $field))
                         ->setParameter($field, $value);
                 } else {
-                    $queryBuilder->andWhere(sprintf('e.%s = :%s', $field, $field))
+                    $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
                         ->setParameter($field, $value);
                 }
             }
@@ -567,7 +583,7 @@ class EntryRepository extends ServiceEntityRepository
             throw new InvalidArgumentException('Invalid period: ' . $period);
         }
 
-        $groupByFunction = str_replace('{field}', 'e.day', $periodFunctions[$period]);
+        $groupByFunction = str_replace(self::FIELD_PLACEHOLDER, 'e.day', $periodFunctions[$period]);
 
         $sql = "SELECT {$groupByFunction} as period_value,
                        SUM(e.duration) as total_duration,
@@ -652,7 +668,7 @@ class EntryRepository extends ServiceEntityRepository
         // Apply filters
         if (isset($arFilter['customer']) && '' !== $arFilter['customer']) {
             if (is_object($arFilter['customer'])) {
-                $queryBuilder->andWhere('e.customer = :customer')
+                $queryBuilder->andWhere(self::WHERE_CUSTOMER)
                     ->setParameter('customer', $arFilter['customer']);
             } else {
                 $queryBuilder->andWhere('IDENTITY(e.customer) = :customer')
@@ -662,7 +678,7 @@ class EntryRepository extends ServiceEntityRepository
 
         if (isset($arFilter['project']) && '' !== $arFilter['project']) {
             if (is_object($arFilter['project'])) {
-                $queryBuilder->andWhere('e.project = :project')
+                $queryBuilder->andWhere(self::WHERE_PROJECT)
                     ->setParameter('project', $arFilter['project']);
             } else {
                 $queryBuilder->andWhere('IDENTITY(e.project) = :project')
@@ -672,7 +688,7 @@ class EntryRepository extends ServiceEntityRepository
 
         if (isset($arFilter['activity']) && '' !== $arFilter['activity']) {
             if (is_object($arFilter['activity'])) {
-                $queryBuilder->andWhere('e.activity = :activity')
+                $queryBuilder->andWhere(self::WHERE_ACTIVITY)
                     ->setParameter('activity', $arFilter['activity']);
             } else {
                 $queryBuilder->andWhere('IDENTITY(e.activity) = :activity')
@@ -682,7 +698,7 @@ class EntryRepository extends ServiceEntityRepository
 
         if (isset($arFilter['user']) && '' !== $arFilter['user']) {
             if (is_object($arFilter['user'])) {
-                $queryBuilder->andWhere('e.user = :user')
+                $queryBuilder->andWhere(self::WHERE_USER)
                     ->setParameter('user', $arFilter['user']);
             } else {
                 $queryBuilder->andWhere('IDENTITY(e.user) = :user')
@@ -732,8 +748,8 @@ class EntryRepository extends ServiceEntityRepository
         ?int $excludeId = null,
     ): array {
         $queryBuilder = $this->createQueryBuilder('e')
-            ->where('e.user = :user')
-            ->andWhere('e.day = :day')
+            ->where(self::WHERE_USER)
+            ->andWhere(self::WHERE_DAY)
             ->andWhere('(
                 (e.start <= :start AND e.end > :start) OR
                 (e.start < :end AND e.end >= :end) OR
@@ -770,7 +786,7 @@ class EntryRepository extends ServiceEntityRepository
             ->leftJoin('e.project', 'p')
             ->leftJoin('e.activity', 'a')
 
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->setParameter('user', $user)
             ->orderBy('e.day', 'ASC')
             ->addOrderBy('e.start', 'ASC');
@@ -821,7 +837,7 @@ class EntryRepository extends ServiceEntityRepository
             ->setParameter('endOfYear', $endOfYear);
 
         if (0 !== $user) {
-            $queryBuilder->andWhere('e.user = :user')
+            $queryBuilder->andWhere(self::WHERE_USER)
                 ->setParameter('user', $user);
         }
 
@@ -831,18 +847,18 @@ class EntryRepository extends ServiceEntityRepository
             $lastDay = (int) (new DateTime(sprintf('%d-%d-01', $year, $month))->format('t'));
             $endOfMonth = sprintf('%04d-%02d-%02d', $year, $month, $lastDay);
             $queryBuilder->andWhere('e.day >= :startOfMonth')
-                ->andWhere('e.day <= :endOfMonth')
+                ->andWhere(self::WHERE_DAY_UNTIL_END_OF_MONTH)
                 ->setParameter('startOfMonth', $startOfMonth)
                 ->setParameter('endOfMonth', $endOfMonth);
         }
 
         if (null !== $project) {
-            $queryBuilder->andWhere('e.project = :project')
+            $queryBuilder->andWhere(self::WHERE_PROJECT)
                 ->setParameter('project', $project);
         }
 
         if (null !== $customer) {
-            $queryBuilder->andWhere('e.customer = :customer')
+            $queryBuilder->andWhere(self::WHERE_CUSTOMER)
                 ->setParameter('customer', $customer);
         }
 
@@ -907,7 +923,7 @@ class EntryRepository extends ServiceEntityRepository
             ->setParameter('endOfYear', $endOfYear);
 
         if (0 !== $user) {
-            $queryBuilder->andWhere('e.user = :user')
+            $queryBuilder->andWhere(self::WHERE_USER)
                 ->setParameter('user', $user);
         }
 
@@ -917,18 +933,18 @@ class EntryRepository extends ServiceEntityRepository
             $lastDay = (int) (new DateTime(sprintf('%d-%d-01', $year, $month))->format('t'));
             $endOfMonth = sprintf('%04d-%02d-%02d', $year, $month, $lastDay);
             $queryBuilder->andWhere('e.day >= :startOfMonth')
-                ->andWhere('e.day <= :endOfMonth')
+                ->andWhere(self::WHERE_DAY_UNTIL_END_OF_MONTH)
                 ->setParameter('startOfMonth', $startOfMonth)
                 ->setParameter('endOfMonth', $endOfMonth);
         }
 
         if (null !== $project) {
-            $queryBuilder->andWhere('e.project = :project')
+            $queryBuilder->andWhere(self::WHERE_PROJECT)
                 ->setParameter('project', $project);
         }
 
         if (null !== $customer) {
-            $queryBuilder->andWhere('e.customer = :customer')
+            $queryBuilder->andWhere(self::WHERE_CUSTOMER)
                 ->setParameter('customer', $customer);
         }
 
@@ -979,7 +995,7 @@ class EntryRepository extends ServiceEntityRepository
     {
         $queryBuilder = $this->createQueryBuilder('e')
             ->select('COUNT(e.id) as count, COALESCE(SUM(e.duration), 0) as duration')
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->setParameter('user', $userId);
 
         $this->applyPeriodFilter($queryBuilder, $period);
@@ -1136,7 +1152,7 @@ class EntryRepository extends ServiceEntityRepository
                 $endOfMonth = $today->format('Y-m-') . $lastDay;
 
                 $queryBuilder->andWhere('e.day >= :startOfMonth')
-                    ->andWhere('e.day <= :endOfMonth')
+                    ->andWhere(self::WHERE_DAY_UNTIL_END_OF_MONTH)
                     ->setParameter('startOfMonth', $startOfMonth)
                     ->setParameter('endOfMonth', $endOfMonth);
                 break;
@@ -1153,7 +1169,7 @@ class EntryRepository extends ServiceEntityRepository
         $fromDate = $this->calculateFromDate($days);
 
         $result = $this->findEntriesWithRelations()
-            ->andWhere('e.user = :user')
+            ->andWhere(self::WHERE_USER)
             ->andWhere('e.day >= :fromDate')
             ->setParameter('user', $user)
             ->setParameter('fromDate', $fromDate->format('Y-m-d'))
@@ -1353,7 +1369,7 @@ class EntryRepository extends ServiceEntityRepository
             ->leftJoin('e.project', 'p')
             ->leftJoin('e.activity', 'a')
             ->where('e.user = :userId')
-            ->andWhere('e.day = :day')
+            ->andWhere(self::WHERE_DAY)
             ->setParameter('userId', $userId)
             ->setParameter('day', $day)
             ->orderBy('e.start', 'ASC')
@@ -1395,23 +1411,23 @@ class EntryRepository extends ServiceEntityRepository
 
         // Apply filters similar to queryByFilterArray but return results directly
         if (isset($arFilter['customer']) && '' !== $arFilter['customer']) {
-            $queryBuilder->andWhere('e.customer = :customer')
+            $queryBuilder->andWhere(self::WHERE_CUSTOMER)
                 ->setParameter('customer', $arFilter['customer']);
         }
 
         if (isset($arFilter['project']) && '' !== $arFilter['project']) {
-            $queryBuilder->andWhere('e.project = :project')
+            $queryBuilder->andWhere(self::WHERE_PROJECT)
                 ->setParameter('project', $arFilter['project']);
         }
 
         if (isset($arFilter['activity']) && '' !== $arFilter['activity']) {
-            $queryBuilder->andWhere('e.activity = :activity')
+            $queryBuilder->andWhere(self::WHERE_ACTIVITY)
                 ->setParameter('activity', $arFilter['activity']);
         }
 
         if (isset($arFilter['user']) && '' !== $arFilter['user']) {
             if (is_object($arFilter['user'])) {
-                $queryBuilder->andWhere('e.user = :user')
+                $queryBuilder->andWhere(self::WHERE_USER)
                     ->setParameter('user', $arFilter['user']);
             } else {
                 $queryBuilder->andWhere('IDENTITY(e.user) = :user')

--- a/src/Repository/OptimizedEntryRepository.php
+++ b/src/Repository/OptimizedEntryRepository.php
@@ -45,6 +45,8 @@ class OptimizedEntryRepository extends ServiceEntityRepository
 
     private const int CACHE_TTL = 300;
 
+    private const string WHERE_USER = 'e.user = :user';
+
     public function __construct(
         ManagerRegistry $managerRegistry,
         private readonly ClockInterface $clock,
@@ -72,7 +74,7 @@ class OptimizedEntryRepository extends ServiceEntityRepository
         $fromDate = $this->calculateFromDate($days);
 
         $queryBuilder = $this->createOptimizedQueryBuilder('e')
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->andWhere('e.day >= :fromDate')
             ->setParameter('user', $user)
             ->setParameter('fromDate', $fromDate)
@@ -104,7 +106,7 @@ class OptimizedEntryRepository extends ServiceEntityRepository
         ?array $arSort = null,
     ): array {
         $queryBuilder = $this->createOptimizedQueryBuilder('e')
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->andWhere($this->generateYearExpression('e.day') . ' = :year')
             ->setParameter('user', $userId)
             ->setParameter('year', $year);
@@ -232,7 +234,7 @@ class OptimizedEntryRepository extends ServiceEntityRepository
 
         $queryBuilder = $this->createQueryBuilder('e')
             ->select('COUNT(e.id) as count, SUM(e.duration) as duration')
-            ->where('e.user = :user')
+            ->where(self::WHERE_USER)
             ->setParameter('user', $userId);
 
         $this->applyPeriodFilter($queryBuilder, $period);
@@ -279,7 +281,7 @@ class OptimizedEntryRepository extends ServiceEntityRepository
 
         // Apply filters with index-aware ordering
         if (isset($filter['user_id'])) {
-            $queryBuilder->andWhere('e.user = :user')
+            $queryBuilder->andWhere(self::WHERE_USER)
                 ->setParameter('user', $filter['user_id']);
         }
 

--- a/src/Service/Entry/EntryQueryService.php
+++ b/src/Service/Entry/EntryQueryService.php
@@ -11,11 +11,11 @@ namespace App\Service\Entry;
 
 use App\Dto\InterpretationFiltersDto;
 use App\Entity\Entry;
+use App\Exception\InvalidPaginationException;
 use App\Repository\EntryRepository;
 use App\ValueObject\PaginatedEntryCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
-use Exception;
 
 use function is_string;
 
@@ -32,7 +32,7 @@ final readonly class EntryQueryService
     /**
      * Find paginated entries based on filters.
      *
-     * @throws Exception When query building fails
+     * @throws InvalidPaginationException When the page parameter is negative
      */
     public function findPaginatedEntries(InterpretationFiltersDto $interpretationFiltersDto): PaginatedEntryCollection
     {
@@ -75,7 +75,7 @@ final readonly class EntryQueryService
 
         // Validate and sanitize inputs
         if ($page < 0) {
-            throw new Exception('page can not be negative.');
+            throw new InvalidPaginationException('page can not be negative.');
         }
 
         $maxResults = $maxResults > 0 ? $maxResults : 50;

--- a/src/Service/Integration/Jira/JiraOAuthApiService.php
+++ b/src/Service/Integration/Jira/JiraOAuthApiService.php
@@ -339,7 +339,7 @@ class JiraOAuthApiService
         $workLogId = $entry->getWorklogId();
         if (null !== $workLogId) {
             $response = $this->put(
-                sprintf('issue/%s/worklog/%d', $sTicket, $workLogId),
+                sprintf(JiraWorkLogService::WORKLOG_ITEM_URL_TEMPLATE, $sTicket, $workLogId),
                 $arData,
             );
         } else {
@@ -389,7 +389,7 @@ class JiraOAuthApiService
         try {
             $workLogId = $entry->getWorklogId() ?? 0;
             $this->delete(sprintf(
-                'issue/%s/worklog/%d',
+                JiraWorkLogService::WORKLOG_ITEM_URL_TEMPLATE,
                 $sTicket,
                 $workLogId,
             ));
@@ -508,7 +508,7 @@ class JiraOAuthApiService
      */
     protected function doesWorkLogExist(string $sTicket, int $workLogId): bool
     {
-        return $this->doesResourceExist(sprintf('issue/%s/worklog/%d', $sTicket, $workLogId));
+        return $this->doesResourceExist(sprintf(JiraWorkLogService::WORKLOG_ITEM_URL_TEMPLATE, $sTicket, $workLogId));
     }
 
     /**

--- a/src/Service/Integration/Jira/JiraTicketService.php
+++ b/src/Service/Integration/Jira/JiraTicketService.php
@@ -28,6 +28,13 @@ use function sprintf;
  */
 class JiraTicketService
 {
+    /**
+     * Jira REST resource path for a single issue.
+     */
+    private const string ISSUE_URL_TEMPLATE = 'issue/%s';
+
+    private const string ERROR_EMPTY_TICKET_KEY = 'Ticket key cannot be empty';
+
     public function __construct(
         private readonly JiraHttpClientService $jiraHttpClientService,
     ) {
@@ -126,7 +133,7 @@ class JiraTicketService
         }
 
         try {
-            $this->jiraHttpClientService->get(sprintf('issue/%s', $ticketKey));
+            $this->jiraHttpClientService->get(sprintf(self::ISSUE_URL_TEMPLATE, $ticketKey));
 
             return true;
         } catch (JiraApiException) {
@@ -148,7 +155,7 @@ class JiraTicketService
         }
 
         try {
-            $response = $this->jiraHttpClientService->get(sprintf('issue/%s', $ticketKey));
+            $response = $this->jiraHttpClientService->get(sprintf(self::ISSUE_URL_TEMPLATE, $ticketKey));
 
             if (!is_object($response)) {
                 return [];
@@ -191,10 +198,10 @@ class JiraTicketService
     public function getTicket(string $ticketKey, array $fields = []): stdClass
     {
         if ('' === $ticketKey) {
-            throw new JiraApiException('Ticket key cannot be empty', 400);
+            throw new JiraApiException(self::ERROR_EMPTY_TICKET_KEY, 400);
         }
 
-        $url = sprintf('issue/%s', $ticketKey);
+        $url = sprintf(self::ISSUE_URL_TEMPLATE, $ticketKey);
 
         if ([] !== $fields) {
             $url .= '?fields=' . implode(',', $fields);
@@ -202,7 +209,7 @@ class JiraTicketService
 
         return $this->ensureObjectResponse(
             $this->jiraHttpClientService->get($url),
-            sprintf('issue/%s', $ticketKey),
+            sprintf(self::ISSUE_URL_TEMPLATE, $ticketKey),
         );
     }
 
@@ -220,11 +227,11 @@ class JiraTicketService
     public function updateTicket(string $ticketKey, array $updateData): stdClass
     {
         if ('' === $ticketKey) {
-            throw new JiraApiException('Ticket key cannot be empty', 400);
+            throw new JiraApiException(self::ERROR_EMPTY_TICKET_KEY, 400);
         }
 
         return $this->ensureObjectResponse(
-            $this->jiraHttpClientService->put(sprintf('issue/%s', $ticketKey), $updateData),
+            $this->jiraHttpClientService->put(sprintf(self::ISSUE_URL_TEMPLATE, $ticketKey), $updateData),
             sprintf('issue/%s update', $ticketKey),
         );
     }
@@ -241,7 +248,7 @@ class JiraTicketService
     public function addComment(string $ticketKey, string $comment): stdClass
     {
         if ('' === $ticketKey) {
-            throw new JiraApiException('Ticket key cannot be empty', 400);
+            throw new JiraApiException(self::ERROR_EMPTY_TICKET_KEY, 400);
         }
 
         if ('' === $comment) {
@@ -316,7 +323,7 @@ class JiraTicketService
     public function transitionTicket(string $ticketKey, string $transitionId, array $fields = []): void
     {
         if ('' === $ticketKey) {
-            throw new JiraApiException('Ticket key cannot be empty', 400);
+            throw new JiraApiException(self::ERROR_EMPTY_TICKET_KEY, 400);
         }
 
         if ('' === $transitionId) {

--- a/src/Service/Integration/Jira/JiraWorkLogService.php
+++ b/src/Service/Integration/Jira/JiraWorkLogService.php
@@ -33,6 +33,11 @@ use function sprintf;
  */
 class JiraWorkLogService
 {
+    /**
+     * Jira REST resource path for a single work log of an issue.
+     */
+    public const string WORKLOG_ITEM_URL_TEMPLATE = 'issue/%s/worklog/%d';
+
     public function __construct(
         private readonly ManagerRegistry $managerRegistry,
         private readonly JiraHttpClientService $jiraHttpClientService,
@@ -203,7 +208,7 @@ class JiraWorkLogService
         }
 
         try {
-            $this->jiraHttpClientService->delete(sprintf('issue/%s/worklog/%d', $ticket, $workLogId));
+            $this->jiraHttpClientService->delete(sprintf(self::WORKLOG_ITEM_URL_TEMPLATE, $ticket, $workLogId));
             $entry->setWorklogId(null);
             $entry->setSyncedToTicketsystem(false);
         } catch (JiraApiInvalidResourceException) {
@@ -219,7 +224,7 @@ class JiraWorkLogService
     private function doesWorkLogExist(string $ticket, int $workLogId): bool
     {
         return $this->jiraHttpClientService->doesResourceExist(
-            sprintf('issue/%s/worklog/%d', $ticket, $workLogId),
+            sprintf(self::WORKLOG_ITEM_URL_TEMPLATE, $ticket, $workLogId),
         );
     }
 
@@ -253,7 +258,7 @@ class JiraWorkLogService
     private function updateWorkLog(string $ticket, int $workLogId, JiraWorkLogPayloadDto $payload): object
     {
         $response = $this->jiraHttpClientService->put(
-            sprintf('issue/%s/worklog/%d', $ticket, $workLogId),
+            sprintf(self::WORKLOG_ITEM_URL_TEMPLATE, $ticket, $workLogId),
             $payload->toArray(),
         );
 

--- a/src/Service/Ldap/LdapClientService.php
+++ b/src/Service/Ldap/LdapClientService.php
@@ -414,6 +414,8 @@ class LdapClientService
     /**
      * Authenticate username and password at the LDAP server.
      *
+     * @throws LdapAuthenticationException
+     * @throws LdapConnectionException
      * @throws LdapException
      */
     public function login(): true

--- a/src/Service/Ldap/LdapClientService.php
+++ b/src/Service/Ldap/LdapClientService.php
@@ -9,13 +9,14 @@ declare(strict_types=1);
 
 namespace App\Service\Ldap;
 
+use App\Exception\Ldap\LdapAuthenticationException;
+use App\Exception\Ldap\LdapConnectionException;
 use BackedEnum;
 use Exception;
 use Laminas\Ldap\Exception\LdapException;
 use Laminas\Ldap\Ldap;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use RuntimeException;
 use SensitiveParameter;
 use Symfony\Component\Yaml\Yaml;
 use UnitEnum;
@@ -88,7 +89,8 @@ class LdapClientService
     /**
      * Verify username by searching for it in LDAP.
      *
-     * @throws Exception
+     * @throws LdapAuthenticationException
+     * @throws LdapConnectionException
      * @throws LdapException
      *
      * @return array<string, array<int, string>>
@@ -97,7 +99,7 @@ class LdapClientService
     {
         // Security check: ensure username is properly set
         if ('' === $this->userName) {
-            throw new Exception('LDAP username must be set via setUserName() before authentication');
+            throw new LdapAuthenticationException('LDAP username must be set via setUserName() before authentication');
         }
 
         $ldapOptions = $this->getLdapOptions();
@@ -127,7 +129,7 @@ class LdapClientService
                 'baseDn' => $this->baseDn,
             ]);
 
-            throw new Exception('No connection to LDAP: ' . $this->getLdapOptions()['host'] . ': ' . $ldapException->getMessage() . '', $ldapException->getCode(), $ldapException);
+            throw new LdapConnectionException('No connection to LDAP: ' . $this->getLdapOptions()['host'] . ': ' . $ldapException->getMessage() . '', $ldapException->getCode(), $ldapException);
         }
 
         $searchFilter = '(' . $this->userNameField . '=' . ldap_escape($this->userName) . ')';
@@ -150,7 +152,7 @@ class LdapClientService
                 'baseDn' => $this->baseDn,
             ]);
 
-            throw new Exception('Username unknown.');
+            throw new LdapAuthenticationException('Username unknown.');
         }
 
         if ($collection->count() > 1) {
@@ -183,7 +185,7 @@ class LdapClientService
      *
      * @param array<string, array<int, string>> $ldapEntry
      *
-     * @throws Exception
+     * @throws LdapAuthenticationException
      *
      * @return true
      */
@@ -191,7 +193,7 @@ class LdapClientService
     {
         // Security check: ensure password is properly set
         if ('' === $this->userPass) {
-            throw new Exception('LDAP password must be set via setUserPass() before authentication');
+            throw new LdapAuthenticationException('LDAP password must be set via setUserPass() before authentication');
         }
 
         // Try multiple ways to extract the DN from LDAP response
@@ -218,7 +220,7 @@ class LdapClientService
                 'entry' => array_map(static fn (array $val): string => implode(', ', $val), $ldapEntry),
             ]);
 
-            throw new Exception('Could not determine user DN for authentication.');
+            throw new LdapAuthenticationException('Could not determine user DN for authentication.');
         }
 
         $ldapOptions = $this->getLdapOptions();
@@ -247,7 +249,7 @@ class LdapClientService
                 'bindDn' => $userDn,
             ]);
 
-            throw new Exception('Login data could not be validated: ' . $ldapException->getMessage(), $ldapException->getCode(), $ldapException);
+            throw new LdapAuthenticationException('Login data could not be validated: ' . $ldapException->getMessage(), $ldapException->getCode(), $ldapException);
         }
 
         return true;
@@ -256,7 +258,7 @@ class LdapClientService
     public function setUserName(string $username): static
     {
         if ('' === $username || '0' === $username) {
-            throw new Exception(sprintf("Invalid user name: '%s'", $username));
+            throw new LdapAuthenticationException(sprintf("Invalid user name: '%s'", $username));
         }
 
         $this->userName = str_replace(
@@ -421,7 +423,7 @@ class LdapClientService
         );
         // verifyPassword returns bool true; enforce literal true for signature
         if (!$result) {
-            throw new RuntimeException('LDAP verification did not return true');
+            throw new LdapAuthenticationException('LDAP verification did not return true');
         }
 
         return true;
@@ -492,14 +494,14 @@ class LdapClientService
      *
      * @param mixed $rawEntry Raw entry from Collection::getFirst()
      *
-     * @throws Exception When entry is null or invalid
+     * @throws LdapAuthenticationException When entry is null or invalid
      *
      * @return array<string, array<int, string>>
      */
     private function normalizeFirstEntry(mixed $rawEntry): array
     {
         if (null === $rawEntry || !is_array($rawEntry)) {
-            throw new Exception('LDAP entry is null or not an array');
+            throw new LdapAuthenticationException('LDAP entry is null or not an array');
         }
 
         // The actual runtime type is richer than stubs declare.

--- a/src/Service/Ldap/LdapClientService.php
+++ b/src/Service/Ldap/LdapClientService.php
@@ -129,7 +129,7 @@ class LdapClientService
                 'baseDn' => $this->baseDn,
             ]);
 
-            throw new LdapConnectionException('No connection to LDAP: ' . $this->getLdapOptions()['host'] . ': ' . $ldapException->getMessage() . '', $ldapException->getCode(), $ldapException);
+            throw new LdapConnectionException('No connection to LDAP: ' . $ldapOptions['host'] . ': ' . $ldapException->getMessage(), $ldapException->getCode(), $ldapException);
         }
 
         $searchFilter = '(' . $this->userNameField . '=' . ldap_escape($this->userName) . ')';

--- a/src/Service/Security/TokenEncryptionService.php
+++ b/src/Service/Security/TokenEncryptionService.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace App\Service\Security;
 
-use RuntimeException;
+use App\Exception\TokenEncryptionException;
 use SensitiveParameter;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
@@ -37,7 +37,7 @@ class TokenEncryptionService
 
         // Ensure we have a valid key
         if (!is_string($key) || '' === $key) {
-            throw new RuntimeException('Encryption key not configured. Set APP_ENCRYPTION_KEY in environment.');
+            throw new TokenEncryptionException('Encryption key not configured. Set APP_ENCRYPTION_KEY in environment.');
         }
 
         // Derive a proper encryption key from the secret
@@ -50,7 +50,7 @@ class TokenEncryptionService
      *
      * @param string $token The plain text token to encrypt
      *
-     * @throws RuntimeException If encryption fails
+     * @throws TokenEncryptionException If encryption fails
      *
      * @return string Base64 encoded encrypted token with IV and auth tag
      */
@@ -63,7 +63,7 @@ class TokenEncryptionService
         // Generate a random IV for each encryption
         $ivLength = openssl_cipher_iv_length(self::CIPHER_METHOD);
         if (false === $ivLength) {
-            throw new RuntimeException('Failed to get IV length for cipher method');
+            throw new TokenEncryptionException('Failed to get IV length for cipher method');
         }
 
         $iv = openssl_random_pseudo_bytes($ivLength);
@@ -81,7 +81,7 @@ class TokenEncryptionService
         );
 
         if (false === $encrypted) {
-            throw new RuntimeException('Token encryption failed');
+            throw new TokenEncryptionException('Token encryption failed');
         }
 
         // Combine IV, tag and encrypted data
@@ -96,7 +96,7 @@ class TokenEncryptionService
      *
      * @param string $encryptedToken Base64 encoded encrypted token
      *
-     * @throws RuntimeException If decryption fails
+     * @throws TokenEncryptionException If decryption fails
      *
      * @return string The decrypted plain text token
      */
@@ -109,17 +109,17 @@ class TokenEncryptionService
         // Decode from base64
         $combined = base64_decode($encryptedToken, true);
         if (false === $combined) {
-            throw new RuntimeException('Invalid encrypted token format');
+            throw new TokenEncryptionException('Invalid encrypted token format');
         }
 
         $ivLength = openssl_cipher_iv_length(self::CIPHER_METHOD);
         if (false === $ivLength) {
-            throw new RuntimeException('Failed to get IV length for cipher method');
+            throw new TokenEncryptionException('Failed to get IV length for cipher method');
         }
 
         // Extract IV, tag and encrypted data
         if (strlen($combined) < $ivLength + self::TAG_LENGTH) {
-            throw new RuntimeException('Encrypted token too short');
+            throw new TokenEncryptionException('Encrypted token too short');
         }
 
         $iv = substr($combined, 0, $ivLength);
@@ -137,7 +137,7 @@ class TokenEncryptionService
         );
 
         if (false === $decrypted) {
-            throw new RuntimeException('Token decryption failed - token may be corrupted or tampered');
+            throw new TokenEncryptionException('Token decryption failed - token may be corrupted or tampered');
         }
 
         return $decrypted;
@@ -149,7 +149,7 @@ class TokenEncryptionService
      *
      * @param string $encryptedToken The current encrypted token
      *
-     * @throws RuntimeException If token decryption or re-encryption fails
+     * @throws TokenEncryptionException If token decryption or re-encryption fails
      *
      * @return string The newly encrypted token with fresh IV
      */

--- a/src/Service/Security/TokenEncryptionService.php
+++ b/src/Service/Security/TokenEncryptionService.php
@@ -32,8 +32,11 @@ class TokenEncryptionService
 
     public function __construct(ParameterBagInterface $parameterBag)
     {
-        // Get encryption key from environment or generate if not set
-        $key = $parameterBag->get('app.encryption_key') ?? $parameterBag->get('APP_SECRET');
+        // Resolves APP_ENCRYPTION_KEY with APP_SECRET fallback via the
+        // app.encryption_key parameter (env default processor in services.yaml);
+        // a plain get('APP_SECRET') fallback here would throw
+        // ParameterNotFoundException instead of falling back.
+        $key = $parameterBag->get('app.encryption_key');
 
         // Ensure we have a valid key
         if (!is_string($key) || '' === $key) {

--- a/src/Service/SubticketSyncService.php
+++ b/src/Service/SubticketSyncService.php
@@ -28,8 +28,9 @@ class SubticketSyncService
      *
      * The project lead user's Jira tokens are used for access.
      *
-     * @throws SubticketSyncException When the project or its ticket system setup is incomplete.
-     *                                Exception codes are sensible HTTP status codes
+     * @throws SubticketSyncException When the project does not exist or its ticket system
+     *                                setup is incomplete (no ticket system, no lead user,
+     *                                no token). Exception codes are sensible HTTP status codes
      * @throws JiraApiException       When fetching subtickets from Jira fails
      *
      * @return list<string> Array of subticket keys

--- a/src/Service/SubticketSyncService.php
+++ b/src/Service/SubticketSyncService.php
@@ -12,9 +12,10 @@ namespace App\Service;
 use App\Entity\Project;
 use App\Entity\TicketSystem;
 use App\Entity\User;
+use App\Exception\Integration\Jira\JiraApiException;
+use App\Exception\SubticketSyncException;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use Doctrine\Persistence\ManagerRegistry;
-use Exception;
 
 class SubticketSyncService
 {
@@ -27,8 +28,9 @@ class SubticketSyncService
      *
      * The project lead user's Jira tokens are used for access.
      *
-     * @throws Exception When something goes wrong.
-     *                   Exception codes are sensible HTTP status codes
+     * @throws SubticketSyncException When the project or its ticket system setup is incomplete.
+     *                                Exception codes are sensible HTTP status codes
+     * @throws JiraApiException       When fetching subtickets from Jira fails
      *
      * @return list<string> Array of subticket keys
      */
@@ -43,12 +45,12 @@ class SubticketSyncService
         }
 
         if (!$project instanceof Project) {
-            throw new Exception('Project does not exist', 404);
+            throw new SubticketSyncException('Project does not exist', 404);
         }
 
         $ticketSystem = $project->getTicketSystem();
         if (!$ticketSystem instanceof TicketSystem) {
-            throw new Exception('No ticket system configured for project', 400);
+            throw new SubticketSyncException('No ticket system configured for project', 400);
         }
 
         $mainTickets = $project->getJiraTicket();
@@ -66,12 +68,12 @@ class SubticketSyncService
 
         $userWithJiraAccess = $project->getProjectLead();
         if (!$userWithJiraAccess instanceof User) {
-            throw new Exception('Project has no lead user: ' . $project->getName(), 400);
+            throw new SubticketSyncException('Project has no lead user: ' . $project->getName(), 400);
         }
 
         $token = $userWithJiraAccess->getTicketSystemAccessToken($ticketSystem);
         if (null === $token || '' === $token) {
-            throw new Exception('Project user has no token for ticket system: ' . $userWithJiraAccess->getUsername() . '@' . $project->getName(), 400);
+            throw new SubticketSyncException('Project user has no token for ticket system: ' . $userWithJiraAccess->getUsername() . '@' . $project->getName(), 400);
         }
 
         // Create the Jira API service with our service's dependencies

--- a/tests/Controller/BaseControllerDeprecationTest.php
+++ b/tests/Controller/BaseControllerDeprecationTest.php
@@ -107,51 +107,64 @@ final class BaseControllerDeprecationTest extends TestCase
         self::assertStringContainsString('::isDEV is deprecated', $this->deprecations[0]);
     }
 
-    private function createController(): object
+    private function createController(): DeprecatedShimBaseController
     {
         $user = new User();
         $user->setUsername('unittest');
         $user->setType('PL');
 
-        return new class($user) extends BaseController {
-            public function __construct(private readonly User $user)
-            {
-            }
+        return new DeprecatedShimBaseController($user);
+    }
+}
 
-            public function callIsLoggedIn(Request $request): bool
-            {
-                return $this->isLoggedIn($request);
-            }
+/**
+ * Test double exposing the deprecated protected shims with a fixed user.
+ *
+ * @internal
+ */
+final class DeprecatedShimBaseController extends BaseController
+{
+    public function __construct(private readonly User $user)
+    {
+    }
 
-            public function callCheckLogin(Request $request): bool
-            {
-                return $this->checkLogin($request);
-            }
+    public function callIsLoggedIn(Request $request): bool
+    {
+        // @phpstan-ignore method.deprecated (the shim under test is deprecated by design)
+        return $this->isLoggedIn($request);
+    }
 
-            public function callHasUserType(Request $request, UserType $userType): bool
-            {
-                return $this->hasUserType($request, $userType);
-            }
+    public function callCheckLogin(Request $request): bool
+    {
+        // @phpstan-ignore method.deprecated (the shim under test is deprecated by design)
+        return $this->checkLogin($request);
+    }
 
-            public function callIsPl(Request $request): bool
-            {
-                return $this->isPl($request);
-            }
+    public function callHasUserType(Request $request, UserType $userType): bool
+    {
+        // @phpstan-ignore method.deprecated (the shim under test is deprecated by design)
+        return $this->hasUserType($request, $userType);
+    }
 
-            public function callIsDEV(Request $request): bool
-            {
-                return $this->isDEV($request);
-            }
+    public function callIsPl(Request $request): bool
+    {
+        // @phpstan-ignore method.deprecated (the shim under test is deprecated by design)
+        return $this->isPl($request);
+    }
 
-            protected function isGranted(mixed $attribute, mixed $subject = null): bool
-            {
-                return true;
-            }
+    public function callIsDEV(Request $request): bool
+    {
+        // @phpstan-ignore method.deprecated (the shim under test is deprecated by design)
+        return $this->isDEV($request);
+    }
 
-            protected function getUser(): ?UserInterface
-            {
-                return $this->user;
-            }
-        };
+    protected function isGranted(mixed $attribute, mixed $subject = null): bool
+    {
+        return true;
+    }
+
+    protected function getUser(): UserInterface
+    {
+        return $this->user;
     }
 }

--- a/tests/Controller/BaseControllerDeprecationTest.php
+++ b/tests/Controller/BaseControllerDeprecationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\BaseController;
+use App\Entity\User;
+use App\Enum\UserType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Unit tests for the deprecated BaseController helper shims.
+ *
+ * Verifies that each shim still delegates correctly and announces its
+ * deprecation (message built by triggerMethodDeprecation()).
+ *
+ * @internal
+ */
+#[CoversClass(BaseController::class)]
+final class BaseControllerDeprecationTest extends TestCase
+{
+    /**
+     * Messages emitted via triggerMethodDeprecation(). The native
+     * #[Deprecated] attribute (PHP >= 8.4) emits its own deprecation per
+     * call, so only "Method ..." messages are collected.
+     *
+     * @var list<string>
+     */
+    private array $deprecations = [];
+
+    protected function setUp(): void
+    {
+        $this->deprecations = [];
+        set_error_handler(
+            function (int $errno, string $errstr): bool {
+                // triggerMethodDeprecation() uses __METHOD__ (no parentheses);
+                // the native attribute formats the name as method() instead.
+                if (str_starts_with($errstr, 'Method ') && !str_contains($errstr, '()')) {
+                    $this->deprecations[] = $errstr;
+                }
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
+    public function testIsLoggedInDelegatesAndDeprecates(): void
+    {
+        $controller = $this->createController();
+
+        self::assertTrue($controller->callIsLoggedIn(new Request()));
+        self::assertCount(1, $this->deprecations);
+        self::assertStringContainsString('::isLoggedIn is deprecated', $this->deprecations[0]);
+        self::assertStringContainsString("use isGranted('IS_AUTHENTICATED_FULLY') directly", $this->deprecations[0]);
+    }
+
+    public function testCheckLoginDelegatesAndDeprecates(): void
+    {
+        $controller = $this->createController();
+
+        self::assertTrue($controller->callCheckLogin(new Request()));
+        self::assertCount(1, $this->deprecations);
+        self::assertStringContainsString('::checkLogin is deprecated', $this->deprecations[0]);
+    }
+
+    public function testHasUserTypeMatchesCurrentUserAndDeprecates(): void
+    {
+        $controller = $this->createController();
+
+        self::assertTrue($controller->callHasUserType(new Request(), UserType::PL));
+        self::assertFalse($controller->callHasUserType(new Request(), UserType::DEV));
+        self::assertCount(2, $this->deprecations);
+        self::assertStringContainsString('::hasUserType is deprecated', $this->deprecations[0]);
+    }
+
+    public function testIsPlDelegatesToHasUserTypeAndDeprecates(): void
+    {
+        $controller = $this->createController();
+
+        self::assertTrue($controller->callIsPl(new Request()));
+        // isPl() delegates to hasUserType(), so both shims announce themselves
+        self::assertCount(2, $this->deprecations);
+        self::assertStringContainsString('::isPl is deprecated', $this->deprecations[0]);
+    }
+
+    public function testIsDevDelegatesToHasUserTypeAndDeprecates(): void
+    {
+        $controller = $this->createController();
+
+        self::assertFalse($controller->callIsDEV(new Request()));
+        self::assertCount(2, $this->deprecations);
+        self::assertStringContainsString('::isDEV is deprecated', $this->deprecations[0]);
+    }
+
+    private function createController(): object
+    {
+        $user = new User();
+        $user->setUsername('unittest');
+        $user->setType('PL');
+
+        return new class($user) extends BaseController {
+            public function __construct(private readonly User $user)
+            {
+            }
+
+            public function callIsLoggedIn(Request $request): bool
+            {
+                return $this->isLoggedIn($request);
+            }
+
+            public function callCheckLogin(Request $request): bool
+            {
+                return $this->checkLogin($request);
+            }
+
+            public function callHasUserType(Request $request, UserType $userType): bool
+            {
+                return $this->hasUserType($request, $userType);
+            }
+
+            public function callIsPl(Request $request): bool
+            {
+                return $this->isPl($request);
+            }
+
+            public function callIsDEV(Request $request): bool
+            {
+                return $this->isDEV($request);
+            }
+
+            protected function isGranted(mixed $attribute, mixed $subject = null): bool
+            {
+                return true;
+            }
+
+            protected function getUser(): ?UserInterface
+            {
+                return $this->user;
+            }
+        };
+    }
+}

--- a/tests/Service/Security/TokenEncryptionServiceTest.php
+++ b/tests/Service/Security/TokenEncryptionServiceTest.php
@@ -35,29 +35,12 @@ final class TokenEncryptionServiceTest extends TestCase
         self::assertNotSame('test', $encrypted);
     }
 
-    public function testConstructorFallsBackToAppSecret(): void
-    {
-        $parameterBag = self::createStub(ParameterBagInterface::class);
-        $parameterBag->method('get')
-            ->willReturnMap([
-                ['app.encryption_key', null],
-                ['APP_SECRET', 'fallback-app-secret'],
-            ]);
-
-        $service = new TokenEncryptionService($parameterBag);
-
-        // Verify service works by encrypting a token
-        $encrypted = $service->encryptToken('test');
-        self::assertNotSame('test', $encrypted);
-    }
-
     public function testConstructorThrowsOnEmptyKey(): void
     {
         $parameterBag = self::createStub(ParameterBagInterface::class);
         $parameterBag->method('get')
             ->willReturnMap([
-                ['app.encryption_key', null],
-                ['APP_SECRET', ''],
+                ['app.encryption_key', ''],
             ]);
 
         $this->expectException(RuntimeException::class);
@@ -72,7 +55,6 @@ final class TokenEncryptionServiceTest extends TestCase
         $parameterBag->method('get')
             ->willReturnMap([
                 ['app.encryption_key', null],
-                ['APP_SECRET', null],
             ]);
 
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
Part of #320 — the three most mechanical PHP rule families, scoped to `src/`, `config/` and `public/` (test findings are accepted per the issue).

## php:S1192 — duplicated string literals (24 findings, all fixed)

| File | Literal | Fix |
| --- | --- | --- |
| `config/quality/phpat.php` | `App\Entity`, `App\Service`, `App\Enum`, `App\Repository`, `DateTime*`, `*Exception` | private consts on `ArchitectureTest` |
| `public/coverage.php` | `/*.json` | `COVERAGE_FILE_PATTERN` constant (`define()`, matching file style) |
| `src/Controller/BaseController.php` | `'Method '` (5 deprecation messages) | private `triggerMethodDeprecation()` helper with one `sprintf` template; messages byte-identical |
| `src/Dto/EntrySaveDto.php` | `Y-m-d\TH:i:s` | `FORMAT_ISO_DATETIME` |
| `src/EventSubscriber/AccessDeniedSubscriber.php` | `application/json` | `MIME_TYPE_JSON` |
| `src/EventSubscriber/ExceptionSubscriber.php` | `Internal server error` | `ERROR_INTERNAL_SERVER` |
| `src/Repository/EntryRepository.php` | `e.user = :user` (12x), `e.day = :day`, `e.activity = :activity`, `e.project = :project`, `e.customer = :customer`, `e.%s = :%s`, `e.day <= :endOfMonth`, `{field}` | private `WHERE_*` / `FIELD_PLACEHOLDER` consts, replaced at every occurrence |
| `src/Repository/OptimizedEntryRepository.php` | `e.user = :user` | own private `WHERE_USER` const |
| `src/Service/Integration/Jira/JiraWorkLogService.php` + `JiraOAuthApiService.php` | `issue/%s/worklog/%d` | public `JiraWorkLogService::WORKLOG_ITEM_URL_TEMPLATE` (worklog service owns the REST path), referenced by `JiraOAuthApiService` |
| `src/Service/Integration/Jira/JiraTicketService.php` | `issue/%s` (5x), `Ticket key cannot be empty` (4x) | `ISSUE_URL_TEMPLATE`, `ERROR_EMPTY_TICKET_KEY` |

Skipped: none.

## php:S112 — generic exceptions (39 findings, all fixed)

New narrowly-named classes under `src/Exception/`; every class extends the previously thrown base (`Exception` or `RuntimeException`), and messages/codes are preserved, so all existing catch sites (`catch (Exception)` / `catch (Throwable)`) and PHPUnit `expectException*` assertions keep working unchanged. No catch was widened.

| Throw sites | New exception |
| --- | --- |
| 8 admin `Delete*Action` controllers (`'Already deleted'`) | `EntityAlreadyDeletedException` (extends `RuntimeException`) |
| `SavePresetAction` | `IncompletePresetException` |
| `BulkEntryAction` (`'Preset not found'`) | `PresetNotFoundException` |
| `BaseTrackingController` (3x), `Entry::validateDuration()` | `InvalidEntryTimeException` |
| `BaseInterpretationController` (`'Invalid date'` 2x) | `InvalidDateFormatException` |
| `BaseInterpretationController` (missing filter criteria) | `MissingSearchCriteriaException` |
| `EntryQueryService` (`'page can not be negative.'`) | `InvalidPaginationException` |
| `LdapClientService` (8x auth/response sites) | `Ldap\LdapAuthenticationException` |
| `LdapClientService` (`'No connection to LDAP: …'`) | `Ldap\LdapConnectionException` |
| `TokenEncryptionService` (7x) | `TokenEncryptionException` (extends `RuntimeException`) |
| `SubticketSyncService` (4x, HTTP status codes kept) | `SubticketSyncException` |

Skipped: none.

Notable: narrowing the `@throws` docblock on `SubticketSyncService::syncProjectSubtickets()` exposed that the method also propagates `JiraApiException` from `getSubtickets()` — documented it explicitly so the existing `catch (JiraApiUnauthorizedException)` in `TtSyncSubticketsCommand` stays correct under PHPStan level 10.

## php:S4144 — identical method implementations (2 src findings, both fixed)

| Site | Fix |
| --- | --- |
| `Customer::addProjects()` ≡ `addProject()` | legacy plural alias now delegates to `addProject()` |
| `Entry::addClass()` ≡ `setClass()` | delegates to `setClass()` |

Skipped (test scope, accepted per #320): `tests/Service/Ldap/ModernLdapServiceTest.php:983`, `tests/Repository/EntryRepositoryFullIntegrationTest.php:693`, `tests/Fixtures/TokenStub.php:74`.

## Gates

```
php -d memory_limit=1G bin/phpstan analyse --no-progress           # level 10, src + tests
 [OK] No errors

PHP_CS_FIXER_IGNORE_ENV=1 bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run
 {"files":[], ...}   # no violations

docker compose run --rm app-dev php -d memory_limit=1G bin/rector process src \
  --config=config/quality/rector.php --dry-run
 [OK] Rector is done!

docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=off \
  -e DATABASE_URL="mysql://unittest:unittest@db_unittest:3306/unittest?serverVersion=mariadb-12.1.2&charset=utf8mb4" \
  app-dev php -d memory_limit=2G ./bin/phpunit
 OK, but some tests were skipped!
 Tests: 1944, Assertions: 5749, Skipped: 1   # pre-existing skip
```


## Review-driven fixes (Copilot rounds)

- **`TokenEncryptionService` could never fall back** (real runtime bug): `ParameterBag::get('app.encryption_key')` threw `ParameterNotFoundException` (parameter undefined; the `?? get('APP_SECRET')` fallback was dead code and the parameter is actually named `secret`). `app.encryption_key` is now defined as `%env(default:secret:APP_ENCRYPTION_KEY)%` and the constructor reads just that parameter — verified against a booted kernel.
- **`LdapAuthenticationException` extends `RuntimeException`** to preserve the prior catch contract of `login()`'s contract-violation throw; previously-`Exception` sites stay compatible via the inheritance chain.
- Docblock accuracy: `login()` declares all three propagated exceptions; `SubticketSyncException` wording covers project-not-found; `addProject()` says "Add a project."


## Coverage note

`codecov/patch` flags refactor-touched lines in paths that were already untested before this PR (repository DQL query branches, openssl/LDAP defensive failure paths, Jira OAuth flow) — the refactor swaps literals for constants without changing behavior, but rewriting an uncovered line counts as a new uncovered line. The genuinely testable gap was covered: `BaseControllerDeprecationTest` now verifies all five deprecated shims (delegation + deprecation message). Writing DB-fixture tests for the pre-existing untested repository finders is out of scope for this refactoring PR.
