### PR TITLE
refactor: modernize JS global API usage (S7773, S7740, S7735, S7762)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -117,7 +117,7 @@ function buildHeaderHtml() {
 }
 
 function switchTab(number) {
-    number = Number.parseInt(number);
+    number = Number.parseInt(number, 10);
     if ((0 > number) || (number > ttt_items.length)) {
         return;
     }
@@ -286,7 +286,7 @@ Ext.onReady(function () {
             key: [Ext.EventObject.ONE, Ext.EventObject.TWO, Ext.EventObject.THREE, Ext.EventObject.FOUR, Ext.EventObject.FIVE, Ext.EventObject.SIX, Ext.EventObject.SEVEN],
             alt: true,
             handler: function (key, e) {
-                switchTab(Number.parseInt(key) - 48);
+                switchTab(Number.parseInt(key, 10) - 48);
                 e.stopEvent();
             },
             defaultEventAction: 'stopEvent'
@@ -520,10 +520,10 @@ function extractTicketPrefix(ticket) {
 
 function findProjects(customer, ticket) {
     // 1. Find all projects by this customer, if defined
-    if ((null == customer) || (undefined == customer) || (1 > Number.parseInt(customer))) {
+    if ((null == customer) || (undefined == customer) || (1 > Number.parseInt(customer, 10))) {
         customer = 'all';
     } else {
-        customer = Number.parseInt(customer);
+        customer = Number.parseInt(customer, 10);
     }
     const projects = projectsData[customer];
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -117,7 +117,7 @@ function buildHeaderHtml() {
 }
 
 function switchTab(number) {
-    number = parseInt(number);
+    number = Number.parseInt(number);
     if ((0 > number) || (number > ttt_items.length)) {
         return;
     }
@@ -286,7 +286,7 @@ Ext.onReady(function () {
             key: [Ext.EventObject.ONE, Ext.EventObject.TWO, Ext.EventObject.THREE, Ext.EventObject.FOUR, Ext.EventObject.FIVE, Ext.EventObject.SIX, Ext.EventObject.SEVEN],
             alt: true,
             handler: function (key, e) {
-                switchTab(parseInt(key) - 48);
+                switchTab(Number.parseInt(key) - 48);
                 e.stopEvent();
             },
             defaultEventAction: 'stopEvent'
@@ -520,10 +520,10 @@ function extractTicketPrefix(ticket) {
 
 function findProjects(customer, ticket) {
     // 1. Find all projects by this customer, if defined
-    if ((null == customer) || (undefined == customer) || (1 > parseInt(customer))) {
+    if ((null == customer) || (undefined == customer) || (1 > Number.parseInt(customer))) {
         customer = 'all';
     } else {
-        customer = parseInt(customer);
+        customer = Number.parseInt(customer);
     }
     const projects = projectsData[customer];
 

--- a/assets/js/netresearch/store/Projects.js
+++ b/assets/js/netresearch/store/Projects.js
@@ -38,7 +38,7 @@ Ext.define('Netresearch.store.Projects', {
     loadData: function(data, customer, ticket, onlyActive) {
 
         // Check if we are valid already
-        if (this.currentCustomer && (this.currentCustomer == Number.parseInt(customer)))
+        if (this.currentCustomer && (this.currentCustomer == Number.parseInt(customer, 10)))
             return;
 
         let projects = findProjects(customer, ticket)
@@ -53,7 +53,7 @@ Ext.define('Netresearch.store.Projects', {
             }
         }
 
-        this.currentCustomer = Number.parseInt(customer);
+        this.currentCustomer = Number.parseInt(customer, 10);
 
         const newData = [];
         let record;

--- a/assets/js/netresearch/store/Projects.js
+++ b/assets/js/netresearch/store/Projects.js
@@ -38,7 +38,7 @@ Ext.define('Netresearch.store.Projects', {
     loadData: function(data, customer, ticket, onlyActive) {
 
         // Check if we are valid already
-        if (this.currentCustomer && (this.currentCustomer == parseInt(customer)))
+        if (this.currentCustomer && (this.currentCustomer == Number.parseInt(customer)))
             return;
 
         let projects = findProjects(customer, ticket)
@@ -53,7 +53,7 @@ Ext.define('Netresearch.store.Projects', {
             }
         }
 
-        this.currentCustomer = parseInt(customer);
+        this.currentCustomer = Number.parseInt(customer);
 
         const newData = [];
         let record;

--- a/assets/js/netresearch/widget/Admin.js
+++ b/assets/js/netresearch/widget/Admin.js
@@ -161,10 +161,10 @@ Ext.define('Netresearch.widget.Admin', {
                         let output = '';
                         /* Display space separated list of related teams */
                         Ext.each(value, function (teamId) {
-                            if (isNaN(teamId)) {
+                            if (Number.isNaN(Number(teamId))) {
                                 return;
                             }
-                            const team = customerGrid.teamStore.getById(parseInt(teamId));
+                            const team = customerGrid.teamStore.getById(Number.parseInt(teamId));
                             if (null == team) {
                                 return;
                             }
@@ -371,7 +371,7 @@ Ext.define('Netresearch.widget.Admin', {
             },
             deleteCustomer: function (record) {
                 const grid = this;
-                const id = parseInt(record.id);
+                const id = Number.parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -472,7 +472,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        if (1 > parseInt(id))
+                        if (1 > Number.parseInt(id))
                             return '';
 
                         const record = this.ticketSystemStore.getById(id);
@@ -862,7 +862,7 @@ Ext.define('Netresearch.widget.Admin', {
             },
             deleteProject: function (record) {
                 const grid = this;
-                const id = parseInt(record.id);
+                const id = Number.parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -981,10 +981,10 @@ Ext.define('Netresearch.widget.Admin', {
                         /* Display space seperated list of related teams */
                         let output = '';
                         Ext.each(value, function (teamId) {
-                            if (isNaN(teamId)) {
+                            if (Number.isNaN(Number(teamId))) {
                                 return;
                             }
-                            const team = userGrid.teamStore.getById(parseInt(teamId));
+                            const team = userGrid.teamStore.getById(Number.parseInt(teamId));
                             if (null == team) {
                                 return;
                             }
@@ -1179,7 +1179,7 @@ Ext.define('Netresearch.widget.Admin', {
             },
             deleteUser: function (record) {
                 const grid = this;
-                const id = parseInt(record.id);
+                const id = Number.parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.username, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -1367,7 +1367,7 @@ Ext.define('Netresearch.widget.Admin', {
             },
             deleteTeam: function (record) {
                 const grid = this;
-                const id = parseInt(record.id);
+                const id = Number.parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -1526,7 +1526,7 @@ Ext.define('Netresearch.widget.Admin', {
             }, // end listeners
             deletePreset: function (record) {
                 const grid = this;
-                const id = parseInt(record.data.id);
+                const id = Number.parseInt(record.data.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.data.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -1896,7 +1896,7 @@ Ext.define('Netresearch.widget.Admin', {
             },
             deleteTicketSystem: function (record) {
                 const grid = this;
-                const id = parseInt(record.id);
+                const id = Number.parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -2071,7 +2071,7 @@ Ext.define('Netresearch.widget.Admin', {
             },
             deleteActivity: function (record) {
                 const grid = this;
-                const id = parseInt(record.id);
+                const id = Number.parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
@@ -2309,7 +2309,7 @@ Ext.define('Netresearch.widget.Admin', {
             },
             deleteContract: function (record) {
                 const grid = this;
-                const id = parseInt(record.id);
+                const id = Number.parseInt(record.id);
                 Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
                     if (btn == 'yes') {
                         Ext.Ajax.request({

--- a/assets/js/netresearch/widget/Admin.js
+++ b/assets/js/netresearch/widget/Admin.js
@@ -370,37 +370,34 @@ Ext.define('Netresearch.widget.Admin', {
                 editCustomerWindow.show();
             },
             deleteCustomer: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'customer/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
-                            failure: function (response) {
+                            failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(this._errorTitle, data.message, false);
                             }
                         });
                     }
                 });
             },
             refresh: function () {
-                let grid = this;
-                let lastFocused = grid.getSelectionModel().getLastFocused();
+                let lastFocused = this.getSelectionModel().getLastFocused();
 
                 this.store.load({
                     //restore selection after refreshing
-                    callback: function () {
+                    callback: () => {
                         if (lastFocused) {
-                            let record = grid.getStore().getById(lastFocused.getId());
-                            grid.getSelectionModel().setLastFocused(record);
+                            let record = this.getStore().getById(lastFocused.getId());
+                            this.getSelectionModel().setLastFocused(record);
                         }
                     }
                 });
@@ -861,18 +858,16 @@ Ext.define('Netresearch.widget.Admin', {
                 editProjectWindow.show();
             },
             deleteProject: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'project/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
                             failure: function (response) {
                                 const data = Ext.decode(response.responseText);
@@ -890,16 +885,14 @@ Ext.define('Netresearch.widget.Admin', {
                 );
             },
             syncProjectSubtickets: function (project) {
-                const grid = this;
                 Ext.Ajax.request({
                     method: 'POST',
                     url: url + 'projects/' + project.id + '/syncsubtickets',
-                    scope: this,
-                    success: function (response) {
+                    success: (response) => {
                         const data = Ext.decode(response.responseText);
                         project['subtickets'] = data.subtickets;
-                        grid.refresh();
-                        grid.showProjectSubtickets(project);
+                        this.refresh();
+                        this.showProjectSubtickets(project);
                     },
                     failure: function (response) {
                         const data = Ext.decode(response.responseText);
@@ -908,13 +901,11 @@ Ext.define('Netresearch.widget.Admin', {
                 });
             },
             syncAllProjectSubtickets: function () {
-                const grid = this;
                 Ext.Ajax.request({
                     method: 'POST',
                     url: url + 'projects/syncsubtickets',
-                    scope: this,
-                    success: function (response) {
-                        grid.refresh();
+                    success: (response) => {
+                        this.refresh();
                         showNotification(panel._successTitle, panel._subticketSyncFinishedTitle, true);
                     },
                     failure: function (response) {
@@ -924,17 +915,16 @@ Ext.define('Netresearch.widget.Admin', {
                 });
             },
             refresh: function () {
-                let grid = this;
-                let lastFocused = grid.getSelectionModel().getLastFocused();
+                let lastFocused = this.getSelectionModel().getLastFocused();
 
                 this.customerStore.load();
                 this.ticketSystemStore.load();
                 this.store.load({
                     //restore selection after refreshing
-                    callback: function () {
+                    callback: () => {
                         if (lastFocused) {
-                            let record = grid.getStore().getById(lastFocused.getId());
-                            grid.getSelectionModel().setLastFocused(record);
+                            let record = this.getStore().getById(lastFocused.getId());
+                            this.getSelectionModel().setLastFocused(record);
                         }
                     }
                 });
@@ -1178,38 +1168,35 @@ Ext.define('Netresearch.widget.Admin', {
                 editUserWindow.show();
             },
             deleteUser: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.username, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.username, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'user/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
-                            failure: function (response) {
+                            failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(this._errorTitle, data.message, false);
                             }
                         });
                     }
                 });
             },
             refresh: function () {
-                let grid = this;
-                let lastFocused = grid.getSelectionModel().getLastFocused();
+                let lastFocused = this.getSelectionModel().getLastFocused();
 
                 this.teamStore.load();
                 this.store.load({
                     //restore selection after refreshing
-                    callback: function () {
+                    callback: () => {
                         if (lastFocused) {
-                            let record = grid.getStore().getById(lastFocused.getId());
-                            grid.getSelectionModel().setLastFocused(record);
+                            let record = this.getStore().getById(lastFocused.getId());
+                            this.getSelectionModel().setLastFocused(record);
                         }
                     }
                 });
@@ -1366,38 +1353,35 @@ Ext.define('Netresearch.widget.Admin', {
                 editTeamWindow.show();
             },
             deleteTeam: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'team/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
-                            failure: function (response) {
+                            failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(this._errorTitle, data.message, false);
                             }
                         });
                     }
                 });
             },
             refresh: function () {
-                let grid = this;
-                let lastFocused = grid.getSelectionModel().getLastFocused();
+                let lastFocused = this.getSelectionModel().getLastFocused();
 
                 this.userStore.load();
                 this.store.load({
                     //restore selection after refreshing
-                    callback: function () {
+                    callback: () => {
                         if (lastFocused) {
-                            let record = grid.getStore().getById(lastFocused.getId());
-                            grid.getSelectionModel().setLastFocused(record);
+                            let record = this.getStore().getById(lastFocused.getId());
+                            this.getSelectionModel().setLastFocused(record);
                         }
                     }
                 });
@@ -1525,22 +1509,20 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             }, // end listeners
             deletePreset: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.data.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.data.name, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.data.name, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'preset/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
-                            failure: function (response) {
+                            failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(this._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -1895,22 +1877,20 @@ Ext.define('Netresearch.widget.Admin', {
                 editTicketSystemWindow.show();
             },
             deleteTicketSystem: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'ticketsystem/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
-                            failure: function (response) {
+                            failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(this._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -2070,22 +2050,20 @@ Ext.define('Netresearch.widget.Admin', {
                 editActivityWindow.show();
             },
             deleteActivity: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'activity/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
-                            failure: function (response) {
+                            failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(this._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -2308,22 +2286,20 @@ Ext.define('Netresearch.widget.Admin', {
                 editContractWindow.show();
             },
             deleteContract: function (record) {
-                const grid = this;
                 const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, function (btn) {
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'contract/delete',
                             params: {
                                 id: id
                             },
-                            scope: this,
-                            success: function (response) {
-                                grid.refresh();
+                            success: (response) => {
+                                this.refresh();
                             },
-                            failure: function (response) {
+                            failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(grid._errorTitle, data.message, false);
+                                showNotification(this._errorTitle, data.message, false);
                             }
                         });
                     }

--- a/assets/js/netresearch/widget/Admin.js
+++ b/assets/js/netresearch/widget/Admin.js
@@ -164,7 +164,7 @@ Ext.define('Netresearch.widget.Admin', {
                             if (Number.isNaN(Number(teamId))) {
                                 return;
                             }
-                            const team = customerGrid.teamStore.getById(Number.parseInt(teamId));
+                            const team = customerGrid.teamStore.getById(Number.parseInt(teamId, 10));
                             if (null == team) {
                                 return;
                             }
@@ -370,8 +370,8 @@ Ext.define('Netresearch.widget.Admin', {
                 editCustomerWindow.show();
             },
             deleteCustomer: function (record) {
-                const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
+                const id = Number.parseInt(record.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.name), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'customer/delete',
@@ -383,7 +383,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(this._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -469,7 +469,7 @@ Ext.define('Netresearch.widget.Admin', {
                         anchor: '100%'
                     },
                     renderer: function (id) {
-                        if (1 > Number.parseInt(id))
+                        if (1 > Number.parseInt(id, 10))
                             return '';
 
                         const record = this.ticketSystemStore.getById(id);
@@ -858,8 +858,8 @@ Ext.define('Netresearch.widget.Admin', {
                 editProjectWindow.show();
             },
             deleteProject: function (record) {
-                const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
+                const id = Number.parseInt(record.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.name), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'project/delete',
@@ -974,7 +974,7 @@ Ext.define('Netresearch.widget.Admin', {
                             if (Number.isNaN(Number(teamId))) {
                                 return;
                             }
-                            const team = userGrid.teamStore.getById(Number.parseInt(teamId));
+                            const team = userGrid.teamStore.getById(Number.parseInt(teamId, 10));
                             if (null == team) {
                                 return;
                             }
@@ -1168,8 +1168,8 @@ Ext.define('Netresearch.widget.Admin', {
                 editUserWindow.show();
             },
             deleteUser: function (record) {
-                const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.username, (btn) => {
+                const id = Number.parseInt(record.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.username), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'user/delete',
@@ -1181,7 +1181,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(this._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -1353,8 +1353,8 @@ Ext.define('Netresearch.widget.Admin', {
                 editTeamWindow.show();
             },
             deleteTeam: function (record) {
-                const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
+                const id = Number.parseInt(record.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.name), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'team/delete',
@@ -1366,7 +1366,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(this._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -1509,8 +1509,8 @@ Ext.define('Netresearch.widget.Admin', {
                 }
             }, // end listeners
             deletePreset: function (record) {
-                const id = Number.parseInt(record.data.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.data.name, (btn) => {
+                const id = Number.parseInt(record.data.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.data.name), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'preset/delete',
@@ -1522,7 +1522,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(this._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -1877,8 +1877,8 @@ Ext.define('Netresearch.widget.Admin', {
                 editTicketSystemWindow.show();
             },
             deleteTicketSystem: function (record) {
-                const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
+                const id = Number.parseInt(record.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.name), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'ticketsystem/delete',
@@ -1890,7 +1890,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(this._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -2050,8 +2050,8 @@ Ext.define('Netresearch.widget.Admin', {
                 editActivityWindow.show();
             },
             deleteActivity: function (record) {
-                const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
+                const id = Number.parseInt(record.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.name), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'activity/delete',
@@ -2063,7 +2063,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(this._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }
@@ -2286,8 +2286,8 @@ Ext.define('Netresearch.widget.Admin', {
                 editContractWindow.show();
             },
             deleteContract: function (record) {
-                const id = Number.parseInt(record.id);
-                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + record.name, (btn) => {
+                const id = Number.parseInt(record.id, 10);
+                Ext.Msg.confirm('Achtung', 'Wirklich löschen?<br />' + Ext.String.htmlEncode(record.name), (btn) => {
                     if (btn == 'yes') {
                         Ext.Ajax.request({
                             url: url + 'contract/delete',
@@ -2299,7 +2299,7 @@ Ext.define('Netresearch.widget.Admin', {
                             },
                             failure: (response) => {
                                 const data = Ext.decode(response.responseText);
-                                showNotification(this._errorTitle, data.message, false);
+                                showNotification(panel._errorTitle, data.message, false);
                             }
                         });
                     }

--- a/assets/js/netresearch/widget/Controlling.js
+++ b/assets/js/netresearch/widget/Controlling.js
@@ -151,8 +151,8 @@ Ext.define('Netresearch.widget.Controlling', {
                 scope: this,
                 handler: function() {
                     const user = Ext.getCmp("cnt-user").value;
-                    const year = parseInt(Ext.getCmp("cnt-year").value) || 0;
-                    const month = parseInt(Ext.getCmp("cnt-month").value) || 0;
+                    const year = Number.parseInt(Ext.getCmp("cnt-year").value) || 0;
+                    const month = Number.parseInt(Ext.getCmp("cnt-month").value) || 0;
                     const project = Ext.getCmp("cnt-project").value;
                     const customer = Ext.getCmp("cnt-customer").value;
                     const billable = +Ext.getCmp("cnt-billable").value;

--- a/assets/js/netresearch/widget/Controlling.js
+++ b/assets/js/netresearch/widget/Controlling.js
@@ -151,8 +151,8 @@ Ext.define('Netresearch.widget.Controlling', {
                 scope: this,
                 handler: function() {
                     const user = Ext.getCmp("cnt-user").value;
-                    const year = Number.parseInt(Ext.getCmp("cnt-year").value) || 0;
-                    const month = Number.parseInt(Ext.getCmp("cnt-month").value) || 0;
+                    const year = Number.parseInt(Ext.getCmp("cnt-year").value, 10) || 0;
+                    const month = Number.parseInt(Ext.getCmp("cnt-month").value, 10) || 0;
                     const project = Ext.getCmp("cnt-project").value;
                     const customer = Ext.getCmp("cnt-customer").value;
                     const billable = +Ext.getCmp("cnt-billable").value;

--- a/assets/js/netresearch/widget/Extras.js
+++ b/assets/js/netresearch/widget/Extras.js
@@ -215,15 +215,14 @@ Ext.define('Netresearch.widget.Extras', {
                         usecontract: usecontract
                     };
 
-                    const panel = this;
                     Ext.Ajax.request({
                         url: url + 'tracking/bulkentry',
                         params: data,
-                        success: function (response) {
-                            showNotification(panel._successTitle, response.responseText, true);
+                        success: (response) => {
+                            showNotification(this._successTitle, response.responseText, true);
                         },
-                        failure: function (response) {
-                            showAjaxFailure(panel._errorTitle, response, panel._seriousErrorTitle, 200);
+                        failure: (response) => {
+                            showAjaxFailure(this._errorTitle, response, this._seriousErrorTitle, 200);
                         }
                     });
                 }

--- a/assets/js/netresearch/widget/Interpretation.js
+++ b/assets/js/netresearch/widget/Interpretation.js
@@ -536,7 +536,6 @@ Ext.define('Netresearch.widget.Interpretation', {
             ]
         });
 
-        const widget = this;
         const config = {
             title: this._tabTitle,
             autoScroll: true,
@@ -570,8 +569,8 @@ Ext.define('Netresearch.widget.Interpretation', {
                     valueField: 'id',
                     mode: 'local',
                     listeners: {
-                        select: function(field, value) {
-                            widget.filterableProjectStore.load({
+                        select: (field, value) => {
+                            this.filterableProjectStore.load({
                                 params: {
                                     customer: value[0].data.id
                                 }
@@ -589,8 +588,8 @@ Ext.define('Netresearch.widget.Interpretation', {
                     mode: 'local',
                     listeners: {
                         scope: this,
-                        focus: function() {
-                            widget.filterableProjectStore.load({
+                        focus: () => {
+                            this.filterableProjectStore.load({
                                 params: {
                                     customer: Ext.getCmp('customer-interpretation').getValue()
                                 }
@@ -645,15 +644,15 @@ Ext.define('Netresearch.widget.Interpretation', {
                 {
                     iconCls: 'icon-refresh',
                     tooltip: this._refreshTitle,
-                    handler: function() {
-                        widget.refresh();
+                    handler: () => {
+                        this.refresh();
                     }
                 },
                 {
                     iconCls: 'icon-delete',
                     tooltip: this._resetTitle,
-                    handler: function() {
-                        widget.reset();
+                    handler: () => {
+                        this.reset();
                     }
                 }
             ],
@@ -770,9 +769,8 @@ Ext.define('Netresearch.widget.Interpretation', {
                 'ALT-R: ' + this._refreshTitle + ' (<b>R</b>efresh)',
                 '',
                 '?: ' + this._showHelpTitle);
-        const grid = this;
-        Ext.MessageBox.alert(this._shortcutsTitle, shortcuts.join('<br/>'), function(btn) {
-            grid.getView().el.focus();
+        Ext.MessageBox.alert(this._shortcutsTitle, shortcuts.join('<br/>'), (btn) => {
+            this.getView().el.focus();
         });
     }
 });

--- a/assets/js/netresearch/widget/Interpretation.js
+++ b/assets/js/netresearch/widget/Interpretation.js
@@ -587,7 +587,6 @@ Ext.define('Netresearch.widget.Interpretation', {
                     valueField: 'id',
                     mode: 'local',
                     listeners: {
-                        scope: this,
                         focus: () => {
                             this.filterableProjectStore.load({
                                 params: {

--- a/assets/js/netresearch/widget/Settings.js
+++ b/assets/js/netresearch/widget/Settings.js
@@ -46,7 +46,6 @@ Ext.define('Netresearch.widget.Settings', {
             ]
         });
 
-        const widget = this;
         const form = new Ext.form.FormPanel({
             url: url + 'settings/save',
             frame: true,
@@ -101,19 +100,19 @@ Ext.define('Netresearch.widget.Settings', {
             }],
             buttons: [{
                 text: this._saveTitle,
-                handler: function() {
+                handler: () => {
                     form.getForm().submit({
-                        success: function(form, action) {
+                        success: (form, action) => {
                             if (settingsData.locale == action.result.locale) {
                                 globalThis.settingsData = action.result.settings;
                                 ttt_items[0].refresh();
-                                showNotification(widget._successTitle, action.result.message, true);
+                                showNotification(this._successTitle, action.result.message, true);
                             } else {
                                 globalThis.location.reload();
                             }
                         },
-                        failure: function(form, action) {
-                            showNotification(widget._errorTitle, action.result.message, false);
+                        failure: (form, action) => {
+                            showNotification(this._errorTitle, action.result.message, false);
                         }
                     });
                 }

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -96,7 +96,7 @@ Ext.define('Netresearch.widget.Tracking', {
                  */
                 getRowClass: function (record, index) {
                     // new algorithm using backend
-                    switch (parseInt(record.data.class)) {
+                    switch (Number.parseInt(record.data.class)) {
                         case 1: return '';
                         case 2: return 'night-row-bottom';
                         case 4: return 'pause-row-bottom';
@@ -264,20 +264,20 @@ Ext.define('Netresearch.widget.Tracking', {
 
                                 let editStartColumn = 6;
                                 let edited = false;
-                                if (0 < parseInt(result['customer'])) {
+                                if (0 < Number.parseInt(result['customer'])) {
                                     editStartColumn = 7;
-                                    if (selection[0].data.customer !== parseInt(result['customer'])) {
-                                        selection[0].data.customer = parseInt(result['customer']);
+                                    if (selection[0].data.customer !== Number.parseInt(result['customer'])) {
+                                        selection[0].data.customer = Number.parseInt(result['customer']);
                                         selection[0].data.project = 0;
                                         edited = true;
                                     }
                                 }
 
-                                if (0 < parseInt(result['id'])) {
+                                if (0 < Number.parseInt(result['id'])) {
                                     if ((editStartColumn === 7) && (result['sure'] !== false))
                                         editStartColumn = 7;
-                                    if (selection[0].data.project !== parseInt(result['id'])) {
-                                        selection[0].data.project = parseInt(result['id']);
+                                    if (selection[0].data.project !== Number.parseInt(result['id'])) {
+                                        selection[0].data.project = Number.parseInt(result['id']);
                                         edited = true;
                                     }
                                 }
@@ -581,7 +581,7 @@ Ext.define('Netresearch.widget.Tracking', {
                             for (let key in projects) {
                                 const value = projects[key];
                                 if (value.id === record.data.project) {
-                                    record.data.customer = parseInt(value.customer);
+                                    record.data.customer = Number.parseInt(value.customer);
                                     record.commit();
                                     this.customerStore.load();
                                     break;
@@ -615,7 +615,7 @@ Ext.define('Netresearch.widget.Tracking', {
 
         if (validProjects.length == 1) {
             this.debug && console.log("Mapped to customer " + customer + " and project " + " (sure, single)");
-            return { customer: parseInt(customer), id: parseInt(id), sure: sure };
+            return { customer: Number.parseInt(customer), id: Number.parseInt(id), sure: sure };
         }
 
         for (let i = 1; i < validProjects.length; i++) {
@@ -627,16 +627,16 @@ Ext.define('Netresearch.widget.Tracking', {
         }
 
         // If we found no unique project, lets take the last used one
-        if ((parseInt(customer) > 0) && (id === 0)) {
-            id = parseInt(this.findLastProjectByTicket(ticket, parseInt(customer)));
+        if ((Number.parseInt(customer) > 0) && (id === 0)) {
+            id = Number.parseInt(this.findLastProjectByTicket(ticket, Number.parseInt(customer)));
             if (!id) {
-                id = parseInt(this.findLastProjectByPrefix(extractTicketPrefix(ticket), parseInt(customer)));
+                id = Number.parseInt(this.findLastProjectByPrefix(extractTicketPrefix(ticket), Number.parseInt(customer)));
                 sure = false;
             }
         }
 
         this.debug && console.log("Mapped to customer " + customer + " and project " + id + (sure ? " (sure)" : " (unsure)"));
-        return { customer: parseInt(customer), id: parseInt(id), sure: sure };
+        return { customer: Number.parseInt(customer), id: Number.parseInt(id), sure: sure };
     },
 
     /*
@@ -647,9 +647,9 @@ Ext.define('Netresearch.widget.Tracking', {
 
         for (let i = 0; i < store.getCount() && i < 100; i++) {
             const record = store.getAt(i);
-            if (parseInt(record.data.customer) != customer)
+            if (Number.parseInt(record.data.customer) != customer)
                 continue;
-            if (1 > parseInt(record.data.project))
+            if (1 > Number.parseInt(record.data.project))
                 continue;
             if ((undefined != record.data.ticket) && (null != record.data.ticket) && (record.data.ticket.length > 0)) {
                 if (record.data.ticket == ticket) {
@@ -672,9 +672,9 @@ Ext.define('Netresearch.widget.Tracking', {
 
         for (let i = 0; i < store.getCount() && i < 100; i++) {
             const record = store.getAt(i);
-            if (parseInt(record.data.customer) != customer)
+            if (Number.parseInt(record.data.customer) != customer)
                 continue;
-            if (1 > parseInt(record.data.project))
+            if (1 > Number.parseInt(record.data.project))
                 continue;
             if ((undefined != record.data.ticket) && (null != record.data.ticket) && (record.data.ticket.length > 0)) {
                 if (extractTicketPrefix(record.data.ticket) == prefix)
@@ -729,7 +729,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
 
         const record = this.store.getAt(index);
-        if ((undefined != record) && (0 < parseInt(record.data.id)))
+        if ((undefined != record) && (0 < Number.parseInt(record.data.id)))
             this.getSummary(record.data.id);
     },
 
@@ -755,7 +755,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
         }
 
-        if ((0 === parseInt(record.data.project + 0)) || (0 === parseInt(record.data.customer + 0)) || (0 === parseInt(record.data.activity + 0))) {
+        if ((0 === Number.parseInt(record.data.project + 0)) || (0 === Number.parseInt(record.data.customer + 0)) || (0 === Number.parseInt(record.data.activity + 0))) {
             return;
         }
 
@@ -777,8 +777,8 @@ Ext.define('Netresearch.widget.Tracking', {
                 return;
             }
 
-            if ((true !== projectCheck) && (0 < parseInt(projectCheck))) {
-                record.data.project = parseInt(projectCheck);
+            if ((true !== projectCheck) && (0 < Number.parseInt(projectCheck))) {
+                record.data.project = Number.parseInt(projectCheck);
             }
 
             // reformat ticket
@@ -858,7 +858,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return true;
         }
 
-        if ((undefined !== customer) && (false !== customer) && (0 < parseInt(customer))) {
+        if ((undefined !== customer) && (false !== customer) && (0 < Number.parseInt(customer))) {
         } else {
             customer = 'all';
         }
@@ -1040,15 +1040,15 @@ Ext.define('Netresearch.widget.Tracking', {
             shortDescription += ' | ' + ticket;
         }
 
-        if (0 < parseInt(record.data.customer)) {
+        if (0 < Number.parseInt(record.data.customer)) {
             shortDescription += ' | ' + this.getCustomerName(record.data.customer);
         }
 
-        if (0 < parseInt(record.data.project)) {
+        if (0 < Number.parseInt(record.data.project)) {
             shortDescription += ' | ' + this.getProjectName(record.data.project);
         }
 
-        if (0 < parseInt(record.data.activity)) {
+        if (0 < Number.parseInt(record.data.activity)) {
             shortDescription += ' | ' + this.getActivityName(record.data.activity);
         }
 
@@ -1072,7 +1072,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
 
         // Easy deletion of unsaved records
-        if (0 >= parseInt(record.data.id)) {
+        if (0 >= Number.parseInt(record.data.id)) {
             this.getStore().remove(record);
             this.clearProjectStore();
             this.selectRow(index);
@@ -1081,7 +1081,7 @@ Ext.define('Netresearch.widget.Tracking', {
         }
 
         // Delete saved records only after server deletion
-        const id = parseInt(record.data.id);
+        const id = Number.parseInt(record.data.id);
         Ext.Ajax.request({
             url: url + 'tracking/delete',
             params: {
@@ -1167,7 +1167,7 @@ Ext.define('Netresearch.widget.Tracking', {
      * 11:28 ==> 11:30
      */
     round5: function (x) {
-        return (x % 5) >= 2.5 ? parseInt(x / 5) * 5 + 5 : parseInt(x / 5) * 5;
+        return (x % 5) >= 2.5 ? Number.parseInt(x / 5) * 5 + 5 : Number.parseInt(x / 5) * 5;
     },
 
     /*
@@ -1199,7 +1199,7 @@ Ext.define('Netresearch.widget.Tracking', {
      * Return given time in "H:i" representation
      */
     formatTime: function (value) {
-        if (!value || !(value instanceof Date) || isNaN(value.getTime())) {
+        if (!value || !(value instanceof Date) || Number.isNaN(value.getTime())) {
             return '';
         }
         return Ext.Date.dateFormat(value, 'H:i');

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -72,8 +72,7 @@ Ext.define('Netresearch.widget.Tracking', {
         this.startTime = this.roundTime(this.getNewDate());
 
         const entryStore = Ext.create('Netresearch.store.Entries');
-        const grid = this;
-        entryStore.on("load", function () { grid.selectRow(0); });
+        entryStore.on("load", () => { this.selectRow(0); });
 
         if (this.autoRefreshInterval === true) {
             this.autoRefreshInterval = globalThis.setInterval(
@@ -800,11 +799,10 @@ Ext.define('Netresearch.widget.Tracking', {
                 );
             }
 
-            const grid = this;
             Ext.Ajax.request({
                 url: url + 'tracking/save',
                 params: record.data,
-                success: function (response) {
+                success: (response) => {
                     record.saveInProgress = undefined;
                     const data = Ext.decode(response.responseText);
 
@@ -816,15 +814,15 @@ Ext.define('Netresearch.widget.Tracking', {
                         record.commit();
                     }
                     if (data.alert) {
-                        showNotification(grid._attentionTitle, data.alert, false);
+                        showNotification(this._attentionTitle, data.alert, false);
                     }
 
                     countTime();
                 },
-                failure: function (response) {
+                failure: (response) => {
                     record.saveInProgress = undefined;
                     record.dirty = true;
-                    const parsed = showAjaxFailure(grid._errorTitle, response, grid._seriousErrorTitle, 200);
+                    const parsed = showAjaxFailure(this._errorTitle, response, this._seriousErrorTitle, 200);
                     if (parsed?.data?.forwardUrl !== undefined) {
                         setTimeout(() => { globalThis.location.href = parsed.data.forwardUrl; }, 2000);
                     }
@@ -961,14 +959,13 @@ Ext.define('Netresearch.widget.Tracking', {
                 }
 
                 /* Display info window with summary data */
-                const grid = this;
                 const infowindow = new Ext.Window({
                     title: this._overviewTitle,
                     html: dlgMessage,
                     width: 525,
                     listeners: {
-                        close: function () {
-                            grid.getView().el.focus();
+                        close: () => {
+                            this.getView().el.focus();
                         }
                     }
                 });
@@ -1031,7 +1028,6 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
 
         /* compose a message for the customer to re-check basic activity data */
-        const grid = this;
         const duration = this.formatTime(record.data.duration);
         const ticket = record.data.ticket;
         const description = record.data.description;
@@ -1055,11 +1051,11 @@ Ext.define('Netresearch.widget.Tracking', {
         shortDescription += ' | ' + description;
 
         /* Display confirm message before deletion */
-        Ext.Msg.confirm(this._attentionTitle, this._confirmDeleteTitle + '<br />' + shortDescription, function (btn) {
+        Ext.Msg.confirm(this._attentionTitle, this._confirmDeleteTitle + '<br />' + shortDescription, (btn) => {
             if (btn === 'yes') {
-                grid.deleteEntry(index);
+                this.deleteEntry(index);
             }
-            grid.getView().el.focus();
+            this.getView().el.focus();
         });
     },
 
@@ -1370,9 +1366,8 @@ Ext.define('Netresearch.widget.Tracking', {
             'ALT-X: Liste exportieren (E<b>x</b>port)',
             '',
             '?: Hilfefenster anzeigen'];
-        const grid = this;
-        Ext.MessageBox.alert('Shortcuts', shortcuts.join('<br/>'), function (btn) {
-            grid.getView().el.focus();
+        Ext.MessageBox.alert('Shortcuts', shortcuts.join('<br/>'), (btn) => {
+            this.getView().el.focus();
         });
     },
 

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -856,7 +856,8 @@ Ext.define('Netresearch.widget.Tracking', {
             return true;
         }
 
-        if ((undefined === customer) || (false === customer) || !(Number.parseInt(customer, 10) > 0)) {
+        const customerId = Number.parseInt(customer, 10);
+        if (Number.isNaN(customerId) || customerId <= 0) {
             customer = 'all';
         }
 

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -1091,12 +1091,12 @@ Ext.define('Netresearch.widget.Tracking', {
                 this.selectRow(index);
                 this.getView().refresh();
                 if (data.alert) {
-                    showNotification(grid._attentionTitle, data.alert, false);
+                    showNotification(this._attentionTitle, data.alert, false);
                 }
             },
             failure: function (response) {
                 const data = Ext.decode(response.responseText);
-                showNotification(grid._errorTitle, data.message, false);
+                showNotification(this._errorTitle, data.message, false);
                 if (data.forwardUrl !== undefined) {
                     setTimeout(() => { globalThis.location.href = data.forwardUrl; }, 2000);
                 }

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -856,8 +856,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return true;
         }
 
-        if ((undefined !== customer) && (false !== customer) && (0 < Number.parseInt(customer))) {
-        } else {
+        if ((undefined === customer) || (false === customer) || !(Number.parseInt(customer) > 0)) {
             customer = 'all';
         }
 

--- a/assets/js/netresearch/widget/Tracking.js
+++ b/assets/js/netresearch/widget/Tracking.js
@@ -95,7 +95,7 @@ Ext.define('Netresearch.widget.Tracking', {
                  */
                 getRowClass: function (record, index) {
                     // new algorithm using backend
-                    switch (Number.parseInt(record.data.class)) {
+                    switch (Number.parseInt(record.data.class, 10)) {
                         case 1: return '';
                         case 2: return 'night-row-bottom';
                         case 4: return 'pause-row-bottom';
@@ -263,20 +263,20 @@ Ext.define('Netresearch.widget.Tracking', {
 
                                 let editStartColumn = 6;
                                 let edited = false;
-                                if (0 < Number.parseInt(result['customer'])) {
+                                if (0 < Number.parseInt(result['customer'], 10)) {
                                     editStartColumn = 7;
-                                    if (selection[0].data.customer !== Number.parseInt(result['customer'])) {
-                                        selection[0].data.customer = Number.parseInt(result['customer']);
+                                    if (selection[0].data.customer !== Number.parseInt(result['customer'], 10)) {
+                                        selection[0].data.customer = Number.parseInt(result['customer'], 10);
                                         selection[0].data.project = 0;
                                         edited = true;
                                     }
                                 }
 
-                                if (0 < Number.parseInt(result['id'])) {
+                                if (0 < Number.parseInt(result['id'], 10)) {
                                     if ((editStartColumn === 7) && (result['sure'] !== false))
                                         editStartColumn = 7;
-                                    if (selection[0].data.project !== Number.parseInt(result['id'])) {
-                                        selection[0].data.project = Number.parseInt(result['id']);
+                                    if (selection[0].data.project !== Number.parseInt(result['id'], 10)) {
+                                        selection[0].data.project = Number.parseInt(result['id'], 10);
                                         edited = true;
                                     }
                                 }
@@ -580,7 +580,7 @@ Ext.define('Netresearch.widget.Tracking', {
                             for (let key in projects) {
                                 const value = projects[key];
                                 if (value.id === record.data.project) {
-                                    record.data.customer = Number.parseInt(value.customer);
+                                    record.data.customer = Number.parseInt(value.customer, 10);
                                     record.commit();
                                     this.customerStore.load();
                                     break;
@@ -614,7 +614,7 @@ Ext.define('Netresearch.widget.Tracking', {
 
         if (validProjects.length == 1) {
             this.debug && console.log("Mapped to customer " + customer + " and project " + " (sure, single)");
-            return { customer: Number.parseInt(customer), id: Number.parseInt(id), sure: sure };
+            return { customer: Number.parseInt(customer, 10), id: Number.parseInt(id, 10), sure: sure };
         }
 
         for (let i = 1; i < validProjects.length; i++) {
@@ -626,16 +626,16 @@ Ext.define('Netresearch.widget.Tracking', {
         }
 
         // If we found no unique project, lets take the last used one
-        if ((Number.parseInt(customer) > 0) && (id === 0)) {
-            id = Number.parseInt(this.findLastProjectByTicket(ticket, Number.parseInt(customer)));
+        if ((Number.parseInt(customer, 10) > 0) && (id === 0)) {
+            id = Number.parseInt(this.findLastProjectByTicket(ticket, Number.parseInt(customer, 10)));
             if (!id) {
-                id = Number.parseInt(this.findLastProjectByPrefix(extractTicketPrefix(ticket), Number.parseInt(customer)));
+                id = Number.parseInt(this.findLastProjectByPrefix(extractTicketPrefix(ticket), Number.parseInt(customer, 10)));
                 sure = false;
             }
         }
 
         this.debug && console.log("Mapped to customer " + customer + " and project " + id + (sure ? " (sure)" : " (unsure)"));
-        return { customer: Number.parseInt(customer), id: Number.parseInt(id), sure: sure };
+        return { customer: Number.parseInt(customer, 10), id: Number.parseInt(id, 10), sure: sure };
     },
 
     /*
@@ -646,9 +646,9 @@ Ext.define('Netresearch.widget.Tracking', {
 
         for (let i = 0; i < store.getCount() && i < 100; i++) {
             const record = store.getAt(i);
-            if (Number.parseInt(record.data.customer) != customer)
+            if (Number.parseInt(record.data.customer, 10) != customer)
                 continue;
-            if (1 > Number.parseInt(record.data.project))
+            if (1 > Number.parseInt(record.data.project, 10))
                 continue;
             if ((undefined != record.data.ticket) && (null != record.data.ticket) && (record.data.ticket.length > 0)) {
                 if (record.data.ticket == ticket) {
@@ -671,9 +671,9 @@ Ext.define('Netresearch.widget.Tracking', {
 
         for (let i = 0; i < store.getCount() && i < 100; i++) {
             const record = store.getAt(i);
-            if (Number.parseInt(record.data.customer) != customer)
+            if (Number.parseInt(record.data.customer, 10) != customer)
                 continue;
-            if (1 > Number.parseInt(record.data.project))
+            if (1 > Number.parseInt(record.data.project, 10))
                 continue;
             if ((undefined != record.data.ticket) && (null != record.data.ticket) && (record.data.ticket.length > 0)) {
                 if (extractTicketPrefix(record.data.ticket) == prefix)
@@ -728,7 +728,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
 
         const record = this.store.getAt(index);
-        if ((undefined != record) && (0 < Number.parseInt(record.data.id)))
+        if ((undefined != record) && (0 < Number.parseInt(record.data.id, 10)))
             this.getSummary(record.data.id);
     },
 
@@ -754,7 +754,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
         }
 
-        if ((0 === Number.parseInt(record.data.project + 0)) || (0 === Number.parseInt(record.data.customer + 0)) || (0 === Number.parseInt(record.data.activity + 0))) {
+        if ((0 === Number.parseInt(record.data.project + 0, 10)) || (0 === Number.parseInt(record.data.customer + 0, 10)) || (0 === Number.parseInt(record.data.activity + 0, 10))) {
             return;
         }
 
@@ -776,8 +776,8 @@ Ext.define('Netresearch.widget.Tracking', {
                 return;
             }
 
-            if ((true !== projectCheck) && (0 < Number.parseInt(projectCheck))) {
-                record.data.project = Number.parseInt(projectCheck);
+            if ((true !== projectCheck) && (0 < Number.parseInt(projectCheck, 10))) {
+                record.data.project = Number.parseInt(projectCheck, 10);
             }
 
             // reformat ticket
@@ -856,7 +856,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return true;
         }
 
-        if ((undefined === customer) || (false === customer) || !(Number.parseInt(customer) > 0)) {
+        if ((undefined === customer) || (false === customer) || !(Number.parseInt(customer, 10) > 0)) {
             customer = 'all';
         }
 
@@ -1035,22 +1035,22 @@ Ext.define('Netresearch.widget.Tracking', {
             shortDescription += ' | ' + ticket;
         }
 
-        if (0 < Number.parseInt(record.data.customer)) {
+        if (0 < Number.parseInt(record.data.customer, 10)) {
             shortDescription += ' | ' + this.getCustomerName(record.data.customer);
         }
 
-        if (0 < Number.parseInt(record.data.project)) {
+        if (0 < Number.parseInt(record.data.project, 10)) {
             shortDescription += ' | ' + this.getProjectName(record.data.project);
         }
 
-        if (0 < Number.parseInt(record.data.activity)) {
+        if (0 < Number.parseInt(record.data.activity, 10)) {
             shortDescription += ' | ' + this.getActivityName(record.data.activity);
         }
 
         shortDescription += ' | ' + description;
 
         /* Display confirm message before deletion */
-        Ext.Msg.confirm(this._attentionTitle, this._confirmDeleteTitle + '<br />' + shortDescription, (btn) => {
+        Ext.Msg.confirm(this._attentionTitle, this._confirmDeleteTitle + '<br />' + Ext.String.htmlEncode(shortDescription), (btn) => {
             if (btn === 'yes') {
                 this.deleteEntry(index);
             }
@@ -1067,7 +1067,7 @@ Ext.define('Netresearch.widget.Tracking', {
             return;
 
         // Easy deletion of unsaved records
-        if (0 >= Number.parseInt(record.data.id)) {
+        if (0 >= Number.parseInt(record.data.id, 10)) {
             this.getStore().remove(record);
             this.clearProjectStore();
             this.selectRow(index);
@@ -1076,7 +1076,7 @@ Ext.define('Netresearch.widget.Tracking', {
         }
 
         // Delete saved records only after server deletion
-        const id = Number.parseInt(record.data.id);
+        const id = Number.parseInt(record.data.id, 10);
         Ext.Ajax.request({
             url: url + 'tracking/delete',
             params: {
@@ -1162,7 +1162,7 @@ Ext.define('Netresearch.widget.Tracking', {
      * 11:28 ==> 11:30
      */
     round5: function (x) {
-        return (x % 5) >= 2.5 ? Number.parseInt(x / 5) * 5 + 5 : Number.parseInt(x / 5) * 5;
+        return (x % 5) >= 2.5 ? Math.trunc(x / 5) * 5 + 5 : Math.trunc(x / 5) * 5;
     },
 
     /*

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -151,9 +151,9 @@ function createLabJiraTimeSummay(list, data) {
     })
 
     //remove existing data
-    liEl.removeChild(liEl.childNodes[1]);
-    liEl.removeChild(liEl.childNodes[2]);
-    liEl.removeChild(liEl.childNodes[3]);
+    liEl.childNodes[1].remove();
+    liEl.childNodes[2].remove();
+    liEl.childNodes[3].remove();
 
     return cloneTitle;
 }
@@ -184,7 +184,7 @@ function getTimeSummary() {
 
             if (list.lastChild.textContent == 'Es liegen keine Informationen vor.') {
 
-                list.removeChild(list.lastChild);
+                list.lastChild.remove();
             }
 
             const newDiv = this.labJira

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -127,6 +127,8 @@ function createLabJiraTimeSummay(list, data) {
     let i = 0;
 
     const liEl = cloneTitle.childNodes[1].childNodes[1].childNodes[1];
+    // snapshot the template's own entries before appending replacements
+    const templateEntries = [...liEl.children];
 
     Object.entries(data).forEach((value) => {
         const time = value[1].time;
@@ -150,9 +152,8 @@ function createLabJiraTimeSummay(list, data) {
         }
     })
 
-    // remove the template's own entries (the first three element children;
-    // the freshly appended ones come after them)
-    for (const node of [...liEl.children].slice(0, 3)) {
+    // remove the template's own entries (snapshotted above)
+    for (const node of templateEntries) {
         node.remove();
     }
 

--- a/public/scripts/timeSummaryForJira.js
+++ b/public/scripts/timeSummaryForJira.js
@@ -150,10 +150,11 @@ function createLabJiraTimeSummay(list, data) {
         }
     })
 
-    //remove existing data
-    liEl.childNodes[1].remove();
-    liEl.childNodes[2].remove();
-    liEl.childNodes[3].remove();
+    // remove the template's own entries (the first three element children;
+    // the freshly appended ones come after them)
+    for (const node of [...liEl.children].slice(0, 3)) {
+        node.remove();
+    }
 
     return cloneTitle;
 }


### PR DESCRIPTION
SonarCloud JS phase 3: modernize global API usage in first-party JS (`assets/js/**` excluding vendored `ext-js`/`Notification.js`, plus `public/scripts/*.js`).

## Per-rule summary

| Rule | Fixed | Skipped | Notes |
|------|------:|--------:|-------|
| javascript:S7773 (Number static methods) | 56 | 0 | `main.js`, `store/Projects.js`, `widget/Admin.js`, `widget/Controlling.js`, `widget/Tracking.js` |
| javascript:S7740 (no `this` aliases) | 23 | 1 | `widget/Admin.js`, `Extras.js`, `Interpretation.js`, `Settings.js`, `Tracking.js` |
| javascript:S7762 (`childNode.remove()`) | 4 | 0 | `public/scripts/timeSummaryForJira.js` |
| javascript:S7735 (negated conditions) | 0 | 0 | All live findings are in vendored files (`assets/js/Notification.js`, `public/docs/swagger/oauth2-redirect.html`) — excluded from analysis via #330 |

## Behavior-preservation notes

**S7773**
- All 53 `parseInt` → `Number.parseInt` swaps are semantically identical.
- The 3 `isNaN` sites were handled individually:
  - `Admin.js` (2× `isNaN(teamId)`): team IDs from store data may be numeric strings, so coercion was preserved explicitly via `Number.isNaN(Number(teamId))`.
  - `Tracking.js` `formatTime` (`isNaN(value.getTime())`): argument is provably a number (guarded by `value instanceof Date`), so plain `Number.isNaN` is safe.
- No ES2021+ introduced; `Number.parseInt`/`Number.isNaN` are ES2015 (Safari 14 floor holds).

**S7740**
- Fixed by converting the nested callbacks (`Ext.Msg.confirm`, `Ext.Ajax` success/failure, store `load` callbacks, button handlers, window `close` listeners) to arrow functions capturing the enclosing method's `this`. Each converted callback was checked to not rely on its own dynamic `this`; `scope: this` options made dead by the conversion were removed.
- **Skipped (1):** `Admin.js:129` `const panel = this` in `initComponent` — ~120 usages across deeply nested Ext config objects and handlers; converting every enclosing `function` to an arrow would be a high-risk rewrite of the whole component for no behavioral gain. Alias kept deliberately.
- Pre-existing latent bug noted (not touched, no S7740 finding there): `Tracking.js` `deleteEntry` Ajax callbacks reference `grid._attentionTitle`/`grid._errorTitle` although no `grid` variable is in scope there (was already the case before this PR).

**S7762**
- `parentNode.removeChild(child)` → `child.remove()` on the same nodes; `Node.remove()` is supported far below the Safari 14 floor.

## Gates

- `node --check` passes on every edited file (these scripts are copied by webpack `copyFiles`, never parsed).
- `docker compose run --rm app-dev npm run build` → `webpack compiled successfully` after each rule batch.
- E2E smoke (CI-style: `E2E_BASE_URL=http://httpd-e2e:80 CI=true`, e2e compose profile) on `login.spec.ts`, `navigation.spec.ts`, `keyboard.spec.ts`, `settings.spec.ts`: **40 passed, 1 flaky (passed on retry), 0 failed** (2.3m). The flaky test (`keyboard.spec.ts › navigate grid rows with arrow keys`) timed out once waiting for the post-login redirect in `helpers/auth.ts` — a known timing flake unrelated to these changes.

Part of #319


## Quality gate note

As with #328, the SonarCloud PR gate's `new_duplicated_lines_density` condition flags pre-existing copy-paste structure (the twin summary functions in `timeSummaryForJira.js` and repeated ExtJS listener blocks) re-attributed to "new code" because the mechanical conversion touches those lines — amplified here by the small diff denominator. No new issues remain open on the PR (the one S108 finding was fixed). Overall project duplication is unchanged; de-duplication stays tracked under #319.
