### PR TITLE
feat(ui): Extras/Billing/Settings/Help as modal-as-route dialogs

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -78,6 +78,21 @@ test.describe('Tab Navigation', () => {
     await expect(page.locator('input[type="checkbox"][name="show_empty_line"]')).toBeAttached();
   });
 
+  test('Settings opens as a modal dialog over the page and closes on Escape', async ({ page }) => {
+    // Modal-as-route: /ui/settings opens a dialog over the background page (the
+    // URL is preserved); Escape closes it and returns to that page.
+    await goToSettingsPage(page);
+    await expect(page).toHaveURL(/\/ui\/settings/);
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator('form.stack-form')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page).toHaveURL(/\/ui\/month/, { timeout: 10000 });
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+
   test('should restore the tracking grid on page reload', async ({ page }) => {
     await goToTrackingTab(page);
 

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -10,6 +10,7 @@
   "app_load_error": "Daten konnten nicht geladen werden.",
   "kbd_hint": "Drücke ? für die Tastenkürzel",
   "kbd_hint_dismiss": "Schließen",
+  "dialog_close": "Schließen",
   "app_retry": "Erneut versuchen",
   "app_yes": "Ja",
   "app_no": "Nein",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -10,6 +10,7 @@
   "app_load_error": "Could not load data.",
   "kbd_hint": "Press ? for keyboard shortcuts",
   "kbd_hint_dismiss": "Dismiss",
+  "dialog_close": "Close",
   "app_retry": "Retry",
   "app_yes": "Yes",
   "app_no": "No",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
-import { Navigate, Route, Router, useLocation } from '@solidjs/router'
+import { Dialog } from '@ark-ui/solid/dialog'
+import { Navigate, Route, Router, useLocation, useNavigate } from '@solidjs/router'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { createEffect, createMemo, createSignal, onMount, Show, type Component, type ParentProps } from 'solid-js'
+import { createEffect, createMemo, createSignal, onMount, Show, type Component, type JSX, type ParentProps } from 'solid-js'
+import { Dynamic, Portal } from 'solid-js/web'
 
 import { SessionExpiredError } from './api/client'
 import { appConfig, canBill, canBulkEnter, hasRole } from './config'
@@ -44,8 +46,37 @@ const PAGE_TITLES: Record<string, () => string> = {
 // load we surface a dismissible hint pointing at the "?" shortcut overview.
 const HINT_SEEN_KEY = 'tt-kbd-hint-seen'
 
+// Secondary pages that present as a modal dialog over the page you were on.
+// Deep-linkable: /ui/settings opens the dialog over the last full page (or Month
+// for a direct visit); closing returns to that page.
+const MODAL_SEGMENTS = new Set(['settings', 'help', 'extras', 'billing'])
+
+const segmentOf = (pathname: string): string =>
+  pathname.replace(/^\/ui\/?/, '').split('/')[0] || 'month'
+
+/** Wraps a routed modal page in the shared Ark dialog (focus trap, Esc, backdrop). */
+function PageDialog(props: { title: string; onClose: () => void; children: JSX.Element }) {
+  return (
+    <Dialog.Root open onOpenChange={(details) => { if (!details.open) props.onClose() }} lazyMount unmountOnExit>
+      <Portal>
+        <Dialog.Backdrop class="modal-backdrop" />
+        <Dialog.Positioner class="modal-positioner">
+          <Dialog.Content class="modal modal-page">
+            <header class="modal-page-header">
+              <Dialog.Title class="modal-page-title">{props.title}</Dialog.Title>
+              <Dialog.CloseTrigger class="modal-close" aria-label={m.dialog_close()}>×</Dialog.CloseTrigger>
+            </header>
+            <div class="modal-page-body">{props.children}</div>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  )
+}
+
 function Layout(props: ParentProps) {
   const location = useLocation()
+  const navigate = useNavigate()
   // Theming (apply + toggle) is handled framework-neutrally by the shared
   // header (templates/partials/theme-init.html.twig), so it works on both the
   // ExtJS and SolidJS shells and the SPA needs no theme code of its own.
@@ -53,12 +84,17 @@ function Layout(props: ParentProps) {
   let liveRef: HTMLElement | undefined
   let initialRoute = true
   const [showHint, setShowHint] = createSignal(false)
+  // The last full-page route — rendered behind an open modal page, and where
+  // closing the modal returns to. Defaults to Month for a direct deep-link.
+  const [lastFullPath, setLastFullPath] = createSignal('/month')
 
-  const routeTitle = createMemo(() => {
-    const segment = location.pathname.replace(/^\/ui\/?/, '').split('/')[0] || 'month'
-
-    return (PAGE_TITLES[segment] ?? m.month_title)()
-  })
+  const isModal = createMemo(() => MODAL_SEGMENTS.has(segmentOf(location.pathname)))
+  const routeTitle = createMemo(() => (PAGE_TITLES[segmentOf(location.pathname)] ?? m.month_title)())
+  // #main-content names the BACKGROUND page when a modal is open (that's what
+  // the region shows); the modal dialog carries its own title separately.
+  const mainHeading = createMemo(() =>
+    isModal() ? (PAGE_TITLES[segmentOf(lastFullPath())] ?? m.month_title)() : routeTitle())
+  const background = createMemo(() => BG_PAGES[segmentOf(lastFullPath())] ?? Month)
 
   onMount(() => {
     initHeaderDynamics(appConfig())
@@ -84,17 +120,28 @@ function Layout(props: ParentProps) {
   })
 
   createEffect(() => {
+    const modal = isModal()
     const title = routeTitle()
     syncNav(location.pathname)
     // WCAG 2.4.2: every route is a "page" and needs its own document title.
     document.title = `${title} – ${appConfig().appTitle}`
+    // Remember the last full page so a modal renders it behind and returns to it.
+    if (!modal) {
+      setLastFullPath(location.pathname)
+    }
     if (initialRoute) {
       initialRoute = false
 
       return
     }
-    // Client-side navigation: a route swap is silent to screen readers, so push
-    // the new page title into a polite live region (WCAG 4.1.3 status message),
+    // A modal page autofocuses its dialog (Ark) and the dialog is labelled, so
+    // it announces itself — don't also move focus to #main-content or
+    // double-announce via the live region.
+    if (modal) {
+      return
+    }
+    // Client-side navigation to a full page: a route swap is silent to screen
+    // readers, so push the new page title into a polite live region (WCAG 4.1.3)
     // and move focus to the page region (WCAG 2.4.3) — from there ArrowUp
     // re-enters the menubar (handled in header.ts), so the nav stays reachable.
     if (liveRef !== undefined) {
@@ -109,10 +156,19 @@ function Layout(props: ParentProps) {
           valid heading outline and names the focus region (aria-labelledby).
           Pages render their own sub-sections as <h2>. */}
       <main id="main-content" ref={(el) => { mainRef = el }} tabindex="-1" aria-labelledby="page-heading">
-        <h1 id="page-heading" class="visually-hidden">{routeTitle()}</h1>
+        <h1 id="page-heading" class="visually-hidden">{mainHeading()}</h1>
         <p ref={(el) => { liveRef = el }} class="visually-hidden" aria-live="polite" aria-atomic="true" />
-        {props.children}
+        {/* On a modal route #main-content shows the page you came from; the
+            modal page itself is rendered in the dialog below. */}
+        <Show when={isModal()} fallback={props.children}>
+          <Dynamic component={background()} />
+        </Show>
       </main>
+      <Show when={isModal()}>
+        <PageDialog title={routeTitle()} onClose={() => navigate(lastFullPath())}>
+          {props.children}
+        </PageDialog>
+      </Show>
       <Show when={showHint()}>
         <div class="kbd-hint" role="status">
           <span>{m.kbd_hint()}</span>
@@ -132,6 +188,14 @@ function RedirectToMonth() {
 // its data endpoints.
 function guarded(component: Component, allowed: () => boolean): Component {
   return () => (allowed() ? component({}) : <RedirectToMonth />)
+}
+
+// Full pages that can sit behind an open modal (rendered as the modal's
+// backdrop content). Admin keeps its role guard.
+const BG_PAGES: Record<string, Component> = {
+  month: Month,
+  auswertung: Auswertung,
+  admin: guarded(Admin, () => hasRole('ROLE_ADMIN')),
 }
 
 export default function App() {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1264,10 +1264,12 @@ th[aria-sort='descending'] .th-sort-glyph {
 }
 
 .modal-close {
+  align-items: center;
+  display: flex;
   flex-shrink: 0;
-  width: 32px;
-  height: 32px;
-  line-height: 1;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
   font-size: 1.4rem;
   background: transparent;
   border: 0;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1225,3 +1225,58 @@ th[aria-sort='descending'] .th-sort-glyph {
 @media (prefers-reduced-motion: reduce) {
   .kbd-hint { animation: none; }
 }
+
+/* ---- Full-page content presented as a modal (App.tsx PageDialog) ---- */
+.modal-page {
+  max-width: 46rem;
+  max-height: 92vh;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.4rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.modal-page-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.modal-page-body {
+  overflow-y: auto;
+  padding: 1.4rem;
+}
+
+/* Inside the modal the page wrapper must not re-centre or cap its width. */
+.modal-page-body .form-page,
+.modal-page-body .help-page {
+  margin: 0;
+  max-width: none;
+}
+
+.modal-close {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  line-height: 1;
+  font-size: 1.4rem;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--color-text-muted);
+}
+
+.modal-close:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-text);
+}


### PR DESCRIPTION
Converts the four secondary pages (**Extras, Billing, Settings, Help**) into deep-linkable modal dialogs, per the agreed design (modal-as-route, keep URL).

## Behaviour
- Clicking the nav item (or visiting `/ui/settings` directly) opens the page as an **Ark dialog** over the last full page — Month for a direct deep-link. The **URL is preserved** and shareable; **Back / Esc / ×** close the dialog and return to the page behind.
- Reuses the existing edit-dialog primitive (focus trap, backdrop, Escape, portal).

## Implementation
- New `PageDialog` wraps the routed page in the shared modal.
- The Layout tracks the last full-page route, renders it behind the open modal (`Dynamic` over a small `BG_PAGES` map), and closes by navigating back to it.
- A11y: `#main-content`'s `<h1>`/`aria-labelledby` names the **background** page; the dialog carries the **modal** page's title; `document.title` / the live region track the foreground; focus + route-announcement skip `#main-content` for modal routes (the dialog autofocuses and is self-labelling).
- New `dialog_close` message (en/de); `.modal-page*` styling.

## Verification
- **In-browser smoke** (e2e stack): deep-link opens the dialog over Month, Esc/× and the nav links close/open it, no page errors.
- The **4 e2e specs** that drive these pages (`settings`, `navigation`, `error-handling`, `export` — 35 tests) **pass unchanged** — they use global selectors that match the portaled dialog content, so no spec rewrites were needed.
- Added a `navigation.spec` regression test (dialog opens, Escape closes).
- Typecheck, ESLint, 125 unit tests green.

First of the two requested features; **inline cell editing** for the data tables (pass 2) follows in a separate PR. Built on merged #356.
