### PR TITLE
feat(ui): header keyboard shortcuts + timezone-safe worktime deep-links

### DIFF
--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -64,16 +64,13 @@ async function updateWorktime(): Promise<void> {
   }
 }
 
-// Nav order matching the shared header markup; role-gated items that aren't
-// rendered are simply skipped, so Alt+N maps to the n-th *available* item.
-const NAV_KEYS = ['tracking', 'month', 'auswertung', 'extras', 'billing', 'admin', 'settings', 'help']
-
+// The nav links are rendered in document order (and the overflow script keeps
+// that order: it folds items from the end into the "More" menu, which itself is
+// the last child of .main-nav). Role-gated items are simply absent. So a single
+// query yields the n-th *available* item for Alt+N, with no key list to keep in
+// sync with the Twig template.
 function navLinks(): HTMLAnchorElement[] {
-  return NAV_KEYS.map((key) =>
-    key === 'tracking'
-      ? document.querySelector<HTMLAnchorElement>('.app-header .main-nav a.main-nav-link:not([data-nav])')
-      : document.querySelector<HTMLAnchorElement>(`.app-header .main-nav a.main-nav-link[data-nav="${key}"]`),
-  ).filter((link): link is HTMLAnchorElement => link !== null)
+  return Array.from(document.querySelectorAll<HTMLAnchorElement>('.app-header .main-nav a.main-nav-link'))
 }
 
 let shortcutsWired = false

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -64,6 +64,57 @@ async function updateWorktime(): Promise<void> {
   }
 }
 
+// Nav order matching the shared header markup; role-gated items that aren't
+// rendered are simply skipped, so Alt+N maps to the n-th *available* item.
+const NAV_KEYS = ['tracking', 'month', 'auswertung', 'extras', 'billing', 'admin', 'settings', 'help']
+
+function navLinks(): HTMLAnchorElement[] {
+  return NAV_KEYS.map((key) =>
+    key === 'tracking'
+      ? document.querySelector<HTMLAnchorElement>('.app-header .main-nav a.main-nav-link:not([data-nav])')
+      : document.querySelector<HTMLAnchorElement>(`.app-header .main-nav a.main-nav-link[data-nav="${key}"]`),
+  ).filter((link): link is HTMLAnchorElement => link !== null)
+}
+
+let shortcutsWired = false
+
+/**
+ * Keyboard shortcuts for the SolidJS shell (documented on the Help page):
+ * Alt+1–7 switches to the n-th nav item, and `?` opens Help. The grid-specific
+ * shortcuts (Alt+A/C/D/…) still live in the ExtJS tracking shell. Clicking the
+ * nav link reuses the router's anchor interception and the role gating.
+ */
+function initShortcuts(): void {
+  if (shortcutsWired) {
+    return
+  }
+  shortcutsWired = true
+
+  document.addEventListener('keydown', (event) => {
+    const target = event.target as HTMLElement | null
+    const inField = target !== null
+      && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT' || target.isContentEditable)
+
+    if (event.altKey && !event.ctrlKey && !event.metaKey && /^Digit[1-7]$/.test(event.code)) {
+      const link = navLinks()[Number(event.code.slice(5)) - 1]
+      if (link !== undefined) {
+        event.preventDefault()
+        link.click()
+      }
+
+      return
+    }
+
+    if (event.key === '?' && !inField) {
+      const help = document.querySelector<HTMLAnchorElement>('.app-header .main-nav a[data-nav="help"]')
+      if (help !== null) {
+        event.preventDefault()
+        help.click()
+      }
+    }
+  })
+}
+
 function pollLoginStatus(config: AppConfig): void {
   void getJson<{ loginStatus: boolean }>('/status/check')
     .then((status) => {
@@ -81,6 +132,7 @@ function pollLoginStatus(config: AppConfig): void {
 
 export function initHeaderDynamics(config: AppConfig): void {
   setBadge(true, config.userName)
+  initShortcuts()
   void updateWorktime()
   setTimeout(() => {
     pollLoginStatus(config)

--- a/frontend/src/pages/Month.test.tsx
+++ b/frontend/src/pages/Month.test.tsx
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import type { HolidayRecord, WorktimeRecord } from '../api/queries'
-import Month from './Month'
+import Month, { resolveDayTokens } from './Month'
 
 // One booking in the past, one in the future (Fri 2026-06-19) relative to the
 // frozen "today" — the until-today summary must ignore the future one.
@@ -121,5 +121,30 @@ describe('Month page', () => {
     expect(await axe(container)).toHaveNoViolations()
 
     unmount()
+  })
+})
+
+describe('resolveDayTokens', () => {
+  const now = new Date(2026, 5, 15) // Mon 2026-06-15 (local)
+
+  it('resolves "today" to the local day key', () => {
+    expect(resolveDayTokens('today', now)).toEqual(['2026-06-15'])
+  })
+
+  it('resolves "current-week" to the local Mon–Sun keys', () => {
+    expect(resolveDayTokens('current-week', now)).toEqual([
+      '2026-06-15', '2026-06-16', '2026-06-17', '2026-06-18', '2026-06-19', '2026-06-20', '2026-06-21',
+    ])
+  })
+
+  it('resolves "current-month" to every day of the local month', () => {
+    const keys = resolveDayTokens('current-month', now)
+    expect(keys).toHaveLength(30)
+    expect(keys[0]).toBe('2026-06-01')
+    expect(keys.at(-1)).toBe('2026-06-30')
+  })
+
+  it('passes through an explicit CSV of keys', () => {
+    expect(resolveDayTokens('2026-06-01, 2026-06-02 ,', now)).toEqual(['2026-06-01', '2026-06-02'])
   })
 })

--- a/frontend/src/pages/Month.tsx
+++ b/frontend/src/pages/Month.tsx
@@ -158,7 +158,10 @@ function CalendarDayCell(props: { cell: CalendarCell; locale: string; selected: 
  * the calendar's highlighted today, with no server-timezone skew. Any other
  * value is treated as the explicit CSV of YYYY-MM-DD keys written back on edit.
  */
-export function resolveDayTokens(raw: string, now: Date = new Date()): string[] {
+export function resolveDayTokens(raw: string, nowInput: Date = new Date()): string[] {
+  // Normalize to midday so the day-arithmetic below can't slip to an adjacent
+  // day across a DST transition (a 23/25-hour day) or right at midnight.
+  const now = new Date(nowInput.getFullYear(), nowInput.getMonth(), nowInput.getDate(), 12)
   switch (raw.trim()) {
     case 'today':
       return [isoDate(now)]

--- a/frontend/src/pages/Month.tsx
+++ b/frontend/src/pages/Month.tsx
@@ -151,6 +151,38 @@ function CalendarDayCell(props: { cell: CalendarCell; locale: string; selected: 
   )
 }
 
+/**
+ * Resolve the `days` query param into ISO day keys. The header worktime badges
+ * deep-link with symbolic tokens (`today`, `current-week`, `current-month`) that
+ * are resolved here against the client's *local* clock — so they always match
+ * the calendar's highlighted today, with no server-timezone skew. Any other
+ * value is treated as the explicit CSV of YYYY-MM-DD keys written back on edit.
+ */
+export function resolveDayTokens(raw: string, now: Date = new Date()): string[] {
+  switch (raw.trim()) {
+    case 'today':
+      return [isoDate(now)]
+    case 'current-week': {
+      const monday = new Date(now)
+      monday.setDate(now.getDate() - ((now.getDay() + 6) % 7))
+
+      return Array.from({ length: 7 }, (_, i) => {
+        const day = new Date(monday)
+        day.setDate(monday.getDate() + i)
+
+        return isoDate(day)
+      })
+    }
+    case 'current-month': {
+      const last = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()
+
+      return Array.from({ length: last }, (_, i) => isoDate(new Date(now.getFullYear(), now.getMonth(), i + 1)))
+    }
+    default:
+      return raw.split(',').map((key) => key.trim()).filter(Boolean)
+  }
+}
+
 export default function Month() {
   const config = appConfig()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -176,7 +208,7 @@ export default function Month() {
   const selectedKeys = createMemo<ReadonlySet<string>>(() => {
     const raw = typeof searchParams.days === 'string' ? searchParams.days : ''
 
-    return new Set(raw.split(',').map((key) => key.trim()).filter(Boolean))
+    return new Set(resolveDayTokens(raw))
   })
   const yearMode = createMemo(() => searchParams.scope === 'year')
   const scope = createMemo<Scope>(() => (selectedKeys().size > 0 ? 'selection' : yearMode() ? 'year' : 'month'))

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -14,11 +14,10 @@
    (theme cycle), so it works on BOTH shells. #}
 {% set isAdmin = 'ROLE_ADMIN' in settings.roles %}
 {% set canBill = isAdmin or 'ROLE_PL' in settings.roles %}
-{# Each worktime badge deep-links to the Overview pre-scoped to that period. #}
-{% set weekDays = [] %}
-{% for i in 0..6 %}
-    {% set weekDays = weekDays|merge(["monday this week +#{i} days"|date('Y-m-d')]) %}
-{% endfor %}
+{# Each worktime badge deep-links to the Overview pre-scoped to that period.
+   The Today/Week links use symbolic tokens (resolved client-side against the
+   local clock in Month.tsx) instead of server-computed dates, so they never
+   skew with the server timezone. #}
 {% set monthPath = path('ui_spa', {'path': 'month'}) %}
 <div id="page-header" class="page-header">
     <a href="#main-content" class="skip-link">{{ 'Skip to main content'|trans }}</a>
@@ -83,11 +82,11 @@
             <dl class="worktime-list">
                 <div class="worktime-item worktime-item-link">
                     <dt>{{ 'Today'|trans }}</dt>
-                    <dd><a id="worktime-day" data-nav="month" href="{{ monthPath }}?days={{ 'now'|date('Y-m-d') }}" aria-label="{{ 'Overview'|trans }}: {{ 'Today'|trans }}">0:00</a></dd>
+                    <dd><a id="worktime-day" data-nav="month" href="{{ monthPath }}?days=today" aria-label="{{ 'Overview'|trans }}: {{ 'Today'|trans }}">0:00</a></dd>
                 </div>
                 <div class="worktime-item worktime-item-link">
                     <dt>{{ 'Week'|trans }}</dt>
-                    <dd><a id="worktime-week" data-nav="month" href="{{ monthPath }}?days={{ weekDays|join(',') }}" aria-label="{{ 'Overview'|trans }}: {{ 'Week'|trans }}">0:00</a></dd>
+                    <dd><a id="worktime-week" data-nav="month" href="{{ monthPath }}?days=current-week" aria-label="{{ 'Overview'|trans }}: {{ 'Week'|trans }}">0:00</a></dd>
                 </div>
                 <div class="worktime-item worktime-item-link worktime-item-month">
                     <dt>{{ 'Month'|trans }}</dt>


### PR DESCRIPTION
Two shared-header improvements for the SolidJS shell, from review feedback on the migrated UI.

## Keyboard shortcuts (Help-documented)
- **Alt+1–7** switches to the n-th available nav item (role-gated items are skipped, so the mapping follows what the user actually sees).
- **`?`** opens Help (ignored while typing in a field).

Implemented in `header.ts` (SolidJS shell only — the ExtJS tracking shell keeps its own `Alt+1–7` / grid bindings in `main.js`). Navigation reuses `@solidjs/router`'s anchor-click interception by clicking the nav link, so routing + role gating are respected. The grid-specific shortcuts (Alt+A/C/D/…) remain in the ExtJS tracking grid and will return with the table-migration work.

## Timezone-safe Today/Week deep-links
The Today/Week worktime badges previously deep-linked with dates **precomputed server-side in Twig** (server runs UTC), so just after local midnight they selected the *previous* day/week. They now use **symbolic tokens** (`?days=today`, `?days=current-week`) that `Month.tsx` resolves against the **local** clock — guaranteed to match the calendar's highlighted today, with no server-timezone skew and no per-request date baked into the URL. `resolveDayTokens` also handles `current-month` and the existing explicit CSV.

## Tests
- `resolveDayTokens` unit tests (today / current-week / current-month / CSV passthrough) — 93 frontend tests green.
- Verified live on the e2e stack: Alt+2 → /ui/month, Alt+3 → /ui/auswertung, `?` → /ui/help; `?days=today` selects the local today; login + navigation specs still green.

I'll deploy a review build to tt.netresearch.de next.