### PR TITLE
chore: drop APP_MONTHLY_OVERVIEW_URL stats link

### DIFF
--- a/.env
+++ b/.env
@@ -54,7 +54,6 @@ LDAP_CREATE_USER=true
 ###> Application Configuration ###
 APP_LOCALE="en"
 APP_LOGO_URL="/build/images/logo-netresearch.svg"
-APP_MONTHLY_OVERVIEW_URL="https://stats.timetracker.nr/?user="
 APP_TITLE="Netresearch TimeTracker"
 APP_HEADER_URL=""
 APP_SHOW_BILLABLE_FIELD_IN_EXPORT=false

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,7 +11,6 @@ parameters:
     app_locale: '%env(APP_LOCALE)%'
     app_logo_url: '%env(default:app_logo_url_default:APP_LOGO_URL)%'
     app_logo_url_default: '/build/images/logo-netresearch.svg'
-    app_monthly_overview_url: '%env(APP_MONTHLY_OVERVIEW_URL)%'
     app_header_url: '%env(APP_HEADER_URL)%'
     app_show_billable_field_in_export: '%env(bool:APP_SHOW_BILLABLE_FIELD_IN_EXPORT)%'
     service_users: '%env(SERVICE_USERS)%'

--- a/src/Controller/Default/IndexAction.php
+++ b/src/Controller/Default/IndexAction.php
@@ -56,7 +56,6 @@ final class IndexAction extends BaseController
         return $this->render('index.html.twig', [
             'globalConfig' => [
                 'logo_url' => $this->params->get('app_logo_url'),
-                'monthly_overview_url' => $this->params->get('app_monthly_overview_url'),
                 'header_url' => $this->params->get('app_header_url'),
             ],
             'apptitle' => $this->params->get('app_title'),

--- a/src/Controller/Ui/SpaAction.php
+++ b/src/Controller/Ui/SpaAction.php
@@ -45,7 +45,6 @@ final class SpaAction extends BaseController
         return $this->render('ui/index.html.twig', [
             'globalConfig' => [
                 'logo_url' => $this->params->get('app_logo_url'),
-                'monthly_overview_url' => $this->params->get('app_monthly_overview_url'),
                 'header_url' => $this->params->get('app_header_url'),
             ],
             'apptitle' => $this->params->get('app_title'),

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -60,7 +60,6 @@
 "Today": "Heute"
 "Week": "Woche"
 "Month": "Monat"
-"Monthly overview": "Monatsauswertung"
 "Overview": "Übersicht"
 "Time tracking": "Zeiterfassung"
 "Worklog": "Worklog"


### PR DESCRIPTION
## What

Removes the `APP_MONTHLY_OVERVIEW_URL` feature, which rendered a "Monthly overview" link pointing to `stats.timetracker.nr`.

The stats feature is now part of timetracker itself, and the frontend no longer renders the link. This removes the now-dead wiring so the env var can be retired without breaking Symfony parameter resolution:

- `.env` — removed `APP_MONTHLY_OVERVIEW_URL`
- `config/services.yaml` — removed `app_monthly_overview_url` parameter
- `src/Controller/Default/IndexAction.php` — removed `globalConfig.monthly_overview_url`
- `src/Controller/Ui/SpaAction.php` — removed `globalConfig.monthly_overview_url`
- `translations/messages.de.yml` — removed the now-orphaned "Monthly overview" string

## Why

Phase 1 of decommissioning `stats.timetracker.nr` (the standalone `timetracker-ui` stats app), tracked in NRS-4501. After this, `stats.timetracker.nr` has no runtime consumers in this app.

## Verification

- `php -l` passes on both controllers
- `git grep monthly_overview` returns no remaining references