### PR TITLE
fix(ui): worklog grid — cursor-row Continue/Info, sort, themed select, row borders

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -120,12 +120,34 @@ interface TrackingEntryRow {
   entry: TrackingEntry
 }
 
+// A chronological sort key from the row format: date is 'd/m/Y', so reorder it
+// to 'Y-m-d' (lexically = chronological) and append start ('H:i') as the
+// tiebreaker. A blank/non-matching date sorts to the end of its direction.
+function entrySortKey(entry: TrackingEntry): string {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(entry.date ?? '')
+  const iso = match !== null ? `${match[3]}-${match[2]}-${match[1]}` : (entry.date ?? '')
+
+  return `${iso} ${entry.start ?? ''}`
+}
+
 export function trackingEntriesQuery(days: number) {
   return {
     queryKey: ['tracking-entries', days] as const,
     queryFn: () => getJson<TrackingEntryRow[]>(`/getData/days/${days}`),
+    // Newest entry first. The backend (getEntriesByUser) returns day/start
+    // ASCending (shared with the legacy ExtJS grid + export), so the new grid
+    // sorts client-side instead — which also makes [0] the latest entry, as
+    // Add (suggest-start) / Prolong-last / Continue all assume.
     select: (rows: TrackingEntryRow[]): TrackingEntry[] =>
-      rows.map((row) => row?.entry).filter((entry): entry is TrackingEntry => entry != null),
+      rows
+        .map((row) => row?.entry)
+        .filter((entry): entry is TrackingEntry => entry != null)
+        .sort((a, b) => {
+          const ka = entrySortKey(a)
+          const kb = entrySortKey(b)
+
+          return ka < kb ? 1 : ka > kb ? -1 : 0
+        }),
     // Keep the current rows visible while switching the days range (no flicker).
     placeholderData: keepPreviousData,
   }

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -7,6 +7,7 @@ import Tracking from './Tracking'
 
 const getJson = vi.fn()
 const postJson = vi.fn()
+const postForm = vi.fn()
 
 vi.mock('../api/client', () => ({
   SessionExpiredError: class extends Error {},
@@ -14,6 +15,7 @@ vi.mock('../api/client', () => ({
   apiErrorMessage: (error: unknown, fallback: string) => (error instanceof Error ? error.message : fallback),
   getJson: (...args: unknown[]) => getJson(...args),
   postJson: (...args: unknown[]) => postJson(...args),
+  postForm: (...args: unknown[]) => postForm(...args),
 }))
 
 // Single source for the grid's GET endpoints; each test supplies only the data
@@ -74,8 +76,25 @@ function renderTracking() {
 afterEach(() => {
   getJson.mockReset()
   postJson.mockReset()
+  postForm.mockReset()
   vi.restoreAllMocks()
 })
+
+// Move the keyboard cursor to the Nth body row (0-based) so the active-row
+// (aria-current) toolbar actions target it. gridNav sets aria-current on focus,
+// then each ArrowDown advances one row.
+function focusBodyRow(container: HTMLElement, index: number): void {
+  const firstCell = container.querySelector<HTMLElement>('tbody td[data-row-id]')
+  if (firstCell === null) {
+    throw new Error('no body cell')
+  }
+  firstCell.focus()
+  // gridNav moves focus to the new cell on each step, so fire on whatever cell
+  // currently holds focus (not always the first one).
+  for (let i = 0; i < index; i += 1) {
+    fireEvent.keyDown(document.activeElement ?? firstCell, { key: 'ArrowDown' })
+  }
+}
 
 // Open the inline editor on a column's first cell and return its control.
 function editCell(container: HTMLElement, colKey: string): HTMLInputElement {
@@ -336,19 +355,23 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
-  it('Alt+I shows the per-scope summary popup', async () => {
+  it('Alt+I requests the summary as form-encoded (legacy $request->request) and shows it', async () => {
     mockApi()
-    postJson.mockResolvedValue({
+    // /getSummary reads form params, so the client uses postForm and returns the
+    // JSON *text*; a JSON body would leave the server's id null → all-zero totals.
+    postForm.mockResolvedValue(JSON.stringify({
       customer: { scope: 'customer', name: 'ACME', entries: 5, total: 300, own: 120, estimation: 0 },
       project: { scope: 'project', name: 'Site', entries: 3, total: 180, own: 90, estimation: 600 },
       activity: { scope: 'activity', name: 'Dev', entries: 2, total: 120, own: 60, estimation: 0 },
       ticket: { scope: 'ticket', name: 'ABC-1', entries: 1, total: 60, own: 60, estimation: 0 },
-    })
+    }))
     const { getByRole, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
 
     fireEvent.keyDown(document, { key: 'i', altKey: true })
 
+    expect(postForm).toHaveBeenCalledWith('/getSummary', { id: 1 })
+    expect(postJson).not.toHaveBeenCalledWith('/getSummary', expect.anything())
     // The summary dialog is portalled to document.body → query via screen.
     const dialog = await screen.findByRole('dialog')
     expect(within(dialog).getByText('ACME')).toBeInTheDocument()
@@ -356,6 +379,75 @@ describe('Tracking (Worklog grid)', () => {
     expect(within(dialog).getByText('Dev')).toBeInTheDocument()
     // estimation shown for the project scope (600 min → 10:00).
     expect(within(dialog).getByText('10:00')).toBeInTheDocument()
+
+    unmount()
+  })
+
+  it('sorts fetched entries newest-first regardless of server order', async () => {
+    mockTracking({
+      entries: [
+        { entry: { ...DEFAULT_ENTRY, id: 1, date: '14/06/2026', start: '09:00', description: 'Oldest', class: 0 } },
+        { entry: { ...DEFAULT_ENTRY, id: 2, date: '16/06/2026', start: '10:00', description: 'Newest', class: 0 } },
+        { entry: { ...DEFAULT_ENTRY, id: 3, date: '15/06/2026', start: '14:00', description: 'Middle', class: 0 } },
+      ],
+      customers: [{ customer: { id: 1, name: 'ACME' } }],
+      projects: [{ project: { id: 4, name: 'Site' } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
+    const { container, getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Newest' })).toBeInTheDocument())
+
+    const dates = Array.from(container.querySelectorAll('tbody tr td[data-col-key="date"]')).map((td) => td.textContent)
+    expect(dates).toEqual(['16/06/2026', '15/06/2026', '14/06/2026'])
+
+    unmount()
+  })
+
+  it('Continue clones the keyboard-cursor row (incl. ticket), not the top row', async () => {
+    mockTracking({
+      entries: [
+        { entry: { ...DEFAULT_ENTRY, id: 1, date: '16/06/2026', ticket: 'ABC-1', customer: 1, project: 4 } },
+        { entry: { ...DEFAULT_ENTRY, id: 2, date: '15/06/2026', ticket: 'XYZ-9', customer: 2, project: 5 } },
+      ],
+      customers: [{ customer: { id: 1, name: 'ACME' } }, { customer: { id: 2, name: 'BroCorp' } }],
+      projects: [{ project: { id: 4, name: 'Site', customer: 1 } }, { project: { id: 5, name: 'App', customer: 2 } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
+    const { container, getByRole, getAllByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'BroCorp' })).toBeInTheDocument())
+
+    // Cursor on the 2nd (older, XYZ-9/BroCorp) row, then Continue.
+    focusBodyRow(container, 1)
+    fireEvent.click(getByRole('button', { name: 'Continue' }))
+
+    // The cloned new row carries the cursor row's customer + ticket (not ABC-1/ACME).
+    await waitFor(() => expect(getAllByRole('gridcell', { name: 'BroCorp' }).length).toBe(2))
+    const xyzLinks = Array.from(container.querySelectorAll('a.ticket-link')).filter((a) => a.textContent === 'XYZ-9')
+    expect(xyzLinks.length).toBe(2)
+
+    unmount()
+  })
+
+  it('Alt+I summarizes the keyboard-cursor row, not the top row', async () => {
+    mockTracking({
+      entries: [
+        { entry: { ...DEFAULT_ENTRY, id: 1, date: '16/06/2026', description: 'Top' } },
+        { entry: { ...DEFAULT_ENTRY, id: 2, date: '15/06/2026', description: 'Second' } },
+      ],
+      customers: [{ customer: { id: 1, name: 'ACME' } }],
+      projects: [{ project: { id: 4, name: 'Site' } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
+    postForm.mockResolvedValue(JSON.stringify({
+      customer: { scope: 'customer', name: 'ACME', entries: 1, total: 60, own: 60, estimation: 0 },
+    }))
+    const { container, getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Second' })).toBeInTheDocument())
+
+    focusBodyRow(container, 1) // cursor on the 2nd row (id 2)
+    fireEvent.keyDown(document, { key: 'i', altKey: true })
+
+    expect(postForm).toHaveBeenCalledWith('/getSummary', { id: 2 })
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
-import { apiErrorMessage, postJson } from '../api/client'
+import { apiErrorMessage, postForm, postJson } from '../api/client'
 import { activitiesQuery, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, type NamedOption, type SummaryScope, type TrackingEntry } from '../api/queries'
 import { appConfig } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
@@ -152,6 +152,8 @@ export default function Tracking() {
   // above the fetched entries; they save as creates and drop on success.
   const [newRows, setNewRows] = createSignal<TrackingEntry[]>([])
   let tempId = -1
+  // The grid element, captured in its ref — read for the keyboard-cursor row.
+  let tableEl: HTMLTableElement | undefined
   const rows = createMemo<TrackingEntry[]>(() => [...newRows(), ...(entries.data ?? [])])
   const allProjectOptions = createMemo<NamedOption[]>(() => (projects.data ?? []).map((project) => ({ id: project.id, label: project.name })))
 
@@ -309,14 +311,37 @@ export default function Tracking() {
     return displayCell(entry, colKey)
   }
 
-  // Alt+I: per-customer/project/activity/ticket totals for an entry (or the latest).
-  async function showInfo(entry?: TrackingEntry): Promise<void> {
-    const target = entry ?? (entries.data ?? [])[0]
+  // The entry of the row holding the keyboard cursor (gridNav marks it
+  // aria-current); undefined when focus is on the header or outside the grid.
+  function activeEntry(): TrackingEntry | undefined {
+    const rowId = tableEl?.querySelector('tr[aria-current="true"] [data-row-id]')?.getAttribute('data-row-id')
+    if (rowId === null || rowId === undefined) {
+      return undefined
+    }
+
+    return rows().find((entry) => String(num(entry.id)) === rowId)
+  }
+
+  // The saved entry under the cursor, else the most recent saved entry — the
+  // target for Continue and Info. A new/unsaved cursor row (id <= 0) has no
+  // server summary and nothing meaningful to clone, so it falls back.
+  function activeOrLatestEntry(): TrackingEntry | undefined {
+    const active = activeEntry()
+
+    return active !== undefined && num(active.id) > 0 ? active : (entries.data ?? [])[0]
+  }
+
+  // Alt+I: per-customer/project/activity/ticket totals for the cursor row (or
+  // the latest entry). /getSummary is a legacy endpoint that reads form params
+  // ($request->request->get('id')), so it must be POSTed as form-encoded — a
+  // JSON body leaves `id` null and the server answers all-zero totals.
+  async function showInfo(): Promise<void> {
+    const target = activeOrLatestEntry()
     if (target === undefined) {
       return
     }
     try {
-      const result = await postJson<Record<string, SummaryScope>>('/getSummary', { id: num(target.id) })
+      const result = JSON.parse(await postForm('/getSummary', { id: num(target.id) })) as Record<string, SummaryScope>
       setSummary([result.customer, result.project, result.activity, result.ticket].filter((scope): scope is SummaryScope => scope != null))
     } catch (caught) {
       window.alert(apiErrorMessage(caught, m.app_load_error()))
@@ -368,22 +393,22 @@ export default function Tracking() {
     pushNewRow({ start: appConfig().suggestTime && previous !== undefined ? str(previous.end) : '' }, 'customer')
   }
 
-  // Continue: clone the latest entry's customer/project/activity/ticket/description
-  // into a fresh blank-time row.
+  // Continue: clone the cursor row's (or, with no cursor, the latest entry's)
+  // customer/project/activity/ticket/description into a fresh blank-time row.
   function continueEntry(): void {
-    const previous = (entries.data ?? [])[0]
-    if (previous === undefined) {
+    const source = activeOrLatestEntry()
+    if (source === undefined) {
       addEntry()
 
       return
     }
     pushNewRow(
       {
-        customer: num(previous.customer),
-        project: num(previous.project),
-        activity: num(previous.activity),
-        description: str(previous.description),
-        ticket: str(previous.ticket),
+        customer: num(source.customer),
+        project: num(source.project),
+        activity: num(source.activity),
+        description: str(source.description),
+        ticket: str(source.ticket),
       },
       'start',
     )
@@ -487,7 +512,7 @@ export default function Tracking() {
         <div class="table-scroll">
           <table
             class="data-table tracking-table"
-            ref={(el) => { editor.setTableEl(el) }}
+            ref={(el) => { editor.setTableEl(el); tableEl = el }}
             onFocusIn={editor.onTableFocusIn}
             onFocusOut={editor.onTableFocusOut}
             use:gridNav={{
@@ -544,13 +569,15 @@ export default function Tracking() {
                       {/* data-row-id (no data-col-key → not inline-editable) keeps focus
                           "inside the row" so clicking Delete isn't read as a row-leave. */}
                       <td class="tracking-row-actions" data-row-id={String(id)}>
-                        <button type="button" class="link-button is-danger" onClick={() => void removeEntry(entry)}>
-                          <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6"/><path d="M10 11v6M14 11v6"/></svg>
-                          {m.admin_delete()}
-                        </button>
-                        <Show when={editor.rowErrors[id]}>
-                          <span role="alert" class="form-status is-error">{editor.rowErrors[id]}</span>
-                        </Show>
+                        <div class="row-actions">
+                          <button type="button" class="link-button is-danger" onClick={() => void removeEntry(entry)}>
+                            <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6"/><path d="M10 11v6M14 11v6"/></svg>
+                            {m.admin_delete()}
+                          </button>
+                          <Show when={editor.rowErrors[id]}>
+                            <span role="alert" class="form-status is-error">{editor.rowErrors[id]}</span>
+                          </Show>
+                        </div>
                       </td>
                     </tr>
                   )

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1009,6 +1009,26 @@ kbd {
   gap: 0.5rem;
 }
 
+/* The days-range select must use the theme tokens (like .field select) — an
+   unstyled native select renders a light box in dark mode. color-scheme keeps
+   the option popup legible in both themes. */
+.tracking-days select {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text);
+  color-scheme: light dark;
+  font: inherit;
+  min-height: 36px;
+  padding: 0 0.4rem;
+}
+
+.tracking-days select:focus-visible {
+  border-color: var(--color-accent);
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
 .tracking-empty {
   margin-top: var(--space-3, 0.75rem);
   color: var(--color-text-muted, #666);
@@ -1181,8 +1201,18 @@ th[aria-sort='descending'] .th-sort-glyph {
   overflow: hidden;
 }
 
-.admin-row-actions,
-.tracking-row-actions {
+.admin-row-actions {
+  display: flex;
+  gap: 0.4rem;
+  white-space: nowrap;
+}
+
+/* Tracking's action cell stays a real table-cell so the EntryClass row border
+   (.tracking-row.is-* > td) spans it — a display:flex <td> drops out of the
+   collapse-border model and the colour stops short of the last column. The
+   button row lays out in an inner wrapper instead. */
+.tracking-row-actions > .row-actions {
+  align-items: center;
   display: flex;
   gap: 0.4rem;
   white-space: nowrap;


### PR DESCRIPTION
Fixes five reported defects in the SolidJS Worklog grid (`/ui/tracking`).

## Bugs fixed
1. **Continue (Alt+C) used the top row, not the cursor row** — it now clones the keyboard-cursor row (carrying its ticket/customer/project/activity/description). New `activeEntry()` accessor reads the gridNav `aria-current` row.
2. **Info (Alt+I) showed all-zero totals** — `/getSummary` is a legacy endpoint reading `$request->request->get('id')` (form params), but it was POSTed as a JSON body, so `id` was always null. Now POSTed form-encoded via `postForm`, and it targets the cursor row.
3. **Entries sorted oldest-first** — the shared backend `getEntriesByUser` orders `day/start ASC` (also feeds the legacy ExtJS grid + export), so the new grid sorts client-side newest-first in the query `select`. This also makes `[0]` the latest entry, as Add/Prolong/Continue assume.
4. **"Show last" select wrong in dark mode** — it ignored the theme tokens (light box on dark bg); now styled like `.field select`.
5. **Row-class borders (daybreak/pause/overlap) stopped at the action column** — a `display:flex` `<td>` drops out of the `border-collapse` model. The action cell is now a table-cell with the flex layout moved to an inner wrapper, so the colour spans the full row width.

## Scope
Frontend-only. The shared backend `/getData/days` and `/getSummary` are unchanged (bug 3 fixed client-side to avoid rippling into the ExtJS grid/export; bug 5 fixed by matching the endpoint's existing form-param contract).

## Verification
- `bun run test` — 195 pass (added regression tests: newest-first sort, Continue-from-cursor, Info-form-encoding + cursor id).
- `bun run lint`, `bun run typecheck` — clean.
- CSS bugs 2 & 5 verified visually in headless chromium (light + dark, before/after).
