### PR TITLE
feat(ui): auto-save inline rows on completeness + clear unsaved state

### DIFF
--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -66,12 +66,7 @@ test.describe('Admin inline cell editing', () => {
     await expect(page.locator('td[data-inline-editing]')).toHaveCount(0);
   });
 
-  test('the Edit button hands a pending inline draft to the modal (no stale data, no double-save)', async ({ page }) => {
-    let saved = false;
-    page.on('request', (r) => {
-      if (/\/customer\/save$/.test(r.url()) && r.request().method() === 'POST') saved = true;
-    });
-
+  test('the Edit button opens the modal seeded with the in-progress inline value', async ({ page }) => {
     const row = page.locator('table.admin-table tbody tr').first();
     await row.locator('td[data-col-key="name"]').focus();
     await page.keyboard.press('Enter');
@@ -79,13 +74,12 @@ test.describe('Admin inline cell editing', () => {
     await expect(editor).toBeVisible();
     await editor.fill('Inline-Draft-X');
 
-    // Clicking Edit (same row → no premature flush) commits the draft on blur and
-    // opens the modal seeded from it, so the modal shows the edit, not stale data.
-    await row.locator('.admin-row-actions button.link-button').first().click();
+    // Clicking Edit commits the in-progress value and opens the modal seeded from
+    // it (the complete row also auto-saves in the background), so the modal shows
+    // the edit, not stale list data. Target Edit by name — a dirty row leads with
+    // the disk (force-save) button, so .first() would be the wrong control.
+    await row.getByRole('button', { name: /^(Bearbeiten|Edit)$/i }).click();
     await expect(page.locator('.modal input[type="text"]').first()).toHaveValue('Inline-Draft-X');
-
-    await page.waitForTimeout(600);
-    expect(saved).toBe(false); // the modal took over; no inline save fired
   });
 });
 

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -8,7 +8,7 @@ import { apiErrorMessage, getJson, postJson } from '../api/client'
 import { optionSourceKey } from '../api/queries'
 import { createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
 import { gridNav } from '../lib/gridNavigation'
-import { DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
+import { DiskIcon, DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
 import { m } from '../paraglide/messages.js'
 import type { ColumnDef, EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
 
@@ -284,6 +284,16 @@ export function AdminCrudShell(props: {
     onModalActivate: (row) => { openForm(row); return true },
     onSaved: () => flashNotice(m.admin_saved()),
     saveErrorMessage: (caught) => apiErrorMessage(caught, m.app_load_error()),
+    // Required fields must be filled for the row to auto-save; an empty one is
+    // hinted (border) until then.
+    invalidFields: (draft) => props.descriptor.fields
+      .filter((field) => field.required === true)
+      .filter((field) => {
+        const value = draft[field.name]
+
+        return value === undefined || value === null || value === '' || value === 0
+      })
+      .map((field) => field.name),
   })
 
   // A cell shows the committed draft value (through the column's own formatter)
@@ -480,7 +490,7 @@ export function AdminCrudShell(props: {
               <For each={pagedRows()}>
                 {(row) => (
                   <>
-                  <tr aria-busy={editor.savingRows[Number(row.id)] ? 'true' : undefined} classList={{ 'is-selected': Boolean(selected[Number(row.id)]) }}>
+                  <tr aria-busy={editor.savingRows[Number(row.id)] ? 'true' : undefined} classList={{ 'is-selected': Boolean(selected[Number(row.id)]), 'is-dirty': editor.isDirty(Number(row.id)) }}>
                     <td class="boolean admin-select-col" data-row-id={String(Number(row.id))}>
                       <input
                         type="checkbox"
@@ -499,7 +509,7 @@ export function AdminCrudShell(props: {
 
                         return (
                           <td
-                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable }}
+                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable, 'is-invalid': editor.fieldInvalid(Number(row.id), col.key) }}
                             data-row-id={String(rowId)}
                             data-col-key={col.key}
                             data-inline-editing={editor.isEditing(rowId, col.key) ? '' : undefined}
@@ -531,6 +541,12 @@ export function AdminCrudShell(props: {
                         focusing the row's action buttons "inside the row", so
                         clicking Edit doesn't read as a row-leave and flush. */}
                     <td class="admin-row-actions" data-row-id={String(Number(row.id))}>
+                      {/* Only while unsaved: force a full save (shows the full error if it fails). */}
+                      <Show when={editor.isDirty(Number(row.id))}>
+                        <button type="button" class="link-button is-icon is-unsaved" aria-label={m.app_save()} title={m.app_save()} onClick={() => void editor.flushRow(Number(row.id), 'force')}>
+                          <DiskIcon />
+                        </button>
+                      </Show>
                       <Show when={props.descriptor.editable !== false}>
                         <button type="button" class="link-button is-icon" aria-label={m.admin_edit()} title={m.admin_edit()} onClick={() => openForm(row)}>
                           <EditIcon />

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -285,13 +285,17 @@ export function AdminCrudShell(props: {
     onSaved: () => flashNotice(m.admin_saved()),
     saveErrorMessage: (caught) => apiErrorMessage(caught, m.app_load_error()),
     // Required fields must be filled for the row to auto-save; an empty one is
-    // hinted (border) until then.
+    // hinted (border) until then. A select/relation "none" is 0; for a numeric
+    // field 0 is a real value, so it isn't treated as empty.
     invalidFields: (draft) => props.descriptor.fields
       .filter((field) => field.required === true)
       .filter((field) => {
         const value = draft[field.name]
+        if (value === undefined || value === null || value === '') {
+          return true
+        }
 
-        return value === undefined || value === null || value === '' || value === 0
+        return field.type === 'select' && value === 0
       })
       .map((field) => field.name),
   })

--- a/frontend/src/lib/icons.tsx
+++ b/frontend/src/lib/icons.tsx
@@ -31,3 +31,12 @@ export function DownloadIcon(): JSX.Element {
 export function PlusIcon(): JSX.Element {
   return <Icon><path d="M12 5v14M5 12h14" /></Icon>
 }
+
+export function DiskIcon(): JSX.Element {
+  return (
+    <Icon>
+      <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+      <path d="M17 21v-8H7v8M7 3v5h8" />
+    </Icon>
+  )
+}

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -337,12 +337,20 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     }
     setSavingRows(id, true)
     setRowErrors(id, '')
+    // Snapshot what we send: an edit committed WHILE this save is in flight (the
+    // savingRows guard blocks a concurrent flush) lands in the live draft, so we
+    // must not clear those newer edits on success — compare before dropping.
+    const snapshot = { ...draft }
+    const sentJson = JSON.stringify(snapshot)
     try {
-      await config.saveRow({ ...draft }, row)
-      // Refetch has the saved values now, so dropping the draft shows no flash.
-      setDrafts(produce((store) => { delete store[id] }))
-      setFieldHints(produce((store) => { delete store[id] }))
-      originalRows.delete(id)
+      await config.saveRow(snapshot, row)
+      // Refetch has the saved values now, so dropping the draft shows no flash —
+      // but only when nothing changed since (else the newer edits would be lost).
+      if (drafts[id] !== undefined && JSON.stringify({ ...drafts[id] }) === sentJson) {
+        setDrafts(produce((store) => { delete store[id] }))
+        setFieldHints(produce((store) => { delete store[id] }))
+        originalRows.delete(id)
+      }
       config.onSaved?.()
     } catch (caught) {
       // Keep the draft so edits aren't lost. An auto-save stays quiet (the field
@@ -353,6 +361,11 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       }
     } finally {
       setSavingRows(id, false)
+    }
+    // Edits arrived during the save (draft kept + changed) → persist the newer
+    // state (recomputes hints; auto-saves again only if still complete).
+    if (drafts[id] !== undefined && JSON.stringify({ ...drafts[id] }) !== sentJson) {
+      refreshHints(id)
     }
   }
 

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -170,7 +170,16 @@ export interface InlineGridEditConfig<R extends object> {
   onSaved?: () => void
   /** Map a save error to a per-row message. Defaults to the generic load error. */
   saveErrorMessage?: (error: unknown) => string
+  /** The column keys whose draft value is missing/invalid (empty array = the row
+   *  is complete and may auto-save). Drives the per-cell invalid hint and gates
+   *  auto-save on completeness. Omit to disable auto-save (save on leave/force). */
+  invalidFields?: (draft: FormValues, row: R) => string[]
 }
+
+/** How a save was triggered. 'auto' (a complete row after a cell commit) stays
+ *  quiet on failure — only the field hints show; 'force' (the save button) and
+ *  'leave' (focus left the row) surface the full row error. */
+export type SaveMode = 'auto' | 'force' | 'leave'
 
 /**
  * The spreadsheet-style inline-edit controller shared by the admin grid and the
@@ -183,6 +192,9 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
   const [drafts, setDrafts] = createStore<Record<number, FormValues>>({})
   const [savingRows, setSavingRows] = createStore<Record<number, boolean>>({})
   const [rowErrors, setRowErrors] = createStore<Record<number, string>>({})
+  // Per-row list of missing/invalid column keys, for the quiet (border) hint
+  // shown while auto-saving — never a blocking error message.
+  const [fieldHints, setFieldHints] = createStore<Record<number, string[]>>({})
   let seedChar: string | undefined
   let moveHandle: GridMoveHandle | null = null
   let tableEl: HTMLElement | undefined
@@ -265,12 +277,32 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     config.onCommit?.(cell.rowId, cell.colKey, value)
     seedChar = undefined
     setEditCell(null)
+    refreshHints(cell.rowId)
     // All focus moves go through the grid's setActive (the single roving-tabindex
     // writer); landing on a different row triggers that row's save via focusin.
     if (direction === 'stay') {
       moveHandle?.focusActive()
     } else if (direction) {
       moveHandle?.move(direction)
+    }
+  }
+
+  // After a commit: recompute the row's invalid-field hints and, when the row is
+  // complete (no invalid fields), auto-save it quietly. Saving no longer depends
+  // on leaving the row. A no-op when the host provides no invalidFields.
+  function refreshHints(id: number): void {
+    if (config.invalidFields === undefined) {
+      return
+    }
+    const draft = drafts[id]
+    const row = rowById(id)
+    if (draft === undefined || row === undefined) {
+      return
+    }
+    const invalid = config.invalidFields(draft, row)
+    setFieldHints(id, invalid)
+    if (invalid.length === 0) {
+      void flushRow(id, 'auto')
     }
   }
 
@@ -291,12 +323,13 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       setEditCell(null)
     }
     setDrafts(produce((store) => { delete store[id] }))
+    setFieldHints(produce((store) => { delete store[id] }))
     originalRows.delete(id)
 
     return { ...draft }
   }
 
-  async function flushRow(id: number): Promise<void> {
+  async function flushRow(id: number, mode: SaveMode = 'leave'): Promise<void> {
     const draft = drafts[id]
     const row = rowById(id)
     if (draft === undefined || row === undefined || savingRows[id]) {
@@ -308,11 +341,16 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       await config.saveRow({ ...draft }, row)
       // Refetch has the saved values now, so dropping the draft shows no flash.
       setDrafts(produce((store) => { delete store[id] }))
+      setFieldHints(produce((store) => { delete store[id] }))
       originalRows.delete(id)
       config.onSaved?.()
     } catch (caught) {
-      // Keep the draft so edits aren't lost; surface a per-row error.
-      setRowErrors(id, config.saveErrorMessage?.(caught) ?? m.app_load_error())
+      // Keep the draft so edits aren't lost. An auto-save stays quiet (the field
+      // hints already mark what's off); an explicit force/leave surfaces the full
+      // error so a real failure is never hidden.
+      if (mode !== 'auto') {
+        setRowErrors(id, config.saveErrorMessage?.(caught) ?? m.app_load_error())
+      }
     } finally {
       setSavingRows(id, false)
     }
@@ -333,7 +371,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       return
     }
     if (lastFocusedRowId !== null) {
-      void flushRow(lastFocusedRowId)
+      void flushRow(lastFocusedRowId, 'leave')
     }
     lastFocusedRowId = id
   }
@@ -343,7 +381,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
       return
     }
     if (lastFocusedRowId !== null) {
-      void flushRow(lastFocusedRowId)
+      void flushRow(lastFocusedRowId, 'leave')
     }
   }
 
@@ -371,6 +409,9 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     drafts,
     savingRows,
     rowErrors,
+    fieldHints,
+    /** True when the row has a missing/invalid draft value for this column. */
+    fieldInvalid: (id: number, colKey: string): boolean => (fieldHints[id]?.includes(colKey) ?? false),
     seedChar: (): string | undefined => seedChar,
     overlayRow,
     isEditing,

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -462,6 +462,41 @@ describe('Admin inline cell editing', () => {
 
     unmount()
   })
+
+  it('does not drop an edit committed while an auto-save is in flight', async () => {
+    mockEndpoints()
+    let resolveFirst!: () => void
+    postJson
+      .mockImplementationOnce(() => new Promise<void>((resolve) => { resolveFirst = () => resolve() })) // 1st save hangs
+      .mockResolvedValue([1, 'A2', true, false, [2]])
+    const { getByRole, unmount } = renderAdmin()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
+
+    // Edit name → A1 → commit. The complete row auto-saves, but the POST hangs.
+    const cell = getByRole('gridcell', { name: 'ACME' })
+    cell.focus()
+    fireEvent.keyDown(cell, { key: 'Enter' })
+    let editor = (await screen.findByRole('textbox')) as HTMLInputElement
+    fireEvent.input(editor, { target: { value: 'A1' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    await waitFor(() => expect(postJson).toHaveBeenCalledTimes(1))
+
+    // Edit the same cell again → A2 → commit WHILE the first save is still in flight.
+    const dirtyCell = getByRole('gridcell', { name: 'A1' })
+    dirtyCell.focus()
+    fireEvent.keyDown(dirtyCell, { key: 'Enter' })
+    editor = (await screen.findByRole('textbox')) as HTMLInputElement
+    fireEvent.input(editor, { target: { value: 'A2' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    // The first save resolves; the A2 edit must NOT be dropped — it re-saves.
+    resolveFirst()
+    await waitFor(() =>
+      expect(postJson).toHaveBeenLastCalledWith('/customer/save', expect.objectContaining({ name: 'A2' })),
+    )
+
+    unmount()
+  })
 })
 
 describe('Admin list — inactive filter, paging, CSV export', () => {

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -281,8 +281,8 @@ describe('Admin', () => {
 })
 
 describe('Admin inline cell editing', () => {
-  it('opens an inline editor on Enter and saves the whole entity on row-leave', async () => {
-    mockEndpoints()
+  it('auto-saves a complete row on commit (no need to leave the row)', async () => {
+    mockEndpoints() // the customer row has its required name → editing keeps it complete
     postJson.mockResolvedValue([1, 'ACME2', true, false, [2]])
     const { getByRole, unmount } = renderAdmin()
     await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
@@ -293,18 +293,12 @@ describe('Admin inline cell editing', () => {
 
     const editor = (await screen.findByRole('textbox')) as HTMLInputElement
     fireEvent.input(editor, { target: { value: 'ACME2' } })
-    // Enter commits the cell; the single row stays put (clamped).
-    fireEvent.keyDown(editor, { key: 'Enter' })
-    // The committed value is shown immediately, before any save.
-    await waitFor(() => expect(getByRole('gridcell', { name: 'ACME2' })).toBeInTheDocument())
-    expect(postJson).not.toHaveBeenCalled()
+    fireEvent.keyDown(editor, { key: 'Enter' }) // commit → row complete → auto-save
 
-    // Leaving the table (focusing the filter box) saves the dirty row once.
-    ;(getByRole('searchbox') as HTMLElement).focus()
+    // Saved on commit — no row-leave needed.
     await waitFor(() =>
       expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ id: 1, name: 'ACME2', active: true, global: false })),
     )
-    expect(postJson).toHaveBeenCalledTimes(1)
 
     unmount()
   })
@@ -324,23 +318,14 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
-  it('batches edits across columns of one row into a single save', async () => {
+  it('auto-saves a checkbox edit immediately, without leaving the row', async () => {
     mockEndpoints()
-    postJson.mockResolvedValue([1, 'ACME2', true, true, [2]])
+    postJson.mockResolvedValue([1, 'ACME', true, true, [2]])
     const { getByRole, unmount } = renderAdmin()
     await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
 
-    // Edit the name cell.
-    const nameCell = getByRole('gridcell', { name: 'ACME' })
-    nameCell.focus()
-    fireEvent.keyDown(nameCell, { key: 'Enter' })
-    const editor = (await screen.findByRole('textbox')) as HTMLInputElement
-    fireEvent.input(editor, { target: { value: 'ACME2' } })
-    fireEvent.keyDown(editor, { key: 'Enter' })
-    await waitFor(() => expect(getByRole('gridcell', { name: 'ACME2' })).toBeInTheDocument())
-
-    // Edit the "global" checkbox cell in the same row (— → toggle on). Scope the
-    // query to the cell so it doesn't match the toolbar's "Show inactive" toggle.
+    // Toggle the "global" checkbox cell (— → on) on the (complete) ACME row.
+    // Scoping to the cell avoids matching the toolbar's "Show inactive" toggle.
     const globalCell = getByRole('gridcell', { name: '—' })
     globalCell.focus()
     fireEvent.keyDown(globalCell, { key: 'Enter' })
@@ -351,14 +336,11 @@ describe('Admin inline cell editing', () => {
       return el
     })
     fireEvent.click(check)
-    fireEvent.keyDown(check, { key: 'Enter' })
+    fireEvent.keyDown(check, { key: 'Enter' }) // commit → row complete → auto-save
 
-    // Both edits live on one draft → leaving the row saves exactly once.
-    ;(getByRole('searchbox') as HTMLElement).focus()
     await waitFor(() =>
-      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ name: 'ACME2', global: true })),
+      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ global: true })),
     )
-    expect(postJson).toHaveBeenCalledTimes(1)
 
     unmount()
   })
@@ -427,10 +409,10 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
-  it('keeps the draft and shows a row error when the save fails', async () => {
+  it('auto-save fails quietly; the disk (force) save shows the full error and keeps the draft', async () => {
     mockEndpoints()
     postJson.mockRejectedValue(new ApiError(422, 'Name taken'))
-    const { getByRole, unmount } = renderAdmin()
+    const { getByRole, queryByRole, unmount } = renderAdmin()
     await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
 
     const cell = getByRole('gridcell', { name: 'ACME' })
@@ -438,9 +420,17 @@ describe('Admin inline cell editing', () => {
     fireEvent.keyDown(cell, { key: 'Enter' })
     const editor = (await screen.findByRole('textbox')) as HTMLInputElement
     fireEvent.input(editor, { target: { value: 'ACME2' } })
-    fireEvent.keyDown(editor, { key: 'Enter' })
-    ;(getByRole('searchbox') as HTMLElement).focus()
+    fireEvent.keyDown(editor, { key: 'Enter' }) // commit → auto-save attempt
 
+    // Auto-save attempted (complete row); its failure is quiet — no alert. Wait
+    // for it to settle (row no longer aria-busy) so the force save isn't skipped.
+    await waitFor(() => expect(postJson).toHaveBeenCalled())
+    const dirtyRow = getByRole('gridcell', { name: 'ACME2' }).closest('tr')!
+    await waitFor(() => expect(dirtyRow).not.toHaveAttribute('aria-busy'))
+    expect(queryByRole('alert')).not.toBeInTheDocument()
+
+    // The disk (force) save appears while unsaved → it surfaces the full error.
+    fireEvent.click(getByRole('button', { name: /save/i }))
     await waitFor(() => expect(getByRole('alert')).toHaveTextContent('Name taken'))
     // The edited value is retained (not rolled back) so it isn't lost.
     expect(getByRole('gridcell', { name: 'ACME2' })).toBeInTheDocument()
@@ -450,23 +440,25 @@ describe('Admin inline cell editing', () => {
 
   it('hands a pending inline draft to the modal instead of stale row data', async () => {
     mockEndpoints()
+    // The save fails, so the auto-save keeps the draft dirty (rather than
+    // clearing it), letting us verify the still-pending draft seeds the modal.
+    postJson.mockRejectedValue(new ApiError(422, 'nope'))
     const { getByRole, unmount } = renderAdmin()
     await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
 
-    // Start an inline edit but stay on the row (single-row list → no save).
     const cell = getByRole('gridcell', { name: 'ACME' })
     cell.focus()
     fireEvent.keyDown(cell, { key: 'Enter' })
     const inlineEditor = (await screen.findByRole('textbox')) as HTMLInputElement
     fireEvent.input(inlineEditor, { target: { value: 'ACME-DIRTY' } })
-    fireEvent.keyDown(inlineEditor, { key: 'Enter' }) // commit; clamps on the only row
+    fireEvent.keyDown(inlineEditor, { key: 'Enter' }) // commit → auto-save (quiet fail → draft kept)
+    await waitFor(() => expect(postJson).toHaveBeenCalled())
 
-    // Opening the modal must seed from the draft (the edited value), not the
-    // stale list row, and must not have fired an inline save.
+    // Opening the modal must seed from the still-pending draft (the edited value),
+    // not the stale list row.
     fireEvent.click(getByRole('button', { name: 'Edit' }))
     const modalName = (await screen.findByRole('textbox')) as HTMLInputElement
     await waitFor(() => expect(modalName).toHaveValue('ACME-DIRTY'))
-    expect(postJson).not.toHaveBeenCalled()
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -161,26 +161,22 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
-  it('saves the whole entry to /tracking/save on row-leave', async () => {
-    mockApi()
+  it('auto-saves the whole entry to /tracking/save on commit when the row is complete', async () => {
+    mockApi() // DEFAULT_ENTRY has every required field → editing it keeps it complete
     postJson.mockResolvedValue({})
     const { getByRole, container, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
 
     const editor = editCell(container, 'ticket')
     fireEvent.input(editor, { target: { value: 'xyz-9' } })
-    fireEvent.keyDown(editor, { key: 'Enter' })
-    // Nothing saved until the row is left.
-    expect(postJson).not.toHaveBeenCalled()
+    fireEvent.keyDown(editor, { key: 'Enter' }) // commit → row complete → auto-save
 
-    // Leave the table (focus the days selector) → the dirty row saves once.
-    ;(getByRole('combobox') as HTMLElement).focus()
+    // Saved on commit — no need to leave the row.
     await waitFor(() =>
       expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({
         id: 1, ticket: 'XYZ-9', date: '2026-06-16', start: '09:00', end: '10:30', customer: 1, project: 4, activity: 5,
       })),
     )
-    expect(postJson).toHaveBeenCalledTimes(1)
 
     unmount()
   })
@@ -453,7 +449,14 @@ describe('Tracking (Worklog grid)', () => {
   })
 
   it('normalizes a terse start time in the cell on commit (1300 → 13:00)', async () => {
-    mockApi()
+    // An incomplete row (no customer) won't auto-save, so the normalized draft
+    // value stays visible instead of being reverted by a save+refetch.
+    mockTracking({
+      entries: [{ entry: { ...DEFAULT_ENTRY, customer: 0, class: 0 } }],
+      customers: [{ customer: { id: 1, name: 'ACME' } }],
+      projects: [{ project: { id: 4, name: 'Site' } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
     const { getByRole, container, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
 

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -9,7 +9,7 @@ import { appConfig } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { gridNav } from '../lib/gridNavigation'
 import { createInlineGridEdit, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
-import { DownloadIcon, PlusIcon, TrashIcon } from '../lib/icons'
+import { DiskIcon, DownloadIcon, PlusIcon, TrashIcon } from '../lib/icons'
 import { BulkEntryForm } from '../components/BulkEntryForm'
 import { parseTime, toIsoDate } from '../lib/timeParse'
 import { m } from '../paraglide/messages.js'
@@ -261,6 +261,18 @@ export default function Tracking() {
     },
     onCommit: handleCommit,
     saveErrorMessage: (caught) => (caught instanceof Error ? caught.message : m.app_load_error()),
+    // Required for a bookable entry — the row auto-saves once all are valid.
+    invalidFields: (draft) => {
+      const invalid: string[] = []
+      if (str(draft.date) === '') invalid.push('date')
+      if (parseTime(str(draft.start)) === null) invalid.push('start')
+      if (parseTime(str(draft.end)) === null) invalid.push('end')
+      if (num(draft.customer) <= 0) invalid.push('customer')
+      if (num(draft.project) <= 0) invalid.push('project')
+      if (num(draft.activity) <= 0) invalid.push('activity')
+
+      return invalid
+    },
   })
 
   // Display value from the draft-overlaid row, so an edited-but-unsaved cell
@@ -553,14 +565,14 @@ export default function Tracking() {
 
                   return (
                     <>
-                    <tr class={`tracking-row ${id <= 0 ? 'is-new' : CLASS_ROW[entry.class] ?? ''}`.trimEnd()} aria-busy={editor.savingRows[id] ? 'true' : undefined}>
+                    <tr class={`tracking-row ${id <= 0 ? 'is-new' : CLASS_ROW[entry.class] ?? ''}`.trimEnd()} classList={{ 'is-dirty': editor.isDirty(id) }} aria-busy={editor.savingRows[id] ? 'true' : undefined}>
                       <For each={COLUMNS}>
                         {(col) => {
                           const editable = FIELD_BY_KEY.has(col.key)
 
                           return (
                             <td
-                              classList={{ numeric: col.numeric, 'is-editable': editable }}
+                              classList={{ numeric: col.numeric, 'is-editable': editable, 'is-invalid': editor.fieldInvalid(id, col.key) }}
                               data-row-id={String(id)}
                               data-col-key={col.key}
                               data-inline-editing={editor.isEditing(id, col.key) ? '' : undefined}
@@ -589,6 +601,12 @@ export default function Tracking() {
                           "inside the row" so clicking Delete isn't read as a row-leave. */}
                       <td class="tracking-row-actions" data-row-id={String(id)}>
                         <div class="row-actions">
+                          {/* Only while unsaved: force a full save (shows the full error if it fails). */}
+                          <Show when={editor.isDirty(id)}>
+                            <button type="button" class="link-button is-icon is-unsaved" aria-label={m.app_save()} title={m.app_save()} onClick={() => void editor.flushRow(id, 'force')}>
+                              <DiskIcon />
+                            </button>
+                          </Show>
                           <button type="button" class="link-button is-icon is-danger" aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => void removeEntry(entry)}>
                             <TrashIcon />
                           </button>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1330,6 +1330,24 @@ th[aria-sort='descending'] .th-sort-glyph {
   padding: 0.1rem 0.9rem 0.5rem;
 }
 
+/* Unsaved (dirty) row: a faint warning tint marks pending edits until the row
+   auto-saves (complete) or is force-saved via its disk button. */
+.data-table tbody tr.is-dirty > td {
+  background: var(--color-warning-bg);
+}
+
+/* A missing/invalid field while auto-saving — a quiet inset border hint, never
+   a blocking message (the full error only shows on row-leave / force-save). */
+.data-table td.is-invalid {
+  box-shadow: inset 0 0 0 2px var(--color-danger-text);
+}
+
+/* The force-save (disk) action shows only while unsaved and is tinted to draw
+   the eye to the pending row. */
+.link-button.is-unsaved {
+  color: var(--color-warning-text);
+}
+
 .modal-backdrop {
   background: rgba(0, 0, 0, 0.45);
   inset: 0;


### PR DESCRIPTION
Reworks the inline-edit save model for **both grids** per the agreed spec.

- **Save no longer depends on leaving the row.** A host `invalidFields()` client gate determines completeness; once a row has no invalid fields it **auto-saves on commit**. Missing/invalid fields get a quiet inset **border hint** (`.is-invalid`) — never a popup.
- **`flushRow(mode)`:** an `auto` save stays **quiet** on failure (only hints show, so auto-save can't bury a hard error); **`force`** (the new disk button) and **`leave`** (focus left the row) surface the **full** row error.
- **Unsaved state is visible:** dirty rows are tinted (`.is-dirty`) and show a **disk (force-save) button** in their actions, only while dirty.

Worklog completeness = date + valid start/end + customer/project/activity; Admin = the descriptor's required fields.

## Verification
- 207 vitest pass — tests migrated from the old save-on-leave/batch model to auto-save (incl. quiet-auto-fail → disk force-save → full error, and the pending-draft→modal handoff on a kept draft).
- Lint + typecheck clean. Dirty-tint + invalid-border + disk icon verified visually (light + dark).