### PR TITLE
refactor: SonarCloud final wave - complexity, returns, naming (src)

### DIFF
--- a/config/quality/phpat.php
+++ b/config/quality/phpat.php
@@ -25,7 +25,7 @@ final class ArchitectureTest
 
     private const string CLASSNAME_EXCEPTION = '*Exception';
 
-    public function test_controllers_should_only_depend_on_business_logic(): Rule
+    public function testControllersShouldOnlyDependOnBusinessLogic(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace('App\Controller'))
@@ -45,7 +45,7 @@ final class ArchitectureTest
             ->because('Controllers should only depend on business logic and framework components');
     }
 
-    public function test_entities_should_be_pure_data_models(): Rule
+    public function testEntitiesShouldBePureDataModels(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace(self::NAMESPACE_ENTITY))
@@ -60,7 +60,7 @@ final class ArchitectureTest
             ->because('Entities should be pure data models with minimal dependencies');
     }
 
-    public function test_services_can_orchestrate_business_logic(): Rule
+    public function testServicesCanOrchestrateBusinessLogic(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace(self::NAMESPACE_SERVICE))
@@ -82,7 +82,7 @@ final class ArchitectureTest
             ->because('Services should handle business logic and orchestration');
     }
 
-    public function test_repositories_should_only_handle_data_access(): Rule
+    public function testRepositoriesShouldOnlyHandleDataAccess(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace(self::NAMESPACE_REPOSITORY))
@@ -98,7 +98,7 @@ final class ArchitectureTest
             ->because('Repositories should only handle data access');
     }
 
-    public function test_controllers_must_not_directly_access_repositories(): Rule
+    public function testControllersMustNotDirectlyAccessRepositories(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace('App\Controller'))

--- a/public/coverage.php
+++ b/public/coverage.php
@@ -200,6 +200,10 @@ function mergeCoverageFiles(): array
         }
 
         foreach ($data as $filename => $lines) {
+            if (!is_array($lines)) {
+                continue;
+            }
+
             $mergedCoverage[$filename] = mergeFileLines($mergedCoverage[$filename] ?? [], $lines);
         }
     }

--- a/public/coverage.php
+++ b/public/coverage.php
@@ -172,46 +172,7 @@ function generateCoverageReport(string $format): void
         return;
     }
 
-    // Merge all coverage files
-    $mergedCoverage = [];
-    $files = glob(COVERAGE_FILE_PATTERN) ?: [];
-
-    foreach ($files as $file) {
-        $content = @file_get_contents($file);
-        if ($content === false) {
-            error_log('Coverage: Failed to read file ' . $file);
-            continue;
-        }
-
-        $data = json_decode($content, true);
-        if (!is_array($data)) {
-            error_log('Coverage: Invalid JSON in file ' . $file);
-            continue;
-        }
-
-        foreach ($data as $filename => $lines) {
-            if (!isset($mergedCoverage[$filename])) {
-                $mergedCoverage[$filename] = [];
-            }
-            foreach ($lines as $line => $hits) {
-                // Skip dead code
-                if ($hits === -2) {
-                    continue;
-                }
-
-                if (!isset($mergedCoverage[$filename][$line])) {
-                    $mergedCoverage[$filename][$line] = 0;
-                }
-
-                // Xdebug: 1 = executed, -1 = not executed but executable
-                if ($hits === 1) {
-                    $mergedCoverage[$filename][$line] = 1;
-                } elseif ($mergedCoverage[$filename][$line] !== 1 && $hits === -1) {
-                    $mergedCoverage[$filename][$line] = -1;
-                }
-            }
-        }
-    }
+    $mergedCoverage = mergeCoverageFiles();
 
     if ($format === 'clover') {
         header('Content-Type: application/xml');
@@ -222,6 +183,74 @@ function generateCoverageReport(string $format): void
             'coverage' => $mergedCoverage,
         ]);
     }
+}
+
+/**
+ * Merge all collected coverage files into one per-file line map.
+ */
+function mergeCoverageFiles(): array
+{
+    $mergedCoverage = [];
+    $files = glob(COVERAGE_FILE_PATTERN) ?: [];
+
+    foreach ($files as $file) {
+        $data = readCoverageFile($file);
+        if ($data === null) {
+            continue;
+        }
+
+        foreach ($data as $filename => $lines) {
+            $mergedCoverage[$filename] = mergeFileLines($mergedCoverage[$filename] ?? [], $lines);
+        }
+    }
+
+    return $mergedCoverage;
+}
+
+/**
+ * Read and decode a single coverage file, returning null on failure.
+ */
+function readCoverageFile(string $file): ?array
+{
+    $content = @file_get_contents($file);
+    if ($content === false) {
+        error_log('Coverage: Failed to read file ' . $file);
+        return null;
+    }
+
+    $data = json_decode($content, true);
+    if (!is_array($data)) {
+        error_log('Coverage: Invalid JSON in file ' . $file);
+        return null;
+    }
+
+    return $data;
+}
+
+/**
+ * Merge the line hits of one coverage file into the already merged lines.
+ */
+function mergeFileLines(array $mergedLines, array $lines): array
+{
+    foreach ($lines as $line => $hits) {
+        // Skip dead code
+        if ($hits === -2) {
+            continue;
+        }
+
+        if (!isset($mergedLines[$line])) {
+            $mergedLines[$line] = 0;
+        }
+
+        // Xdebug: 1 = executed, -1 = not executed but executable
+        if ($hits === 1) {
+            $mergedLines[$line] = 1;
+        } elseif ($mergedLines[$line] !== 1 && $hits === -1) {
+            $mergedLines[$line] = -1;
+        }
+    }
+
+    return $mergedLines;
 }
 
 /**

--- a/src/Controller/Admin/SaveProjectAction.php
+++ b/src/Controller/Admin/SaveProjectAction.php
@@ -44,17 +44,13 @@ final class SaveProjectAction extends BaseController
     #[IsGranted('ROLE_ADMIN')]
     public function __invoke(#[MapRequestPayload] ProjectSaveDto $projectSaveDto): Response|Error|JsonResponse
     {
-        $projectId = $projectSaveDto->id;
-
-        $this->doctrineRegistry->getRepository(TicketSystem::class);
         $ticketSystem = null !== $projectSaveDto->ticket_system ? $this->doctrineRegistry->getRepository(TicketSystem::class)->find($projectSaveDto->ticket_system) : null;
 
-        $this->doctrineRegistry->getRepository(User::class);
-        $projectLead = null !== $projectSaveDto->project_lead ? $this->doctrineRegistry->getRepository(User::class)->find($projectSaveDto->project_lead) : null;
-        $technicalLead = null !== $projectSaveDto->technical_lead ? $this->doctrineRegistry->getRepository(User::class)->find($projectSaveDto->technical_lead) : null;
+        $projectLead = $this->findUser($projectSaveDto->project_lead);
+        $technicalLead = $this->findUser($projectSaveDto->technical_lead);
 
-        $jiraId = null !== $projectSaveDto->jiraId && '' !== $projectSaveDto->jiraId ? strtoupper($projectSaveDto->jiraId) : '';
-        $jiraTicket = null !== $projectSaveDto->jiraTicket && '' !== $projectSaveDto->jiraTicket ? strtoupper($projectSaveDto->jiraTicket) : '';
+        $jiraId = $this->normalizeJiraKey($projectSaveDto->jiraId);
+        $jiraTicket = $this->normalizeJiraKey($projectSaveDto->jiraTicket);
         $active = $projectSaveDto->active;
         $global = $projectSaveDto->global;
         $estimation = $this->timeCalculationService->readableToFullMinutes($projectSaveDto->estimation);
@@ -69,26 +65,9 @@ final class SaveProjectAction extends BaseController
         $internalJiraTicketSystem = $projectSaveDto->internalJiraTicketSystem;
         $internalJiraProjectKey = $projectSaveDto->internalJiraProjectKey;
 
-        if (0 !== $projectId) {
-            $project = $objectRepository->find($projectId);
-            if (!$project instanceof Project) {
-                $message = $this->translator->trans('No entry for id.');
-
-                return new Error($message, \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
-            }
-        } else {
-            $project = new Project();
-
-            /** @var Customer $customer */
-            $customer = null !== $projectSaveDto->customer ? $this->doctrineRegistry->getRepository(Customer::class)->find($projectSaveDto->customer) : null;
-            if (!$customer instanceof Customer) {
-                $response = new Response($this->translate('Please choose a customer.'));
-                $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_NOT_ACCEPTABLE);
-
-                return $response;
-            }
-
-            $project->setCustomer($customer);
+        $project = $this->loadOrCreateProject($projectSaveDto, $objectRepository);
+        if (!$project instanceof Project) {
+            return $project;
         }
 
         $projectCustomer = $project->getCustomer();
@@ -139,16 +118,64 @@ final class SaveProjectAction extends BaseController
         $data = [$project->getId(), $projectSaveDto->name, $projectCustomer->getId(), $jiraId];
 
         if ($ticketSystem instanceof TicketSystem) {
-            try {
-                if (null !== $project->getId()) {
-                    $this->subticketSyncService->syncProjectSubtickets($project);
-                }
-            } catch (Exception $e) {
-                $data['message'] = $e->getMessage();
+            $syncError = $this->trySyncSubtickets($project);
+            if (null !== $syncError) {
+                $data['message'] = $syncError;
             }
         }
 
         return new JsonResponse($data);
+    }
+
+    private function findUser(?int $userId): ?User
+    {
+        return null !== $userId ? $this->doctrineRegistry->getRepository(User::class)->find($userId) : null;
+    }
+
+    private function normalizeJiraKey(?string $value): string
+    {
+        return null !== $value && '' !== $value ? strtoupper($value) : '';
+    }
+
+    private function loadOrCreateProject(ProjectSaveDto $projectSaveDto, ProjectRepository $projectRepository): Project|Response|Error
+    {
+        if (0 !== $projectSaveDto->id) {
+            $project = $projectRepository->find($projectSaveDto->id);
+
+            return $project instanceof Project
+                ? $project
+                : new Error($this->translator->trans('No entry for id.'), \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
+        }
+
+        /** @var Customer $customer */
+        $customer = null !== $projectSaveDto->customer ? $this->doctrineRegistry->getRepository(Customer::class)->find($projectSaveDto->customer) : null;
+        if (!$customer instanceof Customer) {
+            $response = new Response($this->translate('Please choose a customer.'));
+            $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_NOT_ACCEPTABLE);
+
+            return $response;
+        }
+
+        $project = new Project();
+        $project->setCustomer($customer);
+
+        return $project;
+    }
+
+    /**
+     * Returns the error message when the subticket sync fails, null on success.
+     */
+    private function trySyncSubtickets(Project $project): ?string
+    {
+        try {
+            if (null !== $project->getId()) {
+                $this->subticketSyncService->syncProjectSubtickets($project);
+            }
+
+            return null;
+        } catch (Exception $exception) {
+            return $exception->getMessage();
+        }
     }
 
     private TimeCalculationService $timeCalculationService;

--- a/src/Controller/Controlling/ExportAction.php
+++ b/src/Controller/Controlling/ExportAction.php
@@ -11,6 +11,7 @@ namespace App\Controller\Controlling;
 
 use App\Controller\BaseController;
 use App\Dto\ExportQueryDto;
+use App\Entity\Activity;
 use App\Entity\Customer;
 use App\Entity\Entry;
 use App\Entity\Project;
@@ -21,6 +22,7 @@ use DateTimeInterface;
 use InvalidArgumentException;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
@@ -53,14 +55,7 @@ final class ExportAction extends BaseController
     {
         // Map legacy path parameters to query parameters for backward compatibility
         // This must happen BEFORE creating the DTO (hence we can't use #[MapQueryString])
-        $attributeKeysToMap = ['project', 'userid', 'year', 'month', 'customer', 'billable'];
-        foreach ($attributeKeysToMap as $attributeKeyToMap) {
-            if ($request->attributes->has($attributeKeyToMap) && !$request->query->has($attributeKeyToMap)) {
-                $attributeValue = $request->attributes->get($attributeKeyToMap);
-                $stringValue = is_scalar($attributeValue) ? (string) $attributeValue : '';
-                $request->query->set($attributeKeyToMap, $stringValue);
-            }
-        }
+        $this->mapLegacyPathParameters($request);
 
         // Create DTO from query params (which now includes mapped path params)
         $exportQueryDto = ExportQueryDto::fromRequest($request);
@@ -121,119 +116,165 @@ final class ExportAction extends BaseController
 
         $sheet = $spreadsheet->getSheet(0);
 
+        $this->writeHeadings($sheet, $showBillableField, $exportQueryDto->tickettitles);
+
+        $lineNumber = 3;
+        $stats = [];
+        foreach ($entries as $entry) {
+            $abbr = null !== $entry->getUser() ? (string) $entry->getUser()->getAbbr() : '';
+            $activityName = $this->collectEntryStats($stats, $abbr, $entry->getActivity());
+
+            $this->writeEntryRow($sheet, $lineNumber, $entry, $abbr, $activityName, $showBillableField, $exportQueryDto->tickettitles);
+
+            ++$lineNumber;
+        }
+
+        $this->writeStatsSheet($spreadsheet->getSheet(2), $stats, $exportQueryDto->month);
+
+        return $this->buildXlsxResponse($spreadsheet, $filename);
+    }
+
+    private function mapLegacyPathParameters(Request $request): void
+    {
+        $attributeKeysToMap = ['project', 'userid', 'year', 'month', 'customer', 'billable'];
+        foreach ($attributeKeysToMap as $attributeKeyToMap) {
+            if ($request->attributes->has($attributeKeyToMap) && !$request->query->has($attributeKeyToMap)) {
+                $attributeValue = $request->attributes->get($attributeKeyToMap);
+                $stringValue = is_scalar($attributeValue) ? (string) $attributeValue : '';
+                $request->query->set($attributeKeyToMap, $stringValue);
+            }
+        }
+    }
+
+    private function writeHeadings(Worksheet $worksheet, bool $showBillableField, bool $showTicketTitles): void
+    {
         $headingStyle = [
             'font' => [
                 'bold' => true,
             ],
         ];
         if ($showBillableField) {
-            $sheet->setCellValue('N2', 'billable');
-            $sheet->getStyle('N2')->applyFromArray($headingStyle);
+            $worksheet->setCellValue('N2', 'billable');
+            $worksheet->getStyle('N2')->applyFromArray($headingStyle);
         }
 
-        if ($exportQueryDto->tickettitles) {
-            $sheet->setCellValue('O2', 'Tickettitel');
-            $sheet->getStyle('O2')->applyFromArray($headingStyle);
+        if ($showTicketTitles) {
+            $worksheet->setCellValue('O2', 'Tickettitel');
+            $worksheet->getStyle('O2')->applyFromArray($headingStyle);
+        }
+    }
+
+    /**
+     * Counts holidays/sickdays per user abbreviation and resolves the activity name.
+     *
+     * @param array<string, array{holidays: int, sickdays: int}> $stats
+     */
+    private function collectEntryStats(array &$stats, string $abbr, ?Activity $activity): string
+    {
+        if (!isset($stats[$abbr])) {
+            $stats[$abbr] = [
+                'holidays' => 0,
+                'sickdays' => 0,
+            ];
         }
 
-        $lineNumber = 3;
-        $stats = [];
-        foreach ($entries as $entry) {
-            $abbr = null !== $entry->getUser() ? (string) $entry->getUser()->getAbbr() : '';
-            if (!isset($stats[$abbr])) {
-                $stats[$abbr] = [
-                    'holidays' => 0,
-                    'sickdays' => 0,
-                ];
-            }
-
-            $activity = $entry->getActivity();
-            if (null !== $activity) {
-                if ($activity->isHoliday()) {
-                    ++$stats[$abbr]['holidays'];
-                }
-
-                if ($activity->isSick()) {
-                    ++$stats[$abbr]['sickdays'];
-                }
-
-                $activity = $activity->getName();
-            } else {
-                $activity = ' ';
-            }
-
-            if ($entry->getDay() instanceof DateTimeInterface) {
-                self::setCellDate($sheet, 'A', $lineNumber, $entry->getDay());
-            }
-
-            if ($entry->getStart() instanceof DateTimeInterface) {
-                self::setCellHours($sheet, 'B', $lineNumber, $entry->getStart());
-            }
-
-            if ($entry->getEnd() instanceof DateTimeInterface) {
-                self::setCellHours($sheet, 'C', $lineNumber, $entry->getEnd());
-            }
-
-            $customerName = '';
-            $customerEntity = $entry->getCustomer();
-            if ($customerEntity instanceof Customer) {
-                $customerName = (string) $customerEntity->getName();
-            } else {
-                $projectEntity = $entry->getProject();
-                if ($projectEntity instanceof Project && $projectEntity->getCustomer() instanceof Customer) {
-                    $customerName = (string) $projectEntity->getCustomer()->getName();
-                }
-            }
-
-            $sheet->setCellValue('D' . $lineNumber, $customerName);
-
-            $projectName = '';
-            $projectEntity = $entry->getProject();
-            if ($projectEntity instanceof Project) {
-                $projectName = $projectEntity->getName();
-            }
-
-            $sheet->setCellValue('E' . $lineNumber, $projectName);
-            $sheet->setCellValue('F' . $lineNumber, $activity);
-            $sheet->setCellValue('G' . $lineNumber, $entry->getDescription());
-            $sheet->setCellValue('H' . $lineNumber, $entry->getTicket());
-            $sheet->setCellValue('I' . $lineNumber, '=C' . $lineNumber . '-B' . $lineNumber);
-            $sheet->setCellValue('J' . $lineNumber, $abbr);
-            $sheet->setCellValue('K' . $lineNumber, $entry->getExternalReporter());
-            $sheet->setCellValue('L' . $lineNumber, $entry->getExternalSummary());
-            $sheet->setCellValue('M' . $lineNumber, implode(', ', $entry->getExternalLabels()));
-            if ($showBillableField) {
-                $sheet->setCellValue('N' . $lineNumber, (int) ((bool) $entry->getBillable()));
-            }
-
-            if ($exportQueryDto->tickettitles) {
-                $sheet->setCellValue('O' . $lineNumber, $entry->getTicketTitle());
-            }
-
-            ++$lineNumber;
+        if (!$activity instanceof Activity) {
+            return ' ';
         }
 
-        $sheet = $spreadsheet->getSheet(2);
+        if ($activity->isHoliday()) {
+            ++$stats[$abbr]['holidays'];
+        }
+
+        if ($activity->isSick()) {
+            ++$stats[$abbr]['sickdays'];
+        }
+
+        return $activity->getName();
+    }
+
+    private function writeEntryRow(
+        Worksheet $worksheet,
+        int $lineNumber,
+        Entry $entry,
+        string $abbr,
+        string $activityName,
+        bool $showBillableField,
+        bool $showTicketTitles,
+    ): void {
+        self::setCellDate($worksheet, 'A', $lineNumber, $entry->getDay());
+        self::setCellHours($worksheet, 'B', $lineNumber, $entry->getStart());
+        self::setCellHours($worksheet, 'C', $lineNumber, $entry->getEnd());
+
+        $worksheet->setCellValue('D' . $lineNumber, $this->resolveCustomerName($entry));
+        $worksheet->setCellValue('E' . $lineNumber, $this->resolveProjectName($entry));
+        $worksheet->setCellValue('F' . $lineNumber, $activityName);
+        $worksheet->setCellValue('G' . $lineNumber, $entry->getDescription());
+        $worksheet->setCellValue('H' . $lineNumber, $entry->getTicket());
+        $worksheet->setCellValue('I' . $lineNumber, '=C' . $lineNumber . '-B' . $lineNumber);
+        $worksheet->setCellValue('J' . $lineNumber, $abbr);
+        $worksheet->setCellValue('K' . $lineNumber, $entry->getExternalReporter());
+        $worksheet->setCellValue('L' . $lineNumber, $entry->getExternalSummary());
+        $worksheet->setCellValue('M' . $lineNumber, implode(', ', $entry->getExternalLabels()));
+        if ($showBillableField) {
+            $worksheet->setCellValue('N' . $lineNumber, (int) ((bool) $entry->getBillable()));
+        }
+
+        if ($showTicketTitles) {
+            $worksheet->setCellValue('O' . $lineNumber, $entry->getTicketTitle());
+        }
+    }
+
+    private function resolveCustomerName(Entry $entry): string
+    {
+        $customerEntity = $entry->getCustomer();
+        if ($customerEntity instanceof Customer) {
+            return (string) $customerEntity->getName();
+        }
+
+        $projectEntity = $entry->getProject();
+        if ($projectEntity instanceof Project && $projectEntity->getCustomer() instanceof Customer) {
+            return (string) $projectEntity->getCustomer()->getName();
+        }
+
+        return '';
+    }
+
+    private function resolveProjectName(Entry $entry): string
+    {
+        $projectEntity = $entry->getProject();
+
+        return $projectEntity instanceof Project ? $projectEntity->getName() : '';
+    }
+
+    /**
+     * @param array<string, array{holidays: int, sickdays: int}> $stats
+     */
+    private function writeStatsSheet(Worksheet $worksheet, array $stats, int $month): void
+    {
         $lineNumber = 2;
         ksort($stats);
         foreach ($stats as $user => $userStats) {
-            $sheet->setCellValue('A' . $lineNumber, $user);
-            $sheet->setCellValue('B' . $lineNumber, $exportQueryDto->month);
-            $sheet->setCellValue('D' . $lineNumber, '=SUMIF(ZE!$J$1:$J$5000,A' . $lineNumber . ',ZE!$I$1:$I$5000)');
-            $sheet->getStyle('D' . $lineNumber)
+            $worksheet->setCellValue('A' . $lineNumber, $user);
+            $worksheet->setCellValue('B' . $lineNumber, $month);
+            $worksheet->setCellValue('D' . $lineNumber, '=SUMIF(ZE!$J$1:$J$5000,A' . $lineNumber . ',ZE!$I$1:$I$5000)');
+            $worksheet->getStyle('D' . $lineNumber)
                 ->getNumberFormat()
                 ->setFormatCode('[HH]:MM');
             if ($userStats['holidays'] > 0) {
-                $sheet->setCellValue('E' . $lineNumber, $userStats['holidays']);
+                $worksheet->setCellValue('E' . $lineNumber, $userStats['holidays']);
             }
 
             if ($userStats['sickdays'] > 0) {
-                $sheet->setCellValue('F' . $lineNumber, $userStats['sickdays']);
+                $worksheet->setCellValue('F' . $lineNumber, $userStats['sickdays']);
             }
 
             ++$lineNumber;
         }
+    }
 
+    private function buildXlsxResponse(Spreadsheet $spreadsheet, string $filename): Response
+    {
         $tmp = tempnam(sys_get_temp_dir(), 'ttt-export-');
         $filePath = false !== $tmp
             ? $tmp

--- a/src/Controller/Tracking/BulkEntryAction.php
+++ b/src/Controller/Tracking/BulkEntryAction.php
@@ -126,7 +126,7 @@ final class BulkEntryAction extends BaseTrackingController
             $contractHoursArray = $this->loadContractHours($bulkEntryDto, $user);
             if (null === $contractHoursArray) {
                 return $this->createResponse(
-                    $this->translator->trans('No contract for user found. Please use custome time.'),
+                    $this->translator->trans('No contract for user found. Please use custom time.'),
                     \Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY,
                 );
             }

--- a/src/Controller/Tracking/BulkEntryAction.php
+++ b/src/Controller/Tracking/BulkEntryAction.php
@@ -39,6 +39,12 @@ use function sprintf;
 
 final class BulkEntryAction extends BaseTrackingController
 {
+    private const array WEEKEND_DAYS = ['0', '6', '7'];
+
+    private const array REGULAR_HOLIDAYS = ['01-01', '05-01', '10-03', '10-31', '12-25', '12-26'];
+
+    private const array IRREGULAR_HOLIDAYS = ['2012-04-06', '2012-04-09', '2012-05-17', '2012-05-28', '2012-11-21', '2013-03-29', '2013-04-01', '2013-05-09', '2013-05-20', '2013-11-20', '2014-04-18', '2014-04-21', '2014-05-29', '2014-06-09', '2014-11-19', '2015-04-03', '2015-04-04', '2015-05-14', '2015-05-25', '2015-11-18'];
+
     private ?EventDispatcherInterface $eventDispatcher = null;
 
     public function __construct(
@@ -80,181 +86,268 @@ final class BulkEntryAction extends BaseTrackingController
         $constraintViolationList = $this->validator->validate($bulkEntryDto);
         if (count($constraintViolationList) > 0) {
             $errorMessage = (string) $constraintViolationList->get(0)->getMessage();
-            $response = new Response($this->translator->trans($errorMessage));
-            $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
 
-            return $response;
+            return $this->createResponse(
+                $this->translator->trans($errorMessage),
+                \Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
         }
 
         try {
-            $this->logData(['preset' => $bulkEntryDto->preset, 'startdate' => $bulkEntryDto->startdate, 'enddate' => $bulkEntryDto->enddate], true);
-
-            $doctrine = $this->managerRegistry;
-            $contractHoursArray = [];
-
-            $preset = $doctrine->getRepository(Preset::class)->find($bulkEntryDto->preset);
-            if (!$preset instanceof Preset) {
-                throw new PresetNotFoundException('Preset not found');
-            }
-
-            $user = $currentUser;
-            $customer = $doctrine->getRepository(Customer::class)->find($preset->getCustomerId());
-            $project = $doctrine->getRepository(Project::class)->find($preset->getProjectId());
-            $activity = $doctrine->getRepository(Activity::class)->find($preset->getActivityId());
-
-            if ($bulkEntryDto->isUseContract()) {
-                $contracts = $doctrine->getRepository(Contract::class)
-                    ->findBy(['user' => $currentUser->getId()], ['start' => 'ASC']);
-
-                foreach ($contracts as $contract) {
-                    if (!$contract instanceof Contract) {
-                        continue;
-                    }
-
-                    $contractHoursArray[] = [
-                        'start' => $contract->getStart(),
-                        'stop' => $contract->getEnd() ?? new DateTime('' !== $bulkEntryDto->enddate ? $bulkEntryDto->enddate : 'now'),
-                        7 => $contract->getHours0(),
-                        1 => $contract->getHours1(),
-                        2 => $contract->getHours2(),
-                        3 => $contract->getHours3(),
-                        4 => $contract->getHours4(),
-                        5 => $contract->getHours5(),
-                        6 => $contract->getHours6(),
-                    ];
-                }
-
-                if ([] === $contracts) {
-                    $response = new Response(
-                        $this->translator->trans('No contract for user found. Please use custome time.'),
-                    );
-                    $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
-
-                    return $response;
-                }
-            }
-
-            $em = $doctrine->getManager();
-            $date = new DateTime('' !== $bulkEntryDto->startdate ? $bulkEntryDto->startdate : 'now');
-            $endDate = new DateTime('' !== $bulkEntryDto->enddate ? $bulkEntryDto->enddate : 'now');
-
-            $c = 0;
-            $weekend = ['0', '6', '7'];
-            $regular_holidays = ['01-01', '05-01', '10-03', '10-31', '12-25', '12-26'];
-            $irregular_holidays = ['2012-04-06', '2012-04-09', '2012-05-17', '2012-05-28', '2012-11-21', '2013-03-29', '2013-04-01', '2013-05-09', '2013-05-20', '2013-11-20', '2014-04-18', '2014-04-21', '2014-05-29', '2014-06-09', '2014-11-19', '2015-04-03', '2015-04-04', '2015-05-14', '2015-05-25', '2015-11-18'];
-
-            $numAdded = 0;
-            do {
-                ++$c;
-                if ($c > 100) {
-                    break;
-                }
-
-                if ($bulkEntryDto->isSkipWeekend() && in_array($date->format('w'), $weekend, true)) {
-                    $date->add(new DateInterval('P1D'));
-
-                    continue;
-                }
-
-                if ($bulkEntryDto->isSkipHolidays()) {
-                    if (in_array($date->format('m-d'), $regular_holidays, true)) {
-                        $date->add(new DateInterval('P1D'));
-
-                        continue;
-                    }
-
-                    if (in_array($date->format('Y-m-d'), $irregular_holidays, true)) {
-                        $date->add(new DateInterval('P1D'));
-
-                        continue;
-                    }
-                }
-
-                if ($bulkEntryDto->isUseContract()) {
-                    foreach ($contractHoursArray as $contractHourArray) {
-                        $workTime = 0;
-                        if ($contractHourArray['start'] <= $date && $contractHourArray['stop'] >= $date) {
-                            $workTime = $contractHourArray[$date->format('N')];
-                            break;
-                        }
-                    }
-
-                    if (!isset($workTime) || $workTime <= 0) {
-                        $date->add(new DateInterval('P1D'));
-
-                        continue;
-                    }
-
-                    $parts = sscanf((string) $workTime, '%d.%d');
-                    $hoursPart = (int) ($parts[0] ?? 0);
-                    $fractionPart = (int) ($parts[1] ?? 0);
-                    $minutesPart = (int) round(60 * ((float) ('0.' . $fractionPart)));
-                    $hoursToAdd = new DateInterval(sprintf('PT%dH%dM', $hoursPart, $minutesPart));
-                    $startTime = new DateTime('08:00:00');
-                    $endTime = new DateTime('08:00:00')->add($hoursToAdd);
-                } else {
-                    $startTime = new DateTime('' !== $bulkEntryDto->starttime ? $bulkEntryDto->starttime : '00:00:00');
-                    $endTime = new DateTime('' !== $bulkEntryDto->endtime ? $bulkEntryDto->endtime : '00:00:00');
-                }
-
-                $entry = new Entry();
-                $entry->setUser($user)
-                    ->setTicket('')
-                    ->setDescription($preset->getDescription())
-                    ->setDay($date->format('Y-m-d'))
-                    ->setStart($startTime->format('H:i:s'))
-                    ->setEnd($endTime->format('H:i:s'))
-                    ->setClass(EntryClass::DAYBREAK)
-                    ->calcDuration();
-
-                if ($project instanceof Project) {
-                    $entry->setProject($project);
-                }
-
-                if ($activity instanceof Activity) {
-                    $entry->setActivity($activity);
-                }
-
-                if ($customer instanceof Customer) {
-                    $entry->setCustomer($customer);
-                }
-
-                $this->logData($entry->toArray());
-                $em->persist($entry);
-                $em->flush();
-
-                // Dispatch entry created event for Jira sync and cache invalidation
-                if ($this->eventDispatcher instanceof EventDispatcherInterface) {
-                    $this->eventDispatcher->dispatch(new EntryEvent($entry), EntryEvent::CREATED);
-                }
-
-                ++$numAdded;
-
-                $this->calculateClasses($user->getId() ?? 0, $entry->getDay()->format('Y-m-d'));
-                $date->add(new DateInterval('P1D'));
-            } while ($date <= $endDate);
-
-            $responseContent = $this->translator->trans('%num% entries have been added', ['%num%' => $numAdded]);
-            if ([] !== $contractHoursArray && (new DateTime('' !== $bulkEntryDto->startdate ? $bulkEntryDto->startdate : 'now')) < $contractHoursArray[0]['start']) {
-                $responseContent .= '<br/>' . $this->translator->trans('Contract is valid from %date%.', ['%date%' => $contractHoursArray[0]['start']->format('d.m.Y')]);
-            }
-
-            if ([] !== $contractHoursArray) {
-                $lastContract = end($contractHoursArray);
-                if ($endDate > $lastContract['stop']) {
-                    $responseContent .= '<br/>' . $this->translator->trans('Contract expired at %date%.', ['%date%' => $lastContract['stop']->format('d.m.Y')]);
-                }
-            }
-
-            $response = new Response($responseContent);
-            $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_OK);
-
-            return $response;
+            return $this->processBulkEntries($bulkEntryDto, $currentUser);
         } catch (Exception $exception) {
-            $response = new Response($this->translator->trans($exception->getMessage()));
-            $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
-
-            return $response;
+            return $this->createResponse(
+                $this->translator->trans($exception->getMessage()),
+                \Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
         }
+    }
+
+    /**
+     * @throws Exception when entry creation or persistence fails
+     */
+    private function processBulkEntries(BulkEntryDto $bulkEntryDto, User $user): Response
+    {
+        $this->logData(['preset' => $bulkEntryDto->preset, 'startdate' => $bulkEntryDto->startdate, 'enddate' => $bulkEntryDto->enddate], true);
+
+        $doctrine = $this->managerRegistry;
+
+        $preset = $doctrine->getRepository(Preset::class)->find($bulkEntryDto->preset);
+        if (!$preset instanceof Preset) {
+            throw new PresetNotFoundException('Preset not found');
+        }
+
+        $customer = $doctrine->getRepository(Customer::class)->find($preset->getCustomerId());
+        $project = $doctrine->getRepository(Project::class)->find($preset->getProjectId());
+        $activity = $doctrine->getRepository(Activity::class)->find($preset->getActivityId());
+
+        $contractHoursArray = [];
+        if ($bulkEntryDto->isUseContract()) {
+            $contractHoursArray = $this->loadContractHours($bulkEntryDto, $user);
+            if (null === $contractHoursArray) {
+                return $this->createResponse(
+                    $this->translator->trans('No contract for user found. Please use custome time.'),
+                    \Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY,
+                );
+            }
+        }
+
+        $em = $doctrine->getManager();
+        $date = $this->createDateOrNow($bulkEntryDto->startdate);
+        $endDate = $this->createDateOrNow($bulkEntryDto->enddate);
+
+        $c = 0;
+        $numAdded = 0;
+        do {
+            ++$c;
+            if ($c > 100) {
+                break;
+            }
+
+            if ($this->shouldSkipDay($date, $bulkEntryDto)) {
+                $date->add(new DateInterval('P1D'));
+
+                continue;
+            }
+
+            $times = $this->resolveDayTimes($date, $contractHoursArray, $bulkEntryDto);
+            if (null === $times) {
+                $date->add(new DateInterval('P1D'));
+
+                continue;
+            }
+
+            $entry = $this->createBulkEntry($preset, $user, $date, $times[0], $times[1], $customer, $project, $activity);
+
+            $this->logData($entry->toArray());
+            $em->persist($entry);
+            $em->flush();
+
+            // Dispatch entry created event for Jira sync and cache invalidation
+            if ($this->eventDispatcher instanceof EventDispatcherInterface) {
+                $this->eventDispatcher->dispatch(new EntryEvent($entry), EntryEvent::CREATED);
+            }
+
+            ++$numAdded;
+
+            $this->calculateClasses($user->getId() ?? 0, $entry->getDay()->format('Y-m-d'));
+            $date->add(new DateInterval('P1D'));
+        } while ($date <= $endDate);
+
+        return $this->createResponse(
+            $this->buildResultMessage($bulkEntryDto, $contractHoursArray, $endDate, $numAdded),
+            \Symfony\Component\HttpFoundation\Response::HTTP_OK,
+        );
+    }
+
+    /**
+     * Builds the per-weekday contract hours lookup for the user's contracts.
+     *
+     * @throws Exception
+     *
+     * @return list<array{start: DateTime, stop: DateTime, 1: float, 2: float, 3: float, 4: float, 5: float, 6: float, 7: float}>|null
+     *                                                                                                                                 null when the user has no contracts
+     */
+    private function loadContractHours(BulkEntryDto $bulkEntryDto, User $user): ?array
+    {
+        $contracts = $this->managerRegistry->getRepository(Contract::class)
+            ->findBy(['user' => $user->getId()], ['start' => 'ASC']);
+
+        if ([] === $contracts) {
+            return null;
+        }
+
+        $contractHoursArray = [];
+        foreach ($contracts as $contract) {
+            if (!$contract instanceof Contract) {
+                continue;
+            }
+
+            $contractHoursArray[] = [
+                'start' => $contract->getStart(),
+                'stop' => $contract->getEnd() ?? $this->createDateOrNow($bulkEntryDto->enddate),
+                7 => $contract->getHours0(),
+                1 => $contract->getHours1(),
+                2 => $contract->getHours2(),
+                3 => $contract->getHours3(),
+                4 => $contract->getHours4(),
+                5 => $contract->getHours5(),
+                6 => $contract->getHours6(),
+            ];
+        }
+
+        return $contractHoursArray;
+    }
+
+    private function shouldSkipDay(DateTime $date, BulkEntryDto $bulkEntryDto): bool
+    {
+        if ($bulkEntryDto->isSkipWeekend() && in_array($date->format('w'), self::WEEKEND_DAYS, true)) {
+            return true;
+        }
+
+        if (!$bulkEntryDto->isSkipHolidays()) {
+            return false;
+        }
+
+        return in_array($date->format('m-d'), self::REGULAR_HOLIDAYS, true)
+            || in_array($date->format('Y-m-d'), self::IRREGULAR_HOLIDAYS, true);
+    }
+
+    /**
+     * Resolves the start and end time for the given day.
+     *
+     * @param list<array{start: DateTime, stop: DateTime, 1: float, 2: float, 3: float, 4: float, 5: float, 6: float, 7: float}> $contractHoursArray
+     *
+     * @throws Exception
+     *
+     * @return array{0: DateTime, 1: DateTime}|null null when no contract covers the day or the work time is zero
+     */
+    private function resolveDayTimes(DateTime $date, array $contractHoursArray, BulkEntryDto $bulkEntryDto): ?array
+    {
+        if (!$bulkEntryDto->isUseContract()) {
+            return [
+                new DateTime('' !== $bulkEntryDto->starttime ? $bulkEntryDto->starttime : '00:00:00'),
+                new DateTime('' !== $bulkEntryDto->endtime ? $bulkEntryDto->endtime : '00:00:00'),
+            ];
+        }
+
+        $workTime = 0;
+        foreach ($contractHoursArray as $contractHourArray) {
+            if ($contractHourArray['start'] <= $date && $contractHourArray['stop'] >= $date) {
+                $workTime = $contractHourArray[$date->format('N')];
+                break;
+            }
+        }
+
+        if ($workTime <= 0) {
+            return null;
+        }
+
+        $parts = sscanf((string) $workTime, '%d.%d');
+        $hoursPart = (int) ($parts[0] ?? 0);
+        $fractionPart = (int) ($parts[1] ?? 0);
+        $minutesPart = (int) round(60 * ((float) ('0.' . $fractionPart)));
+        $hoursToAdd = new DateInterval(sprintf('PT%dH%dM', $hoursPart, $minutesPart));
+
+        return [
+            new DateTime('08:00:00'),
+            new DateTime('08:00:00')->add($hoursToAdd),
+        ];
+    }
+
+    private function createBulkEntry(
+        Preset $preset,
+        User $user,
+        DateTime $date,
+        DateTime $startTime,
+        DateTime $endTime,
+        ?Customer $customer,
+        ?Project $project,
+        ?Activity $activity,
+    ): Entry {
+        $entry = new Entry();
+        $entry->setUser($user)
+            ->setTicket('')
+            ->setDescription($preset->getDescription())
+            ->setDay($date->format('Y-m-d'))
+            ->setStart($startTime->format('H:i:s'))
+            ->setEnd($endTime->format('H:i:s'))
+            ->setClass(EntryClass::DAYBREAK)
+            ->calcDuration();
+
+        if ($project instanceof Project) {
+            $entry->setProject($project);
+        }
+
+        if ($activity instanceof Activity) {
+            $entry->setActivity($activity);
+        }
+
+        if ($customer instanceof Customer) {
+            $entry->setCustomer($customer);
+        }
+
+        return $entry;
+    }
+
+    /**
+     * @param list<array{start: DateTime, stop: DateTime, 1: float, 2: float, 3: float, 4: float, 5: float, 6: float, 7: float}> $contractHoursArray
+     *
+     * @throws Exception
+     */
+    private function buildResultMessage(BulkEntryDto $bulkEntryDto, array $contractHoursArray, DateTime $endDate, int $numAdded): string
+    {
+        $responseContent = $this->translator->trans('%num% entries have been added', ['%num%' => $numAdded]);
+
+        if ([] === $contractHoursArray) {
+            return $responseContent;
+        }
+
+        if ($this->createDateOrNow($bulkEntryDto->startdate) < $contractHoursArray[0]['start']) {
+            $responseContent .= '<br/>' . $this->translator->trans('Contract is valid from %date%.', ['%date%' => $contractHoursArray[0]['start']->format('d.m.Y')]);
+        }
+
+        $lastContract = end($contractHoursArray);
+        if ($endDate > $lastContract['stop']) {
+            $responseContent .= '<br/>' . $this->translator->trans('Contract expired at %date%.', ['%date%' => $lastContract['stop']->format('d.m.Y')]);
+        }
+
+        return $responseContent;
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createDateOrNow(string $value): DateTime
+    {
+        return new DateTime('' !== $value ? $value : 'now');
+    }
+
+    private function createResponse(string $content, int $statusCode): Response
+    {
+        $response = new Response($content);
+        $response->setStatusCode($statusCode);
+
+        return $response;
     }
 }

--- a/src/Controller/Tracking/BulkEntryAction.php
+++ b/src/Controller/Tracking/BulkEntryAction.php
@@ -263,10 +263,9 @@ final class BulkEntryAction extends BaseTrackingController
             return null;
         }
 
-        $parts = sscanf((string) $workTime, '%d.%d');
-        $hoursPart = (int) ($parts[0] ?? 0);
-        $fractionPart = (int) ($parts[1] ?? 0);
-        $minutesPart = (int) round(60 * ((float) ('0.' . $fractionPart)));
+        $hours = (float) $workTime;
+        $hoursPart = (int) $hours;
+        $minutesPart = (int) round(($hours - $hoursPart) * 60);
         $hoursToAdd = new DateInterval(sprintf('PT%dH%dM', $hoursPart, $minutesPart));
 
         return [

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -73,68 +73,31 @@ final class SaveEntryAction extends BaseTrackingController
         #[CurrentUser]
         User $user,
     ): Response|JsonResponse|Error {
-        $customerRepo = $this->managerRegistry->getRepository(Customer::class);
-        assert($customerRepo instanceof CustomerRepository);
-
-        $customerId = $entrySaveDto->getCustomerId();
-        if (null === $customerId) {
-            return new JsonResponse(['error' => 'Customer ID is required'], Response::HTTP_BAD_REQUEST);
-        }
-
-        $customer = $customerRepo->findOneById($customerId);
-
+        $customer = $this->resolveCustomer($entrySaveDto->getCustomerId());
         if (!$customer instanceof Customer) {
-            return new Error('Given customer does not exist.', Response::HTTP_BAD_REQUEST);
+            return $customer;
         }
 
-        $projectRepo = $this->managerRegistry->getRepository(Project::class);
-        assert($projectRepo instanceof ProjectRepository);
-
-        $projectId = $entrySaveDto->getProjectId();
-        if (null === $projectId) {
-            return new JsonResponse(['error' => 'Project ID is required'], Response::HTTP_BAD_REQUEST);
-        }
-
-        $project = $projectRepo->findOneById($projectId);
-
+        $project = $this->resolveProject($entrySaveDto->getProjectId());
         if (!$project instanceof Project) {
-            return new Error('Given project does not exist.', Response::HTTP_BAD_REQUEST);
+            return $project;
         }
 
-        $activityRepo = $this->managerRegistry->getRepository(Activity::class);
-        assert($activityRepo instanceof ActivityRepository);
-
-        $activityId = $entrySaveDto->getActivityId();
-        if (null === $activityId) {
-            return new JsonResponse(['error' => 'Activity ID is required'], Response::HTTP_BAD_REQUEST);
-        }
-
-        $activity = $activityRepo->findOneById($activityId);
-
+        $activity = $this->resolveActivity($entrySaveDto->getActivityId());
         if (!$activity instanceof Activity) {
-            return new Error('Given activity does not exist.', Response::HTTP_BAD_REQUEST);
+            return $activity;
         }
-
-        $entryId = $entrySaveDto->id;
 
         // v4 parity: tickets are stored upper-cased and trimmed
         $ticket = strtoupper(trim($entrySaveDto->ticket));
 
         // Should we check if the ticket belongs to the project
-        if ('' !== $ticket && '0' !== $ticket) {
-            $prefixError = $this->validateTicketPrefix($project, $ticket);
-            if ($prefixError instanceof Error) {
-                return $prefixError;
-            }
+        $ticketError = $this->validateTicket($project, $ticket);
+        if ($ticketError instanceof Error) {
+            return $ticketError;
         }
 
-        $entryRepo = $this->managerRegistry->getRepository(Entry::class);
-        assert($entryRepo instanceof EntryRepository);
-
-        $entry = null;
-        if (null !== $entryId) {
-            $entry = $entryRepo->findOneById($entryId);
-        }
+        $entry = $this->findExistingEntry($entrySaveDto->id);
 
         // Check if someone else already owns the entry (if exists)
         if ($entry instanceof Entry && $entry->getUserId() !== $user->getId()) {
@@ -142,7 +105,7 @@ final class SaveEntryAction extends BaseTrackingController
         }
 
         $isNewEntry = !$entry instanceof Entry;
-        if ($isNewEntry) {
+        if (!$entry instanceof Entry) {
             $entry = new Entry();
         }
 
@@ -150,34 +113,132 @@ final class SaveEntryAction extends BaseTrackingController
         // ticket changes) and the day-class recalculation of a moved entry
         $previousEntry = $isNewEntry ? null : clone $entry;
 
+        $populateError = $this->populateEntry($entry, $entrySaveDto, $user, $customer, $project, $activity, $ticket);
+        if ($populateError instanceof Error) {
+            return $populateError;
+        }
+
+        if (!$project->getActive()) {
+            return new Error('Project is no longer active.', Response::HTTP_BAD_REQUEST);
+        }
+
+        $durationError = $this->calculateDuration($entry);
+        if ($durationError instanceof Error) {
+            return $durationError;
+        }
+
+        try {
+            $this->persistEntry($entry, $isNewEntry, $previousEntry);
+
+            // v4 parity: recalculate the day-break/pause/overlap rendering
+            // classes of the affected day(s)
+            $this->recalculateDayClasses($entry, $previousEntry, $user);
+
+            // Return JSON response matching test expectations
+            return $this->buildEntryResponse($entry, $entrySaveDto);
+        } catch (Throwable $throwable) {
+            return new Error('Could not save entry: ' . $throwable->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private function resolveCustomer(?int $customerId): Customer|JsonResponse|Error
+    {
+        if (null === $customerId) {
+            return new JsonResponse(['error' => 'Customer ID is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $customerRepo = $this->managerRegistry->getRepository(Customer::class);
+        assert($customerRepo instanceof CustomerRepository);
+
+        $customer = $customerRepo->findOneById($customerId);
+
+        if (!$customer instanceof Customer) {
+            return new Error('Given customer does not exist.', Response::HTTP_BAD_REQUEST);
+        }
+
+        return $customer;
+    }
+
+    private function resolveProject(?int $projectId): Project|JsonResponse|Error
+    {
+        if (null === $projectId) {
+            return new JsonResponse(['error' => 'Project ID is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $projectRepo = $this->managerRegistry->getRepository(Project::class);
+        assert($projectRepo instanceof ProjectRepository);
+
+        $project = $projectRepo->findOneById($projectId);
+
+        if (!$project instanceof Project) {
+            return new Error('Given project does not exist.', Response::HTTP_BAD_REQUEST);
+        }
+
+        return $project;
+    }
+
+    private function resolveActivity(?int $activityId): Activity|JsonResponse|Error
+    {
+        if (null === $activityId) {
+            return new JsonResponse(['error' => 'Activity ID is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $activityRepo = $this->managerRegistry->getRepository(Activity::class);
+        assert($activityRepo instanceof ActivityRepository);
+
+        $activity = $activityRepo->findOneById($activityId);
+
+        if (!$activity instanceof Activity) {
+            return new Error('Given activity does not exist.', Response::HTTP_BAD_REQUEST);
+        }
+
+        return $activity;
+    }
+
+    private function validateTicket(Project $project, string $ticket): ?Error
+    {
+        if ('' === $ticket || '0' === $ticket) {
+            return null;
+        }
+
+        return $this->validateTicketPrefix($project, $ticket);
+    }
+
+    private function findExistingEntry(?int $entryId): ?Entry
+    {
+        if (null === $entryId) {
+            return null;
+        }
+
+        $entryRepo = $this->managerRegistry->getRepository(Entry::class);
+        assert($entryRepo instanceof EntryRepository);
+
+        return $entryRepo->findOneById($entryId);
+    }
+
+    /**
+     * Applies the request data to the entry; returns an error for invalid date/time formats.
+     */
+    private function populateEntry(
+        Entry $entry,
+        EntrySaveDto $entrySaveDto,
+        User $user,
+        Customer $customer,
+        Project $project,
+        Activity $activity,
+        string $ticket,
+    ): ?Error {
         $entry->setUser($user);
         $entry->setCustomer($customer);
         $entry->setProject($project);
         $entry->setActivity($activity);
 
         // Use DTO methods for date/time parsing (supports multiple formats)
-        $dayDate = $entrySaveDto->getDateAsDateTime();
-        if (!$dayDate instanceof DateTimeInterface && '' !== $entrySaveDto->date && '0' !== $entrySaveDto->date) {
-            return new Error('Given day does not have a valid format.', Response::HTTP_BAD_REQUEST);
-        }
-        if ($dayDate instanceof DateTimeInterface) {
-            $entry->setDay(DateTime::createFromInterface($dayDate));
-        }
-
-        $startTime = $entrySaveDto->getStartAsDateTime();
-        if (!$startTime instanceof DateTimeInterface && '' !== $entrySaveDto->start && '0' !== $entrySaveDto->start) {
-            return new Error('Given start does not have a valid format.', Response::HTTP_BAD_REQUEST);
-        }
-        if ($startTime instanceof DateTimeInterface) {
-            $entry->setStart(DateTime::createFromInterface($startTime));
-        }
-
-        $endTime = $entrySaveDto->getEndAsDateTime();
-        if (!$endTime instanceof DateTimeInterface && '' !== $entrySaveDto->end && '0' !== $entrySaveDto->end) {
-            return new Error('Given end does not have a valid format.', Response::HTTP_BAD_REQUEST);
-        }
-        if ($endTime instanceof DateTimeInterface) {
-            $entry->setEnd(DateTime::createFromInterface($endTime));
+        $dateError = $this->applyDay($entry, $entrySaveDto)
+            ?? $this->applyStart($entry, $entrySaveDto)
+            ?? $this->applyEnd($entry, $entrySaveDto);
+        if ($dateError instanceof Error) {
+            return $dateError;
         }
 
         if ('' !== $entrySaveDto->description && '0' !== $entrySaveDto->description) {
@@ -194,109 +255,162 @@ final class SaveEntryAction extends BaseTrackingController
             '' !== $entrySaveDto->extTicket ? $entrySaveDto->extTicket : null,
         );
 
-        if (!$project->getActive()) {
-            return new Error('Project is no longer active.', Response::HTTP_BAD_REQUEST);
+        return null;
+    }
+
+    private function applyDay(Entry $entry, EntrySaveDto $entrySaveDto): ?Error
+    {
+        $dayDate = $entrySaveDto->getDateAsDateTime();
+        if (!$dayDate instanceof DateTimeInterface && '' !== $entrySaveDto->date && '0' !== $entrySaveDto->date) {
+            return new Error('Given day does not have a valid format.', Response::HTTP_BAD_REQUEST);
         }
 
-        // Calculate duration
-        if ($entry->getStart() instanceof DateTime && $entry->getEnd() instanceof DateTime) {
-            $start = $entry->getStart();
-            $end = $entry->getEnd();
-
-            if ($start >= $end) {
-                return new Error('Start time cannot be after end time.', Response::HTTP_BAD_REQUEST);
-            }
-
-            $interval = $start->diff($end);
-            $hours = $interval->h;
-            $minutes = $interval->i;
-
-            // Convert to decimal hours with minutes as fractional part, then to minutes as integer
-            $duration = (float) $hours + ((float) $minutes / 60.0);
-            $entry->setDuration((int) round($duration * 60));
+        if ($dayDate instanceof DateTimeInterface) {
+            $entry->setDay(DateTime::createFromInterface($dayDate));
         }
 
-        try {
-            $entityManager = $this->managerRegistry->getManager();
-            $entityManager->persist($entry);
-            $entityManager->flush();
+        return null;
+    }
 
-            // Dispatch entry event for Jira sync and cache invalidation
-            if ($this->eventDispatcher instanceof EventDispatcherInterface) {
-                $eventName = $isNewEntry ? EntryEvent::CREATED : EntryEvent::UPDATED;
-                $this->eventDispatcher->dispatch(
-                    new EntryEvent($entry, ['previous' => $previousEntry]),
-                    $eventName,
-                );
-            }
-
-            // v4 parity: recalculate the day-break/pause/overlap rendering
-            // classes of the affected day(s)
-            $entryDay = $entry->getDay();
-            if ($entryDay instanceof DateTime) {
-                $this->calculateClasses($user->getId() ?? 0, $entryDay->format('Y-m-d'));
-
-                $previousDay = $previousEntry?->getDay();
-                if ($previousDay instanceof DateTime
-                    && $previousDay->format('Y-m-d') !== $entryDay->format('Y-m-d')
-                ) {
-                    $this->calculateClasses($user->getId() ?? 0, $previousDay->format('Y-m-d'));
-                }
-            }
-
-            // Return JSON response matching test expectations
-            $day = $entry->getDay();
-            $start = $entry->getStart();
-            $end = $entry->getEnd();
-            $user = $entry->getUser();
-            $customer = $entry->getCustomer();
-            $project = $entry->getProject();
-            $activity = $entry->getActivity();
-
-            if (!$day instanceof DateTime || !$start instanceof DateTime || !$end instanceof DateTime
-                || !$user instanceof User || !$customer instanceof Customer
-                || !$project instanceof Project || !$activity instanceof Activity) {
-                return new Error('Entry data is incomplete.', Response::HTTP_INTERNAL_SERVER_ERROR);
-            }
-
-            $durationMinutes = $entry->getDuration();
-            $durationString = sprintf('%02d:%02d', (int) ($durationMinutes / 60), $durationMinutes % 60);
-
-            $data = [
-                'result' => [
-                    'id' => $entry->getId(),
-                    'date' => $day->format('d/m/Y'),
-                    'start' => $start->format('H:i'),
-                    'end' => $end->format('H:i'),
-                    'user' => $user->getId(),
-                    'customer' => $customer->getId(),
-                    'project' => $project->getId(),
-                    'activity' => $activity->getId(),
-                    'duration' => $durationString,
-                    'durationMinutes' => $durationMinutes,
-                    'class' => $entry->getClass()->value,
-                ],
-            ];
-
-            // Include ticket and description if present
-            if ('' !== $entrySaveDto->ticket && '0' !== $entrySaveDto->ticket) {
-                $data['result']['ticket'] = $entry->getTicket();
-            }
-
-            // The UI round-trips the original external ticket key of
-            // mirrored entries from this field (v4: part of toArray())
-            if ($entry->hasInternalJiraTicketOriginalKey()) {
-                $data['result']['extTicket'] = $entry->getInternalJiraTicketOriginalKey();
-            }
-
-            if ('' !== $entrySaveDto->description && '0' !== $entrySaveDto->description) {
-                $data['result']['description'] = $entry->getDescription();
-            }
-
-            return new JsonResponse($data);
-        } catch (Throwable $throwable) {
-            return new Error('Could not save entry: ' . $throwable->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+    private function applyStart(Entry $entry, EntrySaveDto $entrySaveDto): ?Error
+    {
+        $startTime = $entrySaveDto->getStartAsDateTime();
+        if (!$startTime instanceof DateTimeInterface && '' !== $entrySaveDto->start && '0' !== $entrySaveDto->start) {
+            return new Error('Given start does not have a valid format.', Response::HTTP_BAD_REQUEST);
         }
+
+        if ($startTime instanceof DateTimeInterface) {
+            $entry->setStart(DateTime::createFromInterface($startTime));
+        }
+
+        return null;
+    }
+
+    private function applyEnd(Entry $entry, EntrySaveDto $entrySaveDto): ?Error
+    {
+        $endTime = $entrySaveDto->getEndAsDateTime();
+        if (!$endTime instanceof DateTimeInterface && '' !== $entrySaveDto->end && '0' !== $entrySaveDto->end) {
+            return new Error('Given end does not have a valid format.', Response::HTTP_BAD_REQUEST);
+        }
+
+        if ($endTime instanceof DateTimeInterface) {
+            $entry->setEnd(DateTime::createFromInterface($endTime));
+        }
+
+        return null;
+    }
+
+    /**
+     * Calculates and sets the entry duration; returns an error when start is not before end.
+     */
+    private function calculateDuration(Entry $entry): ?Error
+    {
+        $start = $entry->getStart();
+        $end = $entry->getEnd();
+
+        if (!$start instanceof DateTime || !$end instanceof DateTime) {
+            return null;
+        }
+
+        if ($start >= $end) {
+            return new Error('Start time cannot be after end time.', Response::HTTP_BAD_REQUEST);
+        }
+
+        $interval = $start->diff($end);
+        $hours = $interval->h;
+        $minutes = $interval->i;
+
+        // Convert to decimal hours with minutes as fractional part, then to minutes as integer
+        $duration = (float) $hours + ((float) $minutes / 60.0);
+        $entry->setDuration((int) round($duration * 60));
+
+        return null;
+    }
+
+    private function persistEntry(Entry $entry, bool $isNewEntry, ?Entry $previousEntry): void
+    {
+        $entityManager = $this->managerRegistry->getManager();
+        $entityManager->persist($entry);
+        $entityManager->flush();
+
+        // Dispatch entry event for Jira sync and cache invalidation
+        if ($this->eventDispatcher instanceof EventDispatcherInterface) {
+            $eventName = $isNewEntry ? EntryEvent::CREATED : EntryEvent::UPDATED;
+            $this->eventDispatcher->dispatch(
+                new EntryEvent($entry, ['previous' => $previousEntry]),
+                $eventName,
+            );
+        }
+    }
+
+    private function recalculateDayClasses(Entry $entry, ?Entry $previousEntry, User $user): void
+    {
+        $entryDay = $entry->getDay();
+        if (!$entryDay instanceof DateTime) {
+            return;
+        }
+
+        $this->calculateClasses($user->getId() ?? 0, $entryDay->format('Y-m-d'));
+
+        $previousDay = $previousEntry?->getDay();
+        if ($previousDay instanceof DateTime
+            && $previousDay->format('Y-m-d') !== $entryDay->format('Y-m-d')
+        ) {
+            $this->calculateClasses($user->getId() ?? 0, $previousDay->format('Y-m-d'));
+        }
+    }
+
+    private function buildEntryResponse(Entry $entry, EntrySaveDto $entrySaveDto): JsonResponse|Error
+    {
+        $day = $entry->getDay();
+        $start = $entry->getStart();
+        $end = $entry->getEnd();
+        $entryUser = $entry->getUser();
+        $customer = $entry->getCustomer();
+        $project = $entry->getProject();
+        $activity = $entry->getActivity();
+
+        if (!$day instanceof DateTime || !$start instanceof DateTime || !$end instanceof DateTime
+            || !$entryUser instanceof User || !$customer instanceof Customer
+            || !$project instanceof Project || !$activity instanceof Activity) {
+            return new Error('Entry data is incomplete.', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $durationMinutes = $entry->getDuration();
+        $durationString = sprintf('%02d:%02d', (int) ($durationMinutes / 60), $durationMinutes % 60);
+
+        $data = [
+            'result' => [
+                'id' => $entry->getId(),
+                'date' => $day->format('d/m/Y'),
+                'start' => $start->format('H:i'),
+                'end' => $end->format('H:i'),
+                'user' => $entryUser->getId(),
+                'customer' => $customer->getId(),
+                'project' => $project->getId(),
+                'activity' => $activity->getId(),
+                'duration' => $durationString,
+                'durationMinutes' => $durationMinutes,
+                'class' => $entry->getClass()->value,
+            ],
+        ];
+
+        // Include ticket and description if present
+        if ('' !== $entrySaveDto->ticket && '0' !== $entrySaveDto->ticket) {
+            $data['result']['ticket'] = $entry->getTicket();
+        }
+
+        // The UI round-trips the original external ticket key of
+        // mirrored entries from this field (v4: part of toArray())
+        if ($entry->hasInternalJiraTicketOriginalKey()) {
+            $data['result']['extTicket'] = $entry->getInternalJiraTicketOriginalKey();
+        }
+
+        if ('' !== $entrySaveDto->description && '0' !== $entrySaveDto->description) {
+            $data['result']['description'] = $entry->getDescription();
+        }
+
+        return new JsonResponse($data);
     }
 
     /**

--- a/src/DTO/Jira/JiraIssueFields.php
+++ b/src/DTO/Jira/JiraIssueFields.php
@@ -52,23 +52,35 @@ final readonly class JiraIssueFields
             $assignee = JiraAssignee::fromApiResponse($data['assignee']);
         }
 
-        $subtasks = [];
-        if (isset($data['subtasks']) && is_iterable($data['subtasks'])) {
-            foreach ($data['subtasks'] as $subtask) {
-                if (is_object($subtask)) {
-                    $subtasks[] = JiraSubtask::fromApiResponse($subtask);
-                }
-            }
-        }
-
         return new self(
             summary: isset($data['summary']) && is_string($data['summary']) ? $data['summary'] : null,
             description: isset($data['description']) && is_string($data['description']) ? $data['description'] : null,
             issuetype: $issuetype,
             status: $status,
             assignee: $assignee,
-            subtasks: $subtasks,
+            subtasks: self::parseSubtasks($data),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<JiraSubtask>
+     */
+    private static function parseSubtasks(array $data): array
+    {
+        if (!isset($data['subtasks']) || !is_iterable($data['subtasks'])) {
+            return [];
+        }
+
+        $subtasks = [];
+        foreach ($data['subtasks'] as $subtask) {
+            if (is_object($subtask)) {
+                $subtasks[] = JiraSubtask::fromApiResponse($subtask);
+            }
+        }
+
+        return $subtasks;
     }
 
     /**

--- a/src/Dto/EntrySaveDto.php
+++ b/src/Dto/EntrySaveDto.php
@@ -95,24 +95,8 @@ final readonly class EntrySaveDto
             return null;
         }
 
-        // Try ISO 8601 format first (from ExtJS: 2026-01-14T00:00:00)
-        $date = DateTime::createFromFormat(self::FORMAT_ISO_DATETIME, $this->date);
-        if (false !== $date) {
-            return $date;
-        }
-
-        // Try Y-m-d format (standard ISO date)
-        $date = DateTime::createFromFormat('Y-m-d', $this->date);
-        if (false !== $date) {
-            return $date;
-        }
-
-        // Fallback to generic DateTime parsing
-        try {
-            return new DateTime($this->date);
-        } catch (Exception) {
-            return null;
-        }
+        // ISO 8601 datetime first (from ExtJS: 2026-01-14T00:00:00), then standard ISO date
+        return $this->parseDateTime($this->date, [self::FORMAT_ISO_DATETIME, 'Y-m-d']);
     }
 
     /**
@@ -125,30 +109,8 @@ final readonly class EntrySaveDto
             return null;
         }
 
-        // Try ISO 8601 format first (from ExtJS: 2026-01-14T08:00:00)
-        $time = DateTime::createFromFormat(self::FORMAT_ISO_DATETIME, $this->start);
-        if (false !== $time) {
-            return $time;
-        }
-
-        // Handle H:i:s format
-        $time = DateTime::createFromFormat('H:i:s', $this->start);
-        if (false !== $time) {
-            return $time;
-        }
-
-        // Handle H:i format
-        $time = DateTime::createFromFormat('H:i', $this->start);
-        if (false !== $time) {
-            return $time;
-        }
-
-        // Fallback to generic DateTime parsing
-        try {
-            return new DateTime($this->start);
-        } catch (Exception) {
-            return null;
-        }
+        // ISO 8601 datetime first (from ExtJS: 2026-01-14T08:00:00), then time-only formats
+        return $this->parseDateTime($this->start, [self::FORMAT_ISO_DATETIME, 'H:i:s', 'H:i']);
     }
 
     /**
@@ -161,27 +123,28 @@ final readonly class EntrySaveDto
             return null;
         }
 
-        // Try ISO 8601 format first (from ExtJS: 2026-01-14T16:00:00)
-        $time = DateTime::createFromFormat(self::FORMAT_ISO_DATETIME, $this->end);
-        if (false !== $time) {
-            return $time;
-        }
+        // ISO 8601 datetime first (from ExtJS: 2026-01-14T16:00:00), then time-only formats
+        return $this->parseDateTime($this->end, [self::FORMAT_ISO_DATETIME, 'H:i:s', 'H:i']);
+    }
 
-        // Handle H:i:s format
-        $time = DateTime::createFromFormat('H:i:s', $this->end);
-        if (false !== $time) {
-            return $time;
-        }
-
-        // Handle H:i format
-        $time = DateTime::createFromFormat('H:i', $this->end);
-        if (false !== $time) {
-            return $time;
+    /**
+     * Parses a date/time string by trying the given formats in order,
+     * falling back to generic DateTime parsing.
+     *
+     * @param list<string> $formats
+     */
+    private function parseDateTime(string $value, array $formats): ?DateTimeInterface
+    {
+        foreach ($formats as $format) {
+            $parsed = DateTime::createFromFormat($format, $value);
+            if (false !== $parsed) {
+                return $parsed;
+            }
         }
 
         // Fallback to generic DateTime parsing
         try {
-            return new DateTime($this->end);
+            return new DateTime($value);
         } catch (Exception) {
             return null;
         }

--- a/src/Dto/ExportQueryDto.php
+++ b/src/Dto/ExportQueryDto.php
@@ -82,20 +82,10 @@ final readonly class ExportQueryDto
 
     private static function toBool(mixed $value): bool
     {
-        if (null === $value) {
-            return false;
-        }
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_scalar($value)) {
-            $normalized = strtolower(trim((string) $value));
-
-            return in_array($normalized, ['1', 'true', 'on', 'yes'], true);
-        }
-
-        return false;
+        return match (true) {
+            is_bool($value) => $value,
+            is_scalar($value) => in_array(strtolower(trim((string) $value)), ['1', 'true', 'on', 'yes'], true),
+            default => false,
+        };
     }
 }

--- a/src/Entity/Holiday.php
+++ b/src/Entity/Holiday.php
@@ -57,7 +57,7 @@ class Holiday extends Base
     /**
      * Set name.
      */
-    public function setName(string $name): void
+    public function setName(): void
     {
         // Cannot modify readonly property after initialization
         throw new BadMethodCallException('Cannot modify readonly property $name after construction. Use constructor instead.');

--- a/src/Entity/Holiday.php
+++ b/src/Entity/Holiday.php
@@ -55,7 +55,9 @@ class Holiday extends Base
     }
 
     /**
-     * Set name.
+     * Backward-compatibility shim: $name is readonly, so this always throws.
+     *
+     * @throws BadMethodCallException always; pass the name to the constructor instead
      */
     public function setName(): void
     {

--- a/src/Extension/NrArrayTranslator.php
+++ b/src/Extension/NrArrayTranslator.php
@@ -100,29 +100,27 @@ class NrArrayTranslator
                 continue;
             }
 
-            $data = $this->translateRow($data, $row[$arrayKey], $rowKey, $arrayKey, $keys, $languageFile);
+            $this->translateRow($data, $row[$arrayKey], $rowKey, $arrayKey, $keys, $languageFile);
         }
 
         return (string) json_encode($data);
     }
 
     /**
-     * Translates the allowed keys of a single row and returns the updated data.
+     * Translates the allowed keys of a single row in place.
      *
      * @param array<int|string, mixed> $data
      * @param iterable<mixed, mixed>   $rowValues
      * @param array<int, string>       $keys
-     *
-     * @return array<int|string, mixed>
      */
     private function translateRow(
-        array $data,
+        array &$data,
         iterable $rowValues,
         int|string $rowKey,
         string $arrayKey,
         array $keys,
         ?string $languageFile,
-    ): array {
+    ): void {
         foreach ($rowValues as $key => $value) {
             // Ensure key is string and in the allowed keys
             if (!is_string($key)) {
@@ -149,7 +147,5 @@ class NrArrayTranslator
                 $languageFile,
             );
         }
-
-        return $data;
     }
 }

--- a/src/Extension/NrArrayTranslator.php
+++ b/src/Extension/NrArrayTranslator.php
@@ -100,34 +100,56 @@ class NrArrayTranslator
                 continue;
             }
 
-            foreach ($row[$arrayKey] as $key => $value) {
-                // Ensure key is string and in the allowed keys
-                if (!is_string($key)) {
-                    continue;
-                }
-                if (!in_array($key, $keys, true)) {
-                    continue;
-                }
-                // Ensure value is string before translation
-                if (!is_string($value)) {
-                    continue;
-                }
-                // Ensure we have array access to the nested structure
-                if (!is_array($data[$rowKey] ?? null)) {
-                    continue;
-                }
-                if (!is_array($data[$rowKey][$arrayKey] ?? null)) {
-                    continue;
-                }
-
-                $data[$rowKey][$arrayKey][$key] = $this->translator->trans(
-                    $value,
-                    [],
-                    $languageFile,
-                );
-            }
+            $data = $this->translateRow($data, $row[$arrayKey], $rowKey, $arrayKey, $keys, $languageFile);
         }
 
         return (string) json_encode($data);
+    }
+
+    /**
+     * Translates the allowed keys of a single row and returns the updated data.
+     *
+     * @param array<int|string, mixed> $data
+     * @param iterable<mixed, mixed>   $rowValues
+     * @param array<int, string>       $keys
+     *
+     * @return array<int|string, mixed>
+     */
+    private function translateRow(
+        array $data,
+        iterable $rowValues,
+        int|string $rowKey,
+        string $arrayKey,
+        array $keys,
+        ?string $languageFile,
+    ): array {
+        foreach ($rowValues as $key => $value) {
+            // Ensure key is string and in the allowed keys
+            if (!is_string($key)) {
+                continue;
+            }
+            if (!in_array($key, $keys, true)) {
+                continue;
+            }
+            // Ensure value is string before translation
+            if (!is_string($value)) {
+                continue;
+            }
+            // Ensure we have array access to the nested structure
+            if (!is_array($data[$rowKey] ?? null)) {
+                continue;
+            }
+            if (!is_array($data[$rowKey][$arrayKey] ?? null)) {
+                continue;
+            }
+
+            $data[$rowKey][$arrayKey][$key] = $this->translator->trans(
+                $value,
+                [],
+                $languageFile,
+            );
+        }
+
+        return $data;
     }
 }

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -459,20 +459,7 @@ class EntryRepository extends ServiceEntityRepository
     ): array {
         $queryBuilder = $this->findEntriesWithRelations();
 
-        // Apply filters
-        foreach ($filters as $field => $value) {
-            if (null !== $value && '' !== $value) {
-                if (in_array($field, ['startDate', 'endDate'], true)) {
-                    $operator = 'startDate' === $field ? '>=' : '<=';
-                    $fieldName = 'day';
-                    $queryBuilder->andWhere(sprintf('e.%s %s :%s', $fieldName, $operator, $field))
-                        ->setParameter($field, $value);
-                } else {
-                    $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
-                        ->setParameter($field, $value);
-                }
-            }
-        }
+        $this->applyFieldFilters($queryBuilder, $filters);
 
         // Apply ordering
         $validOrderFields = ['id', 'day', 'start', 'end', 'duration'];
@@ -520,19 +507,7 @@ class EntryRepository extends ServiceEntityRepository
                 'MAX(e.day) as maxDate',
             ]);
 
-        foreach ($filters as $field => $value) {
-            if (null !== $value && '' !== $value) {
-                if (in_array($field, ['startDate', 'endDate'], true)) {
-                    $operator = 'startDate' === $field ? '>=' : '<=';
-                    $fieldName = 'day';
-                    $queryBuilder->andWhere(sprintf('e.%s %s :%s', $fieldName, $operator, $field))
-                        ->setParameter($field, $value);
-                } else {
-                    $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
-                        ->setParameter($field, $value);
-                }
-            }
-        }
+        $this->applyFieldFilters($queryBuilder, $filters);
 
         $rawResult = $queryBuilder->getQuery()->getSingleResult();
 
@@ -665,47 +640,71 @@ class EntryRepository extends ServiceEntityRepository
             ->leftJoin('e.project', 'p')
             ->leftJoin('e.activity', 'a');
 
-        // Apply filters
-        if (isset($arFilter['customer']) && '' !== $arFilter['customer']) {
-            if (is_object($arFilter['customer'])) {
-                $queryBuilder->andWhere(self::WHERE_CUSTOMER)
-                    ->setParameter('customer', $arFilter['customer']);
+        $this->applyRelationFilters($queryBuilder, $arFilter);
+        $this->applyDateWindowFilters($queryBuilder, $arFilter);
+        $this->applyFilterPagination($queryBuilder, $arFilter);
+
+        $queryBuilder->orderBy('e.day', 'DESC')
+            ->addOrderBy('e.start', 'DESC');
+
+        /* @phpstan-ignore-next-line */
+        return $queryBuilder->getQuery();
+    }
+
+    /**
+     * Applies generic field equality filters; startDate/endDate map to day range bounds.
+     *
+     * @param array<string, mixed> $filters
+     */
+    private function applyFieldFilters(QueryBuilder $queryBuilder, array $filters): void
+    {
+        foreach ($filters as $field => $value) {
+            if (null === $value) {
+                continue;
+            }
+            if ('' === $value) {
+                continue;
+            }
+            if (in_array($field, ['startDate', 'endDate'], true)) {
+                $operator = 'startDate' === $field ? '>=' : '<=';
+                $queryBuilder->andWhere(sprintf('e.day %s :%s', $operator, $field))
+                    ->setParameter($field, $value);
             } else {
-                $queryBuilder->andWhere('IDENTITY(e.customer) = :customer')
-                    ->setParameter('customer', $arFilter['customer']);
+                $queryBuilder->andWhere(sprintf(self::WHERE_FIELD_TEMPLATE, $field, $field))
+                    ->setParameter($field, $value);
             }
         }
+    }
 
-        if (isset($arFilter['project']) && '' !== $arFilter['project']) {
-            if (is_object($arFilter['project'])) {
-                $queryBuilder->andWhere(self::WHERE_PROJECT)
-                    ->setParameter('project', $arFilter['project']);
-            } else {
-                $queryBuilder->andWhere('IDENTITY(e.project) = :project')
-                    ->setParameter('project', $arFilter['project']);
+    /**
+     * Applies customer/project/activity/user filters; entity objects are compared
+     * directly, scalar identifiers via IDENTITY() on the association.
+     *
+     * @param array<string, mixed> $arFilter
+     */
+    private function applyRelationFilters(QueryBuilder $queryBuilder, array $arFilter): void
+    {
+        foreach (['customer', 'project', 'activity', 'user'] as $field) {
+            if (!isset($arFilter[$field])) {
+                continue;
             }
-        }
-
-        if (isset($arFilter['activity']) && '' !== $arFilter['activity']) {
-            if (is_object($arFilter['activity'])) {
-                $queryBuilder->andWhere(self::WHERE_ACTIVITY)
-                    ->setParameter('activity', $arFilter['activity']);
-            } else {
-                $queryBuilder->andWhere('IDENTITY(e.activity) = :activity')
-                    ->setParameter('activity', $arFilter['activity']);
+            if ('' === $arFilter[$field]) {
+                continue;
             }
-        }
+            $dql = is_object($arFilter[$field])
+                ? sprintf('e.%s = :%s', $field, $field)
+                : sprintf('IDENTITY(e.%s) = :%s', $field, $field);
 
-        if (isset($arFilter['user']) && '' !== $arFilter['user']) {
-            if (is_object($arFilter['user'])) {
-                $queryBuilder->andWhere(self::WHERE_USER)
-                    ->setParameter('user', $arFilter['user']);
-            } else {
-                $queryBuilder->andWhere('IDENTITY(e.user) = :user')
-                    ->setParameter('user', $arFilter['user']);
-            }
+            $queryBuilder->andWhere($dql)
+                ->setParameter($field, $arFilter[$field]);
         }
+    }
 
+    /**
+     * @param array<string, mixed> $arFilter
+     */
+    private function applyDateWindowFilters(QueryBuilder $queryBuilder, array $arFilter): void
+    {
         if (isset($arFilter['datestart']) && '' !== $arFilter['datestart']) {
             $queryBuilder->andWhere('e.day >= :datestart')
                 ->setParameter('datestart', $arFilter['datestart']);
@@ -715,9 +714,16 @@ class EntryRepository extends ServiceEntityRepository
             $queryBuilder->andWhere('e.day <= :dateend')
                 ->setParameter('dateend', $arFilter['dateend']);
         }
+    }
 
-        // Apply pagination with safe casting
-        // Prefer 'start' (ExtJS offset) over calculating from 'page'
+    /**
+     * Applies pagination with safe casting.
+     * Prefers 'start' (ExtJS offset) over calculating the offset from 'page'.
+     *
+     * @param array<string, mixed> $arFilter
+     */
+    private function applyFilterPagination(QueryBuilder $queryBuilder, array $arFilter): void
+    {
         $maxResults = isset($arFilter['maxResults']) && is_numeric($arFilter['maxResults']) ? (int) $arFilter['maxResults'] : 50;
         if (isset($arFilter['start']) && is_numeric($arFilter['start'])) {
             $offset = (int) $arFilter['start'];
@@ -727,12 +733,7 @@ class EntryRepository extends ServiceEntityRepository
         }
 
         $queryBuilder->setMaxResults($maxResults)
-            ->setFirstResult($offset)
-            ->orderBy('e.day', 'DESC')
-            ->addOrderBy('e.start', 'DESC');
-
-        /* @phpstan-ignore-next-line */
-        return $queryBuilder->getQuery();
+            ->setFirstResult($offset);
     }
 
     /**
@@ -828,6 +829,27 @@ class EntryRepository extends ServiceEntityRepository
     ): array {
         $queryBuilder = $this->findEntriesWithRelations();
 
+        $this->applyDateRangeCriteria($queryBuilder, $user, $year, $month, $project, $customer);
+        $this->applySortOrder($queryBuilder, $arSort);
+
+        $result = $queryBuilder->getQuery()->getResult();
+        assert(is_array($result) && array_is_list($result));
+
+        /** @var list<Entry> $result */
+        return $result;
+    }
+
+    /**
+     * Restricts the query to the given year/month and optional user/project/customer.
+     */
+    private function applyDateRangeCriteria(
+        QueryBuilder $queryBuilder,
+        int $user,
+        int $year,
+        ?int $month,
+        ?int $project,
+        ?int $customer,
+    ): void {
         // Use date range instead of YEAR function for DQL compatibility
         $startOfYear = sprintf('%04d-01-01', $year);
         $endOfYear = sprintf('%04d-12-31', $year);
@@ -861,38 +883,46 @@ class EntryRepository extends ServiceEntityRepository
             $queryBuilder->andWhere(self::WHERE_CUSTOMER)
                 ->setParameter('customer', $customer);
         }
+    }
 
-        // Apply sorting
-        if (is_array($arSort) && [] !== $arSort) {
-            foreach ($arSort as $field => $direction) {
-                // Handle both string and boolean values for direction
-                if (is_bool($direction)) {
-                    $direction = $direction ? 'ASC' : 'DESC';
-                } else {
-                    $direction = 'ASC' === strtoupper((string) $direction) ? 'ASC' : 'DESC';
-                }
-
-                // Map logical field names to proper DQL expressions
-                $dqlField = match ($field) {
-                    'user.username' => 'u.username',
-                    'entry.day' => 'e.day',
-                    'entry.start' => 'e.start',
-                    'entry.end' => 'e.end',
-                    default => 'e.' . $field,
-                };
-
-                $queryBuilder->addOrderBy($dqlField, $direction);
-            }
-        } else {
+    /**
+     * Applies the requested sort order, falling back to day/start descending.
+     *
+     * @param array<string, string|bool>|null $arSort
+     */
+    private function applySortOrder(QueryBuilder $queryBuilder, ?array $arSort): void
+    {
+        if (null === $arSort || [] === $arSort) {
             $queryBuilder->orderBy('e.day', 'DESC')
                 ->addOrderBy('e.start', 'DESC');
+
+            return;
         }
 
-        $result = $queryBuilder->getQuery()->getResult();
-        assert(is_array($result) && array_is_list($result));
+        foreach ($arSort as $field => $direction) {
+            // Handle both string and boolean values for direction
+            if (is_bool($direction)) {
+                $direction = $direction ? 'ASC' : 'DESC';
+            } else {
+                $direction = 'ASC' === strtoupper($direction) ? 'ASC' : 'DESC';
+            }
 
-        /** @var list<Entry> $result */
-        return $result;
+            $queryBuilder->addOrderBy($this->mapSortField($field), $direction);
+        }
+    }
+
+    /**
+     * Maps logical field names to proper DQL expressions.
+     */
+    private function mapSortField(string|int $field): string
+    {
+        return match ($field) {
+            'user.username' => 'u.username',
+            'entry.day' => 'e.day',
+            'entry.start' => 'e.start',
+            'entry.end' => 'e.end',
+            default => 'e.' . $field,
+        };
     }
 
     /**
@@ -914,66 +944,8 @@ class EntryRepository extends ServiceEntityRepository
     ): array {
         $queryBuilder = $this->findEntriesWithRelations();
 
-        // Use date range instead of YEAR function for DQL compatibility
-        $startOfYear = sprintf('%04d-01-01', $year);
-        $endOfYear = sprintf('%04d-12-31', $year);
-        $queryBuilder->andWhere('e.day >= :startOfYear')
-            ->andWhere('e.day <= :endOfYear')
-            ->setParameter('startOfYear', $startOfYear)
-            ->setParameter('endOfYear', $endOfYear);
-
-        if (0 !== $user) {
-            $queryBuilder->andWhere(self::WHERE_USER)
-                ->setParameter('user', $user);
-        }
-
-        if (null !== $month && $month > 0) {
-            // Use date range instead of MONTH function for DQL compatibility
-            $startOfMonth = sprintf('%04d-%02d-01', $year, $month);
-            $lastDay = (int) (new DateTime(sprintf('%d-%d-01', $year, $month))->format('t'));
-            $endOfMonth = sprintf('%04d-%02d-%02d', $year, $month, $lastDay);
-            $queryBuilder->andWhere('e.day >= :startOfMonth')
-                ->andWhere(self::WHERE_DAY_UNTIL_END_OF_MONTH)
-                ->setParameter('startOfMonth', $startOfMonth)
-                ->setParameter('endOfMonth', $endOfMonth);
-        }
-
-        if (null !== $project) {
-            $queryBuilder->andWhere(self::WHERE_PROJECT)
-                ->setParameter('project', $project);
-        }
-
-        if (null !== $customer) {
-            $queryBuilder->andWhere(self::WHERE_CUSTOMER)
-                ->setParameter('customer', $customer);
-        }
-
-        // Apply sorting
-        if (is_array($arSort) && [] !== $arSort) {
-            foreach ($arSort as $field => $direction) {
-                if (!is_string($field)) {
-                    continue;
-                }
-                if (!is_string($direction)) {
-                    continue;
-                }
-                $direction = 'ASC' === strtoupper($direction) ? 'ASC' : 'DESC';
-
-                // Map logical field names to proper DQL expressions
-                $dqlField = match ($field) {
-                    'user.username' => 'u.username',
-                    'entry.day' => 'e.day',
-                    'entry.start' => 'e.start',
-                    'entry.end' => 'e.end',
-                    default => 'e.' . $field,
-                };
-
-                $queryBuilder->addOrderBy($dqlField, $direction);
-            }
-        } else {
-            $queryBuilder->orderBy('e.day', 'DESC')
-                ->addOrderBy('e.start', 'DESC');
-        }
+        $this->applyDateRangeCriteria($queryBuilder, $user, $year, $month, $project, $customer);
+        $this->applySortOrder($queryBuilder, $arSort);
 
         // Apply pagination
         $queryBuilder->setFirstResult($offset)
@@ -1410,40 +1382,8 @@ class EntryRepository extends ServiceEntityRepository
         $queryBuilder = $this->findEntriesWithRelations();
 
         // Apply filters similar to queryByFilterArray but return results directly
-        if (isset($arFilter['customer']) && '' !== $arFilter['customer']) {
-            $queryBuilder->andWhere(self::WHERE_CUSTOMER)
-                ->setParameter('customer', $arFilter['customer']);
-        }
-
-        if (isset($arFilter['project']) && '' !== $arFilter['project']) {
-            $queryBuilder->andWhere(self::WHERE_PROJECT)
-                ->setParameter('project', $arFilter['project']);
-        }
-
-        if (isset($arFilter['activity']) && '' !== $arFilter['activity']) {
-            $queryBuilder->andWhere(self::WHERE_ACTIVITY)
-                ->setParameter('activity', $arFilter['activity']);
-        }
-
-        if (isset($arFilter['user']) && '' !== $arFilter['user']) {
-            if (is_object($arFilter['user'])) {
-                $queryBuilder->andWhere(self::WHERE_USER)
-                    ->setParameter('user', $arFilter['user']);
-            } else {
-                $queryBuilder->andWhere('IDENTITY(e.user) = :user')
-                    ->setParameter('user', $arFilter['user']);
-            }
-        }
-
-        if (isset($arFilter['datestart']) && '' !== $arFilter['datestart']) {
-            $queryBuilder->andWhere('e.day >= :datestart')
-                ->setParameter('datestart', $arFilter['datestart']);
-        }
-
-        if (isset($arFilter['dateend']) && '' !== $arFilter['dateend']) {
-            $queryBuilder->andWhere('e.day <= :dateend')
-                ->setParameter('dateend', $arFilter['dateend']);
-        }
+        $this->applyRelationFilters($queryBuilder, $arFilter);
+        $this->applyDateWindowFilters($queryBuilder, $arFilter);
 
         // Apply limit if specified with safe casting
         if (isset($arFilter['maxResults']) && is_numeric($arFilter['maxResults'])) {

--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -65,30 +65,65 @@ class ProjectRepository extends ServiceEntityRepository
                 continue;
             }
 
-            foreach ($userProjects as $userProject) {
-                $up = $userProject['project'] ?? null;
-                if (is_array($up) && ($customerId === ArrayTypeHelper::getInt($up, 'customer'))) {
-                    $projects[$customerId][] = [
-                        'id' => ArrayTypeHelper::getInt($up, 'id', 0) ?? 0,
-                        'name' => ArrayTypeHelper::getString($up, 'name', '') ?? '',
-                        'jiraId' => ArrayTypeHelper::getString($up, 'jiraId'),
-                        'active' => (bool) ($up['active'] ?? false),
-                    ];
-                }
-            }
+            $this->appendCustomerProjects($projects, $customerId, $userProjects, $globalProjects);
+        }
 
-            foreach ($globalProjects as $globalProject) {
-                if ($globalProject instanceof Project) {
-                    $projects[$customerId][] = [
-                        'id' => $globalProject->getId(),
-                        'name' => $globalProject->getName(),
-                        'jiraId' => $globalProject->getJiraId(),
-                        'active' => $globalProject->getActive(),
-                    ];
-                }
+        $this->appendAllProjects($projects, $userProjects, $globalProjects);
+
+        foreach ($projects as &$project) {
+            // Both branches construct arrays; phpstan knows they are arrays
+            usort($project, static fn (array $a, array $b): int => strcmp(
+                ArrayTypeHelper::getString($a, 'name') ?? '',
+                ArrayTypeHelper::getString($b, 'name') ?? '',
+            ));
+        }
+
+        return $projects;
+    }
+
+    /**
+     * Appends the user's projects of the given customer and all global projects
+     * to the per-customer project list.
+     *
+     * @param array<int|string, list<array<string, mixed>>>    $projects
+     * @param array<int, array{project: array<string, mixed>}> $userProjects
+     * @param array<int, Project>                              $globalProjects
+     */
+    private function appendCustomerProjects(array &$projects, int $customerId, array $userProjects, array $globalProjects): void
+    {
+        foreach ($userProjects as $userProject) {
+            $up = $userProject['project'] ?? null;
+            if (is_array($up) && ($customerId === ArrayTypeHelper::getInt($up, 'customer'))) {
+                $projects[$customerId][] = [
+                    'id' => ArrayTypeHelper::getInt($up, 'id', 0) ?? 0,
+                    'name' => ArrayTypeHelper::getString($up, 'name', '') ?? '',
+                    'jiraId' => ArrayTypeHelper::getString($up, 'jiraId'),
+                    'active' => (bool) ($up['active'] ?? false),
+                ];
             }
         }
 
+        foreach ($globalProjects as $globalProject) {
+            if ($globalProject instanceof Project) {
+                $projects[$customerId][] = [
+                    'id' => $globalProject->getId(),
+                    'name' => $globalProject->getName(),
+                    'jiraId' => $globalProject->getJiraId(),
+                    'active' => $globalProject->getActive(),
+                ];
+            }
+        }
+    }
+
+    /**
+     * Appends all user and global projects to the "all" key.
+     *
+     * @param array<int|string, list<array<string, mixed>>>    $projects
+     * @param array<int, array{project: array<string, mixed>}> $userProjects
+     * @param array<int, Project>                              $globalProjects
+     */
+    private function appendAllProjects(array &$projects, array $userProjects, array $globalProjects): void
+    {
         foreach ($userProjects as $userProject) {
             $up = $userProject['project'] ?? null;
             if (is_array($up)) {
@@ -119,13 +154,6 @@ class ProjectRepository extends ServiceEntityRepository
                 ];
             }
         }
-
-        foreach ($projects as &$project) {
-            // Both branches construct arrays; phpstan knows they are arrays
-            usort($project, static fn (array $a, array $b): int => strcmp($a['name'] ?? '', $b['name'] ?? ''));
-        }
-
-        return $projects;
     }
 
     /**

--- a/src/Security/LdapAuthenticator.php
+++ b/src/Security/LdapAuthenticator.php
@@ -213,19 +213,12 @@ class LdapAuthenticator extends AbstractLoginFormAuthenticator
 
     private function parsePort(mixed $value): int
     {
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_string($value)) {
-            return (int) $value;
-        }
-
-        if ($value instanceof BackedEnum) {
-            return (int) $value->value;
-        }
-
-        return 0;
+        return match (true) {
+            is_int($value) => $value,
+            is_string($value) => (int) $value,
+            $value instanceof BackedEnum => (int) $value->value,
+            default => 0,
+        };
     }
 
     /**

--- a/src/Security/LdapAuthenticator.php
+++ b/src/Security/LdapAuthenticator.php
@@ -89,88 +89,109 @@ class LdapAuthenticator extends AbstractLoginFormAuthenticator
             throw new CustomUserMessageAuthenticationException('Invalid username format.');
         }
 
-        $userLoader = function (string $userIdentifier): User {
-            try {
-                // --- Perform LDAP Authentication ---
-                // Cast parameter bag values to expected scalar types
-                $this->ldapClientService
-                    ->setHost($this->sanitizeLdapInput((string) (is_scalar($this->parameterBag->get('ldap_host')) ? $this->parameterBag->get('ldap_host') : '')))
-                    ->setPort($this->parsePort($this->parameterBag->get('ldap_port')))
-                    ->setReadUser($this->sanitizeLdapInput((string) (is_scalar($this->parameterBag->get('ldap_readuser')) ? $this->parameterBag->get('ldap_readuser') : '')))
-                    ->setReadPass((string) (is_scalar($this->parameterBag->get('ldap_readpass')) ? $this->parameterBag->get('ldap_readpass') : ''))
-                    ->setBaseDn($this->sanitizeLdapInput((string) (is_scalar($this->parameterBag->get('ldap_basedn')) ? $this->parameterBag->get('ldap_basedn') : '')))
-                    ->setUserName($this->sanitizeLdapInput($userIdentifier))
-                    ->setUserPass($this->currentPassword ?? '')
-                    ->setUseSSL((bool) ($this->parameterBag->get('ldap_usessl') ?? false))
-                    ->setUserNameField((string) (is_scalar($this->parameterBag->get('ldap_usernamefield')) ? $this->parameterBag->get('ldap_usernamefield') : ''))
-                    ->login();
-
-                $this->logger->info('LDAP authentication successful.', ['username' => $userIdentifier]);
-
-                $user = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $userIdentifier]);
-                if ($user instanceof User) {
-                    return $user;
-                }
-
-                if (!(bool) $this->parameterBag->get('ldap_create_user')) {
-                    throw new UserNotFoundException(sprintf('User "%s" authenticated via LDAP but not found locally and creation is disabled.', $userIdentifier));
-                }
-
-                $newUser = new User()
-                    ->setUsername($userIdentifier)
-                    ->setType('DEV')
-                    ->setLocale('de');
-
-                if ([] !== $this->ldapClientService->getTeams()) {
-                    $teamRepo = $this->entityManager->getRepository(Team::class);
-                    foreach ($this->ldapClientService->getTeams() as $teamname) {
-                        $team = $teamRepo->findOneBy(['name' => $teamname]);
-                        if ($team instanceof Team) {
-                            $newUser->addTeam($team);
-                        }
-                    }
-                }
-
-                $this->entityManager->persist($newUser);
-                $this->entityManager->flush();
-
-                return $newUser;
-            } catch (LdapException $ldapException) {
-                // Specific LDAP errors
-                $this->logger->error('LDAP authentication error', [
-                    'username' => substr($userIdentifier, 0, 3) . '***',
-                    'error_code' => $ldapException->getCode(),
-                    'error_type' => $ldapException::class,
-                ]);
-
-                // Don't expose LDAP-specific errors to the user
-                throw new CustomUserMessageAuthenticationException('Authentication failed. Please check your credentials.', [], $ldapException->getCode(), $ldapException);
-            } catch (UserNotFoundException $userException) {
-                // User not found and creation disabled
-                $this->logger->info('User not found in local database', ['username' => substr($userIdentifier, 0, 3) . '***']);
-                throw $userException;
-            } catch (Throwable $throwable) {
-                // Generic error handling
-                $this->logger->error('Unexpected authentication error', [
-                    'username' => substr($userIdentifier, 0, 3) . '***',
-                    'error' => $throwable->getMessage(),
-                    'trace' => $throwable->getTraceAsString(),
-                ]);
-                throw new CustomUserMessageAuthenticationException('An unexpected error occurred during authentication.', [], $throwable->getCode(), $throwable);
-            }
-        };
-
         // Store the current password temporarily for the user loader
         $this->currentPassword = $password;
 
         return new Passport(
-            new UserBadge($username, $userLoader),
+            new UserBadge($username, fn (string $userIdentifier): User => $this->loadUser($userIdentifier)),
             new CustomCredentials(static fn (): true => true, ['username' => $username]),
             [
                 new CsrfTokenBadge('authenticate', $csrfToken),
                 new RememberMeBadge(),
             ],
         );
+    }
+
+    /**
+     * Authenticates the user against LDAP and loads (or creates) the local user record.
+     *
+     * @throws CustomUserMessageAuthenticationException When LDAP authentication fails
+     * @throws UserNotFoundException                    When the user is not found locally and creation is disabled
+     */
+    private function loadUser(string $userIdentifier): User
+    {
+        try {
+            $this->configureLdapClient($userIdentifier)->login();
+
+            $this->logger->info('LDAP authentication successful.', ['username' => $userIdentifier]);
+
+            $user = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $userIdentifier]);
+            if ($user instanceof User) {
+                return $user;
+            }
+
+            if (!(bool) $this->parameterBag->get('ldap_create_user')) {
+                throw new UserNotFoundException(sprintf('User "%s" authenticated via LDAP but not found locally and creation is disabled.', $userIdentifier));
+            }
+
+            return $this->createUserFromLdap($userIdentifier);
+        } catch (LdapException $ldapException) {
+            // Specific LDAP errors
+            $this->logger->error('LDAP authentication error', [
+                'username' => substr($userIdentifier, 0, 3) . '***',
+                'error_code' => $ldapException->getCode(),
+                'error_type' => $ldapException::class,
+            ]);
+
+            // Don't expose LDAP-specific errors to the user
+            throw new CustomUserMessageAuthenticationException('Authentication failed. Please check your credentials.', [], $ldapException->getCode(), $ldapException);
+        } catch (UserNotFoundException $userException) {
+            // User not found and creation disabled
+            $this->logger->info('User not found in local database', ['username' => substr($userIdentifier, 0, 3) . '***']);
+            throw $userException;
+        } catch (Throwable $throwable) {
+            // Generic error handling
+            $this->logger->error('Unexpected authentication error', [
+                'username' => substr($userIdentifier, 0, 3) . '***',
+                'error' => $throwable->getMessage(),
+                'trace' => $throwable->getTraceAsString(),
+            ]);
+            throw new CustomUserMessageAuthenticationException('An unexpected error occurred during authentication.', [], $throwable->getCode(), $throwable);
+        }
+    }
+
+    /**
+     * Configures the LDAP client from container parameters.
+     * Casts parameter bag values to the expected scalar types.
+     */
+    private function configureLdapClient(string $userIdentifier): LdapClientService
+    {
+        return $this->ldapClientService
+            ->setHost($this->sanitizeLdapInput((string) (is_scalar($this->parameterBag->get('ldap_host')) ? $this->parameterBag->get('ldap_host') : '')))
+            ->setPort($this->parsePort($this->parameterBag->get('ldap_port')))
+            ->setReadUser($this->sanitizeLdapInput((string) (is_scalar($this->parameterBag->get('ldap_readuser')) ? $this->parameterBag->get('ldap_readuser') : '')))
+            ->setReadPass((string) (is_scalar($this->parameterBag->get('ldap_readpass')) ? $this->parameterBag->get('ldap_readpass') : ''))
+            ->setBaseDn($this->sanitizeLdapInput((string) (is_scalar($this->parameterBag->get('ldap_basedn')) ? $this->parameterBag->get('ldap_basedn') : '')))
+            ->setUserName($this->sanitizeLdapInput($userIdentifier))
+            ->setUserPass($this->currentPassword ?? '')
+            ->setUseSSL((bool) ($this->parameterBag->get('ldap_usessl') ?? false))
+            ->setUserNameField((string) (is_scalar($this->parameterBag->get('ldap_usernamefield')) ? $this->parameterBag->get('ldap_usernamefield') : ''));
+    }
+
+    /**
+     * Creates a local user for an LDAP-authenticated identifier, mapping LDAP teams.
+     */
+    private function createUserFromLdap(string $userIdentifier): User
+    {
+        $newUser = new User()
+            ->setUsername($userIdentifier)
+            ->setType('DEV')
+            ->setLocale('de');
+
+        if ([] !== $this->ldapClientService->getTeams()) {
+            $teamRepo = $this->entityManager->getRepository(Team::class);
+            foreach ($this->ldapClientService->getTeams() as $teamname) {
+                $team = $teamRepo->findOneBy(['name' => $teamname]);
+                if ($team instanceof Team) {
+                    $newUser->addTeam($team);
+                }
+            }
+        }
+
+        $this->entityManager->persist($newUser);
+        $this->entityManager->flush();
+
+        return $newUser;
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): RedirectResponse

--- a/src/Service/ExportService.php
+++ b/src/Service/ExportService.php
@@ -19,6 +19,7 @@ use App\Enum\TicketSystemType;
 use App\Repository\EntryRepository;
 use App\Repository\UserRepository;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
+use App\Service\Integration\Jira\JiraOAuthApiService;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use Generator;
@@ -86,22 +87,32 @@ class ExportService
                 continue;
             }
 
-            $arReturn[] = [
-                'id' => $arEntry->getId(),
-                'user' => $arEntry->getUser() instanceof User ? $arEntry->getUser()->getUsername() : '',
-                'customer' => $arEntry->getCustomer() instanceof Customer ? $arEntry->getCustomer()->getName() : '',
-                'project' => $arEntry->getProject() instanceof Project ? $arEntry->getProject()->getName() : '',
-                'activity' => $arEntry->getActivity() instanceof Activity ? $arEntry->getActivity()->getName() : '',
-                'description' => $arEntry->getDescription(),
-                'start' => $arEntry->getStart()->format('Y-m-d H:i:s'),
-                'end' => $arEntry->getEnd()->format('Y-m-d H:i:s'),
-                'ticket' => $arEntry->getTicket(),
-                'ticket_url' => $this->getTicketUrl($arEntry, $arApi, $currentUser),
-                'worklog_url' => $this->getWorklogUrl($arEntry, $arApi, $currentUser),
-            ];
+            $arReturn[] = $this->buildEntryRow($arEntry, $arApi, $currentUser);
         }
 
         return $arReturn;
+    }
+
+    /**
+     * @param array<int, mixed> $arApi
+     *
+     * @return array<string, int|string|null>
+     */
+    private function buildEntryRow(Entry $entry, array &$arApi, User $currentUser): array
+    {
+        return [
+            'id' => $entry->getId(),
+            'user' => $entry->getUser() instanceof User ? $entry->getUser()->getUsername() : '',
+            'customer' => $entry->getCustomer() instanceof Customer ? $entry->getCustomer()->getName() : '',
+            'project' => $entry->getProject() instanceof Project ? $entry->getProject()->getName() : '',
+            'activity' => $entry->getActivity() instanceof Activity ? $entry->getActivity()->getName() : '',
+            'description' => $entry->getDescription(),
+            'start' => $entry->getStart()->format('Y-m-d H:i:s'),
+            'end' => $entry->getEnd()->format('Y-m-d H:i:s'),
+            'ticket' => $entry->getTicket(),
+            'ticket_url' => $this->getTicketUrl($entry, $arApi, $currentUser),
+            'worklog_url' => $this->getWorklogUrl($entry, $arApi, $currentUser),
+        ];
     }
 
     /**
@@ -231,7 +242,56 @@ class ExportService
             return $entries;
         }
 
-        // Group entries by ticket system to minimize API calls
+        $entriesByTicketSystem = $this->groupEntriesByTicketSystem($entries);
+
+        // Get user for API calls
+        $objectRepository = $this->managerRegistry->getRepository(User::class);
+        assert($objectRepository instanceof UserRepository);
+        $user = $objectRepository->find($userId);
+        if (null === $user) {
+            return $entries;
+        }
+
+        $fields = [];
+        if ($includeBillable) {
+            $fields[] = 'labels';
+        }
+
+        if ($includeTicketTitle) {
+            $fields[] = 'summary';
+        }
+
+        if ([] === $fields) {
+            return $entries;
+        }
+
+        // Fetch ticket information from JIRA for each ticket system
+        foreach ($entriesByTicketSystem as $ticketSystemData) {
+            $jiraApi = $this->jiraOAuthApiFactory->create($user, $ticketSystemData['ticketSystem']);
+            $tickets = array_unique($ticketSystemData['tickets']);
+
+            try {
+                $ticketData = $this->fetchTicketData($jiraApi, $tickets, $fields);
+                $this->applyTicketData($ticketSystemData['entries'], $ticketData, $includeBillable, $includeTicketTitle);
+            } catch (Exception) {
+                // Log error but continue with other entries
+                // In a real implementation, you might want to use a logger here
+                continue;
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Groups entries by bookable Jira ticket system to minimize API calls.
+     *
+     * @param Entry[] $entries
+     *
+     * @return array<int|string, array{ticketSystem: TicketSystem, entries: list<Entry>, tickets: list<string>}>
+     */
+    private function groupEntriesByTicketSystem(array $entries): array
+    {
         $entriesByTicketSystem = [];
         foreach ($entries as $entry) {
             if (!$entry instanceof Entry) {
@@ -269,85 +329,72 @@ class ExportService
             $entriesByTicketSystem[$key]['tickets'][] = $entry->getTicket();
         }
 
-        // Get user for API calls
-        $objectRepository = $this->managerRegistry->getRepository(User::class);
-        assert($objectRepository instanceof UserRepository);
-        $user = $objectRepository->find($userId);
-        if (null === $user) {
-            return $entries;
-        }
+        return $entriesByTicketSystem;
+    }
 
-        // Fetch ticket information from JIRA for each ticket system
-        foreach ($entriesByTicketSystem as $ticketSystemData) {
-            $ticketSystem = $ticketSystemData['ticketSystem'];
-            $tickets = array_unique($ticketSystemData['tickets']);
+    /**
+     * Searches Jira for the given tickets and maps ticket key to its fields object.
+     *
+     * @param array<int, string> $tickets
+     * @param array<int, string> $fields
+     *
+     * @throws Exception
+     *
+     * @return array<int|string, mixed>
+     */
+    private function fetchTicketData(JiraOAuthApiService $jiraOAuthApiService, array $tickets, array $fields): array
+    {
+        // Build JQL query for all tickets
+        $jql = sprintf('key in (%s)', implode(',', $tickets));
 
-            $jiraApi = $this->jiraOAuthApiFactory->create($user, $ticketSystem);
+        $result = $jiraOAuthApiService->searchTicket($jql, $fields, count($tickets));
+        $ticketData = [];
 
-            // Build JQL query for all tickets
-            $ticketKeys = implode(',', $tickets);
-            $jql = sprintf('key in (%s)', $ticketKeys);
-
-            $fields = [];
-            if ($includeBillable) {
-                $fields[] = 'labels';
-            }
-
-            if ($includeTicketTitle) {
-                $fields[] = 'summary';
-            }
-
-            if ([] === $fields) {
-                continue;
-            }
-
-            try {
-                $result = $jiraApi->searchTicket($jql, $fields, count($tickets));
-                $ticketData = [];
-
-                if (is_object($result) && property_exists($result, 'issues') && is_array($result->issues)) {
-                    foreach ($result->issues as $issue) {
-                        if (is_object($issue) && property_exists($issue, 'key') && property_exists($issue, 'fields')) {
-                            $key = $issue->key;
-                            if (is_string($key) || is_int($key)) {
-                                $ticketData[$key] = $issue->fields;
-                            }
-                        }
+        if (is_object($result) && property_exists($result, 'issues') && is_array($result->issues)) {
+            foreach ($result->issues as $issue) {
+                if (is_object($issue) && property_exists($issue, 'key') && property_exists($issue, 'fields')) {
+                    $key = $issue->key;
+                    if (is_string($key) || is_int($key)) {
+                        $ticketData[$key] = $issue->fields;
                     }
                 }
-
-                // Update entries with ticket information
-                foreach ($ticketSystemData['entries'] as $entry) {
-                    $ticket = $entry->getTicket();
-                    if (!isset($ticketData[$ticket])) {
-                        continue;
-                    }
-
-                    $fields = $ticketData[$ticket];
-
-                    if ($includeBillable && is_object($fields) && property_exists($fields, 'labels')) {
-                        $labels = $fields->labels;
-                        if (is_array($labels)) {
-                            $isBillable = in_array('billable', $labels, true);
-                            $entry->setBillable($isBillable);
-                        }
-                    }
-
-                    if ($includeTicketTitle && is_object($fields) && property_exists($fields, 'summary')) {
-                        $summary = $fields->summary;
-                        if (is_string($summary) || null === $summary) {
-                            $entry->setTicketTitle($summary);
-                        }
-                    }
-                }
-            } catch (Exception) {
-                // Log error but continue with other entries
-                // In a real implementation, you might want to use a logger here
-                continue;
             }
         }
 
-        return $entries;
+        return $ticketData;
+    }
+
+    /**
+     * Updates entries with the fetched ticket information.
+     *
+     * @param list<Entry>              $entries
+     * @param array<int|string, mixed> $ticketData
+     */
+    private function applyTicketData(array $entries, array $ticketData, bool $includeBillable, bool $includeTicketTitle): void
+    {
+        foreach ($entries as $entry) {
+            $ticket = $entry->getTicket();
+            if (!isset($ticketData[$ticket])) {
+                continue;
+            }
+
+            $fields = $ticketData[$ticket];
+
+            if ($includeBillable && is_object($fields) && property_exists($fields, 'labels')) {
+                $labels = $fields->labels;
+                if (is_array($labels)) {
+                    $isBillable = in_array('billable', $labels, true);
+                    $entry->setBillable($isBillable);
+                }
+            }
+
+            if ($includeTicketTitle && is_object($fields) && property_exists($fields, 'summary')) {
+                $summary = $fields->summary;
+                if (is_string($summary) || null === $summary) {
+                    $entry->setTicketTitle($summary);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Service/ExportService.php
+++ b/src/Service/ExportService.php
@@ -23,6 +23,8 @@ use App\Service\Integration\Jira\JiraOAuthApiService;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use Generator;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 use function assert;
 use function count;
@@ -35,7 +37,7 @@ use function sprintf;
 
 class ExportService
 {
-    public function __construct(private readonly ManagerRegistry $managerRegistry, private readonly JiraOAuthApiFactory $jiraOAuthApiFactory)
+    public function __construct(private readonly ManagerRegistry $managerRegistry, private readonly JiraOAuthApiFactory $jiraOAuthApiFactory, private readonly LoggerInterface $logger = new NullLogger())
     {
     }
 
@@ -273,9 +275,11 @@ class ExportService
             try {
                 $ticketData = $this->fetchTicketData($jiraApi, $tickets, $fields);
                 $this->applyTicketData($ticketSystemData['entries'], $ticketData, $includeBillable, $includeTicketTitle);
-            } catch (Exception) {
-                // Log error but continue with other entries
-                // In a real implementation, you might want to use a logger here
+            } catch (Exception $exception) {
+                $this->logger->warning('Export: could not enrich entries with Jira ticket data', [
+                    'exception' => $exception,
+                ]);
+
                 continue;
             }
         }

--- a/src/Service/Integration/Jira/JiraOAuthApiService.php
+++ b/src/Service/Integration/Jira/JiraOAuthApiService.php
@@ -480,20 +480,38 @@ class JiraOAuthApiService
 
         // Check for epic type tickets
         if ($ticket->isEpic()) {
-            $epicSearchResponse = $this->searchTicket('"Epic Link" = ' . $sTicket, ['key', 'subtasks'], 100);
+            return array_merge($subtickets, $this->getEpicSubtickets($sTicket));
+        }
 
-            if (is_object($epicSearchResponse)) {
-                $epicSearchResult = JiraSearchResult::fromApiResponse($epicSearchResponse);
+        return $subtickets;
+    }
 
-                foreach ($epicSearchResult->issues as $epicSubtask) {
-                    if (null !== $epicSubtask->key) {
-                        $subtickets[] = $epicSubtask->key;
+    /**
+     * Collects the issues linked to an epic including their nested subtasks.
+     *
+     * @throws JiraApiException
+     * @throws JiraApiInvalidResourceException
+     *
+     * @return list<string>
+     */
+    private function getEpicSubtickets(string $sTicket): array
+    {
+        $epicSearchResponse = $this->searchTicket('"Epic Link" = ' . $sTicket, ['key', 'subtasks'], 100);
 
-                        // Add nested subtasks
-                        foreach ($epicSubtask->subtaskKeys as $nestedKey) {
-                            $subtickets[] = $nestedKey;
-                        }
-                    }
+        if (!is_object($epicSearchResponse)) {
+            return [];
+        }
+
+        $subtickets = [];
+        $epicSearchResult = JiraSearchResult::fromApiResponse($epicSearchResponse);
+
+        foreach ($epicSearchResult->issues as $epicSubtask) {
+            if (null !== $epicSubtask->key) {
+                $subtickets[] = $epicSubtask->key;
+
+                // Add nested subtasks
+                foreach ($epicSubtask->subtaskKeys as $nestedKey) {
+                    $subtickets[] = $nestedKey;
                 }
             }
         }

--- a/src/Service/Ldap/LdapClientService.php
+++ b/src/Service/Ldap/LdapClientService.php
@@ -282,23 +282,13 @@ class LdapClientService
      */
     private function toStringValue(mixed $value): string
     {
-        if (is_string($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || is_float($value) || is_bool($value)) {
-            return (string) $value;
-        }
-
-        if ($value instanceof BackedEnum) {
-            return (string) $value->value;
-        }
-
-        if ($value instanceof UnitEnum) {
-            return $value->name;
-        }
-
-        return '';
+        return match (true) {
+            is_string($value) => $value,
+            is_int($value), is_float($value), is_bool($value) => (string) $value,
+            $value instanceof BackedEnum => (string) $value->value,
+            $value instanceof UnitEnum => $value->name,
+            default => '',
+        };
     }
 
     /**
@@ -306,23 +296,13 @@ class LdapClientService
      */
     private function toIntValue(mixed $value): int
     {
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_string($value)) {
-            return (int) $value;
-        }
-
-        if ($value instanceof BackedEnum) {
-            return (int) $value->value;
-        }
-
-        if (is_float($value) || is_bool($value)) {
-            return (int) $value;
-        }
-
-        return 0;
+        return match (true) {
+            is_int($value) => $value,
+            is_string($value) => (int) $value,
+            $value instanceof BackedEnum => (int) $value->value,
+            is_float($value), is_bool($value) => (int) $value,
+            default => 0,
+        };
     }
 
     /**

--- a/src/Service/Ldap/LdapClientService.php
+++ b/src/Service/Ldap/LdapClientService.php
@@ -454,36 +454,46 @@ class LdapClientService
         $mappingFile = rtrim($this->projectDir, '/') . '/config/ldap_ou_team_mapping.yml';
 
         $this->teams = [];
-        if (file_exists($mappingFile)) {
-            $this->logger->debug('LDAP: Attempting to map OU to teams.', ['dn' => $dn, 'mappingFile' => $mappingFile]);
-
-            try {
-                $arMapping = Yaml::parse((string) file_get_contents($mappingFile));
-                if (null === $arMapping || !is_array($arMapping)) {
-                    $this->logger->warning('LDAP: Team mapping file is empty or invalid.', ['mappingFile' => $mappingFile]);
-
-                    return;
-                }
-
-                /** @var array<string, string> $arMapping */
-                foreach ($arMapping as $group => $teamName) {
-                    if (str_contains(strtolower($dn), 'ou=' . strtolower($group))) {
-                        $this->teams[] = $teamName;
-                        $this->logger->info('LDAP: Mapped OU to team.', ['ou' => $group, 'team' => $teamName, 'dn' => $dn]);
-                    }
-                }
-
-                if ([] === $this->teams) {
-                    $this->logger->info('LDAP: No matching OUs found in DN for team mapping.', ['dn' => $dn, 'mappingKeys' => array_keys($arMapping)]);
-                }
-            } catch (Exception $e) {
-                $this->logger->error('LDAP: Failed to parse team mapping file.', [
-                    'mappingFile' => $mappingFile,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        } else {
+        if (!file_exists($mappingFile)) {
             $this->logger->warning('LDAP: Team mapping file not found, skipping team assignment.', ['mappingFile' => $mappingFile]);
+
+            return;
+        }
+
+        $this->logger->debug('LDAP: Attempting to map OU to teams.', ['dn' => $dn, 'mappingFile' => $mappingFile]);
+
+        try {
+            $this->applyTeamMapping($dn, $mappingFile);
+        } catch (Exception $e) {
+            $this->logger->error('LDAP: Failed to parse team mapping file.', [
+                'mappingFile' => $mappingFile,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Maps the OUs of the given DN to teams using the mapping file.
+     */
+    private function applyTeamMapping(string $dn, string $mappingFile): void
+    {
+        $arMapping = Yaml::parse((string) file_get_contents($mappingFile));
+        if (null === $arMapping || !is_array($arMapping)) {
+            $this->logger->warning('LDAP: Team mapping file is empty or invalid.', ['mappingFile' => $mappingFile]);
+
+            return;
+        }
+
+        /** @var array<string, string> $arMapping */
+        foreach ($arMapping as $group => $teamName) {
+            if (str_contains(strtolower($dn), 'ou=' . strtolower($group))) {
+                $this->teams[] = $teamName;
+                $this->logger->info('LDAP: Mapped OU to team.', ['ou' => $group, 'team' => $teamName, 'dn' => $dn]);
+            }
+        }
+
+        if ([] === $this->teams) {
+            $this->logger->info('LDAP: No matching OUs found in DN for team mapping.', ['dn' => $dn, 'mappingKeys' => array_keys($arMapping)]);
         }
     }
 
@@ -516,16 +526,7 @@ class LdapClientService
 
             if (is_array($value)) {
                 // Already in expected format: array<int, string>
-                $stringValues = [];
-                foreach ($value as $item) {
-                    if (is_string($item)) {
-                        $stringValues[] = $item;
-                    } elseif (is_int($item) || is_float($item) || is_bool($item)) {
-                        $stringValues[] = (string) $item;
-                    }
-                    // Skip non-stringable values
-                }
-                $normalized[$key] = $stringValues;
+                $normalized[$key] = $this->normalizeAttributeValues($value);
             } elseif (is_string($value)) {
                 // Single string value, wrap in array
                 $normalized[$key] = [$value];
@@ -533,5 +534,27 @@ class LdapClientService
         }
 
         return $normalized;
+    }
+
+    /**
+     * Converts an LDAP attribute value list to a list of strings.
+     *
+     * @param array<int|string, mixed> $values
+     *
+     * @return array<int, string>
+     */
+    private function normalizeAttributeValues(array $values): array
+    {
+        $stringValues = [];
+        foreach ($values as $item) {
+            if (is_string($item)) {
+                $stringValues[] = $item;
+            } elseif (is_int($item) || is_float($item) || is_bool($item)) {
+                $stringValues[] = (string) $item;
+            }
+            // Skip non-stringable values
+        }
+
+        return $stringValues;
     }
 }

--- a/src/Service/SubticketSyncService.php
+++ b/src/Service/SubticketSyncService.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Exception\Integration\Jira\JiraApiException;
 use App\Exception\SubticketSyncException;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
+use App\Service\Integration\Jira\JiraOAuthApiService;
 use Doctrine\Persistence\ManagerRegistry;
 
 class SubticketSyncService
@@ -37,17 +38,7 @@ class SubticketSyncService
      */
     public function syncProjectSubtickets(int|Project $projectOrProjectId): array
     {
-        if ($projectOrProjectId instanceof Project) {
-            $project = $projectOrProjectId;
-        } else {
-            $project = $this->managerRegistry
-                ->getRepository(Project::class)
-                ->find($projectOrProjectId);
-        }
-
-        if (!$project instanceof Project) {
-            throw new SubticketSyncException('Project does not exist', 404);
-        }
+        $project = $this->resolveProject($projectOrProjectId);
 
         $ticketSystem = $project->getTicketSystem();
         if (!$ticketSystem instanceof TicketSystem) {
@@ -80,8 +71,46 @@ class SubticketSyncService
         // Create the Jira API service with our service's dependencies
         $jiraOAuthApiService = $this->jiraOAuthApiFactory->create($userWithJiraAccess, $ticketSystem);
 
-        $mainTickets = array_map(trim(...), explode(',', $mainTickets));
-        /** @var list<string> $allSubtickets */
+        $allSubtickets = $this->collectSubtickets($jiraOAuthApiService, array_map(trim(...), explode(',', $mainTickets)));
+
+        natcasesort($allSubtickets);
+
+        // Convert array to comma-separated string for storage
+        $project->setSubtickets(implode(',', $allSubtickets));
+        $em = $this->managerRegistry->getManager();
+        $em->persist($project);
+        $em->flush();
+
+        return array_values($allSubtickets);
+    }
+
+    /**
+     * @throws SubticketSyncException When the project does not exist
+     */
+    private function resolveProject(int|Project $projectOrProjectId): Project
+    {
+        $project = $projectOrProjectId instanceof Project
+            ? $projectOrProjectId
+            : $this->managerRegistry->getRepository(Project::class)->find($projectOrProjectId);
+
+        if (!$project instanceof Project) {
+            throw new SubticketSyncException('Project does not exist', 404);
+        }
+
+        return $project;
+    }
+
+    /**
+     * Fetches the subtickets of all main tickets from Jira.
+     *
+     * @param list<string> $mainTickets
+     *
+     * @throws JiraApiException When fetching subtickets from Jira fails
+     *
+     * @return list<string>
+     */
+    private function collectSubtickets(JiraOAuthApiService $jiraOAuthApiService, array $mainTickets): array
+    {
         $allSubtickets = [];
         foreach ($mainTickets as $mainTicket) {
             // we want to make it easy to find matching tickets,
@@ -94,14 +123,6 @@ class SubticketSyncService
             }
         }
 
-        natcasesort($allSubtickets);
-
-        // Convert array to comma-separated string for storage
-        $project->setSubtickets(implode(',', $allSubtickets));
-        $em = $this->managerRegistry->getManager();
-        $em->persist($project);
-        $em->flush();
-
-        return array_values($allSubtickets);
+        return $allSubtickets;
     }
 }

--- a/src/Service/TypeSafety/ArrayTypeHelper.php
+++ b/src/Service/TypeSafety/ArrayTypeHelper.php
@@ -35,19 +35,11 @@ final class ArrayTypeHelper
 
         $value = $array[$key];
 
-        if (null === $value) {
-            return $default;
-        }
-
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_numeric($value)) {
-            return (int) $value;
-        }
-
-        return $default;
+        return match (true) {
+            is_int($value) => $value,
+            is_numeric($value) => (int) $value,
+            default => $default,
+        };
     }
 
     /**
@@ -63,19 +55,11 @@ final class ArrayTypeHelper
 
         $value = $array[$key];
 
-        if (null === $value) {
-            return $default;
-        }
-
-        if (is_string($value)) {
-            return $value;
-        }
-
-        if (is_scalar($value)) {
-            return (string) $value;
-        }
-
-        return $default;
+        return match (true) {
+            is_string($value) => $value,
+            is_scalar($value) => (string) $value,
+            default => $default,
+        };
     }
 
     /**

--- a/tests/Entity/HolidayTest.php
+++ b/tests/Entity/HolidayTest.php
@@ -68,7 +68,7 @@ final class HolidayTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot modify readonly property $name after construction');
 
-        $holiday->setName('Changed Name');
+        $holiday->setName();
     }
 
     // ==================== toArray tests ====================

--- a/tests/Service/Integration/Jira/JiraOAuthApiServiceTest.php
+++ b/tests/Service/Integration/Jira/JiraOAuthApiServiceTest.php
@@ -617,6 +617,65 @@ final class JiraOAuthApiServiceTest extends TestCase
         self::assertSame([], $result);
     }
 
+    public function testGetSubticketsReturnsSubtaskKeysForRegularTicket(): void
+    {
+        $issueBody = (string) json_encode((object) [
+            'key' => 'TEST-1',
+            'fields' => (object) [
+                'issuetype' => (object) ['name' => 'Task'],
+                'subtasks' => [
+                    (object) ['key' => 'TEST-2'],
+                    (object) ['key' => 'TEST-3'],
+                ],
+            ],
+        ]);
+
+        $client = $this->createClientReturningSequence(
+            new Response(200, [], '{}'),
+            new Response(200, [], $issueBody),
+        );
+
+        $service = $this->createServiceWithClient($client);
+
+        self::assertSame(['TEST-2', 'TEST-3'], $service->getSubtickets('TEST-1'));
+    }
+
+    public function testGetSubticketsIncludesEpicChildIssuesAndNestedSubtasks(): void
+    {
+        $epicBody = (string) json_encode((object) [
+            'key' => 'EPIC-1',
+            'fields' => (object) [
+                'issuetype' => (object) ['name' => 'Epic'],
+                'subtasks' => [
+                    (object) ['key' => 'EPIC-1-S1'],
+                ],
+            ],
+        ]);
+
+        $searchBody = (string) json_encode((object) [
+            'issues' => [
+                (object) [
+                    'key' => 'STORY-1',
+                    'fields' => (object) [
+                        'subtasks' => [
+                            (object) ['key' => 'STORY-2'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->createClientReturningSequence(
+            new Response(200, [], '{}'),
+            new Response(200, [], $epicBody),
+            new Response(200, [], $searchBody),
+        );
+
+        $service = $this->createServiceWithClient($client);
+
+        self::assertSame(['EPIC-1-S1', 'STORY-1', 'STORY-2'], $service->getSubtickets('EPIC-1'));
+    }
+
     // ==================== fetchOAuthAccessToken tests ====================
 
     public function testFetchOAuthAccessTokenDeletesTokensWhenDenied(): void
@@ -721,6 +780,14 @@ final class JiraOAuthApiServiceTest extends TestCase
     {
         $client = self::createStub(Client::class);
         $client->method('request')->willThrowException($exception);
+
+        return $client;
+    }
+
+    private function createClientReturningSequence(ResponseInterface ...$responses): Client
+    {
+        $client = self::createStub(Client::class);
+        $client->method('request')->willReturnOnConsecutiveCalls(...array_values($responses));
 
         return $client;
     }

--- a/tests/Traits/JsonAssertionsTrait.php
+++ b/tests/Traits/JsonAssertionsTrait.php
@@ -210,7 +210,7 @@ trait JsonAssertionsTrait
         // Handle specific translation issues based on the messages.de.yml
         $translationMap = [
             '%num% Einträge wurden angelegt.' => '%num% entries have been added',
-            'Für den Benutzer wurde kein Vertrag gefunden. Bitte verwenden Sie eine benutzerdefinierte Zeit.' => 'No contract for user found. Please use custome time.',
+            'Für den Benutzer wurde kein Vertrag gefunden. Bitte verwenden Sie eine benutzerdefinierte Zeit.' => 'No contract for user found. Please use custom time.',
         ];
 
         // Check if there's a known translation mapping

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -43,7 +43,7 @@
 "Please enter a valid user.": "Bitte geben Sie einen gültigen Benutzer an."
 "Please enter a valid contract start.": "Bitte geben Sie einen gültigen Vertragsbeginn an."
 "End date has to be greater than the start date.": "Das Vertragsende muss nach dem Vertragsbeginn liegen."
-"No contract for user found. Please use custome time." : "Für den Benutzer wurde kein Vertrag gefunden. Bitte verwenden Sie eine benutzerdefinierte Zeit."
+"No contract for user found. Please use custom time." : "Für den Benutzer wurde kein Vertrag gefunden. Bitte verwenden Sie eine benutzerdefinierte Zeit."
 "Contract expired at %date%." : "Vertrag ist am %date%. abgelaufen."
 "Contract is valid from %date%." : "Vertrag ist gültig ab %date%."
 "There is already an ongoing contract with a closed end date in the future." : "Es besteht bereits ein laufender Vertrag mit einem Enddatum in der Zukunft."


### PR DESCRIPTION
Part of #320 — final SonarCloud PHP wave for `src/` (plus `config/quality` and `public/` where flagged). Findings in `tests/` are out of scope per the accepted-tests precedent and remain open.

## php:S3776 — cognitive complexity (22 in scope, 22 fixed, 0 skipped)

Behavior-preserving extraction of focused private helpers; no public signatures changed.

- Controllers: `SaveEntryAction` (49), `BulkEntryAction` (65), `ExportAction` (56), `SaveProjectAction` (25)
- Repositories: `EntryRepository` ×6 (`getFilteredEntries`, `getSummaryData`, `queryByFilterArray`, `findByDate`, `findByDatePaginated`, `findByFilterArray`) — now share filter/pagination/sort helpers; `ProjectRepository::getProjectStructure` (23)
- Services: `ExportService` ×2 (`getEntries`, `enrichEntriesWithTicketInformation` 65), `LdapAuthenticator::authenticate` (32, user-loader closure extracted to private methods), `LdapClientService` ×2, `SubticketSyncService`, `JiraOAuthApiService::getSubtickets`
- Misc: `NrArrayTranslator::filterArray`, `JiraIssueFields::fromApiResponse`, `public/coverage.php::generateCoverageReport`

8 further S3776 findings are in `tests/` (out of scope).

Notes on equivalence:
- `EntryRepository::findByFilterArray` scalar relation filters now go through the shared helper using `IDENTITY(e.x) = :x`, which generates identical SQL to the previous `e.x = :x` form.
- `findByDatePaginated` shares the sort helper with `findByDate`; under the documented `array<string, string>|null` contract behavior is identical.
- The three `instanceof DateTimeInterface` guards in the export row writer were dropped: `Entry::getDay()/getStart()/getEnd()` natively return non-nullable `DateTimeInterface` (PHPStan flags the guards as always-true once the param is natively typed).

## php:S138 — function length (3 in scope, 3 fixed, 0 skipped)

`ExportAction`, `BulkEntryAction`, `SaveEntryAction` `__invoke` are well under 150 lines after the S3776 extractions. 1 finding in `tests/` (out of scope).

## php:S1142 — too many returns (35 in scope, 10 fixed, 25 skipped)

Fixed where it genuinely improves the code:
- `EntrySaveDto` ×3 — the three duplicated date/time format-fallback chains collapsed into one shared `parseDateTime()` (loop over formats, 3 returns)
- `ArrayTypeHelper::getInt/getString`, `LdapClientService::toStringValue/toIntValue`, `LdapAuthenticator::parsePort`, `ExportQueryDto::toBool` — type-dispatch chains converted to `match (true)` expressions
- `BulkEntryAction::__invoke` — 3 returns after extraction

Skipped (25) — early-return guard/validation chains where multiple returns ARE the clearest form (same reasoning as the deliberately kept `SaveEntryAction::validateTicketPrefix`):
- Admin `Save{Activity,Contract×2,Customer,Project,Team,TicketSystem}Action` validation chains (`SaveProjectAction` still improved 5→4 returns)
- `SaveEntryAction::__invoke` (improved 16→10; the remainder is the canonical entity/format validation chain)
- `GetSummaryAction`, `JiraOAuthCallbackAction`
- `ExportService::getTicketUrl/getWorklogUrl`, `AccessDeniedSubscriber`, `EntryEventSubscriber::shouldAutoSync`, `ExceptionSubscriber::createResponseFromException`
- `JiraAuthenticationService::stringifyParsedValue`, `JiraHttpClientService::extractErrorMessage`, `JiraIntegrationService::shouldSyncWithJira`, `JiraOAuthApiService::updateEntryJiraWorkLog`, `JiraTicketService` ×3, `JiraWorkLogService` ×2, `DatabaseResultDto::safeDateTime`

8 further S1142 findings are in `tests/` (out of scope).

## php:S1172 — unused parameters (1 in scope, 1 fixed)

`Holiday::setName($name)` — BC shim that always throws; parameter removed, test call updated. The other 6 findings are in `tests/` (out of scope).

## php:S100 — function naming (5 in scope, 5 fixed)

`config/quality/phpat.php` rule methods renamed `test_snake_case` → `testCamelCase`. PHPat discovers any public method matching `/^test/` (verified in `vendor/phpat/phpat/src/Test/TestParser.php`); the architecture analysis (`bin/phpstan analyze config/quality/phpat.php` and `-c phpat.neon`) still passes.

## php:S116 — field naming (19 in scope, 0 fixed, 19 skipped)

All findings are public promoted properties on request-payload DTOs (`ContractSaveDto`, `EntrySaveDto`, `InterpretationFiltersDto`, `ProjectSaveDto`, `TeamSaveDto`) bound via `#[MapRequestPayload]`/`fromRequest()`. The property names are the HTTP wire contract — the ExtJS frontend sends exactly these snake_case keys (verified in `assets/js/netresearch/model/{Project,Team,Contract}.js` and `widget/{Admin,Tracking,Interpretation}.js`). Renaming would break request mapping; skipped.

## Tests added

- `JiraOAuthApiService::getSubtickets` regular and epic paths (the extracted epic child-issue collection was previously uncovered).
- All other extracted helpers are exercised by the existing suites (CrudControllerTest covers the bulkentry contract paths incl. skip-weekend/expired-contract; EntrySaveDtoTest covers every date format; ExportServiceTest, LdapAuthenticatorTest, LdapClientServiceTest, SubticketSyncServiceTest, NrArrayTranslatorTest, ArrayTypeHelperTest, JiraIssueTest cover the rest).

## Gate results

- PHPStan (level 10, src+tests): `[OK] No errors`
- PHPStan phpat architecture analysis: `[OK] No errors`
- php-cs-fixer `--dry-run`: `Found 0 of 330 files that can be fixed`
- Rector `--dry-run`: `[OK] Rector is done!` (no changes)
- PHPUnit full suite (db_unittest + ldap-dev): `OK — 1959 tests, 5777 assertions, 1 skipped` (pre-existing skip). One wall-clock assertion (`ExportActionPerformanceTest::testSmallDatasetExcelExportPerformance`, 1036ms vs 1000ms budget) flaked once under full-suite load and passes in isolation and on rerun — unrelated to this change.
