### PR TITLE
refactor: resolve last src complexity finding, exclude vendored JS from Sonar

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,4 +4,4 @@
 # excluding them removes ~200 nonsensical security hotspots (regex
 # backtracking warnings inside the bundled legacy ExtJS builds) and
 # duplicate-literal noise from schema/fixture dumps.
-sonar.exclusions=assets/js/ext-js/**,sql/**,fixtures/**,public/build/**
+sonar.exclusions=assets/js/ext-js/**,assets/js/Notification.js,public/docs/swagger/**,sql/**,fixtures/**,public/build/**

--- a/src/Service/ExportService.php
+++ b/src/Service/ExportService.php
@@ -383,21 +383,44 @@ class ExportService
             }
 
             $fields = $ticketData[$ticket];
-
-            if ($includeBillable && is_object($fields) && property_exists($fields, 'labels')) {
-                $labels = $fields->labels;
-                if (is_array($labels)) {
-                    $isBillable = in_array('billable', $labels, true);
-                    $entry->setBillable($isBillable);
-                }
+            if (!is_object($fields)) {
+                continue;
             }
 
-            if ($includeTicketTitle && is_object($fields) && property_exists($fields, 'summary')) {
-                $summary = $fields->summary;
-                if (is_string($summary) || null === $summary) {
-                    $entry->setTicketTitle($summary);
-                }
+            if ($includeBillable) {
+                $this->applyBillable($entry, $fields);
             }
+
+            if ($includeTicketTitle) {
+                $this->applyTicketTitle($entry, $fields);
+            }
+        }
+    }
+
+    /**
+     * Marks the entry billable when the ticket carries the "billable" label.
+     */
+    private function applyBillable(Entry $entry, object $fields): void
+    {
+        if (!property_exists($fields, 'labels') || !is_array($fields->labels)) {
+            return;
+        }
+
+        $entry->setBillable(in_array('billable', $fields->labels, true));
+    }
+
+    /**
+     * Copies the ticket summary onto the entry.
+     */
+    private function applyTicketTitle(Entry $entry, object $fields): void
+    {
+        if (!property_exists($fields, 'summary')) {
+            return;
+        }
+
+        $summary = $fields->summary;
+        if (is_string($summary) || null === $summary) {
+            $entry->setTicketTitle($summary);
         }
     }
 


### PR DESCRIPTION
Wrap-up of the SonarCloud program (#319, #320):

- `ExportService::applyTicketData()` now delegates billable/title handling to two small appliers — resolves the last open `php:S3776` finding in `src/` (complexity 16 > 15).
- `.sonarcloud.properties`: exclude `assets/js/Notification.js` (vendored Ext.ux notification plugin) and `public/docs/swagger/**` (swagger-ui dist) — same rationale as the existing `ext-js` exclusion; removes the remaining vendored-code findings (24× S3504 and friends) from analysis.

Gates: PHPStan level 10 clean, php-cs-fixer clean, Rector clean, ExportServiceTest green (35 tests).