### PR TITLE
docs: fix remaining stale Symfony version references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,7 +77,7 @@ docker compose run --rm app npm run build
 
 ## Architecture Patterns
 
-- **MVC Pattern:** Using Symfony 7.3 framework
+- **MVC Pattern:** Using Symfony 8 framework
 - **Routing:** PHP attributes for new routes (legacy YAML routes being migrated)
 - **Persistence:** Doctrine ORM with migrations in `migrations/`
 - **Views:** Twig templates in `templates/`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Netresearch TimeTracker
 
 [![PHP Version](https://img.shields.io/badge/php-8.5-blue.svg)](https://www.php.net)
-[![Symfony](https://img.shields.io/badge/symfony-8.0-green.svg)](https://symfony.com)
+[![Symfony](https://img.shields.io/badge/symfony-8-green.svg)](https://symfony.com)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-red.svg)](LICENSE)
 [![CI Status](https://github.com/netresearch/timetracker/workflows/CI/badge.svg)](https://github.com/netresearch/timetracker/actions)
 [![codecov](https://codecov.io/gh/netresearch/timetracker/graph/badge.svg)](https://codecov.io/gh/netresearch/timetracker)

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ __ https://github.com/netresearch/timalytics
 Technology stack (summary)
 ==========================
 
-- PHP 8.4, Symfony 7.3, Doctrine ORM 3, Twig, Monolog
+- PHP 8.5, Symfony 8, Doctrine ORM 3, Twig, Monolog
 - Docker Compose for local dev; MariaDB; Nginx proxy
 - PHPUnit 12 for tests; PHPStan/Psalm for static analysis; PHPCS for style
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -4,14 +4,14 @@
 
 ## Overview
 
-Symfony 7.3 application code: controllers, services, entities, repositories, security, and commands.
+Symfony 8 application code: controllers, services, entities, repositories, security, and commands.
 Uses Doctrine ORM 3, Twig templating, and PSR-12 coding standards.
 
 ## Setup & environment
 
 - Install: `composer install`
-- PHP version: 8.4
-- Framework: Symfony 7.3
+- PHP version: 8.5
+- Framework: Symfony 8
 - Required extensions: `ldap`, `pdo_mysql`, `mbstring`, `json`, `intl`
 - Environment: Copy `.env` to `.env.local` and configure `DATABASE_URL`, `LDAP_*`
 


### PR DESCRIPTION
Follow-up to #348 — I'd missed a few Symfony version references:

- **README.md** badge still read `symfony-8.0` → now `symfony-8` (no minor, matching the prose).
- **src/AGENTS.md**, **.github/copilot-instructions.md**, **README.rst**: living-doc stack claims still said **"Symfony 7.3"** (and PHP 8.4) — corrected to **Symfony 8 / PHP 8.5** (the project runs Symfony 8.1).

Left as historical record (intentionally not retro-edited):
- `docs/adr/ADR-001-php-8-4-symfony-7-3-selection.md` — immutable decision record.
- `TASKS.md` — completed upgrade-phase history.
- `config/routes.yaml` / `config/packages/security.yaml` — "introduced in Symfony 7.3" convention comments (accurate as history).