### PR TITLE
feat(ui): Help & Settings as icon actions beside the theme switch

### DIFF
--- a/assets/styles/header.css
+++ b/assets/styles/header.css
@@ -450,6 +450,17 @@
     outline-offset: 1px;
 }
 
+/* Desktop logout is icon-only (matches the Settings/Help icon actions); the
+   shared :hover above still tints it red as the danger affordance. The drawer
+   logout keeps its text label. */
+.badge-logout {
+    width: 44px;
+    padding: 0;
+    justify-content: center;
+    border: 0;
+    border-radius: 8px;
+}
+
 /* ---- Hamburger + mobile drawer (shown < 600px) ---- */
 .nav-burger {
     display: none;

--- a/assets/styles/header.css
+++ b/assets/styles/header.css
@@ -337,6 +337,40 @@
     display: none;
 }
 
+/* ---- Settings / Help icon actions (sit beside the theme switch) ---- */
+.header-icon-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 8px;
+    color: light-dark(#3a4047, #c4c9cf);
+    text-decoration: none;
+    transition: background-color 0.15s, color 0.15s;
+}
+
+.header-icon-link:hover {
+    background-color: light-dark(rgba(0, 136, 154, 0.1), rgba(111, 208, 221, 0.12));
+    color: light-dark(#00525c, #6fd0dd);
+}
+
+.header-icon-link.is-active {
+    background-color: light-dark(#e0f0f2, #0f3a40);
+    color: light-dark(#00525c, #6fd0dd);
+}
+
+.header-icon-link:focus-visible {
+    outline: 2px solid light-dark(#00889a, #6fd0dd);
+    outline-offset: -2px;
+}
+
+.header-icon {
+    width: 20px;
+    height: 20px;
+}
+
 /* ---- User cluster (status + logout) ---- */
 .header-account {
     display: flex;

--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -159,7 +159,7 @@ test.describe('Admin URL-addressable sub-nav', () => {
     await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
 
     // Client-side nav to a modal route (preserves the page underneath).
-    await page.locator('a.main-nav-link[data-nav="settings"]').click();
+    await page.locator('a[data-nav="settings"]').click();
     await expect(page).toHaveURL(/\/ui\/settings/);
     await expect(page.locator('.modal-page')).toBeVisible();
 

--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -159,7 +159,7 @@ test.describe('Admin URL-addressable sub-nav', () => {
     await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
 
     // Client-side nav to a modal route (preserves the page underneath).
-    await page.locator('a[data-nav="settings"]').click();
+    await page.locator('a.header-icon-link[data-nav="settings"]').click();
     await expect(page).toHaveURL(/\/ui\/settings/);
     await expect(page.locator('.modal-page')).toBeVisible();
 

--- a/e2e/error-handling.spec.ts
+++ b/e2e/error-handling.spec.ts
@@ -171,7 +171,7 @@ test.describe('Success Notifications', () => {
   test('should show success notification after settings save', async ({ page }) => {
     // Settings moved to the SolidJS UI; reach it via the header nav (inline or
     // folded into "More" depending on width).
-    await clickHeaderNav(page, 'a.main-nav-link[data-nav="settings"]');
+    await clickHeaderNav(page, 'a[data-nav="settings"]');
     await page.waitForURL(/\/ui\/settings/, { timeout: 10000 });
     await page.waitForSelector('form.stack-form', { timeout: 10000 });
 

--- a/e2e/error-handling.spec.ts
+++ b/e2e/error-handling.spec.ts
@@ -171,7 +171,7 @@ test.describe('Success Notifications', () => {
   test('should show success notification after settings save', async ({ page }) => {
     // Settings moved to the SolidJS UI; reach it via the header nav (inline or
     // folded into "More" depending on width).
-    await clickHeaderNav(page, 'a[data-nav="settings"]');
+    await clickHeaderNav(page, 'a.header-icon-link[data-nav="settings"]');
     await page.waitForURL(/\/ui\/settings/, { timeout: 10000 });
     await page.waitForSelector('form.stack-form', { timeout: 10000 });
 

--- a/e2e/helpers/navigation.ts
+++ b/e2e/helpers/navigation.ts
@@ -25,8 +25,10 @@ export const NAV_LINKS = {
   auswertung: 'a.main-nav-link[data-nav="auswertung"]',
   extras: 'a.main-nav-link[data-nav="extras"]',
   billing: 'a.main-nav-link[data-nav="billing"]',
-  settings: 'a.main-nav-link[data-nav="settings"]',
-  help: 'a.main-nav-link[data-nav="help"]',
+  // Settings & Help are icon actions beside the theme switch (not main-nav-link),
+  // so match by data-nav alone.
+  settings: 'a[data-nav="settings"]',
+  help: 'a[data-nav="help"]',
   admin: 'a.main-nav-link[data-nav="admin"]',
 } as const;
 

--- a/e2e/helpers/navigation.ts
+++ b/e2e/helpers/navigation.ts
@@ -25,10 +25,10 @@ export const NAV_LINKS = {
   auswertung: 'a.main-nav-link[data-nav="auswertung"]',
   extras: 'a.main-nav-link[data-nav="extras"]',
   billing: 'a.main-nav-link[data-nav="billing"]',
-  // Settings & Help are icon actions beside the theme switch (not main-nav-link),
-  // so match by data-nav alone.
-  settings: 'a[data-nav="settings"]',
-  help: 'a[data-nav="help"]',
+  // Settings & Help are icon actions beside the theme switch — .header-icon-link
+  // (scoped so it doesn't also match the mobile drawer's .drawer-link[data-nav]).
+  settings: 'a.header-icon-link[data-nav="settings"]',
+  help: 'a.header-icon-link[data-nav="help"]',
   admin: 'a.main-nav-link[data-nav="admin"]',
 } as const;
 

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -144,7 +144,9 @@ export function handleShortcut(event: KeyboardEvent): void {
     // Single-character shortcut: only outside fields and without modifiers, so it
     // can't fire while typing text (WCAG 2.1.4 mitigation).
     if (event.key === '?' && !inField && !event.altKey && !event.ctrlKey && !event.metaKey) {
-      const help = document.querySelector<HTMLAnchorElement>('.app-header .main-nav a[data-nav="help"]')
+      // Help moved out of .main-nav into the header icon group, so match by
+      // data-nav across the whole header rather than scoping to .main-nav.
+      const help = document.querySelector<HTMLAnchorElement>('.app-header a[data-nav="help"]')
       if (help !== null) {
         event.preventDefault()
         help.click()

--- a/frontend/src/nav.ts
+++ b/frontend/src/nav.ts
@@ -6,7 +6,9 @@
 export function syncNav(pathname: string): void {
   const segment = pathname.replace(/^\/ui\/?/, '').split('/')[0] || 'month'
 
-  for (const link of document.querySelectorAll<HTMLAnchorElement>('.main-nav-link[data-nav]')) {
+  // Main-bar links plus the relocated Settings/Help icon actions (but not the
+  // worktime badges, which also carry data-nav="month").
+  for (const link of document.querySelectorAll<HTMLAnchorElement>('.main-nav-link[data-nav], .header-icon-link[data-nav]')) {
     const isActive = link.dataset.nav === segment
     link.classList.toggle('is-active', isActive)
     if (isActive) {

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -117,7 +117,7 @@
                 <span class="status-indicator" aria-hidden="true"></span>
                 <span class="user-name js-user-name">{{ settings.user_name }}</span>
             </span>
-            <a href="{{ url('_logout') }}" class="badge-logout" aria-label="{{ 'Logout'|trans }}">{{ 'Logout'|trans }}</a>
+            <a href="{{ url('_logout') }}" class="badge-logout" aria-label="{{ 'Logout'|trans }}" title="{{ 'Logout'|trans }}"><svg class="header-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/></svg></a>
         </div>
 
         <button type="button" class="nav-burger" id="nav-burger"

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -54,15 +54,6 @@
                    {% if active == 'admin' %}aria-current="page"{% endif %}
                    data-nav="admin" href="{{ path('ui_spa', {'path': 'admin'}) }}">{{ 'Administration'|trans }}</a>
             {% endif %}
-            {# Settings & Help carry an icon that shows only when they fold into
-               the "More" menu (hidden inline via CSS). #}
-            <a class="main-nav-link{% if active == 'settings' %} is-active{% endif %}"
-               {% if active == 'settings' %}aria-current="page"{% endif %}
-               data-nav="settings" href="{{ path('ui_spa', {'path': 'settings'}) }}"><svg class="nav-menu-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="3.2"/><path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8 2 2 0 1 1-2.8 2.8 1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0 1.6 1.6 0 0 0-1.7-1.6 1.6 1.6 0 0 0-1.8.3 2 2 0 1 1-2.8-2.8 1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H2a2 2 0 1 1 0-4 1.6 1.6 0 0 0 1.5-1.3 1.6 1.6 0 0 0-.3-1.8 2 2 0 1 1 2.8-2.8 1.6 1.6 0 0 0 1.8.3H8a1.6 1.6 0 0 0 1-1.5V2a2 2 0 1 1 4 0 1.6 1.6 0 0 0 1 1.5 1.6 1.6 0 0 0 1.8-.3 2 2 0 1 1 2.8 2.8 1.6 1.6 0 0 0-.3 1.8v.1a1.6 1.6 0 0 0 1.5 1H22a2 2 0 1 1 0 4 1.6 1.6 0 0 0-1.5 1z"/></svg>{{ 'Settings'|trans }}</a>
-            <a class="main-nav-link{% if active == 'help' %} is-active{% endif %}"
-               {% if active == 'help' %}aria-current="page"{% endif %}
-               aria-keyshortcuts="?" title="{{ 'Help'|trans }} (?)"
-               data-nav="help" href="{{ path('ui_spa', {'path': 'help'}) }}"><svg class="nav-menu-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9.5"/><path d="M9.2 9.3a2.8 2.8 0 0 1 5.4 1c0 1.9-2.6 2.3-2.6 4"/><circle cx="12" cy="17.4" r="1.1" fill="currentColor" stroke="none"/></svg>{{ 'Help'|trans }}</a>
 
             {# Overflow disclosure — empty until the priority-overflow script
                folds bar items into it; the whole control hides when it's empty
@@ -103,6 +94,16 @@
         {# Theme cycle — framework-neutral; wired by partials/theme-init.html.twig.
            One button cycling System → Light → Dark; JS shows the current mode's
            icon and keeps an accessible name in sync. #}
+        {# Settings & Help live with the theme switch as icon-only actions
+           (data-nav kept so the SPA nav sync + the '?' Help shortcut still find them). #}
+        <a class="header-icon-link{% if active == 'settings' %} is-active{% endif %}"
+           {% if active == 'settings' %}aria-current="page"{% endif %}
+           data-nav="settings" href="{{ path('ui_spa', {'path': 'settings'}) }}"
+           aria-label="{{ 'Settings'|trans }}" title="{{ 'Settings'|trans }}"><svg class="header-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="3.2"/><path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8 2 2 0 1 1-2.8 2.8 1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0 1.6 1.6 0 0 0-1.7-1.6 1.6 1.6 0 0 0-1.8.3 2 2 0 1 1-2.8-2.8 1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H2a2 2 0 1 1 0-4 1.6 1.6 0 0 0 1.5-1.3 1.6 1.6 0 0 0-.3-1.8 2 2 0 1 1 2.8-2.8 1.6 1.6 0 0 0 1.8.3H8a1.6 1.6 0 0 0 1-1.5V2a2 2 0 1 1 4 0 1.6 1.6 0 0 0 1 1.5 1.6 1.6 0 0 0 1.8-.3 2 2 0 1 1 2.8 2.8 1.6 1.6 0 0 0-.3 1.8v.1a1.6 1.6 0 0 0 1.5 1H22a2 2 0 1 1 0 4 1.6 1.6 0 0 0-1.5 1z"/></svg></a>
+        <a class="header-icon-link{% if active == 'help' %} is-active{% endif %}"
+           {% if active == 'help' %}aria-current="page"{% endif %}
+           data-nav="help" href="{{ path('ui_spa', {'path': 'help'}) }}"
+           aria-keyshortcuts="?" aria-label="{{ 'Help'|trans }}" title="{{ 'Help'|trans }} (?)"><svg class="header-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9.5"/><path d="M9.2 9.3a2.8 2.8 0 0 1 5.4 1c0 1.9-2.6 2.3-2.6 4"/><circle cx="12" cy="17.4" r="1.1" fill="currentColor" stroke="none"/></svg></a>
         <div id="theme-toggle-mount" class="header-theme">
             <button type="button" class="theme-cycle" id="theme-cycle" aria-label="{{ 'Theme'|trans }}">
                 <svg class="theme-ico" data-theme-icon="system" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2.5" y="4" width="19" height="13" rx="1.5"/><path d="M8.5 21h7M12 17v4"/></svg>


### PR DESCRIPTION
Settings & Help leave the main nav and become icon-only links next to the theme toggle. They keep `data-nav` so SPA nav-sync + the `?` Help shortcut still resolve them (selectors broadened beyond `.main-nav`; syncNav marks the relocated `.header-icon-link` active). They drop out of the arrow-key menubar/More overflow → Tab-reachable icon buttons like the theme button; the mobile drawer keeps its text links.

## Testing
- frontend typecheck/lint/test (146) green; header.css rebuilt via Encore.
- Browser-verified: icons render beside the theme toggle (order settings,help,theme), Settings opens its modal w/ aria-current, `?` opens Help, no console errors.
- e2e green (38): navigation, admin-inline-edit, settings, error-handling.

Part of the batched Admin review.