### PR TITLE
feat(ui): Worklog CSV export + grid keyboard shortcuts (PR5)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -141,6 +141,7 @@
   "tracking_add": "Eintrag hinzufügen",
   "tracking_continue": "Fortsetzen",
   "tracking_prolong": "Verlängern",
+  "tracking_export": "CSV-Export",
   "auswertung_title": "Auswertung",
   "auswertung_no_data": "Keine Daten gefunden.",
   "auswertung_label": "Name",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -141,6 +141,7 @@
   "tracking_add": "Add entry",
   "tracking_continue": "Continue",
   "tracking_prolong": "Prolong",
+  "tracking_export": "Export CSV",
   "auswertung_title": "Evaluation",
   "auswertung_no_data": "No data found.",
   "auswertung_label": "Name",

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -295,4 +295,27 @@ describe('Tracking (Worklog grid)', () => {
 
     unmount()
   })
+
+  it('exposes a CSV export link for the current day range', async () => {
+    mockApi()
+    const { getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    expect(getByRole('link', { name: 'Export CSV' })).toHaveAttribute('href', '/export/3')
+
+    unmount()
+  })
+
+  it('Alt+P prolongs the latest entry from the keyboard', async () => {
+    mockApi()
+    postJson.mockResolvedValue({})
+    const { getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    fireEvent.keyDown(document, { key: 'p', altKey: true })
+
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({ id: 1 })))
+
+    unmount()
+  })
 })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/solid-query'
-import { createMemo, createSignal, For, Show } from 'solid-js'
+import { createMemo, createSignal, For, onCleanup, onMount, Show } from 'solid-js'
 
 import { apiErrorMessage, postJson } from '../api/client'
 import { activitiesQuery, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, type NamedOption, type TrackingEntry } from '../api/queries'
@@ -352,6 +352,44 @@ export default function Tracking() {
     }
   }
 
+  const exportHref = (): string => `/export/${days()}`
+
+  // Grid-local Alt-shortcuts (Add/Alt+A is wired via the shared header). Ignored
+  // while a cell is being edited or focus is in a form control, and only the
+  // keys we own are intercepted.
+  function onGridShortcut(event: KeyboardEvent): void {
+    if (!event.altKey || event.ctrlKey || event.metaKey || event.repeat || editor.editCell() !== null) {
+      return
+    }
+    const target = event.target
+    if (target instanceof HTMLElement && ['INPUT', 'SELECT', 'TEXTAREA'].includes(target.tagName)) {
+      return
+    }
+    switch (event.key.toLowerCase()) {
+      case 'c':
+        event.preventDefault()
+        continueEntry()
+        break
+      case 'p':
+        event.preventDefault()
+        void prolongLast()
+        break
+      case 'r':
+        event.preventDefault()
+        void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+        break
+      case 'x':
+        event.preventDefault()
+        window.location.assign(exportHref())
+        break
+      default:
+        break
+    }
+  }
+
+  onMount(() => document.addEventListener('keydown', onGridShortcut))
+  onCleanup(() => document.removeEventListener('keydown', onGridShortcut))
+
   let daysSelectEl: HTMLSelectElement | undefined
 
   return (
@@ -362,8 +400,9 @@ export default function Tracking() {
         <button type="button" class="primary-button" data-keyboard-add aria-keyshortcuts="Alt+A" onClick={() => addEntry()}>
           {m.tracking_add()}
         </button>
-        <button type="button" class="action-button" onClick={() => continueEntry()}>{m.tracking_continue()}</button>
-        <button type="button" class="action-button" onClick={() => void prolongLast()}>{m.tracking_prolong()}</button>
+        <button type="button" class="action-button" onClick={() => continueEntry()} aria-keyshortcuts="Alt+C">{m.tracking_continue()}</button>
+        <button type="button" class="action-button" onClick={() => void prolongLast()} aria-keyshortcuts="Alt+P">{m.tracking_prolong()}</button>
+        <a class="action-button" href={exportHref()} aria-keyshortcuts="Alt+X">{m.tracking_export()}</a>
         <label class="tracking-days">
           <span>{m.tracking_days_label()}</span>
           <select


### PR DESCRIPTION
Penultimate parity slice for the work-log grid (PR1-4 merged: read/create/edit/delete + cascade + ticket-map).

- **CSV export** link (Alt+X) for the current day range → `/export/{days}`.
- **Grid keyboard shortcuts**: Alt+C continue, Alt+P prolong, Alt+R refresh, Alt+X export — ignored while editing a cell or focused in a form control; Add stays on Alt+A via the shared header; nav Alt+1-7 and Help "?" untouched.

## Remaining (PR6, finishes parity)
Ticket→URL links in the ticket/description cells + the Alt+I summary popup (`/getSummary`). Then `/ui/tracking` is at full ExtJS parity and the legacy bundle can be retired.

## Testing
Frontend typecheck + lint clean; **190 vitest** — new tests assert the export link href and the Alt+P keyboard shortcut. No backend changes.