### PR TITLE
build: tolerate GHA cache export failures in docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,7 +62,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           set: |
             *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            *.cache-to=type=gha,mode=max,ignore-error=true
 
       - name: Build and push E2E image
         uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
@@ -73,4 +73,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           set: |
             *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            *.cache-to=type=gha,mode=max,ignore-error=true


### PR DESCRIPTION
The `gha` cache backend intermittently fails blob writes (`error writing layer blob: not_found`) — three otherwise-green builds failed on 2026-06-12 and needed manual reruns (PR #334/#335). With `ignore-error=true` a failed cache export only costs the next build's cache hits instead of failing the build.

Both bake invocations (production + e2e) get the flag.