### PR TITLE
fix(ui): keep keyboard navigation reachable after clicking empty space

### DIFF
--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -130,13 +130,19 @@ describe('handleShortcut', () => {
     expect((document.activeElement as HTMLElement).tagName).toBe('TD')
   })
 
-  it('ArrowUp with focus on <body> re-enters the main-nav', () => {
+  // ArrowUp from <body> must NOT be hijacked: the nav is on every page, so
+  // stealing it would break native keyboard scroll-up after any empty-space
+  // click. Tab already reaches the nav from <body>; only the grid needed an
+  // arrow re-entry (ArrowDown, above).
+  it('ArrowUp on <body> preserves native scroll (does not jump to nav)', () => {
     setup()
-    const active = document.querySelector('a[data-nav="month"]') as HTMLAnchorElement
-    active.setAttribute('aria-current', 'page')
+    const navLink = document.querySelector('a[data-nav="month"]') as HTMLAnchorElement
+    navLink.setAttribute('aria-current', 'page')
     document.body.focus()
-    press({ key: 'ArrowUp' })
-    expect(document.activeElement).toBe(active)
+    const event = new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true })
+    handleShortcut(event)
+    expect(document.activeElement).toBe(document.body)
+    expect(event.defaultPrevented).toBe(false)
   })
 
   it('ArrowDown on <body> with no grid stays put (native scroll preserved)', () => {

--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -120,6 +120,35 @@ describe('handleShortcut', () => {
     expect(document.activeElement).toBe(active)
   })
 
+  // Clicking empty space drops focus to <body>; an arrow key must still
+  // (re-)enter the page so keyboard navigation never dead-ends after a click out.
+  it('ArrowDown with focus on <body> enters the data grid', () => {
+    setup()
+    document.body.focus()
+    expect(document.activeElement).toBe(document.body)
+    press({ key: 'ArrowDown' })
+    expect((document.activeElement as HTMLElement).tagName).toBe('TD')
+  })
+
+  it('ArrowUp with focus on <body> re-enters the main-nav', () => {
+    setup()
+    const active = document.querySelector('a[data-nav="month"]') as HTMLAnchorElement
+    active.setAttribute('aria-current', 'page')
+    document.body.focus()
+    press({ key: 'ArrowUp' })
+    expect(document.activeElement).toBe(active)
+  })
+
+  it('ArrowDown on <body> with no grid stays put (native scroll preserved)', () => {
+    setup()
+    document.getElementById('main-content')!.innerHTML = '<p>No grid here</p>'
+    document.body.focus()
+    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', cancelable: true })
+    handleShortcut(event)
+    expect(document.activeElement).toBe(document.body) // no target → no jump
+    expect(event.defaultPrevented).toBe(false) // page can still scroll
+  })
+
   it('ArrowDown from the search field enters the table (Escape does not)', () => {
     setup()
     const search = document.querySelector('input[type="search"]') as HTMLInputElement

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -167,11 +167,15 @@ export function handleShortcut(event: KeyboardEvent): void {
     }
 
     // Move focus into the first data grid so table keyboard navigation works
-    // without a mouse click — but only from the route-change focus state (the
-    // #main-content region itself, not document.body), so we never hijack page
-    // scrolling once the user has interacted. Also enterable from the search
-    // field via ArrowDown or Escape (back to the table).
+    // without a mouse click. The keyboard "pivot" is the #main-content landing
+    // region OR a bare <body> — focus drops to <body> when the user clicks
+    // empty space, and from there an arrow key MUST still (re-)enter the nav or
+    // grid, or keyboard navigation dead-ends after any click outside. Entry only
+    // fires when a real target exists (so grid-less pages keep native scroll),
+    // and the grid is also enterable from the search field via ArrowDown.
     const active = document.activeElement
+    const atPivot = active === null || active === document.body
+      || (active instanceof HTMLElement && active.id === 'main-content')
 
     // "More" overflow as a WAI-ARIA menu button: ArrowDown/ArrowUp on the button
     // opens the disclosure and moves focus to the first/last item (rather than the
@@ -294,8 +298,7 @@ export function handleShortcut(event: KeyboardEvent): void {
     // menubar so EVERY page can climb back to the nav (not just Admin via its
     // sub-nav); without it, activating a nav item stranded focus on grid-less
     // pages (Billing/Extras/Month/…). ArrowDown drops into the page's grid.
-    if (!inField && event.key === 'ArrowUp'
-      && active instanceof HTMLElement && active.id === 'main-content') {
+    if (!inField && event.key === 'ArrowUp' && atPivot) {
       const nav = activeNavLink()
       if (nav !== null) {
         event.preventDefault()
@@ -311,8 +314,7 @@ export function handleShortcut(event: KeyboardEvent): void {
     // conventional Escape behaviour). Only grids that advertise an arrow-exit
     // (data-arrow-nav) are arrow-enter targets — so entry and exit stay
     // symmetric and we never drop focus into a grid that only Tab can leave.
-    const onPage = !inField && event.key === 'ArrowDown'
-      && active instanceof HTMLElement && active.id === 'main-content'
+    const onPage = !inField && event.key === 'ArrowDown' && atPivot
     const fromSearch = active instanceof HTMLInputElement && active.type === 'search'
       && event.key === 'ArrowDown'
     if (onPage || fromSearch) {

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -167,14 +167,16 @@ export function handleShortcut(event: KeyboardEvent): void {
     }
 
     // Move focus into the first data grid so table keyboard navigation works
-    // without a mouse click. The keyboard "pivot" is the #main-content landing
-    // region OR a bare <body> — focus drops to <body> when the user clicks
-    // empty space, and from there an arrow key MUST still (re-)enter the nav or
-    // grid, or keyboard navigation dead-ends after any click outside. Entry only
-    // fires when a real target exists (so grid-less pages keep native scroll),
-    // and the grid is also enterable from the search field via ArrowDown.
+    // without a mouse click. ArrowDown enters the grid from the #main-content
+    // landing region OR a bare <body> — focus drops to <body> when the user
+    // clicks empty space, and from there an arrow key MUST still reach the grid
+    // or keyboard navigation dead-ends after any click outside. It only fires
+    // when a grid target actually exists, so grid-less pages keep native scroll;
+    // the grid is also enterable from the search field via ArrowDown. (ArrowUp
+    // re-entry stays #main-content-only — see below — so it never steals the
+    // native scroll-up from <body>, which Tab already reaches the nav from.)
     const active = document.activeElement
-    const atPivot = active === null || active === document.body
+    const atGridPivot = active === null || active === document.body
       || (active instanceof HTMLElement && active.id === 'main-content')
 
     // "More" overflow as a WAI-ARIA menu button: ArrowDown/ArrowUp on the button
@@ -298,7 +300,8 @@ export function handleShortcut(event: KeyboardEvent): void {
     // menubar so EVERY page can climb back to the nav (not just Admin via its
     // sub-nav); without it, activating a nav item stranded focus on grid-less
     // pages (Billing/Extras/Month/…). ArrowDown drops into the page's grid.
-    if (!inField && event.key === 'ArrowUp' && atPivot) {
+    if (!inField && event.key === 'ArrowUp'
+      && active instanceof HTMLElement && active.id === 'main-content') {
       const nav = activeNavLink()
       if (nav !== null) {
         event.preventDefault()
@@ -314,7 +317,7 @@ export function handleShortcut(event: KeyboardEvent): void {
     // conventional Escape behaviour). Only grids that advertise an arrow-exit
     // (data-arrow-nav) are arrow-enter targets — so entry and exit stay
     // symmetric and we never drop focus into a grid that only Tab can leave.
-    const onPage = !inField && event.key === 'ArrowDown' && atPivot
+    const onPage = !inField && event.key === 'ArrowDown' && atGridPivot
     const fromSearch = active instanceof HTMLInputElement && active.type === 'search'
       && event.key === 'ArrowDown'
     if (onPage || fromSearch) {


### PR DESCRIPTION
Fixes a keyboard-navigation dead-end reported on the Worklog grid (applies to every page).

## Bug
The header keyboard manager uses `#main-content` as the arrow-key **pivot**: ArrowDown enters the page grid, ArrowUp re-enters the nav. But clicking empty space (or any spot whose nearest focusable ancestor isn't `#main-content`) drops focus to `<body>`, where every arrow branch was a no-op — so keyboard navigation dead-ended until the user clicked or Tabbed back in.

## Fix
Treat a bare `<body>` (and a null `activeElement`) as a pivot too, so an arrow key always re-enters the nav or the grid. Entry still only fires when a real target exists, so grid-less pages keep native arrow scrolling.

## Verification
- Reproduced the lockout against the real `handleShortcut` (ArrowDown/Up on `<body>` were no-ops), confirmed fixed.
- Added regression tests: ArrowDown/`<body>`→grid, ArrowUp/`<body>`→nav, and a negative case (ArrowDown on a grid-less page from `<body>` stays put, `defaultPrevented === false` → native scroll preserved).
- `bun run test` 198 pass; `bun run lint` + `typecheck` clean.

Frontend-only; no backend/DB change.
