### PR TITLE
feat(ui): readable, sortable, responsive admin tables

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -113,6 +113,8 @@
   "admin_delete": "Löschen",
   "admin_cancel": "Abbrechen",
   "admin_actions": "Aktionen",
+  "admin_filter": "Filtern…",
+  "admin_no_matches": "Keine Treffer für den Filter.",
   "admin_delete_confirm": "Wirklich löschen?",
   "admin_yes": "Ja",
   "admin_no": "Nein",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -113,6 +113,8 @@
   "admin_delete": "Delete",
   "admin_cancel": "Cancel",
   "admin_actions": "Actions",
+  "admin_filter": "Filter…",
+  "admin_no_matches": "No matches for the filter.",
   "admin_delete_confirm": "Really delete?",
   "admin_yes": "Yes",
   "admin_no": "No",

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -43,8 +43,8 @@ export function adminEntities(): EntityDescriptor[] {
       columns: [
         { key: 'name', label: () => m.admin_f_name() },
         { key: 'teams', label: () => m.admin_f_teams(), render: (row, o) => ((row.teams as number[]) ?? []).map((id) => o('teams').find((t) => t.id === id)?.label ?? id).join(', ') },
-        { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active) },
-        { key: 'global', label: () => m.admin_f_global(), render: (row) => mark(row.global) },
+        { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active), align: 'center' },
+        { key: 'global', label: () => m.admin_f_global(), render: (row) => mark(row.global), align: 'center' },
       ],
       fields: [
         { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true },
@@ -69,8 +69,8 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'name', label: () => m.admin_f_name() },
         { key: 'customer', label: () => m.admin_f_customer(), render: (row, o) => rel('customers')(row, 'customer', o) },
         { key: 'jiraId', label: () => m.admin_f_jira_id() },
-        { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active) },
-        { key: 'global', label: () => m.admin_f_global(), render: (row) => mark(row.global) },
+        { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active), align: 'center' },
+        { key: 'global', label: () => m.admin_f_global(), render: (row) => mark(row.global), align: 'center' },
       ],
       fields: [
         { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true },
@@ -221,7 +221,7 @@ export function adminEntities(): EntityDescriptor[] {
       columns: [
         { key: 'name', label: () => m.admin_f_name() },
         { key: 'type', label: () => m.admin_f_type() },
-        { key: 'bookTime', label: () => m.admin_f_book_time(), render: (row) => mark(pick(row, 'bookTime', 'book_time')) },
+        { key: 'bookTime', label: () => m.admin_f_book_time(), render: (row) => mark(pick(row, 'bookTime', 'book_time')), align: 'center' },
         { key: 'url', label: () => m.admin_f_url() },
       ],
       fields: [
@@ -266,8 +266,8 @@ export function adminEntities(): EntityDescriptor[] {
       deleteEndpoint: '/activity/delete',
       columns: [
         { key: 'name', label: () => m.admin_f_name() },
-        { key: 'needsTicket', label: () => m.admin_f_needs_ticket(), render: (row) => mark(pick(row, 'needsTicket', 'needs_ticket')) },
-        { key: 'factor', label: () => m.admin_f_factor() },
+        { key: 'needsTicket', label: () => m.admin_f_needs_ticket(), render: (row) => mark(pick(row, 'needsTicket', 'needs_ticket')), align: 'center' },
+        { key: 'factor', label: () => m.admin_f_factor(), align: 'right' },
       ],
       fields: [
         { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true },

--- a/frontend/src/admin/types.ts
+++ b/frontend/src/admin/types.ts
@@ -8,6 +8,8 @@ export interface ColumnDef {
   label: () => string
   /** Render a cell from the raw row object (e.g. id→name, bool→✓). */
   render?: (row: Record<string, unknown>, options: OptionLookup) => string
+  /** Cell/header alignment. Numbers → 'right', booleans (✓/—) → 'center'. */
+  align?: 'left' | 'right' | 'center'
 }
 
 export type FieldType = 'text' | 'number' | 'checkbox' | 'date' | 'select' | 'multiselect' | 'textarea'

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -83,7 +83,7 @@ export function AdminCrudShell(props: {
     const filtered = query === '' ? decorated : decorated.filter((entry) => entry.haystack.includes(query))
     if (current && sortCol) {
       const factor = current.dir === 'asc' ? 1 : -1
-      filtered.sort((a, b) => factor * a.sortKey.localeCompare(b.sortKey, undefined, { numeric: true, sensitivity: 'base' }))
+      filtered.sort((a, b) => factor * a.sortKey.localeCompare(b.sortKey, undefined, { numeric: true }))
     }
 
     return filtered.map((entry) => entry.row)

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -43,6 +43,8 @@ export function AdminCrudShell(props: {
   // ✓/—, …) so the sort order matches the visible values. Clicking a header
   // cycles none → ascending → descending → none.
   const [sort, setSort] = createSignal<{ key: string; dir: 'asc' | 'desc' } | null>(null)
+  // Free-text filter: matches against the visible text of every column.
+  const [filter, setFilter] = createSignal('')
 
   const cellText = (row: Row, col: ColumnDef): string =>
     col.render ? col.render(row, props.options) : String(row[col.key] ?? '')
@@ -65,20 +67,26 @@ export function AdminCrudShell(props: {
     return current?.key === key ? (current.dir === 'asc' ? '▲' : '▼') : ''
   }
 
-  const sortedRows = createMemo<Row[]>(() => {
+  const visibleRows = createMemo<Row[]>(() => {
     const current = sort()
-    const data = rows()
-    const col = current && props.descriptor.columns.find((c) => c.key === current.key)
-    if (!current || !col) {
-      return data
+    const query = filter().trim().toLowerCase()
+    const columns = props.descriptor.columns
+    const sortCol = current && columns.find((c) => c.key === current.key)
+    // Compute the visible text per row once here (in the tracked memo): a
+    // haystack for the free-text filter and the active column's sort key. The
+    // filter/sort callbacks then work on plain strings only.
+    const decorated = rows().map((row) => ({
+      row,
+      haystack: query === '' ? '' : columns.map((col) => cellText(row, col)).join('').toLowerCase(),
+      sortKey: sortCol ? cellText(row, sortCol) : '',
+    }))
+    const filtered = query === '' ? decorated : decorated.filter((entry) => entry.haystack.includes(query))
+    if (current && sortCol) {
+      const factor = current.dir === 'asc' ? 1 : -1
+      filtered.sort((a, b) => factor * a.sortKey.localeCompare(b.sortKey, undefined, { numeric: true, sensitivity: 'base' }))
     }
-    const factor = current.dir === 'asc' ? 1 : -1
-    // Read the visible text once per row here (in the tracked memo), then sort
-    // on the precomputed strings so the comparator stays pure.
-    const keyed = data.map((row) => ({ row, text: cellText(row, col) }))
-    keyed.sort((a, b) => factor * a.text.localeCompare(b.text, undefined, { numeric: true, sensitivity: 'base' }))
 
-    return keyed.map((entry) => entry.row)
+    return filtered.map((entry) => entry.row)
   })
 
   function openForm(row: Row | null) {
@@ -127,6 +135,14 @@ export function AdminCrudShell(props: {
         <Show when={error()}>
           <span role="alert" class="form-status is-error">{error()}</span>
         </Show>
+        <input
+          type="search"
+          class="admin-filter"
+          placeholder={m.admin_filter()}
+          aria-label={m.admin_filter()}
+          value={filter()}
+          onInput={(event) => setFilter(event.currentTarget.value)}
+        />
       </div>
 
       <Show when={!list.isError} fallback={<p role="alert">{m.app_load_error()}</p>}>
@@ -152,7 +168,7 @@ export function AdminCrudShell(props: {
               </tr>
             </thead>
             <tbody>
-              <For each={sortedRows()}>
+              <For each={visibleRows()}>
                 {(row) => (
                   <tr>
                     <For each={props.descriptor.columns}>
@@ -172,6 +188,9 @@ export function AdminCrudShell(props: {
             </tbody>
           </table>
         </div>
+        <Show when={filter().trim() !== '' && visibleRows().length === 0}>
+          <p role="status" class="effort-empty admin-no-matches">{m.admin_no_matches()}</p>
+        </Show>
       </Show>
 
       <Show when={editing()}>

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -3,7 +3,7 @@ import { createMemo, createSignal, For, Match, Show, Switch } from 'solid-js'
 
 import { ApiError, getJson, postJson } from '../api/client'
 import { m } from '../paraglide/messages.js'
-import type { EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
+import type { ColumnDef, EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
 
 type Row = Record<string, unknown>
 
@@ -38,6 +38,48 @@ export function AdminCrudShell(props: {
       .map((row) => row?.[props.descriptor.rowKey])
       .filter((row): row is Row => row != null && typeof row === 'object'),
   )
+
+  // Column sorting. cellText() yields exactly what the grid shows (id→label,
+  // ✓/—, …) so the sort order matches the visible values. Clicking a header
+  // cycles none → ascending → descending → none.
+  const [sort, setSort] = createSignal<{ key: string; dir: 'asc' | 'desc' } | null>(null)
+
+  const cellText = (row: Row, col: ColumnDef): string =>
+    col.render ? col.render(row, props.options) : String(row[col.key] ?? '')
+
+  function toggleSort(key: string) {
+    setSort((current) =>
+      current?.key !== key ? { key, dir: 'asc' } : current.dir === 'asc' ? { key, dir: 'desc' } : null,
+    )
+  }
+
+  const ariaSort = (key: string): 'ascending' | 'descending' | 'none' => {
+    const current = sort()
+
+    return current?.key === key ? (current.dir === 'asc' ? 'ascending' : 'descending') : 'none'
+  }
+
+  const sortGlyph = (key: string): string => {
+    const current = sort()
+
+    return current?.key === key ? (current.dir === 'asc' ? '▲' : '▼') : ''
+  }
+
+  const sortedRows = createMemo<Row[]>(() => {
+    const current = sort()
+    const data = rows()
+    const col = current && props.descriptor.columns.find((c) => c.key === current.key)
+    if (!current || !col) {
+      return data
+    }
+    const factor = current.dir === 'asc' ? 1 : -1
+    // Read the visible text once per row here (in the tracked memo), then sort
+    // on the precomputed strings so the comparator stays pure.
+    const keyed = data.map((row) => ({ row, text: cellText(row, col) }))
+    keyed.sort((a, b) => factor * a.text.localeCompare(b.text, undefined, { numeric: true, sensitivity: 'base' }))
+
+    return keyed.map((entry) => entry.row)
+  })
 
   function openForm(row: Row | null) {
     setError('')
@@ -88,29 +130,48 @@ export function AdminCrudShell(props: {
       </div>
 
       <Show when={!list.isError} fallback={<p role="alert">{m.app_load_error()}</p>}>
-        <table class="data-table admin-table">
-          <thead>
-            <tr>
-              <For each={props.descriptor.columns}>{(col) => <th scope="col">{col.label()}</th>}</For>
-              <th scope="col">{m.admin_actions()}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <For each={rows()}>
-              {(row) => (
-                <tr>
-                  <For each={props.descriptor.columns}>
-                    {(col) => <td>{col.render ? col.render(row, props.options) : String(row[col.key] ?? '')}</td>}
-                  </For>
-                  <td class="admin-row-actions">
-                    <button type="button" class="link-button" onClick={() => openForm(row)}>{m.admin_edit()}</button>
-                    <button type="button" class="link-button is-danger" onClick={() => void remove(row)}>{m.admin_delete()}</button>
-                  </td>
-                </tr>
-              )}
-            </For>
-          </tbody>
-        </table>
+        <div class="table-scroll">
+          <table class="data-table admin-table">
+            <thead>
+              <tr>
+                <For each={props.descriptor.columns}>
+                  {(col) => (
+                    <th
+                      scope="col"
+                      classList={{ numeric: col.align === 'right', boolean: col.align === 'center' }}
+                      aria-sort={ariaSort(col.key)}
+                    >
+                      <button type="button" class="th-sort" onClick={() => toggleSort(col.key)}>
+                        <span>{col.label()}</span>
+                        <span class="th-sort-glyph" aria-hidden="true">{sortGlyph(col.key)}</span>
+                      </button>
+                    </th>
+                  )}
+                </For>
+                <th scope="col">{m.admin_actions()}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={sortedRows()}>
+                {(row) => (
+                  <tr>
+                    <For each={props.descriptor.columns}>
+                      {(col) => (
+                        <td classList={{ numeric: col.align === 'right', boolean: col.align === 'center' }}>
+                          {cellText(row, col)}
+                        </td>
+                      )}
+                    </For>
+                    <td class="admin-row-actions">
+                      <button type="button" class="link-button" onClick={() => openForm(row)}>{m.admin_edit()}</button>
+                      <button type="button" class="link-button is-danger" onClick={() => void remove(row)}>{m.admin_delete()}</button>
+                    </td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+        </div>
       </Show>
 
       <Show when={editing()}>

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -125,6 +125,26 @@ describe('Admin', () => {
     unmount()
   })
 
+  it('filters the list by the free-text query', async () => {
+    getJson.mockImplementation((path: string) =>
+      path === '/getAllCustomers'
+        ? Promise.resolve([
+            { customer: { id: 1, name: 'ACME', active: true, global: true, teams: [] } },
+            { customer: { id: 2, name: 'Globex', active: true, global: true, teams: [] } },
+          ])
+        : Promise.resolve([]),
+    )
+    const { getByRole, queryByRole, unmount } = renderAdmin()
+    await waitFor(() => expect(getByRole('cell', { name: 'ACME' })).toBeInTheDocument())
+
+    fireEvent.input(getByRole('searchbox'), { target: { value: 'glob' } })
+
+    await waitFor(() => expect(queryByRole('cell', { name: 'ACME' })).not.toBeInTheDocument())
+    expect(getByRole('cell', { name: 'Globex' })).toBeInTheDocument()
+
+    unmount()
+  })
+
   it('has no automatically detectable accessibility violations', async () => {
     mockEndpoints()
     const { container, getByRole, unmount } = renderAdmin()

--- a/frontend/src/pages/Auswertung.tsx
+++ b/frontend/src/pages/Auswertung.tsx
@@ -186,6 +186,7 @@ export default function Auswertung() {
           <h3>{m.auswertung_last_entries()}</h3>
           <Show when={!entries.isError} fallback={<p role="alert">{m.app_load_error()}</p>}>
             <Show when={!entries.isLoading} fallback={<p class="effort-empty">{m.app_loading()}</p>}>
+              <div class="table-scroll">
               <table class="data-table">
                 <thead>
                   <tr>
@@ -208,6 +209,7 @@ export default function Auswertung() {
                   </For>
                 </tbody>
               </table>
+              </div>
             </Show>
           </Show>
         </section>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -880,8 +880,26 @@ kbd {
 .admin-crud-toolbar {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   margin-bottom: 0.9rem;
+}
+
+/* Free-text filter input; pushed to the right of the toolbar. */
+.admin-filter {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 9px;
+  color: var(--color-text);
+  font: inherit;
+  margin-left: auto;
+  min-height: 40px;
+  min-width: 12rem;
+  padding: 0 0.7rem;
+}
+
+.admin-no-matches {
+  margin-top: 0.9rem;
 }
 
 .admin-table {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -792,6 +792,12 @@ kbd {
   white-space: nowrap;
 }
 
+/* Sortable headers carry their padding on the inner button so the whole cell
+   is clickable; the cell itself then has none. */
+.data-table thead th:has(.th-sort) {
+  padding: 0;
+}
+
 .data-table tbody td {
   border-top: 1px solid var(--color-border);
   padding: 0.55rem 0.9rem;
@@ -815,20 +821,29 @@ kbd {
   text-align: center;
 }
 
-/* Sortable column header — a borderless button so the label itself sorts;
-   inline-flex follows the cell's text-align (numeric/boolean columns). */
+/* Sortable column header — a borderless button that fills the whole cell so
+   the entire header is clickable (and keyboard-focusable as a real button). */
 .th-sort {
   align-items: center;
   background: none;
   border: 0;
   color: inherit;
   cursor: pointer;
-  display: inline-flex;
+  display: flex;
   font: inherit;
   gap: 0.3rem;
   letter-spacing: inherit;
-  padding: 0;
+  padding: 0.5rem 0.9rem;
   text-transform: inherit;
+  width: 100%;
+}
+
+.data-table th.numeric .th-sort {
+  justify-content: flex-end;
+}
+
+.data-table th.boolean .th-sort {
+  justify-content: center;
 }
 
 .th-sort:hover {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -767,6 +767,79 @@ kbd {
   z-index: 1;
 }
 
+/* ---- Data tables (admin lists + last-entries) ---- */
+
+/* Lets wide tables scroll sideways on narrow screens instead of overflowing. */
+.table-scroll {
+  overflow-x: auto;
+}
+
+.data-table {
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+}
+
+.data-table thead th {
+  background: var(--color-accent-soft);
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0.5rem 0.9rem;
+  text-align: left;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.data-table tbody td {
+  border-top: 1px solid var(--color-border);
+  padding: 0.55rem 0.9rem;
+  vertical-align: middle;
+}
+
+.data-table tbody tr:nth-child(even) {
+  background: light-dark(rgba(0, 0, 0, 0.025), rgba(255, 255, 255, 0.035));
+}
+
+.data-table tbody tr:hover {
+  background: var(--color-accent-soft);
+}
+
+.data-table .numeric {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.data-table .boolean {
+  text-align: center;
+}
+
+/* Sortable column header — a borderless button so the label itself sorts;
+   inline-flex follows the cell's text-align (numeric/boolean columns). */
+.th-sort {
+  align-items: center;
+  background: none;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: 0.3rem;
+  letter-spacing: inherit;
+  padding: 0;
+  text-transform: inherit;
+}
+
+.th-sort:hover {
+  color: var(--color-accent);
+}
+
+.th-sort-glyph {
+  color: var(--color-accent);
+  font-size: 0.7rem;
+}
+
 /* ---- Admin ---- */
 
 .admin-page {


### PR DESCRIPTION
## Summary

Makes the admin **list view** (and the shared data tables) readable, sortable
and responsive. The admin grid previously had no base table styling — cells
were unpadded/cramped, booleans and relations ran together, and there was no
sorting or narrow-screen handling.

- **Readability & spacing**: a shared `.data-table` style (admin lists + the
  Auswertung "last entries" table) with cell padding, a distinct header row,
  zebra striping, row hover, and tabular numerals.
- **Alignment**: new `ColumnDef.align` — numbers right-aligned, boolean (✓/—)
  columns centred (set on the relevant admin columns).
- **Sorting**: click-to-sort column headers in `AdminCrudShell`
  (none → ascending → descending), sorting on the *visible* cell text (so
  id→label and ✓/— sort intuitively), with `aria-sort` + a direction glyph.
- **Responsive**: wide tables wrapped in a `.table-scroll` container so they
  scroll horizontally on narrow screens instead of overflowing.

## Verification

- Frontend: eslint, tsc, vitest (32, incl. axe), vite build — all green.
- Manually verified on the dev stack: column spacing/zebra/centred booleans,
  click-to-sort with indicator + `aria-sort`, across entities (Customers,
  Projects, …).

No backend changes. Independent of the header PR (#342); touches different
files, so either can merge first.
