### PR TITLE
feat(ui): global Comfort/Compact density toggle + condensed nav gap

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -122,7 +122,9 @@ a {
 main {
   margin: 0 auto;
   max-width: 76rem;
-  padding: 1.5rem 2rem;
+  /* Tighter top padding condenses the gap below the main nav (and above the
+     admin sub-nav) without crowding the sides. */
+  padding: 1rem 2rem;
 }
 
 .today-button {
@@ -1485,4 +1487,48 @@ th[aria-sort='descending'] .th-sort-glyph {
 .modal-close:hover {
   background: var(--color-accent-soft);
   color: var(--color-accent-text);
+}
+
+/* ── Display density ─────────────────────────────────────────────────────────
+   Compact (opt-in via the header toggle → data-density on <html>) tightens the
+   data-dense surfaces and uses the full viewport width; Comfort (default) is
+   unchanged. Every interactive target stays ≥24×24px (WCAG 2.2 AA 2.5.8) — the
+   denser controls clamp at 30px, never below. See density-init.html.twig. */
+:root[data-density='compact'] main {
+  max-width: none;
+  padding: 0.5rem 1rem;
+}
+
+:root[data-density='compact'] .admin-page {
+  max-width: none;
+}
+
+:root[data-density='compact'] .data-table thead th {
+  padding: 0.3rem 0.6rem;
+}
+
+:root[data-density='compact'] .data-table tbody td {
+  padding: 0.25rem 0.6rem;
+}
+
+:root[data-density='compact'] .tracking-toolbar,
+:root[data-density='compact'] .admin-crud-toolbar {
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+}
+
+:root[data-density='compact'] .admin-subnav {
+  margin-bottom: 0.6rem;
+}
+
+:root[data-density='compact'] .link-button,
+:root[data-density='compact'] .action-button,
+:root[data-density='compact'] .admin-subnav-link,
+:root[data-density='compact'] .tracking-days select {
+  min-height: 30px;
+}
+
+:root[data-density='compact'] .link-button.is-icon,
+:root[data-density='compact'] .action-button.is-icon {
+  min-width: 30px;
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1507,6 +1507,16 @@ th[aria-sort='descending'] .th-sort-glyph {
   padding: 0.3rem 0.6rem;
 }
 
+/* Sortable headers carry their padding on the inner button (the th stays at 0)
+   so the whole cell is clickable — keep that in compact and shrink the button. */
+:root[data-density='compact'] .data-table thead th:has(.th-sort) {
+  padding: 0;
+}
+
+:root[data-density='compact'] .th-sort {
+  padding: 0.3rem 0.6rem;
+}
+
 :root[data-density='compact'] .data-table tbody td {
   padding: 0.25rem 0.6rem;
 }

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -33,6 +33,7 @@
         <link rel="stylesheet" href="{{ asset('build/css/header.css') }}" type="text/css">
         <link rel="stylesheet" href="{{ asset('build/css/timetracker.css') }}" type="text/css">
         {% include 'partials/theme-init.html.twig' %}
+        {% include 'partials/density-init.html.twig' %}
         <script type="text/javascript">
             const statusUrlJson = {{ url('check_status')|escape|json_encode(jsonHexFlags)|raw }};
             const logoutUrlHtml = {{ url('_logout')|escape|json_encode(jsonHexFlags)|raw }};

--- a/templates/partials/density-init.html.twig
+++ b/templates/partials/density-init.html.twig
@@ -16,9 +16,9 @@
     }
     function apply(pref) {
         if (pref === 'compact') {
-            document.documentElement.dataset.density = 'compact';
+            document.documentElement.setAttribute('data-density', 'compact');
         } else {
-            delete document.documentElement.dataset.density;
+            document.documentElement.removeAttribute('data-density');
         }
     }
     // Apply immediately (still in <head>) so the first paint matches the choice.

--- a/templates/partials/density-init.html.twig
+++ b/templates/partials/density-init.html.twig
@@ -1,0 +1,73 @@
+{# Framework-neutral display-density toggle shared by BOTH shells (ExtJS + the
+   SolidJS /ui shell). Applies the saved preference before first paint (no flash)
+   and wires the two-state toggle button rendered in the shared header. Comfort
+   (default) keeps the roomy spacing; Compact tightens padding and uses the full
+   width — both stay within WCAG 2.2 AA target sizes. Single source of truth;
+   neither shell needs framework-specific density code. #}
+<script>
+(function () {
+    var KEY = 'timetracker-density';
+    function read() {
+        try {
+            return window.localStorage.getItem(KEY) === 'compact' ? 'compact' : 'comfort';
+        } catch (error) {
+            return 'comfort';
+        }
+    }
+    function apply(pref) {
+        if (pref === 'compact') {
+            document.documentElement.dataset.density = 'compact';
+        } else {
+            delete document.documentElement.dataset.density;
+        }
+    }
+    // Apply immediately (still in <head>) so the first paint matches the choice.
+    apply(read());
+
+    var LABELS = {
+        comfort: {{ ('Comfortable spacing'|trans)|json_encode|raw }},
+        compact: {{ ('Compact spacing'|trans)|json_encode|raw }}
+    };
+    var SWITCH_TO = {{ ('Switch to'|trans)|json_encode|raw }};
+
+    function store(pref) {
+        try {
+            if (pref === 'compact') {
+                window.localStorage.setItem(KEY, 'compact');
+            } else {
+                window.localStorage.removeItem(KEY);
+            }
+        } catch (error) {
+            // Storage disabled/restricted — apply for this session only.
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var button = document.getElementById('density-toggle');
+        if (button === null) {
+            return;
+        }
+        var icons = button.querySelectorAll('[data-density-icon]');
+        function mark(pref) {
+            var next = pref === 'compact' ? 'comfort' : 'compact';
+            button.setAttribute('aria-pressed', pref === 'compact' ? 'true' : 'false');
+            button.setAttribute('aria-label', LABELS[pref] + ' — ' + SWITCH_TO + ' ' + LABELS[next]);
+            button.setAttribute('title', LABELS[pref]);
+            icons.forEach(function (icon) {
+                if (icon.getAttribute('data-density-icon') === pref) {
+                    icon.removeAttribute('hidden');
+                } else {
+                    icon.setAttribute('hidden', '');
+                }
+            });
+        }
+        mark(read());
+        button.addEventListener('click', function () {
+            var next = read() === 'compact' ? 'comfort' : 'compact';
+            store(next);
+            apply(next);
+            mark(next);
+        });
+    });
+})();
+</script>

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -121,6 +121,15 @@
             </button>
         </div>
 
+        {# Display-density toggle — framework-neutral; wired by partials/density-init.html.twig.
+           Two-state button (Comfortable ⇄ Compact), aria-pressed = compact. #}
+        <div class="header-theme">
+            <button type="button" class="theme-cycle" id="density-toggle" aria-pressed="false" aria-label="{{ 'Compact spacing'|trans }}">
+                <svg class="theme-ico" data-density-icon="comfort" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+                <svg class="theme-ico" data-density-icon="compact" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" hidden><path d="M4 4h16M4 8h16M4 12h16M4 16h16M4 20h16"/></svg>
+            </button>
+        </div>
+
         <div class="header-account">
             <span id="user-badge" class="user-badge js-user-badge status_active" role="status" aria-live="polite" aria-label="{{ 'User status'|trans }}">
                 <span class="status-indicator" aria-hidden="true"></span>

--- a/templates/ui/index.html.twig
+++ b/templates/ui/index.html.twig
@@ -8,6 +8,7 @@
         <title>{{ apptitle }}</title>
         <link rel="stylesheet" href="{{ asset('build/css/header.css') }}">
         {% include 'partials/theme-init.html.twig' %}
+        {% include 'partials/density-init.html.twig' %}
         {{ vite_entry_link_tags('app') }}
         <script>
             window.APP_CONFIG = {{ {

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -69,6 +69,8 @@
 "Light": "Hell"
 "Dark": "Dunkel"
 "Switch to": "Wechseln zu"
+"Comfortable spacing": "Komfortable Abstände"
+"Compact spacing": "Kompakte Abstände"
 "More": "Mehr"
 "Open menu": "Menü öffnen"
 "Close menu": "Menü schließen"


### PR DESCRIPTION
Adds the **global Comfort/Compact density toggle** (#2) and condenses the **nav→sub-nav gap** (#6). Both modes stay within **WCAG 2.2 AA**.

## Density toggle
- Framework-neutral `density-init.html.twig` mirroring the existing theme cycle: a two-state header button (Comfortable ⇄ Compact) that sets `data-density` on `<html>`, persists in `localStorage`, applies **before first paint** (no flash), and works on **both** shells (ExtJS + SolidJS `/ui`). `aria-pressed` reflects compact; localized labels (incl. German).
- **Compact** tightens the data-dense surfaces (table cell padding, toolbars, admin sub-nav) and drops the page `max-width` for a **full-width** layout. **Comfort** (default) is unchanged.
- Every interactive target stays ≥24×24px (denser controls clamp at 30px), so neither mode drops below AA 2.5.8. No sub-AA "fast" mode (per the agreed decision).

## #6 nav→content gap
- Trim the `main` top padding (1.5rem → 1rem), condensing the space below the main nav and above the admin sub-nav.

## Verification
- Compact vs comfort verified in headless chromium (denser rows + full-width confirmed; icon buttons stay legible).
- No TS changed; the toggle is Twig + CSS (same pattern as the untested-by-design theme cycle). CI builds the bundle.
