### PR TITLE
feat(ui): move theme switch into the header + theme the header

### DIFF
--- a/assets/styles/header.css
+++ b/assets/styles/header.css
@@ -127,7 +127,7 @@
     margin-left: 4px;
     padding: 2px 8px;
     font-size: 11px;
-    color: light-dark(#666, #c4c9cf);
+    color: light-dark(#333, #c4c9cf);
     text-decoration: none;
     border: 1px solid light-dark(#ddd, #4a525b);
     border-radius: 3px;
@@ -175,7 +175,7 @@
 .worktime-item dt {
     font-size: 10px;
     text-transform: uppercase;
-    color: light-dark(#666, #b9bec4);
+    color: light-dark(#50555b, #b9bec4);
     letter-spacing: 0.5px;
     margin: 0;
 }

--- a/assets/styles/header.css
+++ b/assets/styles/header.css
@@ -2,10 +2,26 @@
    Shared page header + main navigation.
    Loaded by BOTH the ExtJS shell and the SolidJS shell (/ui) — keep this file
    framework-neutral; markup lives in templates/partials/header.html.twig.
+
+   Theming: colours use light-dark() so the header follows the user's theme.
+   The SolidJS theme switch sets data-theme on <html>; we map that to
+   color-scheme here so light-dark() resolves on BOTH shells (the SPA design
+   tokens in app.css are not loaded on the ExtJS shell). With no explicit
+   choice the header follows the OS (prefers-color-scheme).
    ========================================================================== */
 
 .page-header {
-    background-color: #D2D2D2;
+    color-scheme: light dark;
+    background-color: light-dark(#D2D2D2, #1d2127);
+    color: light-dark(#1f2937, #f1f2f4);
+}
+
+:root[data-theme="light"] .page-header {
+    color-scheme: light;
+}
+
+:root[data-theme="dark"] .page-header {
+    color-scheme: dark;
 }
 
 /* Skip Link (WCAG 2.4.1) */
@@ -57,6 +73,13 @@
     object-fit: contain;
 }
 
+/* Theme switch slot (the SolidJS ThemeToggle is portalled in here on /ui). */
+.header-theme {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
 /* User Badge (status + logout merged) */
 .user-badge {
     display: flex;
@@ -82,8 +105,8 @@
 }
 
 .user-badge.status_active {
-    background-color: #c1cbc1;
-    color: #333;
+    background-color: light-dark(#c1cbc1, #283330);
+    color: light-dark(#333, #e6e9ec);
 }
 
 .user-badge.status_active .status-indicator {
@@ -92,8 +115,8 @@
 }
 
 .user-badge.status_inactive {
-    background-color: #cfc1c1;
-    color: #444;
+    background-color: light-dark(#cfc1c1, #332828);
+    color: light-dark(#444, #e6e9ec);
 }
 
 .user-badge.status_inactive .status-indicator {
@@ -104,18 +127,18 @@
     margin-left: 4px;
     padding: 2px 8px;
     font-size: 11px;
-    color: #666;
+    color: light-dark(#666, #c4c9cf);
     text-decoration: none;
-    border: 1px solid #ddd;
+    border: 1px solid light-dark(#ddd, #4a525b);
     border-radius: 3px;
     transition: all 0.2s;
 }
 
 .user-badge .badge-logout:hover,
 .user-badge .badge-logout:focus {
-    background-color: #cfbdbd;
-    border-color: #B00000;
-    color: #8F0000;
+    background-color: light-dark(#cfbdbd, #4a2a2c);
+    border-color: light-dark(#B00000, #e0888c);
+    color: light-dark(#8F0000, #f5bdc0);
 }
 
 .user-badge .badge-logout:focus {
@@ -144,7 +167,7 @@
     flex-direction: column;
     align-items: center;
     padding: 4px 12px;
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.07));
     border-radius: 4px;
     min-width: 70px;
 }
@@ -152,7 +175,7 @@
 .worktime-item dt {
     font-size: 10px;
     text-transform: uppercase;
-    color: #666;
+    color: light-dark(#666, #b9bec4);
     letter-spacing: 0.5px;
     margin: 0;
 }
@@ -160,13 +183,13 @@
 .worktime-item dd {
     font-size: 14px;
     font-weight: 600;
-    color: #333;
+    color: light-dark(#333, #f1f2f4);
     margin: 0;
 }
 
 .worktime-link {
     font-size: 12px;
-    color: #00707F;
+    color: light-dark(#00707F, #6fd0dd);
     text-decoration: none;
     padding: 4px 8px;
     border-radius: 4px;
@@ -175,7 +198,7 @@
 
 .worktime-link:hover,
 .worktime-link:focus {
-    background-color: rgba(0, 136, 154, 0.1);
+    background-color: light-dark(rgba(0, 136, 154, 0.1), rgba(111, 208, 221, 0.15));
     text-decoration: underline;
 }
 
@@ -193,9 +216,9 @@
     display: flex;
     gap: 4px;
     padding: 0 16px;
-    background-color: #c6c9cc;
-    border-top: 1px solid #b5b8bc;
-    border-bottom: 1px solid #9aa0a6;
+    background-color: light-dark(#c6c9cc, #21262d);
+    border-top: 1px solid light-dark(#b5b8bc, #2f353d);
+    border-bottom: 1px solid light-dark(#9aa0a6, #11151a);
 }
 
 .main-nav-link {
@@ -203,7 +226,7 @@
     align-items: center;
     min-height: 44px;
     padding: 0 16px;
-    color: #1f2937;
+    color: light-dark(#1f2937, #e6e9ec);
     font-family: Arial, sans-serif;
     font-size: 13px;
     font-weight: 600;
@@ -213,10 +236,10 @@
 
 .main-nav-link:hover,
 .main-nav-link:focus {
-    background-color: rgba(0, 136, 154, 0.1);
+    background-color: light-dark(rgba(0, 136, 154, 0.1), rgba(111, 208, 221, 0.15));
 }
 
 .main-nav-link.is-active {
-    border-bottom-color: #00889A;
-    color: #00707F;
+    border-bottom-color: light-dark(#00889A, #6fd0dd);
+    color: light-dark(#00707F, #6fd0dd);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
 import { Navigate, Route, Router, useLocation } from '@solidjs/router'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { createEffect, onMount, type Component, type ParentProps } from 'solid-js'
+import { createEffect, onMount, Show, type Component, type ParentProps } from 'solid-js'
+import { Portal } from 'solid-js/web'
 
 import { SessionExpiredError } from './api/client'
+import { ThemeToggle } from './components/ThemeToggle'
 import { appConfig, canBill, canBulkEnter, hasRole } from './config'
 import { initHeaderDynamics } from './header'
 import { syncNav } from './nav'
@@ -28,6 +30,10 @@ const queryClient = new QueryClient({
 // this layout animates it, syncs the active nav item, and hosts the route.
 function Layout(props: ParentProps) {
   const location = useLocation()
+  // The theme switch lives in the server-rendered header (shared with the
+  // ExtJS shell); portal the SolidJS control into its slot so it sits in the
+  // header chrome rather than each page's body.
+  const themeMount = document.getElementById('theme-toggle-mount')
 
   onMount(() => {
     initHeaderDynamics(appConfig())
@@ -39,6 +45,7 @@ function Layout(props: ParentProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <Show when={themeMount}>{(mount) => <Portal mount={mount()}><ThemeToggle /></Portal>}</Show>
       <main id="main-content">{props.children}</main>
     </QueryClientProvider>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Route, Router, useLocation } from '@solidjs/router'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { createEffect, onMount, Show, type Component, type ParentProps } from 'solid-js'
+import { createEffect, createSignal, onMount, Show, type Component, type ParentProps } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
 import { SessionExpiredError } from './api/client'
@@ -32,11 +32,13 @@ function Layout(props: ParentProps) {
   const location = useLocation()
   // The theme switch lives in the server-rendered header (shared with the
   // ExtJS shell); portal the SolidJS control into its slot so it sits in the
-  // header chrome rather than each page's body.
-  const themeMount = document.getElementById('theme-toggle-mount')
+  // header chrome rather than each page's body. Resolve the slot in onMount so
+  // we read the DOM after it's ready, not during component setup.
+  const [themeMount, setThemeMount] = createSignal<HTMLElement | null>(null)
 
   onMount(() => {
     initHeaderDynamics(appConfig())
+    setThemeMount(document.getElementById('theme-toggle-mount'))
   })
 
   createEffect(() => {
@@ -45,7 +47,7 @@ function Layout(props: ParentProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Show when={themeMount}>{(mount) => <Portal mount={mount()}><ThemeToggle /></Portal>}</Show>
+      <Show when={themeMount()}>{(mount) => <Portal mount={mount()}><ThemeToggle /></Portal>}</Show>
       <main id="main-content">{props.children}</main>
     </QueryClientProvider>
   )

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -3,7 +3,6 @@ import { createSignal, For } from 'solid-js'
 import { adminEntities } from '../admin/entities'
 import { useOptionSources } from '../admin/options'
 import { AdminCrudShell } from '../components/AdminCrudShell'
-import { ThemeToggle } from '../components/ThemeToggle'
 import { m } from '../paraglide/messages.js'
 
 export default function Admin() {
@@ -15,10 +14,7 @@ export default function Admin() {
 
   return (
     <section class="admin-page">
-      <div class="month-toolbar">
-        <h2>{m.admin_title()}</h2>
-        <ThemeToggle />
-      </div>
+      <h2 class="visually-hidden">{m.admin_title()}</h2>
 
       <nav class="admin-subnav" aria-label={m.admin_title()}>
         <For each={entities}>

--- a/frontend/src/pages/Auswertung.tsx
+++ b/frontend/src/pages/Auswertung.tsx
@@ -16,7 +16,6 @@ import {
   usersQuery,
 } from '../api/queries'
 import { EffortChart, type EffortRow } from '../components/EffortChart'
-import { ThemeToggle } from '../components/ThemeToggle'
 import { appConfig } from '../config'
 import { m } from '../paraglide/messages.js'
 
@@ -116,10 +115,7 @@ export default function Auswertung() {
 
   return (
     <section class="auswertung">
-      <div class="month-toolbar">
-        <h2>{m.auswertung_title()}</h2>
-        <ThemeToggle />
-      </div>
+      <h2 class="visually-hidden">{m.auswertung_title()}</h2>
 
       <form
         class="filter-bar"

--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -84,7 +84,7 @@ export default function Billing() {
 
   return (
     <section class="form-page">
-      <h2>{m.billing_title()}</h2>
+      <h2 class="visually-hidden">{m.billing_title()}</h2>
       <Show when={users.isError || projects.isError || customers.isError}>
         <p role="alert">{m.app_load_error()}</p>
       </Show>

--- a/frontend/src/pages/Extras.tsx
+++ b/frontend/src/pages/Extras.tsx
@@ -76,7 +76,7 @@ export default function Extras() {
 
   return (
     <section class="form-page">
-      <h2>{m.extras_title()}</h2>
+      <h2 class="visually-hidden">{m.extras_title()}</h2>
       <Show when={presets.isError}>
         <p role="alert">{m.app_load_error()}</p>
       </Show>

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -48,7 +48,7 @@ export default function Help() {
 
   return (
     <section class="help-page">
-      <h2>{m.help_title()}</h2>
+      <h2 class="visually-hidden">{m.help_title()}</h2>
 
       <section class="help-section">
         <h3>{m.help_usage()}</h3>

--- a/frontend/src/pages/Month.tsx
+++ b/frontend/src/pages/Month.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/solid-query'
 import { createMemo, For, Index, Match, Show, Switch } from 'solid-js'
 
 import { holidaysQuery, monthTimesQuery } from '../api/queries'
-import { ThemeToggle } from '../components/ThemeToggle'
 import { appConfig } from '../config'
 import { formatMinutes, formatMonthTitle } from '../lib/format'
 import { computeMonth, type DayRow } from '../lib/month'
@@ -159,12 +158,11 @@ export default function Month() {
   return (
     <section class="month-report">
       <div class="month-toolbar">
-        <h2>{m.month_title()}</h2>
+        <h2 class="visually-hidden">{m.month_title()}</h2>
         <div class="month-toolbar-actions">
           <A class="today-button" href={monthHref(currentTarget.year, currentTarget.month)}>
             {m.month_today()}
           </A>
-          <ThemeToggle />
         </div>
       </div>
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -73,7 +73,7 @@ export default function Settings() {
 
   return (
     <section class="form-page">
-      <h2>{m.settings_title()}</h2>
+      <h2 class="visually-hidden">{m.settings_title()}</h2>
       <form class="stack-form" onSubmit={(event) => void onSubmit(event)}>
         <label class="field">
           <span>{m.settings_language()}</span>

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -30,6 +30,9 @@
                 <a id="sumlink" href="{{ globalConfig.monthly_overview_url ~ settings.user_name }}" target="_blank" rel="noopener noreferrer" class="worktime-link">{{ 'Monthly overview'|trans }}</a>
             {% endif %}
         </section>
+        {# Theme switch — the SolidJS shell portals its ThemeToggle in here
+           (frontend/src/App.tsx); empty on the ExtJS shell, which has no SPA. #}
+        <div id="theme-toggle-mount" class="header-theme"></div>
     </header>
     <nav class="main-nav" aria-label="{{ 'Main navigation'|trans }}">
         <a class="main-nav-link{% if active == 'tracking' %} is-active{% endif %}"


### PR DESCRIPTION
## Summary

Header/theme UX cleanup across the SolidJS `/ui` shell:

- **Theme switch moved into the header.** The System/Light/Dark control now
  lives in the shared, server-rendered header (portalled in from the SPA)
  instead of being repeated in each page's toolbar. Removed the per-page
  `<ThemeToggle/>` from Month, Auswertung and Admin.
- **Dropped the redundant page headings.** Every page's `<h2>` just restated
  the active nav item, so it's now `visually-hidden` — kept in the document
  outline (screen readers / heading order) but removed visually.
- **Header is now light/dark capable.** `header.css` colours use `light-dark()`
  with `color-scheme` mapped from the `data-theme` the switch sets, so the
  shared header follows the chosen theme (and the OS for "system"). The CSS is
  self-contained, so it also themes correctly on the ExtJS shell, which does
  not load the SPA design tokens.

## Verification

- Frontend: eslint, tsc, vitest (32, incl. axe), vite build — all green.
- Encore build (header.css) — green.
- Manually verified on the dev stack in light **and** dark: the toggle sits in
  the header, the header + nav + worktime + badge all theme, no page-title
  headings render, and switching to "Dunkel" themes the whole chrome.

No backend changes.
