### PR TITLE
fix(security): close controlling-export IDOR and ticket-system credential re-leak

### DIFF
--- a/src/Controller/Admin/GetTicketSystemsAction.php
+++ b/src/Controller/Admin/GetTicketSystemsAction.php
@@ -25,21 +25,6 @@ use function is_array;
 final class GetTicketSystemsAction extends BaseController
 {
     /**
-     * Secret credential fields stripped from the list payload. Even though the
-     * route is ROLE_ADMIN-only, there is no reason to ship OAuth secrets and
-     * passwords to every admin browser/proxy on each grid load; they are only
-     * ever needed server-side. Base::toArray() emits each key in both
-     * camelCase and snake_case, so both spellings are removed.
-     */
-    private const array SECRET_KEYS = [
-        'password',
-        'publicKey', 'public_key',
-        'privateKey', 'private_key',
-        'oauthConsumerKey', 'oauth_consumer_key',
-        'oauthConsumerSecret', 'oauth_consumer_secret',
-    ];
-
-    /**
      * @throws Exception
      */
     #[Route(path: '/getTicketSystems', name: '_getTicketSystems_attr', methods: ['GET'])]
@@ -50,9 +35,12 @@ final class GetTicketSystemsAction extends BaseController
         assert($objectRepository instanceof TicketSystemRepository);
         $ticketSystems = $objectRepository->getAllTicketSystems();
 
+        // Even though the route is ROLE_ADMIN-only, there is no reason to ship
+        // OAuth secrets and passwords to every admin browser/proxy on each grid
+        // load; they are only ever needed server-side.
         foreach ($ticketSystems as &$row) {
             if (is_array($row) && array_key_exists('ticketSystem', $row) && is_array($row['ticketSystem'])) {
-                foreach (self::SECRET_KEYS as $secretKey) {
+                foreach (TicketSystem::SECRET_KEYS as $secretKey) {
                     unset($row['ticketSystem'][$secretKey]);
                 }
             }

--- a/src/Controller/Admin/SaveTicketSystemAction.php
+++ b/src/Controller/Admin/SaveTicketSystemAction.php
@@ -126,6 +126,9 @@ final class SaveTicketSystemAction extends BaseController
             return $response;
         }
 
-        return new JsonResponse($ticketSystem->toArray());
+        // Strip the secret credentials the list endpoint also withholds — the
+        // save response must not echo password/keys/OAuth secrets back to the
+        // browser (they were just persisted server-side).
+        return new JsonResponse($ticketSystem->toSafeArray());
     }
 }

--- a/src/Controller/Controlling/ExportAction.php
+++ b/src/Controller/Controlling/ExportAction.php
@@ -48,7 +48,12 @@ final class ExportAction extends BaseController
     /**
      * @throws InvalidArgumentException When export parameters are invalid or file operations fail
      */
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    // Controlling exports any user's entries via ?userid=, so the route must be
+    // restricted to the roles that may see other people's data. Both PL and
+    // ADMIN carry ROLE_ADMIN (DEV/USER do not), which is exactly the frontend's
+    // canBill() gate (ROLE_PL || ROLE_ADMIN); enforcing it here closes the IDOR
+    // a plain IS_AUTHENTICATED_FULLY left open.
+    #[IsGranted('ROLE_ADMIN')]
     #[Route(path: '/controlling/export', name: '_controllingExport_attr_invokable', methods: ['GET'])]
     #[Route(path: '/controlling/export/{userid}/{year}/{month}/{project}/{customer}/{billable}', name: '_controllingExport_bc', requirements: ['year' => '\d+', 'userid' => '\d+'], defaults: ['userid' => 0, 'year' => 0, 'month' => 0, 'project' => 0, 'customer' => 0, 'billable' => 0], methods: ['GET'])]
     public function __invoke(Request $request): Response

--- a/src/Entity/TicketSystem.php
+++ b/src/Entity/TicketSystem.php
@@ -85,6 +85,23 @@ class TicketSystem extends Base
     protected ?string $oauthConsumerSecret = null;
 
     /**
+     * Credential fields that must never leave the server. They are needed only
+     * server-side, so both the list endpoint (GetTicketSystemsAction) and the
+     * save response (SaveTicketSystemAction) strip them. Base::toArray() emits
+     * each protected property in both camelCase and snake_case, so both
+     * spellings are listed here.
+     *
+     * @var list<string>
+     */
+    public const array SECRET_KEYS = [
+        'password',
+        'publicKey', 'public_key',
+        'privateKey', 'private_key',
+        'oauthConsumerKey', 'oauth_consumer_key',
+        'oauthConsumerSecret', 'oauth_consumer_secret',
+    ];
+
+    /**
      * Get id.
      *
      * @return int
@@ -312,5 +329,21 @@ class TicketSystem extends Base
         $this->oauthConsumerSecret = $oauthConsumerSecret;
 
         return $this;
+    }
+
+    /**
+     * toArray() without the secret credential fields — the only shape that may
+     * be sent to a client.
+     *
+     * @return array<string, mixed>
+     */
+    public function toSafeArray(): array
+    {
+        $data = $this->toArray();
+        foreach (self::SECRET_KEYS as $secretKey) {
+            unset($data[$secretKey]);
+        }
+
+        return $data;
     }
 }

--- a/tests/Controller/ControllingControllerTest.php
+++ b/tests/Controller/ControllingControllerTest.php
@@ -36,6 +36,26 @@ final class ControllingControllerTest extends AbstractWebTestCase
         self::assertStringContainsString('02_developer', (string) $contentDisposition); // userid 2 = 'developer'
     }
 
+    /**
+     * The export ships any user's entries via ?userid=, so it must be denied to
+     * non-privileged roles (DEV/USER). 'developer' (fixture id 2) is a DEV and
+     * must not be able to export anyone's data — the IDOR guard.
+     */
+    public function testExportActionForbiddenForNonAdmin(): void
+    {
+        $this->logInSession('developer');
+        // Accept JSON so the ExceptionSubscriber renders the AccessDenied as a
+        // 403 response rather than an HTML error page; the IsGranted gate itself
+        // blocks the request regardless of the requested format.
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/controlling/export', [
+            'year' => 2020,
+            'month' => 2,
+            'userid' => 1,
+            'project' => 0,
+        ], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(403);
+    }
+
     public function testExportActionInvalidMonth(): void
     {
         $this->logInSession('unittest');

--- a/tests/Controller/SaveTicketSystemPreserveSecretsTest.php
+++ b/tests/Controller/SaveTicketSystemPreserveSecretsTest.php
@@ -70,6 +70,13 @@ final class SaveTicketSystemPreserveSecretsTest extends AbstractWebTestCase
         ], [], ['HTTP_ACCEPT' => 'application/json']);
         $this->assertStatusCode(200);
 
+        // The save response must not echo the stored credentials back to the
+        // client (the list endpoint strips them too — same SECRET_KEYS).
+        $body = (string) $this->client->getResponse()->getContent();
+        foreach (self::SECRETS as $secret) {
+            self::assertStringNotContainsString($secret, $body, 'save response leaked a credential');
+        }
+
         $container = $this->client->getContainer();
         /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
         $doctrine = $container->get('doctrine');

--- a/tests/Entity/TicketSystemTest.php
+++ b/tests/Entity/TicketSystemTest.php
@@ -38,6 +38,37 @@ final class TicketSystemTest extends TestCase
         self::assertSame('Jira Cloud', $ticketSystem->getName());
     }
 
+    // ==================== toSafeArray tests ====================
+
+    public function testToSafeArrayOmitsEverySecretKeyInBothSpellings(): void
+    {
+        $ticketSystem = new TicketSystem();
+        $ticketSystem->setName('Jira')
+            ->setUrl('https://jira.example.test')
+            ->setLogin('svc')
+            ->setPassword('s3cr3t')
+            ->setPublicKey('pub')
+            ->setPrivateKey('priv')
+            ->setOauthConsumerKey('ck')
+            ->setOauthConsumerSecret('cs');
+
+        $safe = $ticketSystem->toSafeArray();
+
+        foreach (TicketSystem::SECRET_KEYS as $secretKey) {
+            self::assertArrayNotHasKey($secretKey, $safe);
+        }
+
+        self::assertArrayNotHasKey('password', $safe);
+        // Non-secret fields survive.
+        self::assertSame('Jira', $safe['name']);
+        self::assertSame('https://jira.example.test', $safe['url']);
+        self::assertSame('svc', $safe['login']);
+        // No stored secret value leaks under any key.
+        self::assertNotContains('s3cr3t', $safe);
+        self::assertNotContains('priv', $safe);
+        self::assertNotContains('cs', $safe);
+    }
+
     // ==================== BookTime tests ====================
 
     public function testBookTimeIsFalseByDefault(): void


### PR DESCRIPTION
Two server-side authorization/data-exposure fixes surfaced by an independent multi-reviewer pass over the migrated code. Both are verified against source and covered by regression tests.

## 1. IDOR — controlling export (`ExportAction`)
`GET /controlling/export?userid=N` ships any user's time entries but was gated only by `IS_AUTHENTICATED_FULLY` — any DEV/USER could export **anyone's** data by changing `userid`. The SolidJS Billing page hides the feature behind `canBill()` (ROLE_PL || ROLE_ADMIN), but that is UI-only.

**Fix:** `IS_AUTHENTICATED_FULLY` → `ROLE_ADMIN`. Both PL and ADMIN carry `ROLE_ADMIN` (DEV/USER do not), so this mirrors the frontend gate exactly and enforces it server-side. Both the modern and legacy `#[Route]` on the action are covered (the `#[IsGranted]` is on the method).

## 2. Credential re-leak — ticket-system save (`SaveTicketSystemAction`)
`GetTicketSystemsAction` deliberately strips `password` / public+private key / OAuth consumer key+secret from the list payload, but the save endpoint returned the full `toArray()` — re-leaking exactly those credentials in the save response.

**Fix:** single source of truth `TicketSystem::SECRET_KEYS` + a `toSafeArray()` helper; the save response uses it and the list endpoint references the same constant instead of its own copy (removes the duplication).

## Tests
- `ControllingControllerTest::testExportActionForbiddenForNonAdmin` — a DEV is forbidden (403).
- `SaveTicketSystemPreserveSecretsTest` — asserts the save response body contains none of the stored secrets.
- `TicketSystemTest::testToSafeArrayOmitsEverySecretKeyInBothSpellings` — unit coverage for the strip (both camelCase and snake_case).

Full local gate green: PHPStan, php-cs-fixer, phpat architecture, unit + api-contract suites (via CaptainHook pre-commit).