### PR TITLE
fix(ui): escape days-select keyboard trap + keep cursor put on save error

### DIFF
--- a/frontend/src/lib/gridNavigation.test.ts
+++ b/frontend/src/lib/gridNavigation.test.ts
@@ -151,6 +151,20 @@ describe('enableGridNavigation', () => {
     cleanup()
   })
 
+  it('arrow nav follows the focused cell after a row is inserted above it (no stale-index jump)', () => {
+    const betaCell = grid.table.querySelectorAll('tbody td')[2] as HTMLElement // Beta's name cell
+    betaCell.focus()
+    // Insert a row directly above Beta — mimics a save-error row appearing under
+    // the row above, which shifts Beta's rowIndex without a gridNav re-sync.
+    const inserted = document.createElement('tr')
+    inserted.innerHTML = '<td>Err</td><td></td>'
+    betaCell.closest('tr')!.before(inserted)
+    // ArrowUp must land on the just-inserted neighbour (live position), not jump
+    // to where Beta used to be relative to the stale tracked coords.
+    key(betaCell, 'ArrowUp')
+    expect(document.activeElement?.textContent).toBe('Err')
+  })
+
   it('clamps at the grid edges', () => {
     const firstHeader = grid.table.querySelector('th') as HTMLElement
     firstHeader.focus()

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -159,6 +159,23 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     }
   }
 
+  // The active cell's CURRENT position: its live DOM index while it's still
+  // attached — so a row inserted/removed without a gridNav re-sync (e.g. a
+  // save-error row appearing beneath another row) never leaves the tracked
+  // coords stale and jumps the cursor — falling back to the tracked `active`
+  // only when a re-render has detached the element (sync() then restores to the
+  // same logical position). Single source of truth for every nav path.
+  function currentPos(): [number, number] {
+    if (activeCellEl !== null && table.contains(activeCellEl)) {
+      const pos = position(activeCellEl)
+      if (pos !== null) {
+        return pos
+      }
+    }
+
+    return active
+  }
+
   // The data rows of the first <tbody>, excluding any non-data rows (e.g. a
   // `.row-error` row rendered beneath an entry) so the top/bottom-edge tests and
   // the page-edge landing target track real entries, not error rows.
@@ -188,7 +205,7 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
   // ArrowUp handler this never calls onExit — an inline editor committing with
   // Enter on the top data row should stay in the grid, not leave it.
   function focusRelative(direction: 'up' | 'down' | 'left' | 'right'): void {
-    const [r, c] = active
+    const [r, c] = currentPos()
     const dr = direction === 'up' ? -1 : direction === 'down' ? 1 : 0
     const dc = direction === 'left' ? -1 : direction === 'right' ? 1 : 0
     focusAt(r + dr, c + dc)
@@ -274,14 +291,9 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
       return
     }
 
-    // Derive the position from the focused cell's LIVE DOM index, not the tracked
-    // `active` coords — a row inserted/removed without a gridNav re-sync (e.g. a
-    // save-error row appearing beneath another row) would otherwise leave `active`
-    // stale and jump the cursor on the next key. The focused cell's own rowIndex
-    // is always correct.
-    const livePos = position(cell)
-    const r = livePos ? livePos[0] : active[0]
-    const c = livePos ? livePos[1] : active[1]
+    // Use the active cell's live position (see currentPos) so a row inserted/
+    // removed without a re-sync can't leave the coords stale and jump the cursor.
+    const [r, c] = currentPos()
     const lastRow = table.rows.length - 1 // live count, no per-keystroke allocation
 
     switch (event.key) {

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -274,7 +274,14 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
       return
     }
 
-    const [r, c] = active
+    // Derive the position from the focused cell's LIVE DOM index, not the tracked
+    // `active` coords — a row inserted/removed without a gridNav re-sync (e.g. a
+    // save-error row appearing beneath another row) would otherwise leave `active`
+    // stale and jump the cursor on the next key. The focused cell's own rowIndex
+    // is always correct.
+    const livePos = position(cell)
+    const r = livePos ? livePos[0] : active[0]
+    const c = livePos ? livePos[1] : active[1]
     const lastRow = table.rows.length - 1 // live count, no per-keystroke allocation
 
     switch (event.key) {

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -481,8 +481,6 @@ export default function Tracking() {
   onMount(() => document.addEventListener('keydown', onGridShortcut))
   onCleanup(() => document.removeEventListener('keydown', onGridShortcut))
 
-  let daysSelectEl: HTMLSelectElement | undefined
-
   return (
     <section class="tracking">
       <h2 class="visually-hidden">{m.tracking_title()}</h2>
@@ -498,7 +496,6 @@ export default function Tracking() {
         <label class="tracking-days">
           <span>{m.tracking_days_label()}</span>
           <select
-            ref={(el) => { daysSelectEl = el }}
             value={String(days())}
             onChange={(event) => setDays(Number(event.currentTarget.value))}
           >
@@ -518,7 +515,11 @@ export default function Tracking() {
             onFocusOut={editor.onTableFocusOut}
             use:gridNav={{
               items: rows,
-              onExit: (direction) => { if (direction === 'up') daysSelectEl?.focus() },
+              // ArrowUp off the top row hands focus to the #main-content pivot
+              // (NOT the days <select>, whose own arrow keys change its value and
+              // trap the cursor). From the pivot the header handles ArrowUp→nav /
+              // ArrowDown→grid, so the keyboard chain stays escapable both ways.
+              onExit: (direction) => { if (direction === 'up') document.getElementById('main-content')?.focus() },
               onActivate: editor.onActivate,
               moveRef: (handle) => { editor.setMoveHandle(handle) },
             }}


### PR DESCRIPTION
Two keyboard/focus bugs from review.

**#3 Days-select trap** — ArrowUp off the Worklog grid's top row focused the "Show last" `<select>`; its own arrow keys change the value, so you couldn't return to the grid with the cursor. The up-exit now goes to the `#main-content` pivot (header handles ArrowUp→nav / ArrowDown→grid), keeping the chain escapable both ways. The select stays Tab-reachable.

**#4 Cursor reset on save error** — gridNav now derives the active cell from the focused cell's **live DOM rowIndex** rather than tracked coords, so a row inserted without a re-sync (a save-error row appearing beneath another row) can't leave the coords stale and jump the cursor. Added a regression test.

205 vitest pass; lint + typecheck clean.