### PR TITLE
feat: Account CRUD in the Admin UI

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -191,6 +191,7 @@
   "admin_e_projects": "Projekte",
   "admin_e_users": "Nutzer",
   "admin_e_teams": "Teams",
+  "admin_e_accounts": "Konten",
   "admin_e_presets": "Vorlagen",
   "admin_e_ticketsystems": "Ticket-Systeme",
   "admin_e_activities": "Tätigkeiten",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -191,6 +191,7 @@
   "admin_e_projects": "Projects",
   "admin_e_users": "Users",
   "admin_e_teams": "Teams",
+  "admin_e_accounts": "Accounts",
   "admin_e_presets": "Presets",
   "admin_e_ticketsystems": "Ticket systems",
   "admin_e_activities": "Activities",

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -193,6 +193,23 @@ export function adminEntities(): EntityDescriptor[] {
       toPayload: (v) => ({ id: v.id, name: v.name, lead_user_id: v.lead_user_id }),
     },
     {
+      key: 'accounts',
+      title: () => m.admin_e_accounts(),
+      listEndpoint: '/getAllAccounts',
+      rowKey: 'account',
+      saveEndpoint: '/account/save',
+      deleteEndpoint: '/account/delete',
+      columns: [
+        { key: 'name', label: () => m.admin_f_name() },
+      ],
+      fields: [
+        { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true },
+      ],
+      rowLabel: (row) => str(row.name),
+      toForm: (row) => row === null ? { id: 0, name: '' } : { id: num(row.id), name: str(row.name) },
+      toPayload: (v) => ({ id: v.id, name: v.name }),
+    },
+    {
       key: 'presets',
       title: () => m.admin_e_presets(),
       listEndpoint: '/getAllPresets',

--- a/src/Controller/Admin/DeleteAccountAction.php
+++ b/src/Controller/Admin/DeleteAccountAction.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Controller\BaseController;
+use App\Dto\IdDto;
+use App\Entity\Account;
+use App\Exception\EntityAlreadyDeletedException;
+use App\Model\JsonResponse;
+use App\Model\Response;
+use App\Response\Error;
+use Exception;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function sprintf;
+
+final class DeleteAccountAction extends BaseController
+{
+    #[Route(path: '/account/delete', name: 'deleteAccount_attr', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
+    {
+        try {
+            $doctrine = $this->doctrineRegistry;
+            $account = $doctrine->getRepository(Account::class)->find($idDto->id);
+
+            $em = $doctrine->getManager();
+            if ($account instanceof Account) {
+                $em->remove($account);
+                $em->flush();
+            } else {
+                throw new EntityAlreadyDeletedException('Already deleted');
+            }
+        } catch (Exception $exception) {
+            $reason = '';
+            if (str_contains($exception->getMessage(), 'Integrity constraint violation')) {
+                $reason = $this->translate('Other datasets refer to this one.');
+            }
+
+            $msg = sprintf($this->translate('Dataset could not be removed. %s'), $reason);
+
+            return new Error($msg, \Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return new JsonResponse(['success' => true]);
+    }
+}

--- a/src/Controller/Admin/GetAccountsAction.php
+++ b/src/Controller/Admin/GetAccountsAction.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Controller\BaseController;
+use App\Entity\Account;
+use App\Model\JsonResponse;
+use App\Model\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+final class GetAccountsAction extends BaseController
+{
+    #[Route(path: '/getAllAccounts', name: '_getAllAccounts_attr', methods: ['GET'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function __invoke(): Response|JsonResponse
+    {
+        $accounts = $this->doctrineRegistry->getRepository(Account::class)->findBy([], ['name' => 'ASC']);
+
+        // Row-wrapped to match the other admin list endpoints ({customer:…}, {team:…}).
+        $data = array_map(
+            static fn (Account $account): array => ['account' => ['id' => $account->getId(), 'name' => $account->getName()]],
+            $accounts,
+        );
+
+        return new JsonResponse($data);
+    }
+}

--- a/src/Controller/Admin/SaveAccountAction.php
+++ b/src/Controller/Admin/SaveAccountAction.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Controller\BaseController;
+use App\Dto\AccountSaveDto;
+use App\Entity\Account;
+use App\Model\JsonResponse;
+use App\Model\Response;
+use App\Response\Error;
+use Exception;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+final class SaveAccountAction extends BaseController
+{
+    /**
+     * @throws BadRequestException
+     * @throws Exception
+     */
+    #[Route(path: '/account/save', name: 'saveAccount_attr', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function __invoke(#[MapRequestPayload] AccountSaveDto $accountSaveDto): Response|JsonResponse|Error
+    {
+        $objectRepository = $this->doctrineRegistry->getRepository(Account::class);
+
+        if (0 !== $accountSaveDto->id) {
+            $account = $objectRepository->find($accountSaveDto->id);
+            if (!$account instanceof Account) {
+                return new Error($this->translate('No entry for id.'), \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
+            }
+        } else {
+            $account = new Account();
+        }
+
+        try {
+            $account->setName($accountSaveDto->name);
+
+            $em = $this->doctrineRegistry->getManager();
+            $em->persist($account);
+            $em->flush();
+        } catch (Exception $exception) {
+            $response = new Response($this->translate('Error on save') . ': ' . $exception->getMessage());
+            $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
+
+            return $response;
+        }
+
+        return new JsonResponse([$account->getId(), $account->getName()]);
+    }
+}

--- a/src/Dto/AccountSaveDto.php
+++ b/src/Dto/AccountSaveDto.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Account;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Map(target: Account::class)]
+final readonly class AccountSaveDto
+{
+    public function __construct(
+        public int $id = 0,
+        #[Assert\NotBlank(message: 'Please provide a valid account name with at least 3 letters.')]
+        #[Assert\Length(min: 3, minMessage: 'Please provide a valid account name with at least 3 letters.')]
+        public string $name = '',
+    ) {
+    }
+
+    /**
+     * @throws BadRequestException
+     */
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            id: (int) ($request->request->get('id') ?? 0),
+            name: (string) ($request->request->get('name') ?? ''),
+        );
+    }
+}

--- a/tests/Api/Functional/AccountCrudTest.php
+++ b/tests/Api/Functional/AccountCrudTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+use function is_array;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * API Functional Tests - Account CRUD Operations (real database).
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class AccountCrudTest extends AbstractWebTestCase
+{
+    public function testCreateListUpdateDeleteAccount(): void
+    {
+        $this->logInSession('unittest');
+
+        // Create
+        $name = 'Acct ' . uniqid();
+        $this->client->request(Request::METHOD_POST, '/account/save', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['name' => $name], JSON_THROW_ON_ERROR));
+        $this->assertStatusCode(200);
+        $created = $this->getJsonResponse($this->client->getResponse());
+        self::assertIsArray($created);
+        self::assertNotNull($created[0]); // id
+        self::assertSame($name, $created[1]);
+        $id = $created[0];
+
+        // List — row-wrapped {account: {id, name}}
+        $this->client->request(Request::METHOD_GET, '/getAllAccounts');
+        $this->assertStatusCode(200);
+        $list = $this->getJsonResponse($this->client->getResponse());
+        self::assertIsArray($list);
+        $found = false;
+        foreach ($list as $item) {
+            /** @var array<string, mixed> $item */
+            $account = isset($item['account']) && is_array($item['account']) ? $item['account'] : $item;
+            if (($account['id'] ?? null) === $id) {
+                self::assertSame($name, $account['name']);
+                $found = true;
+            }
+        }
+
+        self::assertTrue($found, 'the created account appears in the list');
+
+        // Update
+        $renamed = $name . ' upd';
+        $this->client->request(Request::METHOD_POST, '/account/save', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['id' => $id, 'name' => $renamed], JSON_THROW_ON_ERROR));
+        $this->assertStatusCode(200);
+        $updated = $this->getJsonResponse($this->client->getResponse());
+        self::assertSame($renamed, $updated[1]);
+
+        // Delete
+        $this->client->request(Request::METHOD_POST, '/account/delete', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['id' => $id], JSON_THROW_ON_ERROR));
+        $this->assertStatusCode(200);
+        $deleted = $this->getJsonResponse($this->client->getResponse());
+        self::assertTrue($deleted['success']);
+    }
+
+    public function testCreateAccountRejectsShortName(): void
+    {
+        $this->logInSession('unittest');
+
+        // name shorter than the 3-char minimum → validation error
+        $this->client->request(Request::METHOD_POST, '/account/save', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['name' => 'ab'], JSON_THROW_ON_ERROR));
+
+        $statusCode = $this->client->getResponse()->getStatusCode();
+        self::assertGreaterThanOrEqual(400, $statusCode);
+        self::assertLessThan(500, $statusCode);
+    }
+}

--- a/tests/Api/Functional/AccountCrudTest.php
+++ b/tests/Api/Functional/AccountCrudTest.php
@@ -76,4 +76,25 @@ final class AccountCrudTest extends AbstractWebTestCase
         self::assertGreaterThanOrEqual(400, $statusCode);
         self::assertLessThan(500, $statusCode);
     }
+
+    public function testSaveAccountWithUnknownIdReturnsNotFound(): void
+    {
+        $this->logInSession('unittest');
+
+        // Updating a non-existent id falls through to the "No entry for id." branch.
+        $this->client->request(Request::METHOD_POST, '/account/save', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['id' => 999999, 'name' => 'Ghost account'], JSON_THROW_ON_ERROR));
+
+        $this->assertStatusCode(404);
+    }
+
+    public function testDeleteUnknownAccountReturnsError(): void
+    {
+        $this->logInSession('unittest');
+
+        // Deleting a non-existent id raises EntityAlreadyDeletedException, which the
+        // action maps to an unprocessable-entity error response.
+        $this->client->request(Request::METHOD_POST, '/account/delete', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['id' => 999999], JSON_THROW_ON_ERROR));
+
+        $this->assertStatusCode(422);
+    }
 }

--- a/tests/Dto/AccountSaveDtoTest.php
+++ b/tests/Dto/AccountSaveDtoTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Dto;
+
+use App\Dto\AccountSaveDto;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class AccountSaveDtoTest extends TestCase
+{
+    public function testConstructorWithDefaultValues(): void
+    {
+        $dto = new AccountSaveDto();
+
+        self::assertSame(0, $dto->id);
+        self::assertSame('', $dto->name);
+    }
+
+    public function testConstructorWithCustomValues(): void
+    {
+        $dto = new AccountSaveDto(id: 7, name: 'Cost Center A');
+
+        self::assertSame(7, $dto->id);
+        self::assertSame('Cost Center A', $dto->name);
+    }
+
+    public function testFromRequest(): void
+    {
+        $request = new Request();
+        $request->request->set('id', '7');
+        $request->request->set('name', 'Cost Center A');
+
+        $dto = AccountSaveDto::fromRequest($request);
+
+        self::assertSame(7, $dto->id);
+        self::assertSame('Cost Center A', $dto->name);
+    }
+}


### PR DESCRIPTION
Adds the **Accounts** entity (id + name) to the Admin UI (audit follow-up — it had no management surface). Controllers mirror the Team pattern: `GET /getAllAccounts`, `POST /account/save` (MapRequestPayload + ROLE_ADMIN), `POST /account/delete` (IdDto). Admin descriptor gains the `accounts` entity.

## Testing
- PHPStan + cs-fixer clean; `AccountSaveDtoTest` (unit) + `AccountCrudTest` (functional create/list/update/delete + validation) green against the real DB (e2e container).
- frontend typecheck/lint/test (146) green.

Backend trio 2/3 (Holiday add/delete next). Batched deploy.