### PR TITLE
fix(admin): correct Project save field types so inline-edit no longer 422s

### DIFF
--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -97,14 +97,14 @@ export function adminEntities(): EntityDescriptor[] {
         },
         { name: 'estimation', label: () => m.admin_f_estimation(), type: 'text' },
         { name: 'internalJiraProjectKey', label: () => m.admin_f_internal_jira_key(), type: 'text' },
-        { name: 'internalJiraTicketSystem', label: () => m.admin_f_internal_jira_system(), type: 'select', source: 'ticketSystems' },
+        { name: 'internalJiraTicketSystem', label: () => m.admin_f_internal_jira_system(), type: 'select', source: 'ticketSystems', stringValue: true },
         { name: 'invoice', label: () => m.admin_f_invoice(), type: 'text' },
         { name: 'internalReference', label: () => m.admin_f_internal_ref(), type: 'text' },
         { name: 'externalReference', label: () => m.admin_f_external_ref(), type: 'text' },
       ],
       rowLabel: (row) => str(row.name),
       toForm: (row) => row === null
-        ? { id: 0, name: '', customer: 0, ticket_system: 0, jiraId: '', jiraTicket: '', additionalInformationFromExternal: false, active: true, global: false, project_lead: 0, technical_lead: 0, offer: '', cost_center: '', billing: 0, estimation: '', internalJiraProjectKey: '', internalJiraTicketSystem: 0, invoice: '', internalReference: '', externalReference: '' }
+        ? { id: 0, name: '', customer: 0, ticket_system: 0, jiraId: '', jiraTicket: '', additionalInformationFromExternal: false, active: true, global: false, project_lead: 0, technical_lead: 0, offer: '', cost_center: '', billing: 0, estimation: '', internalJiraProjectKey: '', internalJiraTicketSystem: '', invoice: '', internalReference: '', externalReference: '' }
         : {
             id: num(row.id),
             name: str(row.name),
@@ -122,7 +122,7 @@ export function adminEntities(): EntityDescriptor[] {
             billing: num(row.billing),
             estimation: str(pick(row, 'estimationText', 'estimation')),
             internalJiraProjectKey: str(pick(row, 'internalJiraProjectKey', 'internal_jira_project_key')),
-            internalJiraTicketSystem: num(pick(row, 'internalJiraTicketSystem', 'internal_jira_ticket_system')),
+            internalJiraTicketSystem: str(pick(row, 'internalJiraTicketSystem', 'internal_jira_ticket_system')),
             invoice: str(row.invoice),
             internalReference: str(pick(row, 'internalReference', 'internal_reference')),
             externalReference: str(pick(row, 'externalReference', 'external_reference')),

--- a/src/Dto/ProjectSaveDto.php
+++ b/src/Dto/ProjectSaveDto.php
@@ -45,7 +45,7 @@ final readonly class ProjectSaveDto
         #[Map(if: false)]
         public ?int $technical_lead = null,
         #[Map(if: false)]
-        public ?string $ticket_system = null,
+        public ?int $ticket_system = null,
         public bool $additionalInformationFromExternal = false,
         public ?string $internalJiraTicketSystem = null,
         public string $internalJiraProjectKey = '',
@@ -78,7 +78,7 @@ final readonly class ProjectSaveDto
             offer: null !== $request->request->get('offer') ? (string) $request->request->get('offer') : null,
             project_lead: null !== $request->request->get('project_lead') ? (int) $request->request->get('project_lead') : null,
             technical_lead: null !== $request->request->get('technical_lead') ? (int) $request->request->get('technical_lead') : null,
-            ticket_system: null !== $request->request->get('ticket_system') ? (string) $request->request->get('ticket_system') : null,
+            ticket_system: null !== $request->request->get('ticket_system') ? (int) $request->request->get('ticket_system') : null,
             additionalInformationFromExternal: (bool) $request->request->get('additionalInformationFromExternal'),
             internalJiraTicketSystem: ('' === $internal || null === $internal) ? null : (string) $internal,
             internalJiraProjectKey: (string) $request->request->get('internalJiraProjectKey', ''),

--- a/tests/Dto/ProjectSaveDtoTest.php
+++ b/tests/Dto/ProjectSaveDtoTest.php
@@ -62,7 +62,7 @@ final class ProjectSaveDtoTest extends TestCase
             offer: 'OFF-001',
             project_lead: 10,
             technical_lead: 20,
-            ticket_system: '1',
+            ticket_system: 1,
             additionalInformationFromExternal: true,
             internalJiraTicketSystem: 'internal-jira',
             internalJiraProjectKey: 'INTERNAL',
@@ -81,10 +81,22 @@ final class ProjectSaveDtoTest extends TestCase
         self::assertSame('OFF-001', $dto->offer);
         self::assertSame(10, $dto->project_lead);
         self::assertSame(20, $dto->technical_lead);
-        self::assertSame('1', $dto->ticket_system);
+        self::assertSame(1, $dto->ticket_system);
         self::assertTrue($dto->additionalInformationFromExternal);
         self::assertSame('internal-jira', $dto->internalJiraTicketSystem);
         self::assertSame('INTERNAL', $dto->internalJiraProjectKey);
+    }
+
+    public function testTicketSystemIsIntForJsonPayload(): void
+    {
+        // The SolidJS admin sends ticket_system as a numeric select id via a JSON
+        // body bound by #[MapRequestPayload]; the property must be int so that
+        // validation accepts it (a ?string property rejected the number, which is
+        // what produced the "should be of type null|string" save error). Sibling
+        // FK selects (customer/project_lead/technical_lead) are int for the same reason.
+        $dto = new ProjectSaveDto(ticket_system: 7);
+
+        self::assertSame(7, $dto->ticket_system);
     }
 
     // ==================== fromRequest tests ====================
@@ -138,7 +150,7 @@ final class ProjectSaveDtoTest extends TestCase
         self::assertSame('OFF-001', $dto->offer);
         self::assertSame(10, $dto->project_lead);
         self::assertSame(20, $dto->technical_lead);
-        self::assertSame('1', $dto->ticket_system);
+        self::assertSame(1, $dto->ticket_system);
         self::assertTrue($dto->additionalInformationFromExternal);
         self::assertSame('internal-jira', $dto->internalJiraTicketSystem);
         self::assertSame('INTERNAL', $dto->internalJiraProjectKey);

--- a/tests/Dto/ProjectSaveDtoTest.php
+++ b/tests/Dto/ProjectSaveDtoTest.php
@@ -68,23 +68,7 @@ final class ProjectSaveDtoTest extends TestCase
             internalJiraProjectKey: 'INTERNAL',
         );
 
-        self::assertSame(42, $dto->id);
-        self::assertSame('Test Project', $dto->name);
-        self::assertSame(5, $dto->customer);
-        self::assertSame('PROJ', $dto->jiraId);
-        self::assertSame('PROJ-123', $dto->jiraTicket);
-        self::assertTrue($dto->active);
-        self::assertTrue($dto->global);
-        self::assertSame('5d', $dto->estimation);
-        self::assertSame(1, $dto->billing);
-        self::assertSame('CC001', $dto->cost_center);
-        self::assertSame('OFF-001', $dto->offer);
-        self::assertSame(10, $dto->project_lead);
-        self::assertSame(20, $dto->technical_lead);
-        self::assertSame(1, $dto->ticket_system);
-        self::assertTrue($dto->additionalInformationFromExternal);
-        self::assertSame('internal-jira', $dto->internalJiraTicketSystem);
-        self::assertSame('INTERNAL', $dto->internalJiraProjectKey);
+        $this->assertSampleProjectDto($dto);
     }
 
     public function testTicketSystemIsIntForJsonPayload(): void
@@ -137,23 +121,7 @@ final class ProjectSaveDtoTest extends TestCase
 
         $dto = ProjectSaveDto::fromRequest($request);
 
-        self::assertSame(42, $dto->id);
-        self::assertSame('Test Project', $dto->name);
-        self::assertSame(5, $dto->customer);
-        self::assertSame('PROJ', $dto->jiraId);
-        self::assertSame('PROJ-123', $dto->jiraTicket);
-        self::assertTrue($dto->active);
-        self::assertTrue($dto->global);
-        self::assertSame('5d', $dto->estimation);
-        self::assertSame(1, $dto->billing);
-        self::assertSame('CC001', $dto->cost_center);
-        self::assertSame('OFF-001', $dto->offer);
-        self::assertSame(10, $dto->project_lead);
-        self::assertSame(20, $dto->technical_lead);
-        self::assertSame(1, $dto->ticket_system);
-        self::assertTrue($dto->additionalInformationFromExternal);
-        self::assertSame('internal-jira', $dto->internalJiraTicketSystem);
-        self::assertSame('INTERNAL', $dto->internalJiraProjectKey);
+        $this->assertSampleProjectDto($dto);
     }
 
     public function testFromRequestWithEmptyInternalJiraTicketSystem(): void
@@ -211,6 +179,32 @@ final class ProjectSaveDtoTest extends TestCase
     }
 
     // ==================== Helper methods ====================
+
+    /**
+     * Assert the field values shared by the constructor and fromRequest "all
+     * data" cases (kept in one place so the two callers don't duplicate the
+     * full assertion block).
+     */
+    private function assertSampleProjectDto(ProjectSaveDto $dto): void
+    {
+        self::assertSame(42, $dto->id);
+        self::assertSame('Test Project', $dto->name);
+        self::assertSame(5, $dto->customer);
+        self::assertSame('PROJ', $dto->jiraId);
+        self::assertSame('PROJ-123', $dto->jiraTicket);
+        self::assertTrue($dto->active);
+        self::assertTrue($dto->global);
+        self::assertSame('5d', $dto->estimation);
+        self::assertSame(1, $dto->billing);
+        self::assertSame('CC001', $dto->cost_center);
+        self::assertSame('OFF-001', $dto->offer);
+        self::assertSame(10, $dto->project_lead);
+        self::assertSame(20, $dto->technical_lead);
+        self::assertSame(1, $dto->ticket_system);
+        self::assertTrue($dto->additionalInformationFromExternal);
+        self::assertSame('internal-jira', $dto->internalJiraTicketSystem);
+        self::assertSame('INTERNAL', $dto->internalJiraProjectKey);
+    }
 
     /**
      * @param array<string, mixed> $data


### PR DESCRIPTION
Fixes the `/ui/admin/projects` inline-edit/save failure: **"This value should be of type null|string. This value should be of type null|string."**

## Root cause
The Projects grid sends the `ticket_system` and `internalJiraTicketSystem` selects as **numbers**, but `ProjectSaveDto` typed both as `?string`. Symfony's `#[MapRequestPayload]` validation rejected each numeric value independently → two identical violations concatenated into the doubled message.

## Fix
- **`ticket_system` → `?int`** in the DTO (it's a `TicketSystem` FK consumed via `->find()`, and its sibling FK selects `customer`/`project_lead`/`technical_lead` are already `?int`). `fromRequest` casts it to int. The frontend already sends a number, so no frontend change for this field.
- **`internalJiraTicketSystem`** maps to a `string` column (the id stored as a string), so the Projects grid now sends it as a **string** (`stringValue: true`), matching `?string`.

## Verification
- `ProjectSaveDtoTest` updated to the int contract + a regression test for the numeric-payload shape that previously 422'd.
- Frontend: 198 vitest pass, lint + typecheck clean. PHP suite runs in CI.

The error-message *placement* (it renders in the actions column) is improved in the follow-up grid-interaction PR; this PR makes the error not happen at all.
