### PR TITLE
feat(ui): Worklog cascade + ticket→project mapping (PR3)

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -131,6 +131,34 @@ export function trackingEntriesQuery(days: number) {
   }
 }
 
+// Projects with the fields the work-log grid needs beyond {id,label}: the
+// customer (for cascading the project dropdown) and jiraId (for ticket→project
+// mapping). Open to all users (/getAllProjects is IS_AUTHENTICATED_FULLY).
+export interface TrackingProject {
+  id: number
+  name: string
+  customer: number
+  jiraId: string
+}
+
+export function trackingProjectsQuery() {
+  return {
+    queryKey: ['tracking-projects'] as const,
+    queryFn: () => getJson<{ project?: Record<string, unknown> }[]>('/getAllProjects'),
+    select: (rows: { project?: Record<string, unknown> }[]): TrackingProject[] =>
+      rows
+        .map((row) => row?.project)
+        .filter((project): project is Record<string, unknown> => project != null)
+        .map((project) => ({
+          id: Number(project.id ?? 0),
+          name: String(project.name ?? ''),
+          customer: Number(project.customer ?? 0),
+          jiraId: String(project.jiraId ?? project.jira_id ?? ''),
+        })),
+    staleTime: REFERENCE_STALE_TIME,
+  }
+}
+
 /** Shared filter shape for every interpretation view. */
 export interface InterpretationFilters {
   datestart: string

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -163,6 +163,9 @@ export interface InlineGridEditConfig<R extends object> {
   /** Fallback for activating a non-inline column (e.g. open a modal); return
    *  true if it handled the activation. */
   onModalActivate?: (row: R) => boolean
+  /** Called right after a cell commits, so the host can derive sibling draft
+   *  fields (e.g. a ticket → project/customer mapping). */
+  onCommit?: (id: number, colKey: string, value: FormValues[string]) => void
   /** Called after a successful row save (e.g. a toast). */
   onSaved?: () => void
   /** Map a save error to a per-row message. Defaults to the generic load error. */
@@ -258,6 +261,8 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       return
     }
     setDrafts(cell.rowId, cell.colKey, value)
+    // Let the host react to a commit (e.g. derive sibling fields from a ticket).
+    config.onCommit?.(cell.rowId, cell.colKey, value)
     seedChar = undefined
     setEditCell(null)
     // All focus moves go through the grid's setActive (the single roving-tabindex
@@ -377,6 +382,12 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     cancelCell,
     takeDraft,
     flushRow,
+    // Set a sibling field on an existing draft (e.g. after a ticket→project map).
+    setDraftField: (id: number, colKey: string, value: FormValues[string]): void => {
+      if (drafts[id] !== undefined) {
+        setDrafts(id, colKey, value)
+      }
+    },
     setMoveHandle: (handle: GridMoveHandle | null): void => { moveHandle = handle },
     setTableEl: (el: HTMLElement | undefined): void => { tableEl = el },
     onTableFocusIn,

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -176,4 +176,66 @@ describe('Tracking (Worklog grid)', () => {
 
     unmount()
   })
+
+  it('maps a ticket prefix to its project and customer on commit', async () => {
+    getJson.mockImplementation((path: string) => {
+      if (path.startsWith('/getData/days/')) {
+        return Promise.resolve([{ entry: { id: 1, date: '16/06/2026', start: '09:00', end: '10:30', user: 3, customer: 0, project: 0, activity: 5, description: 'Work', ticket: '', duration: '1:30', durationMinutes: 90, class: 0, worklog: null, extTicket: null } }])
+      }
+      switch (path) {
+        case '/getCustomers':
+          return Promise.resolve([{ customer: { id: 7, name: 'ACME' } }])
+        case '/getAllProjects':
+          return Promise.resolve([{ project: { id: 9, name: 'Apollo', customer: 7, jiraId: 'APO' } }])
+        case '/getActivities':
+          return Promise.resolve([{ activity: { id: 5, name: 'Dev' } }])
+        default:
+          return Promise.resolve([])
+      }
+    })
+    postJson.mockResolvedValue({})
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
+
+    const editor = editCell(container, 'ticket')
+    fireEvent.input(editor, { target: { value: 'apo-42' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    ;(getByRole('combobox') as HTMLElement).focus()
+
+    await waitFor(() =>
+      expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({ ticket: 'APO-42', project: 9, customer: 7 })),
+    )
+
+    unmount()
+  })
+
+  it('filters the project dropdown by the row customer (cascade)', async () => {
+    getJson.mockImplementation((path: string) => {
+      if (path.startsWith('/getData/days/')) {
+        return Promise.resolve([{ entry: { id: 1, date: '16/06/2026', start: '09:00', end: '10:30', user: 3, customer: 7, project: 9, activity: 5, description: 'Work', ticket: '', duration: '1:30', durationMinutes: 90, class: 0, worklog: null, extTicket: null } }])
+      }
+      switch (path) {
+        case '/getCustomers':
+          return Promise.resolve([{ customer: { id: 7, name: 'ACME' } }])
+        case '/getAllProjects':
+          return Promise.resolve([
+            { project: { id: 9, name: 'Apollo', customer: 7, jiraId: 'APO' } },
+            { project: { id: 10, name: 'Zeus', customer: 8, jiraId: 'ZEU' } },
+          ])
+        case '/getActivities':
+          return Promise.resolve([{ activity: { id: 5, name: 'Dev' } }])
+        default:
+          return Promise.resolve([])
+      }
+    })
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
+
+    const select = editCell(container, 'project')
+    const labels = Array.from(select.querySelectorAll('option')).map((option) => option.textContent)
+    expect(labels).toContain('Apollo') // customer 7's project
+    expect(labels).not.toContain('Zeus') // customer 8's project is filtered out
+
+    unmount()
+  })
 })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createMemo, createSignal, For, Show } from 'solid-js'
 
 import { apiErrorMessage, postJson } from '../api/client'
-import { activitiesQuery, projectsQuery, trackingCustomersQuery, trackingEntriesQuery, type NamedOption, type TrackingEntry } from '../api/queries'
+import { activitiesQuery, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, type NamedOption, type TrackingEntry } from '../api/queries'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { gridNav } from '../lib/gridNavigation'
 import { createInlineGridEdit, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
@@ -88,21 +88,53 @@ export default function Tracking() {
   const [days, setDays] = createSignal<number>(DEFAULT_DAYS)
   const entries = useQuery(() => trackingEntriesQuery(days()))
   const customers = useQuery(trackingCustomersQuery)
-  const projects = useQuery(projectsQuery)
+  const projects = useQuery(trackingProjectsQuery)
   const activities = useQuery(activitiesQuery)
 
   const rows = createMemo<TrackingEntry[]>(() => entries.data ?? [])
+  const allProjectOptions = createMemo<NamedOption[]>(() => (projects.data ?? []).map((project) => ({ id: project.id, label: project.name })))
 
   const optionLookup: OptionLookup = (source: OptionSource) => {
     switch (source) {
       case 'customers':
         return customers.data ?? []
-      case 'projects':
-        return projects.data ?? []
       case 'activities':
         return activities.data ?? []
+      case 'projects': {
+        // Cascade: while editing, show only the projects for the row's customer
+        // (prod has ~1000 projects, so an unfiltered list is unusable).
+        const cell = editor.editCell()
+        const customerId = cell !== null ? num(editor.draftValue(cell.rowId, 'customer')) : 0
+        const list = projects.data ?? []
+        const scoped = customerId > 0 ? list.filter((project) => project.customer === customerId) : list
+
+        return scoped.map((project) => ({ id: project.id, label: project.name }))
+      }
       default:
         return []
+    }
+  }
+
+  // Derive project (+ its customer) from a ticket prefix matching a project's
+  // jiraId; clear a now-mismatched project when the customer changes.
+  function handleCommit(id: number, colKey: string, value: unknown): void {
+    if (colKey === 'ticket') {
+      const prefix = str(value).toUpperCase().trim().split(/[-:]/)[0]
+      if (prefix === '') {
+        return
+      }
+      const project = (projects.data ?? []).find((candidate) => candidate.jiraId !== '' && candidate.jiraId.toUpperCase() === prefix)
+      if (project !== undefined) {
+        editor.setDraftField(id, 'project', project.id)
+        if (project.customer > 0) {
+          editor.setDraftField(id, 'customer', project.customer)
+        }
+      }
+    } else if (colKey === 'customer') {
+      const current = (projects.data ?? []).find((project) => project.id === num(editor.draftValue(id, 'project')))
+      if (current !== undefined && current.customer !== num(value)) {
+        editor.setDraftField(id, 'project', 0)
+      }
     }
   }
 
@@ -144,6 +176,7 @@ export default function Tracking() {
       })
       await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
     },
+    onCommit: handleCommit,
     saveErrorMessage: (caught) => (caught instanceof Error ? caught.message : m.app_load_error()),
   })
 
@@ -164,7 +197,7 @@ export default function Tracking() {
       case 'customer':
         return nameOf(customers.data, num(row.customer))
       case 'project':
-        return nameOf(projects.data, num(row.project))
+        return nameOf(allProjectOptions(), num(row.project))
       case 'activity':
         return nameOf(activities.data, num(row.activity))
       case 'description':


### PR DESCRIPTION
Next slice of the work-log migration (PR1 #367 read, PR2 #368 edit/save/delete). Adds two ExtJS-parity editing conveniences.

- **Cascade**: while editing, the project dropdown shows only the projects for the row's selected customer (prod has ~1000 projects — the unfiltered list was unusable). Changing the customer clears a now-mismatched project.
- **Ticket→project auto-map**: committing a ticket whose prefix matches a project's `jiraId` (e.g. `APO-42` → project "Apollo") sets the project and its customer.

Backed by a richer `trackingProjectsQuery` (id/name/customer/jiraId). The shared inline-grid controller gains an `onCommit` hook + `setDraftField` so a host can derive sibling draft fields from a commit — **no behaviour change for the admin grid** (passes neither).

## Still to come (final parity slice, PR4)
Add new entries (Alt+A) + Continue / Prolong-last, the Info popup (`/getSummary`), CSV export, ticket→URL links, and the grid-local Alt-shortcuts. Then `/ui/tracking` reaches full ExtJS parity and the legacy bundle can be retired.

## Testing
Frontend typecheck + lint clean; **185 vitest** — incl. new tests asserting the ticket-map sets project+customer and the cascade filters the project dropdown by customer. Admin inline-edit suite unchanged (controller extension is additive). No backend changes.