### PR TITLE
feat(ui): Worklog inline editing + save (PR2 of the work-log migration)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -136,6 +136,8 @@
   "tracking_class_daybreak": "Tageswechsel",
   "tracking_class_pause": "Pause",
   "tracking_class_overlap": "Zeitüberschneidung",
+  "tracking_invalid_time": "Bitte eine gültige Start- und Endzeit eingeben.",
+  "tracking_actions": "Aktionen",
   "auswertung_title": "Auswertung",
   "auswertung_no_data": "Keine Daten gefunden.",
   "auswertung_label": "Name",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -136,6 +136,8 @@
   "tracking_class_daybreak": "Day break",
   "tracking_class_pause": "Break",
   "tracking_class_overlap": "Time overlap",
+  "tracking_invalid_time": "Please enter a valid start and end time.",
+  "tracking_actions": "Actions",
   "auswertung_title": "Evaluation",
   "auswertung_no_data": "No data found.",
   "auswertung_label": "Name",

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -1,21 +1,18 @@
 import { Dialog } from '@ark-ui/solid/dialog'
 import { useQueryClient, useQuery } from '@tanstack/solid-query'
-import { createComputed, createMemo, createSignal, For, Match, onCleanup, onMount, Show, Switch } from 'solid-js'
-import { createStore, produce, reconcile } from 'solid-js/store'
+import { createComputed, createMemo, createSignal, For, Match, onCleanup, Show, Switch } from 'solid-js'
+import { createStore, reconcile } from 'solid-js/store'
 import { Portal } from 'solid-js/web'
 
 import { apiErrorMessage, getJson, postJson } from '../api/client'
 import { optionSourceKey } from '../api/queries'
-import { getEnterBehavior } from '../lib/gridEditPref'
-import { gridNav, type ActivateKey, type GridMoveHandle } from '../lib/gridNavigation'
+import { createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { gridNav } from '../lib/gridNavigation'
 import { m } from '../paraglide/messages.js'
 import type { ColumnDef, EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
 
 type Row = Record<string, unknown>
 
-// Field types that get a compact in-cell editor; everything else (multiselect,
-// the locked relation columns) stays modal-only.
-const INLINE_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date', 'checkbox', 'select'])
 
 // Rows rendered per page. The list is fetched whole (a few hundred KB even for
 // ~1k rows) but rendering every row at once is the cost — paging keeps the DOM,
@@ -32,15 +29,6 @@ function csvCell(value: string): string {
   return /[",\r\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe
 }
 
-/** Shared option resolution for both the modal FieldControl and the inline
- *  editor, so relation/static dropdowns stay identical in either surface. */
-function fieldSelectOptions(field: FieldDef, options: OptionLookup): { value: string | number; label: string }[] {
-  if (field.staticOptions) {
-    return field.staticOptions.map((option) => ({ value: option.value, label: option.label() }))
-  }
-
-  return field.source ? options(field.source).map((option) => ({ value: option.id, label: option.label })) : []
-}
 
 /**
  * Reusable admin CRUD surface: a list grid + add/edit modal form + delete,
@@ -268,20 +256,47 @@ export function AdminCrudShell(props: {
     void runBulk((row) => postJson(deleteEndpoint, deletePayload?.(row) ?? { id: row.id }), () => m.admin_deleted())
   }
 
+  const fieldFor = (colKey: string): FieldDef | undefined => props.descriptor.fields.find((field) => field.name === colKey)
+
+  function isColInlineEditable(colKey: string): boolean {
+    if (props.descriptor.editable === false) {
+      return false
+    }
+    const field = fieldFor(colKey)
+
+    return field !== undefined && INLINE_TYPES.has(field.type) && field.lockedOnEdit !== true
+  }
+
+  const inlineEditable = (col: ColumnDef): boolean => isColInlineEditable(col.key)
+
+  // The shared spreadsheet-edit controller (per-row drafts, save-on-row-leave);
+  // gridNav stays the roving-tabindex owner. A row saves the whole entity.
+  const editor = createInlineGridEdit({
+    rows: visibleRows,
+    fieldFor,
+    isInlineEditable: isColInlineEditable,
+    seedDraft: (row) => props.descriptor.toForm(row),
+    saveRow: async (draft) => {
+      await postJson(props.descriptor.saveEndpoint, props.descriptor.toPayload({ ...draft }))
+      await refreshAfterMutation()
+    },
+    onModalActivate: (row) => { openForm(row); return true },
+    onSaved: () => flashNotice(m.admin_saved()),
+    saveErrorMessage: (caught) => apiErrorMessage(caught, m.app_load_error()),
+  })
+
+  // A cell shows the committed draft value (through the column's own formatter)
+  // while the row is dirty, else the persisted value.
+  const displayText = (row: Row, col: ColumnDef): string => cellText(editor.overlayRow(row), col)
+
   function openForm(row: Row | null) {
     setError('')
     // If the row has a pending inline draft, the modal takes it over: seed from
     // the draft (not the now-stale list row) and drop the inline draft + open
     // editor so the inline and modal paths can't both save the same row.
     const rowId = row !== null ? Number(row.id) : 0
-    const draft = rowId ? drafts[rowId] : undefined
-    const form = draft !== undefined ? { ...draft } : props.descriptor.toForm(row)
-    if (draft !== undefined) {
-      if (editCell()?.rowId === rowId) {
-        setEditCell(null)
-      }
-      setDrafts(produce((store) => { delete store[rowId] }))
-    }
+    const draft = rowId ? editor.takeDraft(rowId) : undefined
+    const form = draft !== undefined ? draft : props.descriptor.toForm(row)
     // reconcile replaces every key (and drops stale ones) in one diffed update.
     setValues(reconcile(form))
     setEditing(form)
@@ -316,196 +331,12 @@ export function AdminCrudShell(props: {
       await postJson(props.descriptor.deleteEndpoint, props.descriptor.deletePayload?.(row) ?? { id: row.id })
       await refreshAfterMutation()
       // Drop any pending inline edit for the row that no longer exists.
-      setDrafts(produce((store) => { delete store[rowId] }))
+      editor.takeDraft(rowId)
       flashNotice(m.admin_deleted())
     } catch (caught) {
       setError(apiErrorMessage(caught, m.app_load_error()))
     }
   }
-
-  // ---- Inline cell editing -------------------------------------------------
-  // The grid stays a pure navigation/ARIA controller (use:gridNav); all edit
-  // state lives here, keyed by stable row id so a sort/filter/refetch can't
-  // desync it. A cell commit accumulates onto its row's draft and the whole
-  // entity is saved once, when focus leaves the row (see onTableFocusIn).
-  const [editCell, setEditCell] = createSignal<{ rowId: number; colKey: string } | null>(null)
-  const [drafts, setDrafts] = createStore<Record<number, FormValues>>({})
-  const [savingRows, setSavingRows] = createStore<Record<number, boolean>>({})
-  const [rowErrors, setRowErrors] = createStore<Record<number, string>>({})
-  let seedChar: string | undefined
-  let moveHandle: GridMoveHandle | null = null
-
-  const fieldFor = (colKey: string): FieldDef | undefined => props.descriptor.fields.find((f) => f.name === colKey)
-
-  function inlineEditable(col: ColumnDef): boolean {
-    if (props.descriptor.editable === false) {
-      return false
-    }
-    const field = fieldFor(col.key)
-
-    return field !== undefined && INLINE_TYPES.has(field.type) && field.lockedOnEdit !== true
-  }
-
-  const isEditing = (rowId: number, colKey: string): boolean => {
-    const cell = editCell()
-
-    return cell !== null && cell.rowId === rowId && cell.colKey === colKey
-  }
-
-  // What a cell shows: the committed draft value (rendered through the column's
-  // own formatter) while the row is dirty, else the persisted value. This keeps
-  // edited-but-unsaved cells visibly current without touching the query cache.
-  function displayText(row: Row, col: ColumnDef): string {
-    const draft = drafts[Number(row.id)]
-    if (draft !== undefined && col.key in draft) {
-      return cellText({ ...row, [col.key]: draft[col.key] }, col)
-    }
-
-    return cellText(row, col)
-  }
-
-  function beginEdit(rowId: number, colKey: string, char?: string): boolean {
-    const col = props.descriptor.columns.find((c) => c.key === colKey)
-    if (!col || !inlineEditable(col)) {
-      return false
-    }
-    const row = visibleRows().find((r) => Number(r.id) === rowId)
-    if (!row) {
-      return false
-    }
-    if (drafts[rowId] === undefined) {
-      setDrafts(rowId, props.descriptor.toForm(row))
-    }
-    const field = fieldFor(colKey)
-    // Only text-like fields are seeded with the keystroke that opened them.
-    seedChar = char !== undefined && (field?.type === 'text' || field?.type === 'number' || field?.type === 'date') ? char : undefined
-    setRowErrors(rowId, '')
-    setEditCell({ rowId, colKey })
-
-    return true
-  }
-
-  // gridNav offers the focused cell on Enter/F2/printable; we open an editor and
-  // return true so the grid suppresses its default "focus first control".
-  const onActivate = (cell: HTMLTableCellElement, key: ActivateKey, initial?: string): boolean => {
-    const rowId = Number(cell.getAttribute('data-row-id'))
-    const colKey = cell.getAttribute('data-col-key')
-    if (!rowId || colKey === null) {
-      return false
-    }
-    const col = props.descriptor.columns.find((c) => c.key === colKey)
-    if (col && inlineEditable(col)) {
-      return beginEdit(rowId, colKey, key === 'type' ? initial : undefined)
-    }
-    // A column backed by a modal-only field (multiselect / locked relation, e.g.
-    // Customers → Teams) can't edit in place — Enter/F2 open the full edit modal
-    // so the field stays reachable from the keyboard instead of doing nothing.
-    if (col && fieldFor(colKey) !== undefined && key !== 'type') {
-      const row = visibleRows().find((r) => Number(r.id) === rowId)
-      if (row) {
-        openForm(row)
-
-        return true
-      }
-    }
-
-    return false
-  }
-
-  function commitCell(value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay'): void {
-    const cell = editCell()
-    if (cell === null) {
-      return
-    }
-    setDrafts(cell.rowId, cell.colKey, value)
-    seedChar = undefined
-    setEditCell(null)
-    // All focus moves go through the grid's own setActive (the single
-    // roving-tabindex writer); landing on a different row triggers that row's
-    // save via onTableFocusIn. 'stay' re-focuses the just-edited cell; an
-    // undefined direction (commit-on-blur) leaves focus wherever it went.
-    if (direction === 'stay') {
-      moveHandle?.focusActive()
-    } else if (direction) {
-      moveHandle?.move(direction)
-    }
-  }
-
-  function cancelCell(): void {
-    seedChar = undefined
-    setEditCell(null)
-    moveHandle?.focusActive()
-  }
-
-  async function flushRow(rowId: number): Promise<void> {
-    const draft = drafts[rowId]
-    if (draft === undefined || savingRows[rowId]) {
-      return
-    }
-    setSavingRows(rowId, true)
-    setRowErrors(rowId, '')
-    try {
-      await postJson(props.descriptor.saveEndpoint, props.descriptor.toPayload({ ...draft }))
-      await refreshAfterMutation()
-      // Refetch has the saved values now, so dropping the draft shows no flash.
-      setDrafts(produce((store) => { delete store[rowId] }))
-      flashNotice(m.admin_saved())
-    } catch (caught) {
-      // Keep the draft so the user's edits aren't lost; surface a per-row error.
-      setRowErrors(rowId, apiErrorMessage(caught, m.app_load_error()))
-    } finally {
-      setSavingRows(rowId, false)
-    }
-  }
-
-  // Row-leave detection: when focus moves to a cell in a different row, save the
-  // row we left (if dirty). Tracking focusin alone is robust — an editor closing
-  // and the grid re-focusing the next cell both surface here.
-  let tableEl: HTMLTableElement | undefined
-  let lastFocusedRowId: number | null = null
-
-  function rowIdOf(node: EventTarget | null): number | null {
-    const cell = node instanceof HTMLElement ? node.closest<HTMLElement>('td[data-row-id]') : null
-
-    return cell ? Number(cell.getAttribute('data-row-id')) : null
-  }
-
-  function onTableFocusIn(event: FocusEvent): void {
-    const rowId = rowIdOf(event.target)
-    if (rowId === lastFocusedRowId) {
-      return
-    }
-    if (lastFocusedRowId !== null) {
-      void flushRow(lastFocusedRowId) // a no-op when that row has no pending draft
-    }
-    lastFocusedRowId = rowId
-  }
-
-  function flushIfFocusLeftTable(): void {
-    if (tableEl === undefined || (document.activeElement !== null && tableEl.contains(document.activeElement))) {
-      return
-    }
-    if (lastFocusedRowId !== null) {
-      void flushRow(lastFocusedRowId) // a no-op when that row has no pending draft
-    }
-  }
-
-  function onTableFocusOut(): void {
-    // Deferred so an editor unmounting + the grid re-focusing the next cell (all
-    // synchronous) doesn't read as "left the table"; by the microtask the dust
-    // has settled and document.activeElement is authoritative.
-    queueMicrotask(flushIfFocusLeftTable)
-  }
-
-  // Switching entity / unmounting must not silently drop a pending edit.
-  onCleanup(() => {
-    for (const key of Object.keys(drafts)) {
-      const rowId = Number(key)
-      if (drafts[rowId] !== undefined && !savingRows[rowId]) {
-        void postJson(props.descriptor.saveEndpoint, props.descriptor.toPayload({ ...drafts[rowId]! }))
-      }
-    }
-  })
 
   let searchEl: HTMLInputElement | undefined
 
@@ -583,14 +414,14 @@ export function AdminCrudShell(props: {
         <div class="table-scroll">
           <table
             class="data-table admin-table"
-            ref={(el) => { tableEl = el }}
-            onFocusIn={onTableFocusIn}
-            onFocusOut={onTableFocusOut}
+            ref={(el) => { editor.setTableEl(el) }}
+            onFocusIn={editor.onTableFocusIn}
+            onFocusOut={editor.onTableFocusOut}
             use:gridNav={{
               items: pagedRows,
               onExit: (dir) => { if (dir === 'up') searchEl?.focus() },
-              onActivate,
-              moveRef: (handle) => { moveHandle = handle },
+              onActivate: editor.onActivate,
+              moveRef: (handle) => { editor.setMoveHandle(handle) },
             }}
           >
             <thead>
@@ -624,7 +455,7 @@ export function AdminCrudShell(props: {
             <tbody>
               <For each={pagedRows()}>
                 {(row) => (
-                  <tr aria-busy={savingRows[Number(row.id)] ? 'true' : undefined} classList={{ 'is-selected': Boolean(selected[Number(row.id)]) }}>
+                  <tr aria-busy={editor.savingRows[Number(row.id)] ? 'true' : undefined} classList={{ 'is-selected': Boolean(selected[Number(row.id)]) }}>
                     <td class="boolean admin-select-col">
                       <input
                         type="checkbox"
@@ -646,25 +477,25 @@ export function AdminCrudShell(props: {
                             classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable }}
                             data-row-id={String(rowId)}
                             data-col-key={col.key}
-                            data-inline-editing={isEditing(rowId, col.key) ? '' : undefined}
-                            aria-label={isEditing(rowId, col.key) ? col.label() : undefined}
+                            data-inline-editing={editor.isEditing(rowId, col.key) ? '' : undefined}
+                            aria-label={editor.isEditing(rowId, col.key) ? col.label() : undefined}
                             onDblClick={() => {
                               if (editable) {
-                                beginEdit(rowId, col.key)
+                                editor.beginEdit(rowId, col.key)
                               } else if (modalOnly) {
                                 openForm(row)
                               }
                             }}
                           >
-                            <Show when={isEditing(rowId, col.key)} fallback={displayText(row, col)}>
+                            <Show when={editor.isEditing(rowId, col.key)} fallback={displayText(row, col)}>
                               <InlineEditor
                                 field={fieldFor(col.key)!}
                                 label={col.label()}
-                                initial={drafts[rowId]?.[col.key] ?? ''}
-                                seed={seedChar}
+                                initial={editor.draftValue(rowId, col.key) ?? ''}
+                                seed={editor.seedChar()}
                                 options={props.options}
-                                onCommit={commitCell}
-                                onCancel={cancelCell}
+                                onCommit={editor.commitCell}
+                                onCancel={editor.cancelCell}
                               />
                             </Show>
                           </td>
@@ -685,8 +516,8 @@ export function AdminCrudShell(props: {
                         <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6"/><path d="M10 11v6M14 11v6"/></svg>
                         {m.admin_delete()}
                       </button>
-                      <Show when={rowErrors[Number(row.id)]}>
-                        <span role="alert" class="form-status is-error">{rowErrors[Number(row.id)]}</span>
+                      <Show when={editor.rowErrors[Number(row.id)]}>
+                        <span role="alert" class="form-status is-error">{editor.rowErrors[Number(row.id)]}</span>
                       </Show>
                     </td>
                   </tr>
@@ -836,126 +667,3 @@ function FieldControl(props: {
   )
 }
 
-/**
- * Compact in-cell editor for inline (spreadsheet-style) editing. It owns its
- * keys: Enter commits and moves down, Tab/Shift+Tab commit and move right/left,
- * Escape cancels; all four stopPropagation so neither the grid nor the global
- * shortcut handler sees them. Blur commits in place (click-away). The value is
- * coerced back to the field's payload type on commit, matching FieldControl.
- */
-function InlineEditor(props: {
-  field: FieldDef
-  label: string
-  initial: FormValues[string]
-  seed?: string
-  options: OptionLookup
-  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
-  onCancel: () => void
-}) {
-  const isCheckbox = (): boolean => props.field.type === 'checkbox'
-  const [value, setValue] = createSignal<string | boolean>(isCheckbox() ? Boolean(props.initial) : String(props.initial ?? ''))
-  // Memoized so the <For> below sees a stable array (recreated only when the
-  // option source changes), not a fresh one on every render.
-  const selectOptions = createMemo(() => fieldSelectOptions(props.field, props.options))
-  let control: HTMLInputElement | HTMLSelectElement | undefined
-  // Guards against a second commit: the keydown move already committed, and the
-  // editor then unmounts and blurs — the blur must not re-commit.
-  let done = false
-
-  function coerced(): FormValues[string] {
-    if (isCheckbox()) {
-      return value() as boolean
-    }
-    const raw = value() as string
-    if (props.field.type === 'number' || (props.field.type === 'select' && props.field.stringValue !== true)) {
-      return Number(raw)
-    }
-
-    return raw
-  }
-
-  const finish = (direction?: 'down' | 'left' | 'right' | 'stay') => {
-    if (done) {
-      return
-    }
-    done = true
-    props.onCommit(coerced(), direction)
-  }
-  const cancel = () => {
-    if (done) {
-      return
-    }
-    done = true
-    props.onCancel()
-  }
-
-  const onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      event.stopPropagation()
-      // Enter's focus move is a user preference (default: stay in the cell);
-      // Tab below always advances, so the user keeps an explicit move key.
-      finish(getEnterBehavior())
-    } else if (event.key === 'Tab') {
-      event.preventDefault()
-      event.stopPropagation()
-      finish(event.shiftKey ? 'left' : 'right')
-    } else if (event.key === 'Escape') {
-      event.preventDefault()
-      event.stopPropagation()
-      cancel()
-    }
-  }
-
-  onMount(() => {
-    if (props.seed !== undefined && control instanceof HTMLInputElement) {
-      setValue(props.seed)
-    }
-    control?.focus()
-  })
-
-  return (
-    <Switch>
-      <Match when={isCheckbox()}>
-        <input
-          ref={(el) => { control = el }}
-          type="checkbox"
-          class="inline-editor inline-check"
-          aria-label={props.label}
-          checked={value() as boolean}
-          onInput={(e) => setValue(e.currentTarget.checked)}
-          onKeyDown={onKeyDown}
-          onBlur={() => finish()}
-        />
-      </Match>
-      <Match when={props.field.type === 'select'}>
-        <select
-          ref={(el) => { control = el }}
-          class="inline-editor"
-          aria-label={props.label}
-          value={value() as string}
-          onInput={(e) => setValue(e.currentTarget.value)}
-          onKeyDown={onKeyDown}
-          onBlur={() => finish()}
-        >
-          <option value="">—</option>
-          <For each={selectOptions()}>
-            {(option) => <option value={String(option.value)}>{option.label}</option>}
-          </For>
-        </select>
-      </Match>
-      <Match when={true}>
-        <input
-          ref={(el) => { control = el }}
-          type={props.field.type === 'number' ? 'number' : props.field.type === 'date' ? 'date' : 'text'}
-          class="inline-editor"
-          aria-label={props.label}
-          value={value() as string}
-          onInput={(e) => setValue(e.currentTarget.value)}
-          onKeyDown={onKeyDown}
-          onBlur={() => finish()}
-        />
-      </Match>
-    </Switch>
-  )
-}

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -1,0 +1,378 @@
+import { createMemo, createSignal, For, Match, onCleanup, onMount, Switch, type Accessor } from 'solid-js'
+import { createStore, produce } from 'solid-js/store'
+
+import type { FieldDef, FormValues, OptionLookup } from '../admin/types'
+import { getEnterBehavior } from './gridEditPref'
+import type { ActivateKey, GridMoveHandle } from './gridNavigation'
+import { m } from '../paraglide/messages.js'
+
+export type Row = Record<string, unknown>
+
+// Field types that get a compact in-cell editor; everything else (multiselect,
+// locked relation columns) stays modal-only.
+export const INLINE_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date', 'checkbox', 'select'])
+
+/** Shared option resolution for both the modal FieldControl and the inline
+ *  editor, so relation/static dropdowns stay identical in either surface. */
+export function fieldSelectOptions(field: FieldDef, options: OptionLookup): { value: string | number; label: string }[] {
+  if (field.staticOptions) {
+    return field.staticOptions.map((option) => ({ value: option.value, label: option.label() }))
+  }
+
+  return field.source ? options(field.source).map((option) => ({ value: option.id, label: option.label })) : []
+}
+
+/**
+ * Compact in-cell editor for inline (spreadsheet-style) editing. It owns its
+ * keys: Enter commits (direction from the user's preference), Tab/Shift+Tab
+ * commit and move right/left, Escape cancels; all four stopPropagation so
+ * neither the grid nor the global shortcut handler sees them. Blur commits in
+ * place (click-away). The value is coerced back to the field's payload type on
+ * commit, matching FieldControl.
+ */
+export function InlineEditor(props: {
+  field: FieldDef
+  label: string
+  initial: FormValues[string]
+  seed?: string
+  options: OptionLookup
+  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
+  onCancel: () => void
+}) {
+  const isCheckbox = (): boolean => props.field.type === 'checkbox'
+  const [value, setValue] = createSignal<string | boolean>(isCheckbox() ? Boolean(props.initial) : String(props.initial ?? ''))
+  // Memoized so the <For> below sees a stable array (recreated only when the
+  // option source changes), not a fresh one on every render.
+  const selectOptions = createMemo(() => fieldSelectOptions(props.field, props.options))
+  let control: HTMLInputElement | HTMLSelectElement | undefined
+  // Guards against a second commit: the keydown move already committed, and the
+  // editor then unmounts and blurs — the blur must not re-commit.
+  let done = false
+
+  function coerced(): FormValues[string] {
+    if (isCheckbox()) {
+      return value() as boolean
+    }
+    const raw = value() as string
+    if (props.field.type === 'number' || (props.field.type === 'select' && props.field.stringValue !== true)) {
+      return Number(raw)
+    }
+
+    return raw
+  }
+
+  const finish = (direction?: 'down' | 'left' | 'right' | 'stay') => {
+    if (done) {
+      return
+    }
+    done = true
+    props.onCommit(coerced(), direction)
+  }
+  const cancel = () => {
+    if (done) {
+      return
+    }
+    done = true
+    props.onCancel()
+  }
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      // Enter's focus move is a user preference (default: stay in the cell);
+      // Tab below always advances, so the user keeps an explicit move key.
+      finish(getEnterBehavior())
+    } else if (event.key === 'Tab') {
+      event.preventDefault()
+      event.stopPropagation()
+      finish(event.shiftKey ? 'left' : 'right')
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      cancel()
+    }
+  }
+
+  onMount(() => {
+    if (props.seed !== undefined && control instanceof HTMLInputElement) {
+      setValue(props.seed)
+    }
+    control?.focus()
+  })
+
+  return (
+    <Switch>
+      <Match when={isCheckbox()}>
+        <input
+          ref={(el) => { control = el }}
+          type="checkbox"
+          class="inline-editor inline-check"
+          aria-label={props.label}
+          checked={value() as boolean}
+          onInput={(e) => setValue(e.currentTarget.checked)}
+          onKeyDown={onKeyDown}
+          onBlur={() => finish()}
+        />
+      </Match>
+      <Match when={props.field.type === 'select'}>
+        <select
+          ref={(el) => { control = el }}
+          class="inline-editor"
+          aria-label={props.label}
+          value={value() as string}
+          onInput={(e) => setValue(e.currentTarget.value)}
+          onKeyDown={onKeyDown}
+          onBlur={() => finish()}
+        >
+          <option value="">—</option>
+          <For each={selectOptions()}>
+            {(option) => <option value={String(option.value)}>{option.label}</option>}
+          </For>
+        </select>
+      </Match>
+      <Match when={true}>
+        <input
+          ref={(el) => { control = el }}
+          type={props.field.type === 'number' ? 'number' : props.field.type === 'date' ? 'date' : 'text'}
+          class="inline-editor"
+          aria-label={props.label}
+          value={value() as string}
+          onInput={(e) => setValue(e.currentTarget.value)}
+          onKeyDown={onKeyDown}
+          onBlur={() => finish()}
+        />
+      </Match>
+    </Switch>
+  )
+}
+
+const rowId = (row: Row): number => Number(row.id)
+
+export interface InlineGridEditConfig {
+  /** Reactive list of the rows currently shown (keyed by a numeric `id`). */
+  rows: Accessor<readonly Row[]>
+  /** The field backing a column key (drives the editor type), or undefined. */
+  fieldFor: (colKey: string) => FieldDef | undefined
+  /** Whether a column can be edited in place (vs modal-only / read-only). */
+  isInlineEditable: (colKey: string) => boolean
+  /** Seed a fresh draft from a row (the editable form values). */
+  seedDraft: (row: Row) => FormValues
+  /** Persist one row's draft (POST + refetch); rejects to surface a row error. */
+  saveRow: (draft: FormValues, row: Row) => Promise<void>
+  /** Fallback for activating a non-inline column (e.g. open a modal); return
+   *  true if it handled the activation. */
+  onModalActivate?: (row: Row) => boolean
+  /** Called after a successful row save (e.g. a toast). */
+  onSaved?: () => void
+  /** Map a save error to a per-row message. Defaults to the generic load error. */
+  saveErrorMessage?: (error: unknown) => string
+}
+
+/**
+ * The spreadsheet-style inline-edit controller shared by the admin grid and the
+ * work-log grid. gridNav stays the single roving-tabindex/ARIA owner; this owns
+ * per-row drafts (keyed by `id`) and saves the whole row once focus leaves it.
+ * Create it inside a component (it registers reactive state + onCleanup).
+ */
+export function createInlineGridEdit(config: InlineGridEditConfig) {
+  const [editCell, setEditCell] = createSignal<{ rowId: number; colKey: string } | null>(null)
+  const [drafts, setDrafts] = createStore<Record<number, FormValues>>({})
+  const [savingRows, setSavingRows] = createStore<Record<number, boolean>>({})
+  const [rowErrors, setRowErrors] = createStore<Record<number, string>>({})
+  let seedChar: string | undefined
+  let moveHandle: GridMoveHandle | null = null
+  let tableEl: HTMLElement | undefined
+  let lastFocusedRowId: number | null = null
+
+  const rowById = (id: number): Row | undefined => config.rows().find((row) => rowId(row) === id)
+
+  // The row merged with its pending draft, so edited-but-unsaved cells render
+  // current values without touching the query cache.
+  const overlayRow = (row: Row): Row => {
+    const draft = drafts[rowId(row)]
+
+    return draft !== undefined ? { ...row, ...draft } : row
+  }
+
+  const isEditing = (id: number, colKey: string): boolean => {
+    const cell = editCell()
+
+    return cell !== null && cell.rowId === id && cell.colKey === colKey
+  }
+
+  const draftValue = (id: number, colKey: string): FormValues[string] | undefined => drafts[id]?.[colKey]
+  const isDirty = (id: number): boolean => drafts[id] !== undefined
+
+  function beginEdit(id: number, colKey: string, char?: string): boolean {
+    if (!config.isInlineEditable(colKey)) {
+      return false
+    }
+    const row = rowById(id)
+    if (row === undefined) {
+      return false
+    }
+    if (drafts[id] === undefined) {
+      setDrafts(id, config.seedDraft(row))
+    }
+    const field = config.fieldFor(colKey)
+    // Only text-like fields are seeded with the keystroke that opened them.
+    seedChar = char !== undefined && (field?.type === 'text' || field?.type === 'number' || field?.type === 'date') ? char : undefined
+    setRowErrors(id, '')
+    setEditCell({ rowId: id, colKey })
+
+    return true
+  }
+
+  // gridNav offers the focused cell on Enter/F2/printable; open an editor and
+  // return true so the grid suppresses its default "focus first control".
+  const onActivate = (cell: HTMLTableCellElement, key: ActivateKey, initial?: string): boolean => {
+    const id = Number(cell.getAttribute('data-row-id'))
+    const colKey = cell.getAttribute('data-col-key')
+    if (!id || colKey === null) {
+      return false
+    }
+    if (config.isInlineEditable(colKey)) {
+      return beginEdit(id, colKey, key === 'type' ? initial : undefined)
+    }
+    // A modal-only column (multiselect / locked relation) opens the full editor
+    // on Enter/F2 so it stays reachable from the keyboard.
+    if (config.fieldFor(colKey) !== undefined && key !== 'type' && config.onModalActivate !== undefined) {
+      const row = rowById(id)
+      if (row !== undefined) {
+        return config.onModalActivate(row)
+      }
+    }
+
+    return false
+  }
+
+  function commitCell(value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay'): void {
+    const cell = editCell()
+    if (cell === null) {
+      return
+    }
+    setDrafts(cell.rowId, cell.colKey, value)
+    seedChar = undefined
+    setEditCell(null)
+    // All focus moves go through the grid's setActive (the single roving-tabindex
+    // writer); landing on a different row triggers that row's save via focusin.
+    if (direction === 'stay') {
+      moveHandle?.focusActive()
+    } else if (direction) {
+      moveHandle?.move(direction)
+    }
+  }
+
+  function cancelCell(): void {
+    seedChar = undefined
+    setEditCell(null)
+    moveHandle?.focusActive()
+  }
+
+  // Take over a row's pending draft (e.g. a modal opening on the same row):
+  // returns a copy and drops the inline draft + open editor.
+  function takeDraft(id: number): FormValues | undefined {
+    const draft = drafts[id]
+    if (draft === undefined) {
+      return undefined
+    }
+    if (editCell()?.rowId === id) {
+      setEditCell(null)
+    }
+    setDrafts(produce((store) => { delete store[id] }))
+
+    return { ...draft }
+  }
+
+  async function flushRow(id: number): Promise<void> {
+    const draft = drafts[id]
+    const row = rowById(id)
+    if (draft === undefined || row === undefined || savingRows[id]) {
+      return
+    }
+    setSavingRows(id, true)
+    setRowErrors(id, '')
+    try {
+      await config.saveRow({ ...draft }, row)
+      // Refetch has the saved values now, so dropping the draft shows no flash.
+      setDrafts(produce((store) => { delete store[id] }))
+      config.onSaved?.()
+    } catch (caught) {
+      // Keep the draft so edits aren't lost; surface a per-row error.
+      setRowErrors(id, config.saveErrorMessage?.(caught) ?? m.app_load_error())
+    } finally {
+      setSavingRows(id, false)
+    }
+  }
+
+  // Row-leave detection: when focus moves to a cell in a different row, save the
+  // row we left (if dirty). focusin alone is robust — an editor closing and the
+  // grid re-focusing the next cell both surface here.
+  function rowIdOf(node: EventTarget | null): number | null {
+    const cell = node instanceof HTMLElement ? node.closest<HTMLElement>('td[data-row-id]') : null
+
+    return cell ? Number(cell.getAttribute('data-row-id')) : null
+  }
+
+  function onTableFocusIn(event: FocusEvent): void {
+    const id = rowIdOf(event.target)
+    if (id === lastFocusedRowId) {
+      return
+    }
+    if (lastFocusedRowId !== null) {
+      void flushRow(lastFocusedRowId)
+    }
+    lastFocusedRowId = id
+  }
+
+  function flushIfFocusLeftTable(): void {
+    if (tableEl === undefined || (document.activeElement !== null && tableEl.contains(document.activeElement))) {
+      return
+    }
+    if (lastFocusedRowId !== null) {
+      void flushRow(lastFocusedRowId)
+    }
+  }
+
+  // Deferred so an editor unmounting + the grid re-focusing the next cell (all
+  // synchronous) doesn't read as "left the table".
+  function onTableFocusOut(): void {
+    queueMicrotask(flushIfFocusLeftTable)
+  }
+
+  // Unmount / navigation away must not silently drop a pending edit.
+  onCleanup(() => {
+    for (const key of Object.keys(drafts)) {
+      const id = Number(key)
+      const row = rowById(id)
+      if (drafts[id] !== undefined && row !== undefined && !savingRows[id]) {
+        // Best-effort flush on unmount; the component is gone, so swallow a
+        // failure (nowhere to surface it) rather than leak an unhandled rejection.
+        void config.saveRow({ ...drafts[id]! }, row).catch(() => { /* discarded */ })
+      }
+    }
+  })
+
+  return {
+    editCell,
+    drafts,
+    savingRows,
+    rowErrors,
+    seedChar: (): string | undefined => seedChar,
+    overlayRow,
+    isEditing,
+    isDirty,
+    draftValue,
+    beginEdit,
+    onActivate,
+    commitCell,
+    cancelCell,
+    takeDraft,
+    flushRow,
+    setMoveHandle: (handle: GridMoveHandle | null): void => { moveHandle = handle },
+    setTableEl: (el: HTMLElement | undefined): void => { tableEl = el },
+    onTableFocusIn,
+    onTableFocusOut,
+  }
+}

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -147,22 +147,22 @@ export function InlineEditor(props: {
   )
 }
 
-const rowId = (row: Row): number => Number(row.id)
+const idOf = (row: object): number => Number((row as { id?: unknown }).id)
 
-export interface InlineGridEditConfig {
+export interface InlineGridEditConfig<R extends object> {
   /** Reactive list of the rows currently shown (keyed by a numeric `id`). */
-  rows: Accessor<readonly Row[]>
+  rows: Accessor<readonly R[]>
   /** The field backing a column key (drives the editor type), or undefined. */
   fieldFor: (colKey: string) => FieldDef | undefined
   /** Whether a column can be edited in place (vs modal-only / read-only). */
   isInlineEditable: (colKey: string) => boolean
   /** Seed a fresh draft from a row (the editable form values). */
-  seedDraft: (row: Row) => FormValues
+  seedDraft: (row: R) => FormValues
   /** Persist one row's draft (POST + refetch); rejects to surface a row error. */
-  saveRow: (draft: FormValues, row: Row) => Promise<void>
+  saveRow: (draft: FormValues, row: R) => Promise<void>
   /** Fallback for activating a non-inline column (e.g. open a modal); return
    *  true if it handled the activation. */
-  onModalActivate?: (row: Row) => boolean
+  onModalActivate?: (row: R) => boolean
   /** Called after a successful row save (e.g. a toast). */
   onSaved?: () => void
   /** Map a save error to a per-row message. Defaults to the generic load error. */
@@ -175,7 +175,7 @@ export interface InlineGridEditConfig {
  * per-row drafts (keyed by `id`) and saves the whole row once focus leaves it.
  * Create it inside a component (it registers reactive state + onCleanup).
  */
-export function createInlineGridEdit(config: InlineGridEditConfig) {
+export function createInlineGridEdit<R extends object>(config: InlineGridEditConfig<R>) {
   const [editCell, setEditCell] = createSignal<{ rowId: number; colKey: string } | null>(null)
   const [drafts, setDrafts] = createStore<Record<number, FormValues>>({})
   const [savingRows, setSavingRows] = createStore<Record<number, boolean>>({})
@@ -185,14 +185,14 @@ export function createInlineGridEdit(config: InlineGridEditConfig) {
   let tableEl: HTMLElement | undefined
   let lastFocusedRowId: number | null = null
 
-  const rowById = (id: number): Row | undefined => config.rows().find((row) => rowId(row) === id)
+  const rowById = (id: number): R | undefined => config.rows().find((row) => idOf(row) === id)
 
   // The row merged with its pending draft, so edited-but-unsaved cells render
   // current values without touching the query cache.
-  const overlayRow = (row: Row): Row => {
-    const draft = drafts[rowId(row)]
+  const overlayRow = (row: R): R => {
+    const draft = drafts[idOf(row)]
 
-    return draft !== undefined ? { ...row, ...draft } : row
+    return draft !== undefined ? { ...row, ...draft } as R : row
   }
 
   const isEditing = (id: number, colKey: string): boolean => {

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -184,8 +184,12 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
   let moveHandle: GridMoveHandle | null = null
   let tableEl: HTMLElement | undefined
   let lastFocusedRowId: number | null = null
+  // Non-reactive snapshot of the row a draft was seeded from, so a pending edit
+  // can still save on unmount even if the parent already cleared the rows list
+  // (e.g. route/tab change) — rowById() would then return undefined.
+  const originalRows = new Map<number, R>()
 
-  const rowById = (id: number): R | undefined => config.rows().find((row) => idOf(row) === id)
+  const rowById = (id: number): R | undefined => originalRows.get(id) ?? config.rows().find((row) => idOf(row) === id)
 
   // The row merged with its pending draft, so edited-but-unsaved cells render
   // current values without touching the query cache.
@@ -214,6 +218,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     }
     if (drafts[id] === undefined) {
       setDrafts(id, config.seedDraft(row))
+      originalRows.set(id, row)
     }
     const field = config.fieldFor(colKey)
     // Only text-like fields are seeded with the keystroke that opened them.
@@ -281,6 +286,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       setEditCell(null)
     }
     setDrafts(produce((store) => { delete store[id] }))
+    originalRows.delete(id)
 
     return { ...draft }
   }
@@ -297,6 +303,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       await config.saveRow({ ...draft }, row)
       // Refetch has the saved values now, so dropping the draft shows no flash.
       setDrafts(produce((store) => { delete store[id] }))
+      originalRows.delete(id)
       config.onSaved?.()
     } catch (caught) {
       // Keep the draft so edits aren't lost; surface a per-row error.

--- a/frontend/src/lib/timeParse.test.ts
+++ b/frontend/src/lib/timeParse.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseTime, toIsoDate } from './timeParse'
+
+describe('parseTime', () => {
+  it('parses separated forms', () => {
+    expect(parseTime('9:30')).toBe('09:30')
+    expect(parseTime('09:30')).toBe('09:30')
+    expect(parseTime('9.30')).toBe('09:30')
+    expect(parseTime('9h30')).toBe('09:30')
+    expect(parseTime('14:05')).toBe('14:05')
+  })
+
+  it('parses terse digit forms', () => {
+    expect(parseTime('930')).toBe('09:30')
+    expect(parseTime('0930')).toBe('09:30')
+    expect(parseTime('9')).toBe('09:00')
+    expect(parseTime('09')).toBe('09:00')
+    expect(parseTime('1830')).toBe('18:30')
+  })
+
+  it('applies am/pm', () => {
+    expect(parseTime('9:30am')).toBe('09:30')
+    expect(parseTime('9:30a')).toBe('09:30')
+    expect(parseTime('9:30pm')).toBe('21:30')
+    expect(parseTime('930p')).toBe('21:30')
+    expect(parseTime('9p')).toBe('21:00')
+    expect(parseTime('12a')).toBe('00:00')
+    expect(parseTime('12p')).toBe('12:00')
+  })
+
+  it('trims and is case-insensitive', () => {
+    expect(parseTime('  8:15 AM ')).toBe('08:15')
+  })
+
+  it('rejects invalid input', () => {
+    expect(parseTime('')).toBeNull()
+    expect(parseTime('abc')).toBeNull()
+    expect(parseTime('25:00')).toBeNull()
+    expect(parseTime('9:75')).toBeNull()
+    expect(parseTime('99')).toBeNull()
+  })
+})
+
+describe('toIsoDate', () => {
+  it('converts d/m/Y to Y-m-d', () => {
+    expect(toIsoDate('16/06/2026')).toBe('2026-06-16')
+    expect(toIsoDate('01/01/2025')).toBe('2025-01-01')
+  })
+
+  it('returns empty for unrecognised input', () => {
+    expect(toIsoDate('2026-06-16')).toBe('')
+    expect(toIsoDate('')).toBe('')
+  })
+})

--- a/frontend/src/lib/timeParse.test.ts
+++ b/frontend/src/lib/timeParse.test.ts
@@ -3,53 +3,43 @@ import { describe, expect, it } from 'vitest'
 import { parseTime, toIsoDate } from './timeParse'
 
 describe('parseTime', () => {
-  it('parses separated forms', () => {
-    expect(parseTime('9:30')).toBe('09:30')
-    expect(parseTime('09:30')).toBe('09:30')
-    expect(parseTime('9.30')).toBe('09:30')
-    expect(parseTime('9h30')).toBe('09:30')
-    expect(parseTime('14:05')).toBe('14:05')
+  it.each([
+    ['9:30', '09:30'],
+    ['09:30', '09:30'],
+    ['9.30', '09:30'],
+    ['9h30', '09:30'],
+    ['14:05', '14:05'],
+    ['930', '09:30'],
+    ['0930', '09:30'],
+    ['9', '09:00'],
+    ['09', '09:00'],
+    ['1830', '18:30'],
+    ['9:30am', '09:30'],
+    ['9:30a', '09:30'],
+    ['9:30pm', '21:30'],
+    ['930p', '21:30'],
+    ['9p', '21:00'],
+    ['12a', '00:00'],
+    ['12p', '12:00'],
+    ['  8:15 AM ', '08:15'],
+  ])('parses %s → %s', (input, expected) => {
+    expect(parseTime(input)).toBe(expected)
   })
 
-  it('parses terse digit forms', () => {
-    expect(parseTime('930')).toBe('09:30')
-    expect(parseTime('0930')).toBe('09:30')
-    expect(parseTime('9')).toBe('09:00')
-    expect(parseTime('09')).toBe('09:00')
-    expect(parseTime('1830')).toBe('18:30')
-  })
-
-  it('applies am/pm', () => {
-    expect(parseTime('9:30am')).toBe('09:30')
-    expect(parseTime('9:30a')).toBe('09:30')
-    expect(parseTime('9:30pm')).toBe('21:30')
-    expect(parseTime('930p')).toBe('21:30')
-    expect(parseTime('9p')).toBe('21:00')
-    expect(parseTime('12a')).toBe('00:00')
-    expect(parseTime('12p')).toBe('12:00')
-  })
-
-  it('trims and is case-insensitive', () => {
-    expect(parseTime('  8:15 AM ')).toBe('08:15')
-  })
-
-  it('rejects invalid input', () => {
-    expect(parseTime('')).toBeNull()
-    expect(parseTime('abc')).toBeNull()
-    expect(parseTime('25:00')).toBeNull()
-    expect(parseTime('9:75')).toBeNull()
-    expect(parseTime('99')).toBeNull()
+  it.each(['', 'abc', '25:00', '9:75', '99'])('rejects %s', (input) => {
+    expect(parseTime(input)).toBeNull()
   })
 })
 
 describe('toIsoDate', () => {
-  it('converts d/m/Y to Y-m-d', () => {
-    expect(toIsoDate('16/06/2026')).toBe('2026-06-16')
-    expect(toIsoDate('01/01/2025')).toBe('2025-01-01')
+  it.each([
+    ['16/06/2026', '2026-06-16'],
+    ['01/01/2025', '2025-01-01'],
+  ])('converts %s → %s', (input, expected) => {
+    expect(toIsoDate(input)).toBe(expected)
   })
 
-  it('returns empty for unrecognised input', () => {
-    expect(toIsoDate('2026-06-16')).toBe('')
-    expect(toIsoDate('')).toBe('')
+  it.each(['2026-06-16', ''])('returns empty for unrecognised %s', (input) => {
+    expect(toIsoDate(input)).toBe('')
   })
 })

--- a/frontend/src/lib/timeParse.ts
+++ b/frontend/src/lib/timeParse.ts
@@ -7,19 +7,27 @@
  * 12a (→ 00:00), 12p (→ 12:00).
  */
 export function parseTime(input: string): string | null {
-  const raw = input.trim().toLowerCase()
-  if (raw === '') {
+  let body = input.trim().toLowerCase()
+  if (body === '') {
     return null
   }
 
-  // Optional am/pm suffix (a, p, am, pm, with optional dots/space).
+  // Optional am/pm suffix — string ops (not a regex) to avoid backtracking.
   let meridiem: 'a' | 'p' | null = null
-  let body = raw
-  const suffix = /\s*([ap])\.?m?\.?$/.exec(body)
-  if (suffix !== null) {
-    meridiem = suffix[1] as 'a' | 'p'
-    body = body.slice(0, suffix.index).trim()
+  if (body.endsWith('am')) {
+    meridiem = 'a'
+    body = body.slice(0, -2)
+  } else if (body.endsWith('pm')) {
+    meridiem = 'p'
+    body = body.slice(0, -2)
+  } else if (body.endsWith('a')) {
+    meridiem = 'a'
+    body = body.slice(0, -1)
+  } else if (body.endsWith('p')) {
+    meridiem = 'p'
+    body = body.slice(0, -1)
   }
+  body = body.trim()
 
   let hours: number
   let minutes: number

--- a/frontend/src/lib/timeParse.ts
+++ b/frontend/src/lib/timeParse.ts
@@ -1,0 +1,61 @@
+/**
+ * Parse a terse time entry into 24-hour "H:i", mirroring the legacy ExtJS
+ * work-log grid's flexible altFormats (g:ia | gi | Gi | H:i | ga | …) so users
+ * can type times tersely. Returns null when the input can't be parsed.
+ *
+ * Accepts e.g. 9:30, 09:30, 9.30, 9h30, 930, 0930, 9, 9:30am, 9:30a, 930p, 9p,
+ * 12a (→ 00:00), 12p (→ 12:00).
+ */
+export function parseTime(input: string): string | null {
+  const raw = input.trim().toLowerCase()
+  if (raw === '') {
+    return null
+  }
+
+  // Optional am/pm suffix (a, p, am, pm, with optional dots/space).
+  let meridiem: 'a' | 'p' | null = null
+  let body = raw
+  const suffix = /\s*([ap])\.?m?\.?$/.exec(body)
+  if (suffix !== null) {
+    meridiem = suffix[1] as 'a' | 'p'
+    body = body.slice(0, suffix.index).trim()
+  }
+
+  let hours: number
+  let minutes: number
+  const separated = /^(\d{1,2})[:.h](\d{2})$/.exec(body) // 9:30, 9.30, 9h30
+  if (separated !== null) {
+    hours = Number(separated[1])
+    minutes = Number(separated[2])
+  } else if (/^\d{1,2}$/.test(body)) { // 9, 09
+    hours = Number(body)
+    minutes = 0
+  } else if (/^\d{3}$/.test(body)) { // 930
+    hours = Number(body.slice(0, 1))
+    minutes = Number(body.slice(1))
+  } else if (/^\d{4}$/.test(body)) { // 0930
+    hours = Number(body.slice(0, 2))
+    minutes = Number(body.slice(2))
+  } else {
+    return null
+  }
+
+  if (meridiem === 'p' && hours < 12) {
+    hours += 12
+  } else if (meridiem === 'a' && hours === 12) {
+    hours = 0
+  }
+
+  if (hours > 23 || minutes > 59) {
+    return null
+  }
+
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
+}
+
+/** ExtJS list rows carry the date as d/m/Y; the HTML date input needs Y-m-d. */
+export function toIsoDate(displayDate: string): string {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(displayDate.trim())
+
+  return match !== null ? `${match[3]}-${match[2]}-${match[1]}` : ''
+}

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -6,11 +6,14 @@ import { axe } from 'vitest-axe'
 import Tracking from './Tracking'
 
 const getJson = vi.fn()
+const postJson = vi.fn()
 
 vi.mock('../api/client', () => ({
   SessionExpiredError: class extends Error {},
   ApiError: class extends Error {},
+  apiErrorMessage: (error: unknown, fallback: string) => (error instanceof Error ? error.message : fallback),
   getJson: (...args: unknown[]) => getJson(...args),
+  postJson: (...args: unknown[]) => postJson(...args),
 }))
 
 function mockApi() {
@@ -51,8 +54,25 @@ function renderTracking() {
 
 afterEach(() => {
   getJson.mockReset()
+  postJson.mockReset()
   vi.restoreAllMocks()
 })
+
+// Open the inline editor on a column's first cell and return its control.
+function editCell(container: HTMLElement, colKey: string): HTMLInputElement {
+  const cell = container.querySelector<HTMLElement>(`td[data-col-key="${colKey}"]`)
+  if (cell === null) {
+    throw new Error(`no cell for ${colKey}`)
+  }
+  cell.focus()
+  fireEvent.keyDown(cell, { key: 'Enter' })
+  const control = cell.querySelector<HTMLInputElement>('input, select')
+  if (control === null) {
+    throw new Error(`no editor for ${colKey}`)
+  }
+
+  return control
+}
 
 describe('Tracking (Worklog grid)', () => {
   it('renders recent entries with resolved relation names and the server duration', async () => {
@@ -99,6 +119,60 @@ describe('Tracking (Worklog grid)', () => {
     await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
 
     expect(await axe(container)).toHaveNoViolations()
+
+    unmount()
+  })
+
+  it('saves the whole entry to /tracking/save on row-leave', async () => {
+    mockApi()
+    postJson.mockResolvedValue({})
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    const editor = editCell(container, 'ticket')
+    fireEvent.input(editor, { target: { value: 'xyz-9' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    // Nothing saved until the row is left.
+    expect(postJson).not.toHaveBeenCalled()
+
+    // Leave the table (focus the days selector) → the dirty row saves once.
+    ;(getByRole('combobox') as HTMLElement).focus()
+    await waitFor(() =>
+      expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({
+        id: 1, ticket: 'XYZ-9', date: '2026-06-16', start: '09:00', end: '10:30', customer: 1, project: 4, activity: 5,
+      })),
+    )
+    expect(postJson).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+
+  it('parses a terse start time to H:i before saving', async () => {
+    mockApi()
+    postJson.mockResolvedValue({})
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    const editor = editCell(container, 'start')
+    fireEvent.input(editor, { target: { value: '8' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    ;(getByRole('combobox') as HTMLElement).focus()
+
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({ start: '08:00' })))
+
+    unmount()
+  })
+
+  it('deletes an entry via /tracking/delete after confirmation', async () => {
+    mockApi()
+    postJson.mockResolvedValue({ success: true })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    fireEvent.click(getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith('/tracking/delete', { id: 1 }))
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -182,6 +182,8 @@ export default function Tracking() {
     }
     try {
       await postJson('/tracking/delete', { id: num(entry.id) })
+      // Drop any pending inline draft for the now-deleted entry.
+      editor.takeDraft(num(entry.id))
       await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
     } catch (caught) {
       window.alert(apiErrorMessage(caught, m.app_load_error()))

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -1,8 +1,12 @@
-import { useQuery } from '@tanstack/solid-query'
+import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createMemo, createSignal, For, Show } from 'solid-js'
 
+import { apiErrorMessage, postJson } from '../api/client'
 import { activitiesQuery, projectsQuery, trackingCustomersQuery, trackingEntriesQuery, type NamedOption, type TrackingEntry } from '../api/queries'
+import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { gridNav } from '../lib/gridNavigation'
+import { createInlineGridEdit, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { parseTime, toIsoDate } from '../lib/timeParse'
 import { m } from '../paraglide/messages.js'
 
 // Register the directive with the JSX namespace (Solid tree-shakes unused imports).
@@ -10,17 +14,40 @@ void gridNav
 
 const DAYS_OPTIONS = [1, 3, 7, 35] as const
 const DEFAULT_DAYS = 3
+const ENTRIES_KEY = 'tracking-entries'
 
 // Server-computed EntryClass → row modifier, mirroring the ExtJS row borders.
-// (PLAIN=1 and DEFAULT=0 are unstyled.)
-const CLASS_ROW: Record<number, string> = {
-  2: 'is-daybreak',
-  4: 'is-pause',
-  8: 'is-overlap',
-}
+const CLASS_ROW: Record<number, string> = { 2: 'is-daybreak', 4: 'is-pause', 8: 'is-overlap' }
 
-// Non-colour cue for the row class so the daybreak/break/overlap states are
-// perceivable by screen readers and without colour vision (WCAG 1.4.1 / 1.3.1).
+const num = (value: unknown): number => Number(value ?? 0)
+const str = (value: unknown): string => (value === undefined || value === null ? '' : String(value))
+
+// The editable fields drive the in-cell editor; duration is server-derived.
+const FIELDS: FieldDef[] = [
+  { name: 'date', label: () => m.tracking_col_date(), type: 'date', required: true },
+  { name: 'start', label: () => m.tracking_col_start(), type: 'text', required: true },
+  { name: 'end', label: () => m.tracking_col_end(), type: 'text', required: true },
+  { name: 'ticket', label: () => m.tracking_col_ticket(), type: 'text' },
+  { name: 'customer', label: () => m.tracking_col_customer(), type: 'select', source: 'customers' },
+  { name: 'project', label: () => m.tracking_col_project(), type: 'select', source: 'projects' },
+  { name: 'activity', label: () => m.tracking_col_activity(), type: 'select', source: 'activities' },
+  { name: 'description', label: () => m.tracking_col_description(), type: 'text' },
+]
+const FIELD_BY_KEY = new Map(FIELDS.map((field) => [field.name, field]))
+
+const COLUMNS: { key: string; label: () => string; numeric?: boolean }[] = [
+  { key: 'date', label: () => m.tracking_col_date() },
+  { key: 'start', label: () => m.tracking_col_start(), numeric: true },
+  { key: 'end', label: () => m.tracking_col_end(), numeric: true },
+  { key: 'ticket', label: () => m.tracking_col_ticket() },
+  { key: 'customer', label: () => m.tracking_col_customer() },
+  { key: 'project', label: () => m.tracking_col_project() },
+  { key: 'activity', label: () => m.tracking_col_activity() },
+  { key: 'description', label: () => m.tracking_col_description() },
+  { key: 'duration', label: () => m.tracking_col_duration(), numeric: true },
+]
+
+// Non-colour cue for the row class (WCAG 1.4.1 / 1.3.1).
 function classLabel(entryClass: number): string {
   switch (entryClass) {
     case 2:
@@ -34,53 +61,132 @@ function classLabel(entryClass: number): string {
   }
 }
 
-interface DisplayEntry extends TrackingEntry {
-  customerName: string
-  projectName: string
-  activityName: string
-  rowClass: string
-  stateLabel: string
-}
-
-function nameOf(list: NamedOption[] | undefined, id: number | null): string {
-  // Blank (not the raw id) while the option list is still loading.
-  if (id === null || id <= 0 || list === undefined) {
+function nameOf(list: NamedOption[] | undefined, id: number): string {
+  if (id <= 0 || list === undefined) {
     return ''
   }
 
   return list.find((option) => option.id === id)?.label ?? String(id)
 }
 
+// d/m/Y (list rows) or Y-m-d (date-input draft) → d/m/Y for display.
+function displayDate(value: string): string {
+  const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+
+  return iso !== null ? `${iso[3]}/${iso[2]}/${iso[1]}` : value
+}
+
 /**
- * The SolidJS work-log grid (/ui/tracking) — runs alongside the legacy ExtJS
- * grid until users accept it. This first slice is read-only: it renders the
- * recent entries with server-derived duration + row styling; inline editing and
- * the save path land in a follow-up.
+ * The SolidJS work-log grid (/ui/tracking), running alongside the legacy ExtJS
+ * grid. Inline cell editing reuses the shared inline-grid controller; start/end
+ * accept terse times (930, 9:30a) parsed to H:i; saving a row POSTs the whole
+ * entry to /tracking/save and refetches (the server recomputes duration + the
+ * row class).
  */
 export default function Tracking() {
+  const queryClient = useQueryClient()
   const [days, setDays] = createSignal<number>(DEFAULT_DAYS)
   const entries = useQuery(() => trackingEntriesQuery(days()))
   const customers = useQuery(trackingCustomersQuery)
   const projects = useQuery(projectsQuery)
   const activities = useQuery(activitiesQuery)
 
-  // Resolve relation ids → names (and the row class/label) once per data change,
-  // not on every render — and keep referentially-stable rows for the grid.
-  const rows = createMemo<DisplayEntry[]>(() => {
-    const list = entries.data ?? []
-    const customerList = customers.data
-    const projectList = projects.data
-    const activityList = activities.data
+  const rows = createMemo<TrackingEntry[]>(() => entries.data ?? [])
 
-    return list.map((entry) => ({
-      ...entry,
-      customerName: nameOf(customerList, entry.customer),
-      projectName: nameOf(projectList, entry.project),
-      activityName: nameOf(activityList, entry.activity),
-      rowClass: CLASS_ROW[entry.class] ?? '',
-      stateLabel: classLabel(entry.class),
-    }))
+  const optionLookup: OptionLookup = (source: OptionSource) => {
+    switch (source) {
+      case 'customers':
+        return customers.data ?? []
+      case 'projects':
+        return projects.data ?? []
+      case 'activities':
+        return activities.data ?? []
+      default:
+        return []
+    }
+  }
+
+  const editor = createInlineGridEdit({
+    rows,
+    fieldFor: (colKey) => FIELD_BY_KEY.get(colKey),
+    isInlineEditable: (colKey) => {
+      const field = FIELD_BY_KEY.get(colKey)
+
+      return field !== undefined && INLINE_TYPES.has(field.type)
+    },
+    seedDraft: (entry) => ({
+      id: num(entry.id),
+      date: toIsoDate(str(entry.date)),
+      start: str(entry.start),
+      end: str(entry.end),
+      ticket: str(entry.ticket),
+      customer: num(entry.customer),
+      project: num(entry.project),
+      activity: num(entry.activity),
+      description: str(entry.description),
+    }),
+    saveRow: async (draft, entry) => {
+      const start = parseTime(str(draft.start))
+      const end = parseTime(str(draft.end))
+      if (start === null || end === null) {
+        throw new Error(m.tracking_invalid_time())
+      }
+      await postJson('/tracking/save', {
+        id: num(entry.id),
+        date: str(draft.date),
+        start,
+        end,
+        ticket: str(draft.ticket).toUpperCase().trim(),
+        description: str(draft.description),
+        customer: num(draft.customer),
+        project: num(draft.project),
+        activity: num(draft.activity),
+      })
+      await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+    },
+    saveErrorMessage: (caught) => (caught instanceof Error ? caught.message : m.app_load_error()),
   })
+
+  // Display value from the draft-overlaid row, so an edited-but-unsaved cell
+  // shows the new value (relation ids resolved to names here, not pre-memoized,
+  // because the overlay changes as the draft does).
+  function displayCell(entry: TrackingEntry, colKey: string): string {
+    const row = editor.overlayRow(entry)
+    switch (colKey) {
+      case 'date':
+        return displayDate(str(row.date))
+      case 'start':
+        return str(row.start)
+      case 'end':
+        return str(row.end)
+      case 'ticket':
+        return str(row.ticket)
+      case 'customer':
+        return nameOf(customers.data, num(row.customer))
+      case 'project':
+        return nameOf(projects.data, num(row.project))
+      case 'activity':
+        return nameOf(activities.data, num(row.activity))
+      case 'description':
+        return str(row.description)
+      case 'duration':
+        return str(entry.duration)
+      default:
+        return ''
+    }
+  }
+
+  async function removeEntry(entry: TrackingEntry): Promise<void> {
+    if (!window.confirm(m.admin_delete_confirm())) {
+      return
+    }
+    try {
+      await postJson('/tracking/delete', { id: num(entry.id) })
+      await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+    } catch (caught) {
+      window.alert(apiErrorMessage(caught, m.app_load_error()))
+    }
+  }
 
   let daysSelectEl: HTMLSelectElement | undefined
 
@@ -107,45 +213,81 @@ export default function Tracking() {
         <div class="table-scroll">
           <table
             class="data-table tracking-table"
+            ref={(el) => { editor.setTableEl(el) }}
+            onFocusIn={editor.onTableFocusIn}
+            onFocusOut={editor.onTableFocusOut}
             use:gridNav={{
               items: rows,
-              readonly: true,
               onExit: (direction) => { if (direction === 'up') daysSelectEl?.focus() },
+              onActivate: editor.onActivate,
+              moveRef: (handle) => { editor.setMoveHandle(handle) },
             }}
           >
             <thead>
               <tr>
-                <th scope="col">{m.tracking_col_date()}</th>
-                <th scope="col" class="numeric">{m.tracking_col_start()}</th>
-                <th scope="col" class="numeric">{m.tracking_col_end()}</th>
-                <th scope="col">{m.tracking_col_ticket()}</th>
-                <th scope="col">{m.tracking_col_customer()}</th>
-                <th scope="col">{m.tracking_col_project()}</th>
-                <th scope="col">{m.tracking_col_activity()}</th>
-                <th scope="col">{m.tracking_col_description()}</th>
-                <th scope="col" class="numeric">{m.tracking_col_duration()}</th>
+                <For each={COLUMNS}>{(col) => <th scope="col" classList={{ numeric: col.numeric }}>{col.label()}</th>}</For>
+                <th scope="col">{m.tracking_actions()}</th>
               </tr>
             </thead>
             <tbody>
               <For each={rows()}>
-                {(entry) => (
-                  <tr class={`tracking-row ${entry.rowClass}`.trimEnd()}>
-                    <td>
-                      {entry.date}
-                      <Show when={entry.stateLabel}>
-                        <span class="visually-hidden"> ({entry.stateLabel})</span>
-                      </Show>
-                    </td>
-                    <td class="numeric">{entry.start}</td>
-                    <td class="numeric">{entry.end}</td>
-                    <td>{entry.ticket}</td>
-                    <td>{entry.customerName}</td>
-                    <td>{entry.projectName}</td>
-                    <td>{entry.activityName}</td>
-                    <td>{entry.description}</td>
-                    <td class="numeric">{entry.duration}</td>
-                  </tr>
-                )}
+                {(entry) => {
+                  const id = num(entry.id)
+
+                  return (
+                    <tr class={`tracking-row ${CLASS_ROW[entry.class] ?? ''}`.trimEnd()} aria-busy={editor.savingRows[id] ? 'true' : undefined}>
+                      <For each={COLUMNS}>
+                        {(col) => {
+                          const editable = FIELD_BY_KEY.has(col.key)
+
+                          return (
+                            <td
+                              classList={{ numeric: col.numeric, 'is-editable': editable }}
+                              data-row-id={String(id)}
+                              data-col-key={col.key}
+                              data-inline-editing={editor.isEditing(id, col.key) ? '' : undefined}
+                              aria-label={editor.isEditing(id, col.key) ? col.label() : undefined}
+                              onDblClick={() => { if (editable) editor.beginEdit(id, col.key) }}
+                            >
+                              <Show
+                                when={editor.isEditing(id, col.key)}
+                                fallback={
+                                  <>
+                                    {displayCell(entry, col.key)}
+                                    <Show when={col.key === 'date' && classLabel(entry.class) !== ''}>
+                                      <span class="visually-hidden"> ({classLabel(entry.class)})</span>
+                                    </Show>
+                                  </>
+                                }
+                              >
+                                <InlineEditor
+                                  field={FIELD_BY_KEY.get(col.key)!}
+                                  label={col.label()}
+                                  initial={editor.draftValue(id, col.key) ?? ''}
+                                  seed={editor.seedChar()}
+                                  options={optionLookup}
+                                  onCommit={editor.commitCell}
+                                  onCancel={editor.cancelCell}
+                                />
+                              </Show>
+                            </td>
+                          )
+                        }}
+                      </For>
+                      {/* data-row-id (no data-col-key → not inline-editable) keeps focus
+                          "inside the row" so clicking Delete isn't read as a row-leave. */}
+                      <td class="tracking-row-actions" data-row-id={String(id)}>
+                        <button type="button" class="link-button is-danger" onClick={() => void removeEntry(entry)}>
+                          <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6"/><path d="M10 11v6M14 11v6"/></svg>
+                          {m.admin_delete()}
+                        </button>
+                        <Show when={editor.rowErrors[id]}>
+                          <span role="alert" class="form-status is-error">{editor.rowErrors[id]}</span>
+                        </Show>
+                      </td>
+                    </tr>
+                  )
+                }}
               </For>
             </tbody>
           </table>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1168,7 +1168,8 @@ th[aria-sort='descending'] .th-sort-glyph {
   overflow: hidden;
 }
 
-.admin-row-actions {
+.admin-row-actions,
+.tracking-row-actions {
   display: flex;
   gap: 0.4rem;
   white-space: nowrap;


### PR DESCRIPTION
**PR2 of the work-log migration** (PR1 #367 shipped the read-only grid + parallel run). Makes `/ui/tracking` editable.

## What's here
- **Shared inline-grid controller** — the spreadsheet-edit machinery (per-row drafts, save-on-row-leave, gridNav onActivate, the `InlineEditor` cell control) is **extracted out of `AdminCrudShell` into `lib/inlineGridEdit`** so the Worklog grid reuses it instead of duplicating it. AdminCrudShell now consumes it with **no behaviour change** — its inline-edit unit tests pass unchanged. The controller is generic over the row type.
- **Inline editing** of date / start / end / ticket / customer / project / activity / description (duration stays server-derived). An edited-but-unsaved cell shows the draft value (relation ids resolved to names).
- **Terse time parsing** (`lib/timeParse`): start/end accept `930`, `9:30a`, `9.30`, `0930`, `9p`, `12a` … normalised to `H:i` before saving (mirrors the ExtJS `altFormats`).
- **Save on row-leave** → `POST /tracking/save` with the whole entry, then refetch so the **server-recomputed duration + row class** apply. Per-row **delete** → `/tracking/delete`. Invalid times surface as a per-row error.

## Deferred to PR3 (full ExtJS parity)
Cascading customer→project filtering, ticket→project auto-map, Add (Alt+A) / Continue (Alt+C) / Prolong (Alt+P), the Info popup, CSV export, and the grid-local Alt-shortcuts.

## Testing
- Frontend: typecheck + lint clean; **163 vitest** — incl. the time parser (7), the Admin inline-edit suite unchanged (proves the extraction), and new Worklog tests: save-the-whole-entry-on-row-leave (asserts the parsed payload), terse-time→H:i, and delete.
- No backend changes (reuses /getData, /tracking/save, /tracking/delete).

Batched deploy — nothing reaches prod until you OK a hot-deploy.