### PR TITLE
feat(ui): keyboard page-edge crossing (PageUp/PageDown reach the adjacent page)

### DIFF
--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -435,6 +435,17 @@ export function AdminCrudShell(props: {
 
                 return true
               },
+              // PageUp on the top row → previous page, PageDown on the bottom
+              // row → next page (one keystroke, no scrolling to the pager).
+              onPageEdge: (direction) => {
+                const target = direction === 'prev' ? page() - 1 : page() + 1
+                if (target < 0 || target >= pageCount()) {
+                  return false
+                }
+                setPage(target)
+
+                return true
+              },
             }}
           >
             <thead>

--- a/frontend/src/lib/gridNavigation.page.test.tsx
+++ b/frontend/src/lib/gridNavigation.page.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render } from '@solidjs/testing-library'
+import { createMemo, createSignal, For } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+
+import { gridNav } from './gridNavigation'
+
+void gridNav
+
+// Integration test for the keyboard page-edge crossing: it relies on Solid
+// applying the row update synchronously when the page signal changes, so that
+// the grid can land focus on the new page's row within the same keystroke.
+function PagedGrid() {
+  const PAGES = [
+    [{ id: 1, name: 'P0-A' }, { id: 2, name: 'P0-B' }],
+    [{ id: 3, name: 'P1-A' }, { id: 4, name: 'P1-B' }],
+  ]
+  const [page, setPage] = createSignal(1)
+  const rows = createMemo(() => PAGES[page()]!)
+
+  return (
+    <table
+      class="data-table"
+      use:gridNav={{
+        items: rows,
+        onPageEdge: (direction) => {
+          const target = direction === 'prev' ? page() - 1 : page() + 1
+          if (target < 0 || target >= PAGES.length) {
+            return false
+          }
+          setPage(target)
+
+          return true
+        },
+      }}
+    >
+      <thead><tr><th>Name</th></tr></thead>
+      <tbody>
+        <For each={rows()}>{(row) => <tr><td>{row.name}</td></tr>}</For>
+      </tbody>
+    </table>
+  )
+}
+
+describe('gridNav keyboard pagination (reactive)', () => {
+  it('PageUp on the top row of page 1 lands on the last row of page 0', async () => {
+    const { container, unmount } = render(() => <PagedGrid />)
+    const topCell = container.querySelector('tbody td') as HTMLElement
+    expect(topCell.textContent).toBe('P1-A') // page 1, first row
+    topCell.focus()
+
+    fireEvent.keyDown(topCell, { key: 'PageUp' })
+
+    // Crossed to page 0 and landed on its LAST row (continue-upward).
+    expect(document.activeElement?.textContent).toBe('P0-B')
+    unmount()
+  })
+
+  it('PageDown on the bottom row of page 0 lands on the first row of page 1', async () => {
+    const { container, unmount } = render(() => <PagedGrid />)
+    // Move to page 0 first via PageUp from the top.
+    const topCell = container.querySelector('tbody td') as HTMLElement
+    topCell.focus()
+    fireEvent.keyDown(topCell, { key: 'PageUp' }) // now on P0-B (page 0, last row)
+    expect(document.activeElement?.textContent).toBe('P0-B')
+
+    fireEvent.keyDown(document.activeElement!, { key: 'PageDown' })
+
+    expect(document.activeElement?.textContent).toBe('P1-A') // page 1, first row
+    unmount()
+  })
+})

--- a/frontend/src/lib/gridNavigation.test.ts
+++ b/frontend/src/lib/gridNavigation.test.ts
@@ -94,6 +94,50 @@ describe('enableGridNavigation', () => {
     expect((document.activeElement as HTMLElement).closest('tr')?.querySelector('td')?.textContent).toBe('Beta')
   })
 
+  it('PageUp on the top row crosses to the previous page (onPageEdge) and lands on the last row', () => {
+    grid.cleanup()
+    document.body.innerHTML = '<table class="data-table"><thead><tr><th>N</th></tr></thead><tbody><tr><td>Alpha</td></tr><tr><td>Beta</td></tr></tbody></table>'
+    const table = document.querySelector('table') as HTMLTableElement
+    const onPageEdge = vi.fn(() => true)
+    const cleanup = enableGridNavigation(table, { onPageEdge })
+    const firstCell = table.querySelector('tbody td') as HTMLElement
+    firstCell.focus()
+    key(firstCell, 'PageUp')
+    expect(onPageEdge).toHaveBeenCalledWith('prev')
+    expect(document.activeElement?.textContent).toBe('Beta') // landed on the last row
+    cleanup()
+  })
+
+  it('PageDown on the bottom row crosses to the next page and lands on the first row', () => {
+    grid.cleanup()
+    document.body.innerHTML = '<table class="data-table"><thead><tr><th>N</th></tr></thead><tbody><tr><td>Alpha</td></tr><tr><td>Beta</td></tr></tbody></table>'
+    const table = document.querySelector('table') as HTMLTableElement
+    const onPageEdge = vi.fn(() => true)
+    const cleanup = enableGridNavigation(table, { onPageEdge })
+    const lastCell = table.querySelectorAll('tbody td')[1] as HTMLElement
+    lastCell.focus()
+    key(lastCell, 'PageDown')
+    expect(onPageEdge).toHaveBeenCalledWith('next')
+    expect(document.activeElement?.textContent).toBe('Alpha') // landed on the first row
+    cleanup()
+  })
+
+  it('stays within the page when onPageEdge declines (returns false)', () => {
+    grid.cleanup()
+    document.body.innerHTML = '<table class="data-table"><thead><tr><th>N</th></tr></thead><tbody><tr><td>Alpha</td></tr><tr><td>Beta</td></tr></tbody></table>'
+    const table = document.querySelector('table') as HTMLTableElement
+    const onPageEdge = vi.fn(() => false) // e.g. already at the first page
+    const cleanup = enableGridNavigation(table, { onPageEdge })
+    const firstCell = table.querySelector('tbody td') as HTMLElement
+    firstCell.focus()
+    key(firstCell, 'PageUp')
+    expect(onPageEdge).toHaveBeenCalledWith('prev')
+    // No page change → the normal within-page PageUp runs, clamping to the top
+    // (the header row); it must NOT have crossed to a sibling page's last row.
+    expect(document.activeElement?.textContent).toBe('N')
+    cleanup()
+  })
+
   it('calls onExit("up") when ArrowUp leaves the top row', () => {
     grid.cleanup()
     document.body.innerHTML = '<table class="data-table"><thead><tr><th>H</th></tr></thead><tbody><tr><td>A</td></tr></tbody></table>'

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -175,7 +175,10 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
   function focusPageLanding(edge: 'first' | 'last', column: number): void {
     const rows = dataRows()
     const target = edge === 'first' ? rows[0] : rows[rows.length - 1]
-    const cell = target?.cells[Math.max(0, Math.min(target.cells.length - 1, column))]
+    if (target === undefined) {
+      return
+    }
+    const cell = target.cells[Math.max(0, Math.min(target.cells.length - 1, column))]
     if (cell) {
       setActive(cell)
     }
@@ -295,7 +298,9 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
         const rows = dataRows()
         // On the bottom data row, PageDown crosses to the next page (landing on
         // its first row); otherwise it moves a viewport of rows within the page.
-        if (activeCellEl?.parentElement === rows[rows.length - 1] && options.onPageEdge?.('next')) {
+        // `cell` is the focused cell (always set here), so its row is reliable —
+        // and never undefined-matches an empty dataRows().
+        if (cell.parentElement === rows[rows.length - 1] && options.onPageEdge?.('next')) {
           focusPageLanding('first', c)
         } else {
           focusAt(r + pageRows(), c)
@@ -305,7 +310,7 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
       case 'PageUp': {
         // On the top data row, PageUp crosses to the previous page (landing on
         // its last row, so you keep moving upward); otherwise within the page.
-        if (activeCellEl?.parentElement === dataRows()[0] && options.onPageEdge?.('prev')) {
+        if (cell.parentElement === dataRows()[0] && options.onPageEdge?.('prev')) {
           focusPageLanding('last', c)
         } else {
           focusAt(r - pageRows(), c)

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -55,6 +55,13 @@ export interface GridNavOptions {
    *  behaviour (focus a control / seed an editor). Lets a selectable grid be
    *  ticked with a single keystroke from anywhere in the row. */
   onRowSelectToggle?: (cell: Cell) => boolean
+  /** Page the data at a vertical edge: PageUp on the top data row asks for the
+   *  'prev' page, PageDown on the bottom row for 'next'. Return true if the page
+   *  changed (the grid then lands on the last/first row of the new page), so an
+   *  adjacent page is one keystroke away without scrolling the cursor across the
+   *  whole table. Return false (e.g. already at the first/last page) to fall
+   *  back to the normal within-page PageUp/Down. */
+  onPageEdge?: (direction: 'prev' | 'next') => boolean
 }
 
 interface GridController {
@@ -147,6 +154,28 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
 
   function focusAt(r: number, c: number): void {
     const cell = cellAt(r, c)
+    if (cell) {
+      setActive(cell)
+    }
+  }
+
+  // The data rows of the first <tbody>, excluding any non-data rows (e.g. a
+  // `.row-error` row rendered beneath an entry) so the top/bottom-edge tests and
+  // the page-edge landing target track real entries, not error rows.
+  function dataRows(): HTMLTableRowElement[] {
+    const body = table.tBodies[0]
+
+    return body ? Array.from(body.rows).filter((row) => !row.classList.contains('row-error')) : []
+  }
+
+  // After a page change (onPageEdge), land on the last data row (came up from
+  // the top via PageUp → continue upward) or the first (came down via PageDown),
+  // keeping the column. The new page's rows are already in the DOM by here
+  // (Solid applies the row update synchronously when the page signal changes).
+  function focusPageLanding(edge: 'first' | 'last', column: number): void {
+    const rows = dataRows()
+    const target = edge === 'first' ? rows[0] : rows[rows.length - 1]
+    const cell = target?.cells[Math.max(0, Math.min(target.cells.length - 1, column))]
     if (cell) {
       setActive(cell)
     }
@@ -262,12 +291,27 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
           focusAt(r - 1, c)
         }
         break
-      case 'PageDown':
-        focusAt(r + pageRows(), c)
+      case 'PageDown': {
+        const rows = dataRows()
+        // On the bottom data row, PageDown crosses to the next page (landing on
+        // its first row); otherwise it moves a viewport of rows within the page.
+        if (activeCellEl?.parentElement === rows[rows.length - 1] && options.onPageEdge?.('next')) {
+          focusPageLanding('first', c)
+        } else {
+          focusAt(r + pageRows(), c)
+        }
         break
-      case 'PageUp':
-        focusAt(r - pageRows(), c)
+      }
+      case 'PageUp': {
+        // On the top data row, PageUp crosses to the previous page (landing on
+        // its last row, so you keep moving upward); otherwise within the page.
+        if (activeCellEl?.parentElement === dataRows()[0] && options.onPageEdge?.('prev')) {
+          focusPageLanding('last', c)
+        } else {
+          focusAt(r - pageRows(), c)
+        }
         break
+      }
       case 'Home':
         focusAt(event.ctrlKey ? 0 : r, 0)
         break


### PR DESCRIPTION
Answers your pagination question: the admin grid already has Prev/Next pager buttons, but you asked to reach the **previous page from the first row with one keystroke**, without scrolling the cursor down to the pager.

## Change
- **PageUp on the top data row → previous page**, landing on that page's **last** row (so you keep moving upward).
- **PageDown on the bottom data row → next page**, landing on its **first** row.
- Otherwise PageUp/PageDown move a viewport of rows within the page, as before. At the first/last page the edge-cross declines and the normal within-page behaviour runs.

## How
- gridNav gains an `onPageEdge(direction)` hook, fired only at the top/bottom data row (excluding `.row-error` rows). AdminCrudShell wires it to `setPage` (no wrap).
- Works alongside the existing pager buttons; the worklog grid (no pagination) is unaffected.

## Verification
- 204 vitest pass. Added gridNav unit tests (edge detection + landing + decline) **and** a reactive integration test that mounts a paginated Solid grid and confirms PageUp on page 1's top row lands on page 0's last row in one keystroke (verifies Solid's synchronous row update). Lint + typecheck clean.
