### PR TITLE
feat(ui): URL-addressable Admin sub-nav (/ui/admin/<entity>)

### DIFF
--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -152,4 +152,18 @@ test.describe('Admin URL-addressable sub-nav', () => {
     await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
     await expect(page.locator('.admin-subnav-link[aria-current="page"]')).toHaveText(/Nutzer|Users/);
   });
+
+  test('a modal opened over Admin keeps the background on its entity', async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto('/ui/admin/projects');
+    await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
+
+    // Client-side nav to a modal route (preserves the page underneath).
+    await page.locator('a.main-nav-link[data-nav="settings"]').click();
+    await expect(page).toHaveURL(/\/ui\/settings/);
+    await expect(page.locator('.modal-page')).toBeVisible();
+
+    // The dimmed background Admin stays on Projects, not reset to the first tab.
+    await expect(page.locator('.admin-subnav-link[aria-current="page"]')).toHaveText(/Projekte|Projects/);
+  });
 });

--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -129,3 +129,27 @@ test.describe('Admin list — inactive filter & CSV export', () => {
     await expect(bar).toBeHidden();
   });
 });
+
+test.describe('Admin URL-addressable sub-nav', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, 'i.myself', 'myself123');
+    await page.goto('/ui/admin');
+    await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
+  });
+
+  test('selecting an entity updates the URL and is deep-linkable', async ({ page }) => {
+    await page.locator('.admin-subnav-link', { hasText: /Projekte|Projects/ }).click();
+    await expect(page).toHaveURL(/\/ui\/admin\/projects/);
+
+    // The selection survives a full reload (URL-driven, not client state).
+    await page.reload();
+    await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
+    await expect(page).toHaveURL(/\/ui\/admin\/projects/);
+    await expect(page.locator('.admin-subnav-link[aria-current="page"]')).toHaveText(/Projekte|Projects/);
+
+    // Direct deep-link to another entity.
+    await page.goto('/ui/admin/users');
+    await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
+    await expect(page.locator('.admin-subnav-link[aria-current="page"]')).toHaveText(/Nutzer|Users/);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -213,7 +213,7 @@ export default function App() {
       <Route path="/help" component={Help} />
       <Route path="/extras" component={guarded(Extras, canBulkEnter)} />
       <Route path="/billing" component={guarded(Billing, canBill)} />
-      <Route path="/admin" component={guarded(Admin, () => hasRole('ROLE_ADMIN'))} />
+      <Route path="/admin/:entity?" component={guarded(Admin, () => hasRole('ROLE_ADMIN'))} />
       <Route path="*rest" component={RedirectToMonth} />
     </Router>
   )

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -48,15 +48,15 @@ function mockEndpoints() {
   })
 }
 
-function renderAdmin() {
+function renderAdmin(path = '/admin') {
   const history = createMemoryHistory()
-  history.set({ value: '/admin' })
+  history.set({ value: path })
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   return render(() => (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter history={history}>
-        <Route path="/admin" component={Admin} />
+        <Route path="/admin/:entity?" component={Admin} />
       </MemoryRouter>
     </QueryClientProvider>
   ))
@@ -77,6 +77,15 @@ describe('Admin', () => {
     // teams relation column resolves id 2 → "Backend"
     expect(getByText('Backend')).toBeInTheDocument()
 
+    unmount()
+  })
+
+  it('deep-links to an entity via the URL segment (/admin/users)', async () => {
+    mockEndpoints()
+    const { getByRole, unmount } = renderAdmin('/admin/users')
+
+    // The URL segment selects the entity directly — Users renders, not Customers.
+    await waitFor(() => expect(getByRole('gridcell', { name: 'jdoe' })).toBeInTheDocument())
     unmount()
   })
 

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,5 +1,5 @@
-import { useNavigate, useParams } from '@solidjs/router'
-import { For, Show } from 'solid-js'
+import { useLocation, useNavigate, useParams } from '@solidjs/router'
+import { createEffect, For, Show } from 'solid-js'
 
 import { adminEntities } from '../admin/entities'
 import { useOptionSources } from '../admin/options'
@@ -7,16 +7,34 @@ import { AdminCrudShell } from '../components/AdminCrudShell'
 import { activeNavLink } from '../header'
 import { m } from '../paraglide/messages.js'
 
+// Remembers the entity the Admin URL last selected. When a page-level modal
+// (e.g. /ui/settings) opens over Admin, App.tsx re-renders Admin as the modal's
+// background — but the live route is the modal's, so useParams() no longer
+// carries the :entity segment. The background falls back to this so the (dimmed)
+// backdrop keeps its tab instead of flashing to the first entity.
+let lastAdminEntity: string | undefined
+
 export default function Admin() {
   const entities = adminEntities()
   const params = useParams()
+  const location = useLocation()
   const navigate = useNavigate()
   const { lookup } = useOptionSources()
 
-  // The selected entity is the URL segment (/ui/admin/<key>), so it's
-  // deep-linkable and survives reload/back; an unknown/absent key falls back to
-  // the first entity. Switching navigates (pushes a history entry).
-  const activeKey = () => entities.find((entity) => entity.key === params.entity)?.key ?? entities[0]!.key
+  // True when Admin is the live route; false when it's a modal's background page.
+  const onAdminRoute = () => location.pathname.replace(/^\/ui/, '').startsWith('/admin')
+  // While Admin is the live route the URL segment is authoritative (and is
+  // recorded); as a background it falls back to the last recorded segment.
+  createEffect(() => {
+    if (onAdminRoute()) {
+      lastAdminEntity = params.entity
+    }
+  })
+  const activeKey = () => {
+    const key = params.entity ?? (onAdminRoute() ? undefined : lastAdminEntity)
+
+    return entities.find((entity) => entity.key === key)?.key ?? entities[0]!.key
+  }
   const active = () => entities.find((entity) => entity.key === activeKey()) ?? entities[0]!
 
   return (

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,4 +1,5 @@
-import { createSignal, For, Show } from 'solid-js'
+import { useNavigate, useParams } from '@solidjs/router'
+import { For, Show } from 'solid-js'
 
 import { adminEntities } from '../admin/entities'
 import { useOptionSources } from '../admin/options'
@@ -8,9 +9,14 @@ import { m } from '../paraglide/messages.js'
 
 export default function Admin() {
   const entities = adminEntities()
-  const [activeKey, setActiveKey] = createSignal(entities[0]!.key)
+  const params = useParams()
+  const navigate = useNavigate()
   const { lookup } = useOptionSources()
 
+  // The selected entity is the URL segment (/ui/admin/<key>), so it's
+  // deep-linkable and survives reload/back; an unknown/absent key falls back to
+  // the first entity. Switching navigates (pushes a history entry).
+  const activeKey = () => entities.find((entity) => entity.key === params.entity)?.key ?? entities[0]!.key
   const active = () => entities.find((entity) => entity.key === activeKey()) ?? entities[0]!
 
   return (
@@ -61,7 +67,7 @@ export default function Admin() {
               class="admin-subnav-link"
               classList={{ 'is-active': entity.key === activeKey() }}
               aria-current={entity.key === activeKey() ? 'page' : undefined}
-              onClick={() => setActiveKey(entity.key)}
+              onClick={() => navigate(`/admin/${entity.key}`)}
             >
               {entity.title()}
             </button>


### PR DESCRIPTION
The Admin entity selector is now the route segment `/ui/admin/<key>` — deep-linkable, survives reload/back, shareable. Absent/unknown segment → first entity (so `/ui/admin` still works). Keyboard sub-nav chain + keyed remount unchanged.

## Testing
- unit: deep-link `/admin/users` renders Users; sub-nav switch.
- e2e: sub-nav updates URL, survives reload, direct deep-link to another entity. Full admin+navigation e2e (24) green.

Part of the batched Admin review.