### PR TITLE
feat(ui): icon-only grid actions, one-key row selection, inline error placement

### DIFF
--- a/e2e/admin/admin-ui.spec.ts
+++ b/e2e/admin/admin-ui.spec.ts
@@ -77,9 +77,10 @@ test.describe('Administration UI', () => {
     await expect(page.locator('.modal')).toHaveCount(0);
     await expect(row(page, name)).toHaveCount(1);
 
-    // Edit (rename)
+    // Edit (rename). The action buttons are icon-only, so match the accessible
+    // name (aria-label), not visible text.
     const renamed = `${name}_Renamed`;
-    await row(page, name).locator('button.link-button').filter({ hasText: EDIT }).click();
+    await row(page, name).getByRole('button', { name: EDIT }).click();
     const editForm = page.locator('.modal form.stack-form');
     await expect(editForm).toBeVisible();
     const nameInput = editForm.locator('.field input[type="text"]').first();
@@ -90,7 +91,7 @@ test.describe('Administration UI', () => {
 
     // Delete (native confirm)
     page.once('dialog', (dialog) => dialog.accept());
-    await row(page, renamed).locator('button.link-button').filter({ hasText: DELETE }).click();
+    await row(page, renamed).getByRole('button', { name: DELETE }).click();
     await expect(row(page, renamed)).toHaveCount(0);
   });
 });

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -8,6 +8,7 @@ import { apiErrorMessage, getJson, postJson } from '../api/client'
 import { optionSourceKey } from '../api/queries'
 import { createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
 import { gridNav } from '../lib/gridNavigation'
+import { DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
 import { m } from '../paraglide/messages.js'
 import type { ColumnDef, EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
 
@@ -392,8 +393,8 @@ export function AdminCrudShell(props: {
             <span>{m.admin_show_inactive()}</span>
           </label>
         </Show>
-        <button type="button" class="action-button" onClick={() => exportCsv(visibleRows())} disabled={visibleRows().length === 0}>
-          {m.admin_export_csv()}
+        <button type="button" class="action-button is-icon" aria-label={m.admin_export_csv()} title={m.admin_export_csv()} onClick={() => exportCsv(visibleRows())} disabled={visibleRows().length === 0}>
+          <DownloadIcon />
         </button>
       </div>
 
@@ -404,8 +405,8 @@ export function AdminCrudShell(props: {
             <button type="button" class="action-button" disabled={bulkBusy()} onClick={() => bulkSetActive(true)}>{m.admin_bulk_activate()}</button>
             <button type="button" class="action-button" disabled={bulkBusy()} onClick={() => bulkSetActive(false)}>{m.admin_bulk_deactivate()}</button>
           </Show>
-          <button type="button" class="action-button" disabled={bulkBusy()} onClick={() => exportCsv(selectedRows())}>{m.admin_bulk_export()}</button>
-          <button type="button" class="link-button is-danger" disabled={bulkBusy()} onClick={() => bulkDelete()}>{m.admin_delete()}</button>
+          <button type="button" class="action-button is-icon" disabled={bulkBusy()} aria-label={m.admin_bulk_export()} title={m.admin_bulk_export()} onClick={() => exportCsv(selectedRows())}><DownloadIcon /></button>
+          <button type="button" class="link-button is-icon is-danger" disabled={bulkBusy()} aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => bulkDelete()}><TrashIcon /></button>
           <button type="button" class="link-button" disabled={bulkBusy()} onClick={() => clearSelection()}>{m.admin_bulk_clear()}</button>
         </div>
       </Show>
@@ -422,6 +423,16 @@ export function AdminCrudShell(props: {
               onExit: (dir) => { if (dir === 'up') searchEl?.focus() },
               onActivate: editor.onActivate,
               moveRef: (handle) => { editor.setMoveHandle(handle) },
+              // Space ticks/unticks the cursor row (one keystroke, any cell).
+              onRowSelectToggle: (cell) => {
+                const id = Number(cell.getAttribute('data-row-id'))
+                if (id <= 0) {
+                  return false
+                }
+                toggleRow(id, !selected[id])
+
+                return true
+              },
             }}
           >
             <thead>
@@ -455,8 +466,9 @@ export function AdminCrudShell(props: {
             <tbody>
               <For each={pagedRows()}>
                 {(row) => (
+                  <>
                   <tr aria-busy={editor.savingRows[Number(row.id)] ? 'true' : undefined} classList={{ 'is-selected': Boolean(selected[Number(row.id)]) }}>
-                    <td class="boolean admin-select-col">
+                    <td class="boolean admin-select-col" data-row-id={String(Number(row.id))}>
                       <input
                         type="checkbox"
                         aria-label={m.admin_select_row({ label: props.descriptor.rowLabel(row) })}
@@ -507,20 +519,25 @@ export function AdminCrudShell(props: {
                         clicking Edit doesn't read as a row-leave and flush. */}
                     <td class="admin-row-actions" data-row-id={String(Number(row.id))}>
                       <Show when={props.descriptor.editable !== false}>
-                        <button type="button" class="link-button" onClick={() => openForm(row)}>
-                          <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
-                          {m.admin_edit()}
+                        <button type="button" class="link-button is-icon" aria-label={m.admin_edit()} title={m.admin_edit()} onClick={() => openForm(row)}>
+                          <EditIcon />
                         </button>
                       </Show>
-                      <button type="button" class="link-button is-danger" onClick={() => void remove(row)}>
-                        <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6"/><path d="M10 11v6M14 11v6"/></svg>
-                        {m.admin_delete()}
+                      <button type="button" class="link-button is-icon is-danger" aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => void remove(row)}>
+                        <TrashIcon />
                       </button>
-                      <Show when={editor.rowErrors[Number(row.id)]}>
-                        <span role="alert" class="form-status is-error">{editor.rowErrors[Number(row.id)]}</span>
-                      </Show>
                     </td>
                   </tr>
+                  {/* Save error gets its own full-width row beneath the row, near
+                      the data and not crammed into the icon-only actions cell. */}
+                  <Show when={editor.rowErrors[Number(row.id)]}>
+                    <tr class="admin-row-error">
+                      <td colspan={props.descriptor.columns.length + 2}>
+                        <span role="alert" class="form-status is-error">{editor.rowErrors[Number(row.id)]}</span>
+                      </td>
+                    </tr>
+                  </Show>
+                  </>
                 )}
               </For>
             </tbody>

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -426,7 +426,9 @@ export function AdminCrudShell(props: {
               // Space ticks/unticks the cursor row (one keystroke, any cell).
               onRowSelectToggle: (cell) => {
                 const id = Number(cell.getAttribute('data-row-id'))
-                if (id <= 0) {
+                // A missing/non-numeric data-row-id yields NaN (NaN <= 0 is
+                // false), so test for a positive integer to avoid a NaN key.
+                if (!Number.isInteger(id) || id <= 0) {
                   return false
                 }
                 toggleRow(id, !selected[id])
@@ -531,7 +533,7 @@ export function AdminCrudShell(props: {
                   {/* Save error gets its own full-width row beneath the row, near
                       the data and not crammed into the icon-only actions cell. */}
                   <Show when={editor.rowErrors[Number(row.id)]}>
-                    <tr class="admin-row-error">
+                    <tr class="row-error">
                       <td colspan={props.descriptor.columns.length + 2}>
                         <span role="alert" class="form-status is-error">{editor.rowErrors[Number(row.id)]}</span>
                       </td>

--- a/frontend/src/lib/gridNavigation.test.ts
+++ b/frontend/src/lib/gridNavigation.test.ts
@@ -157,6 +157,27 @@ describe('enableGridNavigation', () => {
     expect(ev.defaultPrevented).toBe(true) // scroll suppressed
   })
 
+  it('Space toggles the row selection (onRowSelectToggle) and skips the default', () => {
+    document.body.innerHTML = `
+      <table class="data-table">
+        <thead><tr><th>Sel</th><th>Name</th></tr></thead>
+        <tbody><tr><td data-row-id="1"><input type="checkbox" /></td><td data-row-id="1">Alpha</td></tr></tbody>
+      </table>`
+    const table = document.querySelector('table') as HTMLTableElement
+    const onRowSelectToggle = vi.fn(() => true)
+    const cleanup = enableGridNavigation(table, { onRowSelectToggle })
+    const nameCell = table.querySelectorAll('tbody td')[1] as HTMLElement
+    nameCell.focus()
+    const ev = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+    nameCell.dispatchEvent(ev)
+
+    expect(onRowSelectToggle).toHaveBeenCalledOnce()
+    expect(ev.defaultPrevented).toBe(true)
+    // The default Space behaviour (focusing a control) is skipped — focus stays.
+    expect(document.activeElement).toBe(nameCell)
+    cleanup()
+  })
+
   it('Tab past the last cell control does not trap (no preventDefault)', () => {
     const actionsCell = grid.table.querySelectorAll('tbody td')[1] as HTMLElement
     actionsCell.focus()

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -50,6 +50,11 @@ export interface GridNavOptions {
   /** Receives the roving handle on setup and `null` on disposal, so an
    *  inline-edit owner can move the active cell after committing an edit. */
   moveRef?: (handle: GridMoveHandle | null) => void
+  /** Toggle the focused cell's row selection. Called on Space (from any cell);
+   *  return true if it handled the key, so the grid skips its default Space
+   *  behaviour (focus a control / seed an editor). Lets a selectable grid be
+   *  ticked with a single keystroke from anywhere in the row. */
+  onRowSelectToggle?: (cell: Cell) => boolean
 }
 
 interface GridController {
@@ -281,9 +286,14 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
         break
       }
       case ' ': {
-        // Space drops into the cell's control (APG) — or, on a display cell with
-        // no control, offers it to the inline editor seeded with a space. Either
-        // way it activates the cell instead of scrolling the page.
+        // On a selectable grid, Space ticks/unticks the row (single keystroke,
+        // from any cell) — this takes precedence over the default below.
+        if (options.onRowSelectToggle?.(cell)) {
+          break
+        }
+        // Otherwise Space drops into the cell's control (APG) — or, on a display
+        // cell with no control, offers it to the inline editor seeded with a
+        // space. Either way it activates the cell instead of scrolling the page.
         const control = cell.querySelector<HTMLElement>(INTERACTIVE)
         if (control) {
           control.focus()

--- a/frontend/src/lib/icons.tsx
+++ b/frontend/src/lib/icons.tsx
@@ -1,0 +1,29 @@
+import type { JSX } from 'solid-js'
+
+// 24×24 line icons (stroke = currentColor) shared by the grid action buttons,
+// so the SVG paths live in one place instead of being inlined per button.
+function Icon(props: { children: JSX.Element }): JSX.Element {
+  return (
+    <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      {props.children}
+    </svg>
+  )
+}
+
+export function EditIcon(): JSX.Element {
+  return <Icon><path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" /></Icon>
+}
+
+export function TrashIcon(): JSX.Element {
+  return (
+    <Icon>
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6" />
+      <path d="M10 11v6M14 11v6" />
+    </Icon>
+  )
+}
+
+export function DownloadIcon(): JSX.Element {
+  return <Icon><path d="M12 3v12" /><path d="m7 10 5 5 5-5" /><path d="M5 21h14" /></Icon>
+}

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -535,6 +535,7 @@ export default function Tracking() {
                   const id = num(entry.id)
 
                   return (
+                    <>
                     <tr class={`tracking-row ${id <= 0 ? 'is-new' : CLASS_ROW[entry.class] ?? ''}`.trimEnd()} aria-busy={editor.savingRows[id] ? 'true' : undefined}>
                       <For each={COLUMNS}>
                         {(col) => {
@@ -574,12 +575,18 @@ export default function Tracking() {
                           <button type="button" class="link-button is-icon is-danger" aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => void removeEntry(entry)}>
                             <TrashIcon />
                           </button>
-                          <Show when={editor.rowErrors[id]}>
-                            <span role="alert" class="form-status is-error">{editor.rowErrors[id]}</span>
-                          </Show>
                         </div>
                       </td>
                     </tr>
+                    {/* Save error gets its own full-width row beneath the row. */}
+                    <Show when={editor.rowErrors[id]}>
+                      <tr class="row-error">
+                        <td colspan={COLUMNS.length + 1}>
+                          <span role="alert" class="form-status is-error">{editor.rowErrors[id]}</span>
+                        </td>
+                      </tr>
+                    </Show>
+                    </>
                   )
                 }}
               </For>

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -9,6 +9,7 @@ import { appConfig } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { gridNav } from '../lib/gridNavigation'
 import { createInlineGridEdit, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { DownloadIcon, TrashIcon } from '../lib/icons'
 import { parseTime, toIsoDate } from '../lib/timeParse'
 import { m } from '../paraglide/messages.js'
 
@@ -493,7 +494,7 @@ export default function Tracking() {
         <button type="button" class="action-button" onClick={() => continueEntry()} aria-keyshortcuts="Alt+C">{m.tracking_continue()}</button>
         <button type="button" class="action-button" onClick={() => void prolongLast()} aria-keyshortcuts="Alt+P">{m.tracking_prolong()}</button>
         <button type="button" class="action-button" onClick={() => void showInfo()} aria-keyshortcuts="Alt+I">{m.tracking_info()}</button>
-        <a class="action-button" href={exportHref()} aria-keyshortcuts="Alt+X">{m.tracking_export()}</a>
+        <a class="action-button is-icon" href={exportHref()} aria-keyshortcuts="Alt+X" aria-label={m.tracking_export()} title={m.tracking_export()}><DownloadIcon /></a>
         <label class="tracking-days">
           <span>{m.tracking_days_label()}</span>
           <select
@@ -570,9 +571,8 @@ export default function Tracking() {
                           "inside the row" so clicking Delete isn't read as a row-leave. */}
                       <td class="tracking-row-actions" data-row-id={String(id)}>
                         <div class="row-actions">
-                          <button type="button" class="link-button is-danger" onClick={() => void removeEntry(entry)}>
-                            <svg class="action-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6"/><path d="M10 11v6M14 11v6"/></svg>
-                            {m.admin_delete()}
+                          <button type="button" class="link-button is-icon is-danger" aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => void removeEntry(entry)}>
+                            <TrashIcon />
                           </button>
                           <Show when={editor.rowErrors[id]}>
                             <span role="alert" class="form-status is-error">{editor.rowErrors[id]}</span>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1323,7 +1323,7 @@ th[aria-sort='descending'] .th-sort-glyph {
 
 /* Inline save error gets its own full-width row beneath the offending row,
    near the data instead of crammed into the (now icon-only) actions cell. */
-.admin-row-error > td {
+.row-error > td {
   border-top: 0;
   padding: 0.1rem 0.9rem 0.5rem;
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1289,12 +1289,43 @@ th[aria-sort='descending'] .th-sort-glyph {
   color: var(--color-danger-text);
 }
 
-/* Leading action glyph (Edit/Delete) — sized to the text, never the link colour
-   alone carrying meaning since the text label stays. */
+/* Leading action glyph (Edit/Delete) — sized to the text when a label is shown. */
 .action-ico {
   width: 1em;
   height: 1em;
   flex-shrink: 0;
+}
+
+/* Icon-only action buttons (Edit/Delete/Export in the grids + bulk bar): the
+   accessible name comes from aria-label/title, so drop the text-link underline
+   and make the button a square target. Kept at 44px (comfort) and never below
+   24×24 (WCAG 2.2 AA 2.5.8); the larger glyph keeps it legible without a label. */
+.link-button.is-icon,
+.action-button.is-icon {
+  gap: 0;
+  justify-content: center;
+  min-width: 44px;
+  padding: 0;
+  text-decoration: none;
+}
+
+.link-button.is-icon .action-ico,
+.action-button.is-icon .action-ico {
+  width: 1.25em;
+  height: 1.25em;
+}
+
+.link-button.is-icon:hover,
+.action-button.is-icon:hover {
+  background: var(--color-accent-soft);
+  border-radius: 8px;
+}
+
+/* Inline save error gets its own full-width row beneath the offending row,
+   near the data instead of crammed into the (now icon-only) actions cell. */
+.admin-row-error > td {
+  border-top: 0;
+  padding: 0.1rem 0.9rem 0.5rem;
 }
 
 .modal-backdrop {


### PR DESCRIPTION
Addresses three grid-interaction items (all within WCAG 2.2 AA):

## Changes
- **Icon-only actions** — Edit/Delete (rows) and Export + bulk Delete (per-table toolbar + bulk bar) are now icon-only buttons with `aria-label` + `title` tooltips. SVG paths are extracted to shared components (`src/lib/icons.tsx`) so they live in one place. Targets stay ≥44px (≥24px floor for AA 2.5.8).
- **One-keystroke row selection** — `Space` ticks/unticks the cursor row from *any* cell. gridNav gains an `onRowSelectToggle` hook (takes precedence over its default focus/seed-editor behaviour), wired in AdminCrudShell to toggle the row's selection.
- **Inline error placement** — the save/validation error moves out of the (now narrow, icon-only) actions cell into a full-width row beneath the offending row — clearer and nearer the data.

## Verification
- 199 vitest pass (added a gridNav test for the `onRowSelectToggle` path). Lint + typecheck clean.
- Icon buttons + error row verified visually in headless chromium (light + dark).

Nav↔sub-nav spacing (#6) and the global density toggle land in the follow-up density PR; pagination keyboard edge-paging in the pagination PR.
