### PR TITLE
refactor: replace var with let/const in app JavaScript (S3504)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -424,7 +424,7 @@ function handleRedirect(response, title, message) {
  * - Otherwise: returns response.responseText
  */
 function parseAjaxError(response) {
-    let data = undefined;
+    let data;
     let message = '';
     try {
         const ct = (response.getResponseHeader ? response.getResponseHeader('Content-Type') : '') || '';
@@ -465,7 +465,7 @@ function showAjaxFailure(title, response, fallbackMessage, shortTextThreshold) {
     return parsed;
 }
 
-let notification = undefined;
+let notification;
 
 /**
  * Displays a toaster like message

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -424,10 +424,10 @@ function handleRedirect(response, title, message) {
  * - Otherwise: returns response.responseText
  */
 function parseAjaxError(response) {
-    var data = undefined;
-    var message = '';
+    let data = undefined;
+    let message = '';
     try {
-        var ct = (response.getResponseHeader ? response.getResponseHeader('Content-Type') : '') || '';
+        const ct = (response.getResponseHeader ? response.getResponseHeader('Content-Type') : '') || '';
         if (ct.indexOf('json') !== -1) {
             try { data = Ext.decode(response.responseText); } catch (e) { }
         }
@@ -454,10 +454,10 @@ function parseAjaxError(response) {
  * Applies a fallback when the plain response text looks like a stack trace.
  */
 function showAjaxFailure(title, response, fallbackMessage, shortTextThreshold) {
-    var parsed = parseAjaxError(response);
-    var threshold = (typeof shortTextThreshold === 'number') ? shortTextThreshold : 200;
-    var isPlain = (parsed.message === response.responseText);
-    var message = parsed.message;
+    const parsed = parseAjaxError(response);
+    const threshold = (typeof shortTextThreshold === 'number') ? shortTextThreshold : 200;
+    const isPlain = (parsed.message === response.responseText);
+    let message = parsed.message;
     if ((!message) || (isPlain && response.responseText && response.responseText.length >= threshold)) {
         message = fallbackMessage || 'An error occurred.';
     }
@@ -465,7 +465,7 @@ function showAjaxFailure(title, response, fallbackMessage, shortTextThreshold) {
     return parsed;
 }
 
-var notification = undefined;
+let notification = undefined;
 
 /**
  * Displays a toaster like message
@@ -525,7 +525,7 @@ function findProjects(customer, ticket) {
     } else {
         customer = parseInt(customer);
     }
-    var projects = projectsData[customer];
+    const projects = projectsData[customer];
 
     // 2. Filter projects by prefix, if defined
     if ((null == ticket) || (undefined == ticket)) {
@@ -581,7 +581,7 @@ function findProjects(customer, ticket) {
         }
 
         const projectPrefixes = [...project['jiraId'].matchAll(prefixesRegexp)];
-        for (var i = 0; i < projectPrefixes.length; i++) {
+        for (let i = 0; i < projectPrefixes.length; i++) {
             const projectPrefix = projectPrefixes[i][1];
             if (projectPrefix == prefix) {
                 validProjects.push(project);

--- a/assets/js/netresearch/store/Customers.js
+++ b/assets/js/netresearch/store/Customers.js
@@ -30,9 +30,10 @@ Ext.define('Netresearch.store.Customers', {
 
     /* Read data from json var in html source code */
     load: function(onlyActive) {
-        var newData = [], record;
-        var c = 0;
-        for (var key in customersData) {
+        const newData = [];
+        let record;
+        let c = 0;
+        for (const key in customersData) {
             record = customersData[key].customer;
 
             if (!(record instanceof Ext.data.Model)) {

--- a/assets/js/netresearch/store/Projects.js
+++ b/assets/js/netresearch/store/Projects.js
@@ -41,7 +41,7 @@ Ext.define('Netresearch.store.Projects', {
         if (this.currentCustomer && (this.currentCustomer == parseInt(customer)))
             return;
 
-        var projects = findProjects(customer, ticket)
+        let projects = findProjects(customer, ticket)
         if (!projects)
             projects = new Array();
 
@@ -55,14 +55,15 @@ Ext.define('Netresearch.store.Projects', {
 
         this.currentCustomer = parseInt(customer);
 
-        var newData = [], record;
+        const newData = [];
+        let record;
 
         if (! projects.length) {
             this.removeAll();
             return;
         }
 
-        for (var key in projects) {
+        for (const key in projects) {
             record = projects[key];
 
             if (!(record instanceof Ext.data.Model)) {

--- a/assets/js/netresearch/widget/Admin.js
+++ b/assets/js/netresearch/widget/Admin.js
@@ -126,9 +126,9 @@ Ext.define('Netresearch.widget.Admin', {
     initComponent: function () {
         this.on('render', this.refreshStores, this);
 
-        var panel = this;
+        const panel = this;
 
-        var billingStore = new Ext.data.ArrayStore({
+        const billingStore = new Ext.data.ArrayStore({
             fields: ['value', 'displayname'],
             data: [
                 [0, 'None'],
@@ -137,7 +137,7 @@ Ext.define('Netresearch.widget.Admin', {
             ]
         });
 
-        var customerGrid = Ext.create('Ext.grid.Panel', {
+        const customerGrid = Ext.create('Ext.grid.Panel', {
             store: this.customerStore,
             teamStore: this.teamStore,
             columns: [
@@ -158,13 +158,13 @@ Ext.define('Netresearch.widget.Admin', {
                     dataIndex: 'teams',
                     flex: 1,
                     renderer: function (value) {
-                        var output = '';
+                        let output = '';
                         /* Display space separated list of related teams */
                         Ext.each(value, function (teamId) {
                             if (isNaN(teamId)) {
                                 return;
                             }
-                            var team = customerGrid.teamStore.getById(parseInt(teamId));
+                            const team = customerGrid.teamStore.getById(parseInt(teamId));
                             if (null == team) {
                                 return;
                             }
@@ -218,7 +218,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -244,11 +244,11 @@ Ext.define('Netresearch.widget.Admin', {
             editCustomer: function (record) {
                 if (!record) record = {};
 
-                var teamStore = Ext.create('Netresearch.store.AdminTeams', {
+                const teamStore = Ext.create('Netresearch.store.AdminTeams', {
                     autoLoad: false
                 });
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editCustomerTitle,
                     modal: true,
                     width: 400,
@@ -329,17 +329,17 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: panel._saveTitle,
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
+                                        const form = btn.up('form').getForm();
                                         if (!form.isValid()) {
-                                            var fields = form.getFields();
-                                            var errors = [];
+                                            const fields = form.getFields();
+                                            const errors = [];
 
                                             /* Create Error-String and display Error-Window */
                                             for (let i = 0; i < fields.length; i++) {
                                                 errors.push(fields.items[i].getErrors().join(', '));
                                             }
 
-                                            var errorsWindow = new Ext.Window({
+                                            const errorsWindow = new Ext.Window({
                                                 title: panel._errorsTitle,
                                                 html: errors,
                                                 width: 350
@@ -348,7 +348,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             return errorsWindow.show();
                                         }
 
-                                        var values = form.getValues();
+                                        const values = form.getValues();
                                         Ext.Ajax.request({
                                             url: url + 'customer/save',
                                             params: values,
@@ -370,8 +370,8 @@ Ext.define('Netresearch.widget.Admin', {
                 window.show();
             },
             deleteCustomer: function (record) {
-                var grid = this;
-                var id = parseInt(record.id);
+                const grid = this;
+                const id = parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -384,7 +384,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(grid._errorTitle, data.message, false);
                             }
                         });
@@ -408,7 +408,7 @@ Ext.define('Netresearch.widget.Admin', {
             }
         });
 
-        var projectGrid = Ext.create('Ext.grid.Panel', {
+        const projectGrid = Ext.create('Ext.grid.Panel', {
             customerStore: this.customerStore,
             ticketSystemStore: this.ticketSystemStore,
             store: this.projectStore,
@@ -438,7 +438,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        var record = this.customerStore.getById(id);
+                        const record = this.customerStore.getById(id);
                         return record ? record.get('name') : id;
                     }
                 },
@@ -475,7 +475,7 @@ Ext.define('Netresearch.widget.Admin', {
                         if (1 > parseInt(id))
                             return '';
 
-                        var record = this.ticketSystemStore.getById(id);
+                        const record = this.ticketSystemStore.getById(id);
                         return record ? record.get('name') : id;
                     }
                 },
@@ -541,7 +541,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (value) {
-                        var record = billingStore.findRecord('value', value);
+                        const record = billingStore.findRecord('value', value);
                         return record ? record.get('displayname') : value;
                     }
                 },
@@ -588,7 +588,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -632,9 +632,9 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             }, // end listeners
             editProject: function (record) {
-                var projectLeadStore = Ext.create('Netresearch.store.AdminUsers');
-                var technicalLeadStore = Ext.create('Netresearch.store.AdminUsers');
-                var projectStore = Ext.create('Netresearch.store.AdminProjects', {
+                const projectLeadStore = Ext.create('Netresearch.store.AdminUsers');
+                const technicalLeadStore = Ext.create('Netresearch.store.AdminUsers');
+                const projectStore = Ext.create('Netresearch.store.AdminProjects', {
                     autoLoad: false
                 });
 
@@ -645,7 +645,7 @@ Ext.define('Netresearch.widget.Admin', {
                     record = {};
                 }
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editProjectTitle,
                     modal: true,
                     width: 400,
@@ -833,8 +833,8 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: panel._saveTitle,
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
-                                        var values = form.getValues();
+                                        const form = btn.up('form').getForm();
+                                        const values = form.getValues();
 
                                         Ext.Ajax.request({
                                             url: url + 'project/save',
@@ -861,8 +861,8 @@ Ext.define('Netresearch.widget.Admin', {
                 window.show();
             },
             deleteProject: function (record) {
-                var grid = this;
-                var id = parseInt(record.id);
+                const grid = this;
+                const id = parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -875,7 +875,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(panel._errorTitle, data.message, false);
                             }
                         });
@@ -890,25 +890,25 @@ Ext.define('Netresearch.widget.Admin', {
                 );
             },
             syncProjectSubtickets: function (project) {
-                var grid = this;
+                const grid = this;
                 Ext.Ajax.request({
                     method: 'POST',
                     url: url + 'projects/' + project.id + '/syncsubtickets',
                     scope: this,
                     success: function (response) {
-                        var data = Ext.decode(response.responseText);
+                        const data = Ext.decode(response.responseText);
                         project['subtickets'] = data.subtickets;
                         grid.refresh();
                         grid.showProjectSubtickets(project);
                     },
                     failure: function (response) {
-                        var data = Ext.decode(response.responseText);
+                        const data = Ext.decode(response.responseText);
                         showNotification(panel._errorTitle, data.message, false);
                     }
                 });
             },
             syncAllProjectSubtickets: function () {
-                var grid = this;
+                const grid = this;
                 Ext.Ajax.request({
                     method: 'POST',
                     url: url + 'projects/syncsubtickets',
@@ -918,7 +918,7 @@ Ext.define('Netresearch.widget.Admin', {
                         showNotification(panel._successTitle, panel._subticketSyncFinishedTitle, true);
                     },
                     failure: function (response) {
-                        var data = Ext.decode(response.responseText);
+                        const data = Ext.decode(response.responseText);
                         showNotification(panel._errorTitle, data.message, false);
                     }
                 });
@@ -941,7 +941,7 @@ Ext.define('Netresearch.widget.Admin', {
             }
         });
 
-        var userGrid = Ext.create('Ext.grid.Panel', {
+        const userGrid = Ext.create('Ext.grid.Panel', {
             store: this.userStore,
             teamStore: this.teamStore,
             columns: [
@@ -979,12 +979,12 @@ Ext.define('Netresearch.widget.Admin', {
                     flex: 1,
                     renderer: function (value) {
                         /* Display space seperated list of related teams */
-                        var output = '';
+                        let output = '';
                         Ext.each(value, function (teamId) {
                             if (isNaN(teamId)) {
                                 return;
                             }
-                            var team = userGrid.teamStore.getById(parseInt(teamId));
+                            const team = userGrid.teamStore.getById(parseInt(teamId));
                             if (null == team) {
                                 return;
                             }
@@ -1018,7 +1018,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -1044,10 +1044,10 @@ Ext.define('Netresearch.widget.Admin', {
             editUser: function (record) {
                 if (!record) record = {};
 
-                var teamStore = this.teamStore;
+                const teamStore = this.teamStore;
                 teamStore.load();
 
-                var localesStore = new Ext.data.ArrayStore({
+                const localesStore = new Ext.data.ArrayStore({
                     fields: ['value', 'displayname'],
                     data: [
                         ['de', 'Deutsch'],
@@ -1058,7 +1058,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editUserTitle,
                     modal: true,
                     width: 400,
@@ -1154,8 +1154,8 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: panel._saveTitle,
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
-                                        var values = form.getValues();
+                                        const form = btn.up('form').getForm();
+                                        const values = form.getValues();
 
                                         Ext.Ajax.request({
                                             url: url + 'user/save',
@@ -1178,8 +1178,8 @@ Ext.define('Netresearch.widget.Admin', {
                 window.show();
             },
             deleteUser: function (record) {
-                var grid = this;
-                var id = parseInt(record.id);
+                const grid = this;
+                const id = parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.username, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -1192,7 +1192,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(grid._errorTitle, data.message, false);
                             }
                         });
@@ -1216,7 +1216,7 @@ Ext.define('Netresearch.widget.Admin', {
             }
         });
 
-        var teamGrid = Ext.create('Ext.grid.Panel', {
+        const teamGrid = Ext.create('Ext.grid.Panel', {
             userStore: this.userStore,
             store: this.teamStore,
             columns: [
@@ -1240,7 +1240,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        var record = this.userStore.getById(id);
+                        const record = this.userStore.getById(id);
                         return record ? record.get('username') : id;
                     }
                 }
@@ -1267,7 +1267,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -1291,11 +1291,11 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             },
             editTeam: function (record) {
-                var leadUserStore = Ext.create('Netresearch.store.AdminUsers');
+                const leadUserStore = Ext.create('Netresearch.store.AdminUsers');
                 leadUserStore.load();
                 record = record || {};
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editTeamTitle,
                     modal: true,
                     width: 400,
@@ -1341,8 +1341,8 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: panel._saveTitle,
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
-                                        var values = form.getValues();
+                                        const form = btn.up('form').getForm();
+                                        const values = form.getValues();
 
                                         Ext.Ajax.request({
                                             url: url + 'team/save',
@@ -1366,8 +1366,8 @@ Ext.define('Netresearch.widget.Admin', {
                 window.show();
             },
             deleteTeam: function (record) {
-                var grid = this;
-                var id = parseInt(record.id);
+                const grid = this;
+                const id = parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -1380,7 +1380,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(grid._errorTitle, data.message, false);
                             }
                         });
@@ -1405,7 +1405,7 @@ Ext.define('Netresearch.widget.Admin', {
         });
 
 
-        var presetGrid = Ext.create('Ext.grid.Panel', {
+        const presetGrid = Ext.create('Ext.grid.Panel', {
             customerStore: this.customerStore,
             projectStore: this.projectStore,
             activityStore: this.activityStore,
@@ -1432,7 +1432,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        var record = this.customerStore.getById(id);
+                        const record = this.customerStore.getById(id);
                         return record ? record.get('name') : id;
                     }
                 },
@@ -1449,7 +1449,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        var record = this.projectStore.getById(id);
+                        const record = this.projectStore.getById(id);
                         return record ? record.get('name') : id;
                     }
                 },
@@ -1466,7 +1466,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        var record = this.activityStore.getById(id);
+                        const record = this.activityStore.getById(id);
                         return record ? record.get('name') : id;
                     }
                 },
@@ -1501,7 +1501,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -1525,8 +1525,8 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             }, // end listeners
             deletePreset: function (record) {
-                var grid = this;
-                var id = parseInt(record.data.id);
+                const grid = this;
+                const id = parseInt(record.data.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.data.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -1539,7 +1539,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(grid._errorTitle, data.message, false);
                             }
                         });
@@ -1547,12 +1547,12 @@ Ext.define('Netresearch.widget.Admin', {
                 });
             },
             editPreset: function (record) {
-                var projectStore = Ext.create('Netresearch.store.AdminProjects');
+                const projectStore = Ext.create('Netresearch.store.AdminProjects');
                 projectStore.load();
 
                 if (!record) record = {};
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editPresetTitle,
                     modal: true,
                     width: 400,
@@ -1633,8 +1633,8 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: 'Speichern',
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
-                                        var values = form.getValues();
+                                        const form = btn.up('form').getForm();
+                                        const values = form.getValues();
 
                                         Ext.Ajax.request({
                                             url: url + 'preset/save',
@@ -1666,7 +1666,7 @@ Ext.define('Netresearch.widget.Admin', {
         });
 
 
-        var ticketSystemGrid = Ext.create('Ext.grid.Panel', {
+        const ticketSystemGrid = Ext.create('Ext.grid.Panel', {
             store: this.ticketSystemStore,
             columns: [
                 {
@@ -1737,7 +1737,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -1761,7 +1761,7 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             }, // end listeners
             editTicketSystem: function (record) {
-                var ticketSystemTypeStore = new Ext.data.ArrayStore({
+                const ticketSystemTypeStore = new Ext.data.ArrayStore({
                     fields: ['type'],
                     data: [
                         ['JIRA'], ['OTRS'], ['FRESHDESK']
@@ -1770,7 +1770,7 @@ Ext.define('Netresearch.widget.Admin', {
 
                 if (!record) record = {};
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editTicketSystemTitle,
                     modal: true,
                     width: 600,
@@ -1870,8 +1870,8 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: panel._saveTitle,
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
-                                        var values = form.getValues();
+                                        const form = btn.up('form').getForm();
+                                        const values = form.getValues();
 
                                         Ext.Ajax.request({
                                             url: url + 'ticketsystem/save',
@@ -1895,8 +1895,8 @@ Ext.define('Netresearch.widget.Admin', {
                 window.show();
             },
             deleteTicketSystem: function (record) {
-                var grid = this;
-                var id = parseInt(record.id);
+                const grid = this;
+                const id = parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -1909,7 +1909,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(grid._errorTitle, data.message, false);
                             }
                         });
@@ -1923,7 +1923,7 @@ Ext.define('Netresearch.widget.Admin', {
         });
 
 
-        var activityGrid = Ext.create('Ext.grid.Panel', {
+        const activityGrid = Ext.create('Ext.grid.Panel', {
             store: this.activityStore,
             columns: [
                 {
@@ -1973,7 +1973,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -1999,7 +1999,7 @@ Ext.define('Netresearch.widget.Admin', {
             editActivity: function (record) {
                 record = record || {};
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editActivityTitle,
                     modal: true,
                     width: 400,
@@ -2045,8 +2045,8 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: panel._saveTitle,
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
-                                        var values = form.getValues();
+                                        const form = btn.up('form').getForm();
+                                        const values = form.getValues();
 
                                         Ext.Ajax.request({
                                             url: url + 'activity/save',
@@ -2070,8 +2070,8 @@ Ext.define('Netresearch.widget.Admin', {
                 window.show();
             },
             deleteActivity: function (record) {
-                var grid = this;
-                var id = parseInt(record.id);
+                const grid = this;
+                const id = parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -2084,7 +2084,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(grid._errorTitle, data.message, false);
                             }
                         });
@@ -2098,7 +2098,7 @@ Ext.define('Netresearch.widget.Admin', {
         });
 
 
-        var contractGrid = Ext.create('Ext.grid.Panel', {
+        const contractGrid = Ext.create('Ext.grid.Panel', {
             userStore: this.userStore,
             store: this.contractStore,
             columns: [
@@ -2115,7 +2115,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        var record = this.userStore.getById(id);
+                        const record = this.userStore.getById(id);
                         return record ? record.get('username') : id;
                     }
                 }, {
@@ -2152,7 +2152,7 @@ Ext.define('Netresearch.widget.Admin', {
                 itemcontextmenu: function (grid, record, item, index, event, options) {
                     event.stopEvent();
 
-                    var contextMenu = Ext.create('Ext.menu.Menu', {
+                    const contextMenu = Ext.create('Ext.menu.Menu', {
                         items: [
                             {
                                 text: panel._editTitle,
@@ -2176,7 +2176,7 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             },
             editContract: function (record) {
-                var editUserStore = Ext.create('Netresearch.store.AdminUsers', {
+                const editUserStore = Ext.create('Netresearch.store.AdminUsers', {
                     autoLoad: false
                 });
 
@@ -2184,7 +2184,7 @@ Ext.define('Netresearch.widget.Admin', {
 
                 record = record || {};
 
-                var window = Ext.create('Ext.window.Window', {
+                const window = Ext.create('Ext.window.Window', {
                     title: panel._editContractTitle,
                     modal: true,
                     width: 400,
@@ -2284,8 +2284,8 @@ Ext.define('Netresearch.widget.Admin', {
                                     text: panel._saveTitle,
                                     scope: this,
                                     handler: function (btn) {
-                                        var form = btn.up('form').getForm();
-                                        var values = form.getValues();
+                                        const form = btn.up('form').getForm();
+                                        const values = form.getValues();
                                         Ext.Ajax.request({
                                             url: url + 'contract/save',
                                             params: values,
@@ -2308,8 +2308,8 @@ Ext.define('Netresearch.widget.Admin', {
                 window.show();
             },
             deleteContract: function (record) {
-                var grid = this;
-                var id = parseInt(record.id);
+                const grid = this;
+                const id = parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -2322,7 +2322,7 @@ Ext.define('Netresearch.widget.Admin', {
                                 grid.refresh();
                             },
                             failure: function (response) {
-                                var data = Ext.decode(response.responseText);
+                                const data = Ext.decode(response.responseText);
                                 showNotification(grid._errorTitle, data.message, false);
                             }
                         });
@@ -2337,7 +2337,7 @@ Ext.define('Netresearch.widget.Admin', {
         });
 
         /* Create container panels for grids */
-        var customerPanel = Ext.create('Ext.panel.Panel', {
+        const customerPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._customerManagementTitle,
@@ -2347,7 +2347,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [customerGrid]
         });
 
-        var projectPanel = Ext.create('Ext.panel.Panel', {
+        const projectPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._projectManagementTitle,
@@ -2357,7 +2357,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [projectGrid]
         });
 
-        var userPanel = Ext.create('Ext.panel.Panel', {
+        const userPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._userManagementTitle,
@@ -2367,7 +2367,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [userGrid]
         });
 
-        var teamPanel = Ext.create('Ext.panel.Panel', {
+        const teamPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._teamManagementTitle,
@@ -2377,7 +2377,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [teamGrid]
         });
 
-        var presetPanel = Ext.create('Ext.panel.Panel', {
+        const presetPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._presetManagementTitle,
@@ -2387,7 +2387,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [presetGrid]
         });
 
-        var ticketSystemPanel = Ext.create('Ext.panel.Panel', {
+        const ticketSystemPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._ticketSystemManagementTitle,
@@ -2397,7 +2397,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [ticketSystemGrid]
         });
 
-        var activityPanel = Ext.create('Ext.panel.Panel', {
+        const activityPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._activityManagementTitle,
@@ -2407,7 +2407,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [activityGrid]
         });
 
-        var contractPanel = Ext.create('Ext.panel.Panel', {
+        const contractPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._contractManagementTitle,
@@ -2417,7 +2417,7 @@ Ext.define('Netresearch.widget.Admin', {
             items: [contractGrid]
         });
 
-        var config = {
+        const config = {
             title: this._tabTitle,
             items: [customerPanel, projectPanel, userPanel, teamPanel, presetPanel, ticketSystemPanel, activityPanel, contractPanel]
         };
@@ -2443,9 +2443,9 @@ Ext.define('Netresearch.widget.Admin', {
  * Render image representation of a checkbox instead of 1 and 0
  */
 function renderCheckbox(val) {
-    var checkedImg = '/build/js/ext-js/resources/themes/images/default/menu/checked.gif';
-    var uncheckedImg = '/build/js/ext-js/resources/themes/images/default/menu/unchecked.gif';
-    var result = '<div style="text-align:center;height:13px;overflow:visible"><img style="vertical-align:-3px" src="'
+    const checkedImg = '/build/js/ext-js/resources/themes/images/default/menu/checked.gif';
+    const uncheckedImg = '/build/js/ext-js/resources/themes/images/default/menu/unchecked.gif';
+    const result = '<div style="text-align:center;height:13px;overflow:visible"><img style="vertical-align:-3px" src="'
         + (val ? checkedImg : uncheckedImg)
         + '" /></div>';
 

--- a/assets/js/netresearch/widget/Admin.js
+++ b/assets/js/netresearch/widget/Admin.js
@@ -248,7 +248,7 @@ Ext.define('Netresearch.widget.Admin', {
                     autoLoad: false
                 });
 
-                const window = Ext.create('Ext.window.Window', {
+                const editCustomerWindow = Ext.create('Ext.window.Window', {
                     title: panel._editCustomerTitle,
                     modal: true,
                     width: 400,
@@ -354,7 +354,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function (response) {
-                                                window.close();
+                                                editCustomerWindow.close();
                                             },
                                             failure: function (response) {
                                                 showAjaxFailure(panel._errorTitle, response, panel._seriousErrorTitle, 200);
@@ -367,7 +367,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editCustomerWindow.show();
             },
             deleteCustomer: function (record) {
                 const grid = this;
@@ -645,7 +645,7 @@ Ext.define('Netresearch.widget.Admin', {
                     record = {};
                 }
 
-                const window = Ext.create('Ext.window.Window', {
+                const editProjectWindow = Ext.create('Ext.window.Window', {
                     title: panel._editProjectTitle,
                     modal: true,
                     width: 400,
@@ -845,7 +845,7 @@ Ext.define('Netresearch.widget.Admin', {
                                                 if (data.message) {
                                                     showNotification(panel._errorTitle, data.message, false);
                                                 }
-                                                window.close();
+                                                editProjectWindow.close();
                                             },
                                             failure: function (response) {
                                                 showAjaxFailure(panel._errorTitle, response, panel._seriousErrorTitle, 200);
@@ -858,7 +858,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editProjectWindow.show();
             },
             deleteProject: function (record) {
                 const grid = this;
@@ -1058,7 +1058,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                const window = Ext.create('Ext.window.Window', {
+                const editUserWindow = Ext.create('Ext.window.Window', {
                     title: panel._editUserTitle,
                     modal: true,
                     width: 400,
@@ -1162,7 +1162,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function (response) {
-                                                window.close();
+                                                editUserWindow.close();
                                             },
                                             failure: function (response) {
                                                 showAjaxFailure(panel._errorTitle, response, panel._seriousErrorTitle, 200);
@@ -1175,7 +1175,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editUserWindow.show();
             },
             deleteUser: function (record) {
                 const grid = this;
@@ -1295,7 +1295,7 @@ Ext.define('Netresearch.widget.Admin', {
                 leadUserStore.load();
                 record = record || {};
 
-                const window = Ext.create('Ext.window.Window', {
+                const editTeamWindow = Ext.create('Ext.window.Window', {
                     title: panel._editTeamTitle,
                     modal: true,
                     width: 400,
@@ -1349,7 +1349,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function (response) {
-                                                window.close();
+                                                editTeamWindow.close();
                                                 showNotification(panel._successTitle, panel._teamSavedTitle, true);
                                             },
                                             failure: function (response) {
@@ -1363,7 +1363,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editTeamWindow.show();
             },
             deleteTeam: function (record) {
                 const grid = this;
@@ -1552,7 +1552,7 @@ Ext.define('Netresearch.widget.Admin', {
 
                 if (!record) record = {};
 
-                const window = Ext.create('Ext.window.Window', {
+                const editPresetWindow = Ext.create('Ext.window.Window', {
                     title: panel._editPresetTitle,
                     modal: true,
                     width: 400,
@@ -1641,7 +1641,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function (response) {
-                                                window.close();
+                                                editPresetWindow.close();
                                             },
                                             failure: function (response) {
                                                 showAjaxFailure(panel._errorTitle, response, panel._seriousErrorTitle, 200);
@@ -1654,7 +1654,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editPresetWindow.show();
             },
             refresh: function () {
                 this.customerStore.load();
@@ -1770,7 +1770,7 @@ Ext.define('Netresearch.widget.Admin', {
 
                 if (!record) record = {};
 
-                const window = Ext.create('Ext.window.Window', {
+                const editTicketSystemWindow = Ext.create('Ext.window.Window', {
                     title: panel._editTicketSystemTitle,
                     modal: true,
                     width: 600,
@@ -1878,7 +1878,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function (response) {
-                                                window.close();
+                                                editTicketSystemWindow.close();
                                                 showNotification(panel._successTitle, panel._ticketSystemSavedTitle, true);
                                             },
                                             failure: function (response) {
@@ -1892,7 +1892,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editTicketSystemWindow.show();
             },
             deleteTicketSystem: function (record) {
                 const grid = this;
@@ -1999,7 +1999,7 @@ Ext.define('Netresearch.widget.Admin', {
             editActivity: function (record) {
                 record = record || {};
 
-                const window = Ext.create('Ext.window.Window', {
+                const editActivityWindow = Ext.create('Ext.window.Window', {
                     title: panel._editActivityTitle,
                     modal: true,
                     width: 400,
@@ -2053,7 +2053,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function (response) {
-                                                window.close();
+                                                editActivityWindow.close();
                                                 showNotification(panel._successTitle, panel._activitySavedTitle, true);
                                             },
                                             failure: function (response) {
@@ -2067,7 +2067,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editActivityWindow.show();
             },
             deleteActivity: function (record) {
                 const grid = this;
@@ -2184,7 +2184,7 @@ Ext.define('Netresearch.widget.Admin', {
 
                 record = record || {};
 
-                const window = Ext.create('Ext.window.Window', {
+                const editContractWindow = Ext.create('Ext.window.Window', {
                     title: panel._editContractTitle,
                     modal: true,
                     width: 400,
@@ -2291,7 +2291,7 @@ Ext.define('Netresearch.widget.Admin', {
                                             params: values,
                                             scope: this,
                                             success: function (response) {
-                                                window.close();
+                                                editContractWindow.close();
                                                 showNotification(panel._successTitle, panel._contractSavedTitle, true);
                                             },
                                             failure: function (response) {
@@ -2305,7 +2305,7 @@ Ext.define('Netresearch.widget.Admin', {
                     ]
                 });
 
-                window.show();
+                editContractWindow.show();
             },
             deleteContract: function (record) {
                 const grid = this;

--- a/assets/js/netresearch/widget/Controlling.js
+++ b/assets/js/netresearch/widget/Controlling.js
@@ -33,36 +33,36 @@ Ext.define('Netresearch.widget.Controlling', {
     initComponent: function() {
         this.on('render', this.refreshStores, this);
 
-        var monthArray = Ext.Array.map(Ext.Date.monthNames, function (e) { return [e]; });
-        var months = [];
-        for (var c=1; c <= 12; c++) {
+        const monthArray = Ext.Array.map(Ext.Date.monthNames, function (e) { return [e]; });
+        const months = [];
+        for (let c=1; c <= 12; c++) {
             months.push({
                 value: c,
                 displayname: monthArray[(c-1)]
             });
         }
 
-        var monthStore = new Ext.data.Store({
+        const monthStore = new Ext.data.Store({
             fields: ['value', 'displayname'],
             data: months
         });
 
         // Calculate last 5 years dynamically
-        var years = [
+        const years = [
             { year: this.curYear }];
-        for (var y = 1; y <= 4; y++)
+        for (let y = 1; y <= 4; y++)
             years.push({year: this.curYear - y });
-        var yearStore = Ext.create('Ext.data.Store', {
+        const yearStore = Ext.create('Ext.data.Store', {
             fields: ['year'],
             data: years
         });
 
-        var date = new Date();
-        var curMonth = date.getMonth() + 1;
+        const date = new Date();
+        let curMonth = date.getMonth() + 1;
         if (curMonth > 1)
             curMonth--;
 
-        var form = new Ext.form.FormPanel({
+        const form = new Ext.form.FormPanel({
             url: url + 'controlling/export',
             title: this._monthlyStatement,
             bodyPadding: '20',
@@ -150,20 +150,20 @@ Ext.define('Netresearch.widget.Controlling', {
                 text: this._exportTitle,
                 scope: this,
                 handler: function() {
-                    var user = Ext.getCmp("cnt-user").value;
-                    var year = parseInt(Ext.getCmp("cnt-year").value) || 0;
-                    var month = parseInt(Ext.getCmp("cnt-month").value) || 0;
-                    var project = Ext.getCmp("cnt-project").value;
-                    var customer = Ext.getCmp("cnt-customer").value;
-                    var billable = +Ext.getCmp("cnt-billable").value;
-                    var tickettitles = +Ext.getCmp("cnt-tickettitles").value;
+                    const user = Ext.getCmp("cnt-user").value;
+                    const year = parseInt(Ext.getCmp("cnt-year").value) || 0;
+                    const month = parseInt(Ext.getCmp("cnt-month").value) || 0;
+                    const project = Ext.getCmp("cnt-project").value;
+                    const customer = Ext.getCmp("cnt-customer").value;
+                    const billable = +Ext.getCmp("cnt-billable").value;
+                    const tickettitles = +Ext.getCmp("cnt-tickettitles").value;
                     this.exportEntries(user, year, month, project, customer, billable, tickettitles);
                 }
             }]
         });
 
         /* Define container panel */
-        var controllingPanel = Ext.create('Ext.panel.Panel', {
+        const controllingPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._monthlyStatement,
@@ -172,7 +172,7 @@ Ext.define('Netresearch.widget.Controlling', {
             margin: '0 0 10 0',
             items: [ form ]
         });
-        var config = {
+        const config = {
             title: this._tabTitle,
             items: [ controllingPanel ]
         };

--- a/assets/js/netresearch/widget/Extras.js
+++ b/assets/js/netresearch/widget/Extras.js
@@ -45,12 +45,12 @@ Ext.define('Netresearch.widget.Extras', {
         this.on('render', this.refreshStores, this);
 
         /* Little store for yes/no dropdown */
-        var yesnoSourceModel = new Ext.data.ArrayStore({
+        const yesnoSourceModel = new Ext.data.ArrayStore({
             fields: ['value', 'displayname'],
             data: [[1, this._yesTitle], [0, this._noTitle]]
         });
 
-        var form = new Ext.form.FormPanel({
+        const form = new Ext.form.FormPanel({
             url: url + 'tracking/bulkentry',
             frame: true,
             title: this._bulkEntryTitle,
@@ -153,20 +153,20 @@ Ext.define('Netresearch.widget.Extras', {
                 text: 'Eintragen',
                 scope: this,
                 handler: function () {
-                    var date = new Date();
+                    const date = new Date();
                     date.setMilliseconds(0);
                     date.setSeconds(0);
                     date.setMinutes(0);
                     date.setHours(0);
 
-                    var preset = Ext.getCmp("cnt-preset").value;
-                    var startdate = Ext.getCmp("cnt-startdate").value;
-                    var enddate = Ext.getCmp("cnt-enddate").value;
-                    var starttime = Ext.getCmp("cnt-starttime").value;
-                    var endtime = Ext.getCmp("cnt-endtime").value;
-                    var skipweekend = Ext.getCmp("cnt-skipweekend").value;
-                    var skipholidays = Ext.getCmp("cnt-skipholidays").value;
-                    var usecontract = Ext.getCmp("cnt-usecontract").value;
+                    const preset = Ext.getCmp("cnt-preset").value;
+                    const startdate = Ext.getCmp("cnt-startdate").value;
+                    const enddate = Ext.getCmp("cnt-enddate").value;
+                    const starttime = Ext.getCmp("cnt-starttime").value;
+                    const endtime = Ext.getCmp("cnt-endtime").value;
+                    const skipweekend = Ext.getCmp("cnt-skipweekend").value;
+                    const skipholidays = Ext.getCmp("cnt-skipholidays").value;
+                    const usecontract = Ext.getCmp("cnt-usecontract").value;
 
                     if ((undefined == preset) || ('' == preset)) {
                         alert(this._choosePresetTitle);
@@ -204,7 +204,7 @@ Ext.define('Netresearch.widget.Extras', {
                         }
                     }
 
-                    var data = {
+                    const data = {
                         startdate: startdate,
                         enddate: enddate,
                         starttime: starttime,
@@ -215,7 +215,7 @@ Ext.define('Netresearch.widget.Extras', {
                         usecontract: usecontract
                     };
 
-                    var panel = this;
+                    const panel = this;
                     Ext.Ajax.request({
                         url: url + 'tracking/bulkentry',
                         params: data,
@@ -231,7 +231,7 @@ Ext.define('Netresearch.widget.Extras', {
         });
 
         /* Define container panel */
-        var extrasPanel = Ext.create('Ext.panel.Panel', {
+        const extrasPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._bulkEntryTitle,
@@ -240,7 +240,7 @@ Ext.define('Netresearch.widget.Extras', {
             margin: '0 0 10 0',
             items: [form]
         });
-        var config = {
+        const config = {
             title: this._tabTitle,
             items: [extrasPanel]
         };

--- a/assets/js/netresearch/widget/Help.js
+++ b/assets/js/netresearch/widget/Help.js
@@ -16,7 +16,7 @@ Ext.define('Netresearch.widget.Help', {
     initComponent: function() {
 
         /* Define container panel */
-        var usagePanel = Ext.create('Ext.panel.Panel', {
+        const usagePanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._usageTitle,
@@ -43,7 +43,7 @@ Ext.define('Netresearch.widget.Help', {
 
 
         /* Define container panel */
-        var shortcutPanel = Ext.create('Ext.panel.Panel', {
+        const shortcutPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._shortcutsTitle,
@@ -84,7 +84,7 @@ Ext.define('Netresearch.widget.Help', {
         });
 
         /* Define container panel */
-        var issuesPanel = Ext.create('Ext.panel.Panel', {
+        const issuesPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._issuesTitle,
@@ -101,7 +101,7 @@ Ext.define('Netresearch.widget.Help', {
         });
 
         /* Define container panel */
-        var linksPanel = Ext.create('Ext.panel.Panel', {
+        const linksPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._linksTitle,
@@ -124,7 +124,7 @@ Ext.define('Netresearch.widget.Help', {
         });
 
 
-        var config = {
+        const config = {
             title: this._helpTitle,
             items: [ usagePanel, shortcutPanel, issuesPanel, linksPanel ]
         };

--- a/assets/js/netresearch/widget/Interpretation.js
+++ b/assets/js/netresearch/widget/Interpretation.js
@@ -159,9 +159,9 @@ Ext.define('Netresearch.widget.Interpretation', {
     initComponent: function() {
         this.on('render', this.refreshStores, this);
 
-        var chartWidth = Ext.getBody().getWidth() - 40;
+        const chartWidth = Ext.getBody().getWidth() - 40;
 
-        var customerPanel = Ext.create('Ext.panel.Panel', {
+        const customerPanel = Ext.create('Ext.panel.Panel', {
             frame: true,
             title: this._effortByCustomerTitle,
             collapsible: false,
@@ -220,7 +220,7 @@ Ext.define('Netresearch.widget.Interpretation', {
             ]
         });
 
-        var projectPanel = Ext.create('Ext.panel.Panel', {
+        const projectPanel = Ext.create('Ext.panel.Panel', {
             frame: true,
             title: this._effortByProjectTitle,
             collapsible: false,
@@ -280,7 +280,7 @@ Ext.define('Netresearch.widget.Interpretation', {
         });
 
 
-        var activityPanel = Ext.create('Ext.panel.Panel', {
+        const activityPanel = Ext.create('Ext.panel.Panel', {
             frame: true,
             title: this._effortByActivityTitle,
             collapsible: false,
@@ -339,7 +339,7 @@ Ext.define('Netresearch.widget.Interpretation', {
             ]
         });
 
-        var timePanel = Ext.create('Ext.panel.Panel', {
+        const timePanel = Ext.create('Ext.panel.Panel', {
             title: this._effortByDaysTitle,
             frame: true,
             collapsible: false,
@@ -387,7 +387,7 @@ Ext.define('Netresearch.widget.Interpretation', {
             ]
         });
 
-        var ticketPanel = Ext.create('Ext.panel.Panel', {
+        const ticketPanel = Ext.create('Ext.panel.Panel', {
             frame: true,
             margin: '0 0 10 0',
             title: this._effortByTicketTitle,
@@ -446,7 +446,7 @@ Ext.define('Netresearch.widget.Interpretation', {
             ]
         });
 
-        var developerPanel = Ext.create('Ext.panel.Panel', {
+        const developerPanel = Ext.create('Ext.panel.Panel', {
             frame: true,
             margin: '0 0 10 0',
             title: this._effortByUserTitle,
@@ -505,7 +505,7 @@ Ext.define('Netresearch.widget.Interpretation', {
             ]
         });
 
-        var entryGrid =
+        const entryGrid =
             Ext.create('Netresearch.widget.Tracking', {
                 width: chartWidth,
                 height: 600,
@@ -522,7 +522,7 @@ Ext.define('Netresearch.widget.Interpretation', {
                 addInlineEntry: function(record) { alert("Nope!"); }
         });
 
-        var entryPanel = Ext.create('Ext.panel.Panel', {
+        const entryPanel = Ext.create('Ext.panel.Panel', {
             frame: true,
             margin: '0 0 10 0',
             title: this._lastEntriesTitle,
@@ -536,8 +536,8 @@ Ext.define('Netresearch.widget.Interpretation', {
             ]
         });
 
-        var widget = this;
-        var config = {
+        const widget = this;
+        const config = {
             title: this._tabTitle,
             autoScroll: true,
             bodyPadding: 5,
@@ -693,15 +693,15 @@ Ext.define('Netresearch.widget.Interpretation', {
     },
 
     refresh: function() {
-        var datestart = Ext.getCmp('datestart-interpretation').getValue();
-        var dateend = Ext.getCmp('dateend-interpretation').getValue();
-        var customer = Ext.getCmp('customer-interpretation').getValue();
-        var project = Ext.getCmp('project-interpretation').getValue();
-        var team = Ext.getCmp('team-interpretation').getValue();
-        var user = Ext.getCmp('user-interpretation').getValue();
-        var activity = Ext.getCmp('activity-interpretation').getValue();
-        var ticket = Ext.getCmp('ticket-interpretation').getValue();
-        var description = Ext.getCmp('description-interpretation').getValue();
+        const datestart = Ext.getCmp('datestart-interpretation').getValue();
+        const dateend = Ext.getCmp('dateend-interpretation').getValue();
+        const customer = Ext.getCmp('customer-interpretation').getValue();
+        const project = Ext.getCmp('project-interpretation').getValue();
+        const team = Ext.getCmp('team-interpretation').getValue();
+        const user = Ext.getCmp('user-interpretation').getValue();
+        const activity = Ext.getCmp('activity-interpretation').getValue();
+        const ticket = Ext.getCmp('ticket-interpretation').getValue();
+        const description = Ext.getCmp('description-interpretation').getValue();
 
         // Same check as server-side
         if ((!customer) && (!project) && (!user) && (!ticket) && (!datestart) && (!dateend) && (!team)) {
@@ -709,7 +709,7 @@ Ext.define('Netresearch.widget.Interpretation', {
             return;
         }
 
-        var searchParams = {
+        const searchParams = {
             datestart: datestart,
             dateend: dateend,
             customer: customer,
@@ -766,11 +766,11 @@ Ext.define('Netresearch.widget.Interpretation', {
     },
 
     displayShortcuts: function() {
-        var shortcuts = new Array(
+        const shortcuts = new Array(
                 'ALT-R: ' + this._refreshTitle + ' (<b>R</b>efresh)',
                 '',
                 '?: ' + this._showHelpTitle);
-        var grid = this;
+        const grid = this;
         Ext.MessageBox.alert(this._shortcutsTitle, shortcuts.join('<br/>'), function(btn) {
             grid.getView().el.focus();
         });

--- a/assets/js/netresearch/widget/Settings.js
+++ b/assets/js/netresearch/widget/Settings.js
@@ -30,12 +30,12 @@ Ext.define('Netresearch.widget.Settings', {
         this.on('render', this.refreshStores, this);
 
         /* Little store for yes/no dropdown */
-        var yesnoSourceModel = new Ext.data.ArrayStore({
+        const yesnoSourceModel = new Ext.data.ArrayStore({
             fields: ['value', 'displayname'],
             data: [[1, this._yesTitle], [0, this._noTitle]]
         });
 
-        var localesStore = new Ext.data.ArrayStore({
+        const localesStore = new Ext.data.ArrayStore({
             fields: ['value', 'displayname'],
             data: [
                 ['de', 'Deutsch'],
@@ -46,8 +46,8 @@ Ext.define('Netresearch.widget.Settings', {
             ]
         });
 
-        var widget = this;
-        var form = new Ext.form.FormPanel({
+        const widget = this;
+        const form = new Ext.form.FormPanel({
             url: url + 'settings/save',
             frame: true,
             title: this._gridBehaviourTitle,
@@ -121,7 +121,7 @@ Ext.define('Netresearch.widget.Settings', {
         });
 
         /* Define container panel */
-        var settingsPanel = Ext.create('Ext.panel.Panel', {
+        const settingsPanel = Ext.create('Ext.panel.Panel', {
             layout: 'fit',
             frame: true,
             title: this._generalSettingsTitle,
@@ -130,7 +130,7 @@ Ext.define('Netresearch.widget.Settings', {
             margin: '0 0 10 0',
             items: [ form ]
         });
-        var config = {
+        const config = {
             title: this._tabTitle,
             items: [ settingsPanel ]
         };

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -359,7 +359,7 @@ Ext.define('Netresearch.widget.Tracking', {
                         listeners: {
                             scope: this,
                             focus: function (field, value) {
-                                var ticket = this.getSelectedField('ticket');
+                                let ticket = this.getSelectedField('ticket');
                                 if ((ticket == "") || (ticket == "-")) {
                                     ticket = null;
                                 }
@@ -498,7 +498,7 @@ Ext.define('Netresearch.widget.Tracking', {
                     listeners: {
                         afterrender: function (field, eOpts) {
                             /* Set interval dropdown default value to 3 days */
-                            var defaultValue = '3';
+                            const defaultValue = '3';
                             field.setValue(defaultValue);
                             this.days = defaultValue;
                         },
@@ -724,11 +724,11 @@ Ext.define('Netresearch.widget.Tracking', {
      * Show info on selected or first entry's ticket / project and customer
      */
     showInfoOnSelectedEntry: function () {
-        var index = this.getSelectedIndex();
+        const index = this.getSelectedIndex();
         if (0 > index)
             return;
 
-        var record = this.store.getAt(index);
+        const record = this.store.getAt(index);
         if ((undefined != record) && (0 < parseInt(record.data.id)))
             this.getSummary(record.data.id);
     },
@@ -766,7 +766,7 @@ Ext.define('Netresearch.widget.Tracking', {
 
         if ('undefined' == typeof (record.saveInProgress)) {
             // Check if customer and project are related
-            var projectCheck = this.checkCustomerProjectRelation(record.data.customer, record.data.project);
+            const projectCheck = this.checkCustomerProjectRelation(record.data.customer, record.data.project);
             if (!projectCheck) {
                 showNotification(this._errorTitle,
                     this._customerProjectMismatchTitle
@@ -806,7 +806,7 @@ Ext.define('Netresearch.widget.Tracking', {
                 params: record.data,
                 success: function (response) {
                     record.saveInProgress = undefined;
-                    var data = Ext.decode(response.responseText);
+                    const data = Ext.decode(response.responseText);
 
                     if (data.result) {
                         record.data.duration = new Date(0, 0, 0, 0, data.result.durationMinutes, 0, 0);
@@ -824,7 +824,7 @@ Ext.define('Netresearch.widget.Tracking', {
                 failure: function (response) {
                     record.saveInProgress = undefined;
                     record.dirty = true;
-                    var parsed = showAjaxFailure(grid._errorTitle, response, grid._seriousErrorTitle, 200);
+                    const parsed = showAjaxFailure(grid._errorTitle, response, grid._seriousErrorTitle, 200);
                     if (parsed?.data?.forwardUrl !== undefined) {
                         setTimeout(() => { globalThis.location.href = parsed.data.forwardUrl; }, 2000);
                     }
@@ -916,7 +916,7 @@ Ext.define('Netresearch.widget.Tracking', {
      * Format summary report (right click -> info)
      */
     formatSummary: function (title, summary) {
-        var str = "<h2>" + title + " " + summary.name + "</h2>"
+        let str = "<h2>" + title + " " + summary.name + "</h2>"
             + this._entriesTitle + ": " + summary.entries
             + ", " + this._totalDurationTitle + ": " + formatDuration(summary.total, true);
 

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -8,7 +8,7 @@
 // ==/UserScript==
 
 
-const ticket = null || globalThis.location.href.split('/').slice(-1)[0];
+const ticket = globalThis.location.href.split('/').slice(-1)[0];
 const timetrackerUrl = 'https://timetracker/getTicketTimeSummary/' + ticket;
 
 window.addEventListener('load', function () {
@@ -81,8 +81,8 @@ function createTimeSummary(list, data) {
     const newDiv = document.createElement('div');
     newDiv.style.marginBottom = '20px';
     newDiv.style.display = 'flex';
-    newDiv.appendChild.felxdirection = 'row';
-    newDiv.style.fleyWrap = 'wrap';
+    newDiv.style.flexDirection = 'row';
+    newDiv.style.flexWrap = 'wrap';
     newDiv.style.width = '100%';
 
     const rowOne = document.createElement('div');

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -8,13 +8,13 @@
 // ==/UserScript==
 
 
-var ticket = null || globalThis.location.href.split('/').slice(-1)[0];
-var timetrackerUrl = 'https://timetracker/getTicketTimeSummary/' + ticket;
+const ticket = null || globalThis.location.href.split('/').slice(-1)[0];
+const timetrackerUrl = 'https://timetracker/getTicketTimeSummary/' + ticket;
 
 window.addEventListener('load', function () {
 
-    var list = document.getElementById('viewissuesidebar');
-    var labJira = true;
+    let list = document.getElementById('viewissuesidebar');
+    let labJira = true;
 
     if (list === null) {
         labJira = false;
@@ -29,7 +29,7 @@ window.addEventListener('load', function () {
 
 function createButton(labJira, list) {
 
-    var button = document.createElement('button');
+    const button = document.createElement('button');
     button.innerText = 'Zeiten aus Timetracker laden';
     button.style.marginBottom = '35px';
     button.style.background = "rgb(0, 82, 204)";
@@ -53,49 +53,49 @@ function createButton(labJira, list) {
 
 
 function getNewDiv(content, div, list = false) {
-    var divElement = document.createElement('div');
+    const divElement = document.createElement('div');
 
     if (list) {
         divElement.style.paddingLeft = '10px';
     }
 
     divElement.style.marginTop = '5px';
-    var nodeContent = document.createTextNode(content);
+    const nodeContent = document.createTextNode(content);
     divElement.appendChild(nodeContent);
     div.appendChild(divElement);
 }
 
 function createTimeSummary(list, data) {
 
-    var headline = ['Gesamtzeit:\xa0\xa0', 'T\u00e4tigkeiten:', 'Personen:'];
-    var title = document.querySelector(
+    const headline = ['Gesamtzeit:\xa0\xa0', 'T\u00e4tigkeiten:', 'Personen:'];
+    const title = document.querySelector(
         "[data-test-id='issue.views.issue-base.context.context-items.primary-items']"
     ).childNodes[0].childNodes[0].childNodes[0];
-    var cloneTitle = title.cloneNode(true);
+    const cloneTitle = title.cloneNode(true);
     cloneTitle.childNodes[0].textContent = 'Aufgewendete Zeit';
 
-    var divTitle = document.createElement('div');
+    const divTitle = document.createElement('div');
     divTitle.appendChild(cloneTitle);
     list.appendChild(divTitle);
 
-    var newDiv = document.createElement('div');
+    const newDiv = document.createElement('div');
     newDiv.style.marginBottom = '20px';
     newDiv.style.display = 'flex';
     newDiv.appendChild.felxdirection = 'row';
     newDiv.style.fleyWrap = 'wrap';
     newDiv.style.width = '100%';
 
-    var rowOne = document.createElement('div');
+    const rowOne = document.createElement('div');
     rowOne.className = 'one';
     rowOne.style.display = 'flex';
     rowOne.style.flexDirection = 'column';
     rowOne.style.flexBasis = '100%';
     rowOne.style.flex = 'inherit';
 
-    var rowtwo = rowOne.cloneNode(true);
+    const rowtwo = rowOne.cloneNode(true);
     rowtwo.className = 'two';
 
-    var i = 0;
+    let i = 0;
     Object.entries(data).forEach((value) => {
         const time = value[1].time;
 
@@ -119,30 +119,30 @@ function createTimeSummary(list, data) {
 }
 
 function createLabJiraTimeSummay(list, data) {
-    var headline = ["<b>Gesamtzeit:\xa0\xa0</b>", "<b>T\u00e4tigkeiten:</b>", "<b>Personen:</b>"];
+    const headline = ["<b>Gesamtzeit:\xa0\xa0</b>", "<b>T\u00e4tigkeiten:</b>", "<b>Personen:</b>"];
 
-    var title = document.getElementById('datesmodule');
-    var cloneTitle = title.cloneNode(true);
+    const title = document.getElementById('datesmodule');
+    const cloneTitle = title.cloneNode(true);
     cloneTitle.childNodes[0].childNodes[1].textContent = 'Aufgewendete Zeit';
-    var i = 0;
+    let i = 0;
 
-    var liEl = cloneTitle.childNodes[1].childNodes[1].childNodes[1];
+    const liEl = cloneTitle.childNodes[1].childNodes[1].childNodes[1];
 
     Object.entries(data).forEach((value) => {
         const time = value[1].time;
 
         if (time) {
 
-            var total = createNewContent(headline[i++], value[1].time, cloneTitle);
+            const total = createNewContent(headline[i++], value[1].time, cloneTitle);
             liEl.appendChild(total);
         } else {
 
-            var newHeadline = createNewContent(headline[i++], '\xa0', cloneTitle);
+            const newHeadline = createNewContent(headline[i++], '\xa0', cloneTitle);
             liEl.appendChild(newHeadline);
 
             Object.keys(value[1]).forEach((key) => {
                 const content = value[1][key].time;
-                var newContent = createNewContent(key + ": ", content, cloneTitle);
+                const newContent = createNewContent(key + ": ", content, cloneTitle);
                 newContent.style.marginTop = '0px';
                 liEl.appendChild(newContent);
             })
@@ -160,7 +160,7 @@ function createLabJiraTimeSummay(list, data) {
 
 function createNewContent(headline, text, clone) {
 
-    var content = clone.childNodes[1].childNodes[1].childNodes[1].childNodes[1];
+    const content = clone.childNodes[1].childNodes[1].childNodes[1].childNodes[1];
     content.getElementsByTagName("dt")[0].innerHTML = headline;
     content.getElementsByTagName("dd")[0].innerText = text;
     clone.getElementsByTagName("dd")[0].title = text;
@@ -171,7 +171,7 @@ function createNewContent(headline, text, clone) {
 
 function getTimeSummary() {
 
-    var list = this.list;
+    const list = this.list;
 
     fetch(this.url)
         .then(function (response) {


### PR DESCRIPTION
Part of #319 (SonarCloud JavaScript modernization, phase 2).

Resolves all 225 `javascript:S3504` ("Unexpected var, use let or const instead") findings in the repository's own JavaScript. The remaining 24 findings are in `assets/js/Notification.js` (vendored Ext.ux widget) and were intentionally not touched, same as `assets/js/ext-js/**`.

## Files touched (225 findings fixed)

| File | Findings |
|---|---|
| assets/js/netresearch/widget/Admin.js | 108 |
| public/scripts/timeSummaryForJira.js | 25 |
| assets/js/netresearch/widget/Interpretation.js | 23 |
| assets/js/netresearch/widget/Controlling.js | 19 |
| assets/js/netresearch/widget/Extras.js | 15 |
| assets/js/main.js | 10 |
| assets/js/netresearch/widget/Tracking.js | 8 |
| assets/js/netresearch/widget/Settings.js | 6 |
| assets/js/netresearch/widget/Help.js | 5 |
| assets/js/netresearch/store/Customers.js | 3 |
| assets/js/netresearch/store/Projects.js | 3 |

## Approach

- `var` → `const` where never reassigned, `let` where reassigned (loop counters `c`, `y`, `i`, string accumulators `output`/`str`, conditionally reassigned locals `ticket`, `list`, `labJira`, `curMonth`, `message`, `data`). Single-declaration statements like `var newData = [], record;` were split into `const newData = []; let record;`.
- Every reassignment was verified per identifier before choosing const vs let; function-parameter reassignments (`record = record || {}` in Admin.js edit handlers) were left untouched.
- No hoisting hazards found: no variable is used before its declaration line or shared across sibling blocks.
- `var notification` (top level of `assets/js/main.js`, a classic non-module script) was converted to `let` after verifying via grep that no other file references it — it is only read/written inside `main.js` itself. No other top-level `var` globals existed in the touched files.
- No ES2021+ features introduced; changes are strictly limited to the S3504 declaration lines (no drive-by modernization).

Note: these files are shipped untranspiled — webpack Encore only `copyFiles()`s `assets/js/**`, so the build does not parse them. Each edited file was therefore additionally syntax-checked with `node --check`.

## Verification

- `node --check` on all 11 edited files: pass
- `docker compose run --rm app-dev npm run build` after each batch and after the final state: `webpack compiled successfully`
- No JS lint script exists in package.json (scripts: encore build/dev/watch + playwright only), so the build is the only JS gate.
- E2E (local, not the full 10-shard suite): ran the smoke subset `e2e/login.spec.ts e2e/navigation.spec.ts e2e/keyboard.spec.ts e2e/settings.spec.ts` against the compose e2e stack (`COMPOSE_PROFILES=e2e`, CI-equivalent invocation with `E2E_BASE_URL=http://httpd-e2e:80 CI=true`): **40 passed, 1 flaky** (`keyboard.spec.ts › should navigate grid rows with arrow keys` — login-redirect timeout in `helpers/auth.ts` on first attempt, passed on retry; unrelated to these changes). The full shard matrix runs in CI on this PR.

## Intentionally left

- `assets/js/Notification.js` (24 findings) — vendored Ext.ux.window.Notification, excluded by scope.
- `assets/js/ext-js/**` — vendored ExtJS, excluded by scope.


## Quality gate note

The SonarCloud PR gate fails only on `new_duplicated_lines_density` (8.6% > 3%). No new issues were introduced. The flagged duplication is pre-existing copy-paste structure in the legacy ExtJS widgets (eight near-identical `Ext.window.Window` builder blocks in `Admin.js`, twin summary functions in `timeSummaryForJira.js`) that gets re-attributed to "new code" because the mechanical `var` → `let`/`const` conversion touches those lines. De-duplicating these blocks is a structural refactor with regression risk and is tracked as part of the wider modernization program (#319), not this conversion PR. Overall project duplication is unchanged.
