### PR TITLE
feat(ui): Alt-hold reveals keyboard-shortcut badges

### DIFF
--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { formatDays, formatDuration, handleShortcut } from './header'
+import { formatDays, formatDuration, handleShortcut, hideAccessHints, showAccessHints } from './header'
 
 describe('formatDuration', () => {
   it('formats minutes as H:MM like the ExtJS header', () => {
@@ -143,6 +143,24 @@ describe('handleShortcut', () => {
     handleShortcut(event)
     expect(document.activeElement).toBe(document.body)
     expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('the Alt-hold overlay badges nav items 1..N and shortcut elements with their key', () => {
+    setup()
+    document.getElementById('main-content')!.insertAdjacentHTML(
+      'afterbegin', '<button type="button" aria-keyshortcuts="Alt+A">Add</button>',
+    )
+
+    showAccessHints()
+    expect(document.body.classList.contains('show-access-keys')).toBe(true)
+    const navHints = Array.from(document.querySelectorAll('.main-nav a.main-nav-link'))
+      .map((el) => el.getAttribute('data-access-hint'))
+    expect(navHints.slice(0, 3)).toEqual(['1', '2', '3'])
+    expect(document.querySelector('[aria-keyshortcuts="Alt+A"]')?.getAttribute('data-access-hint')).toBe('A')
+
+    hideAccessHints()
+    expect(document.body.classList.contains('show-access-keys')).toBe(false)
+    expect(document.querySelector('[data-access-hint]')).toBeNull()
   })
 
   it('ArrowDown on <body> with no grid stays put (native scroll preserved)', () => {

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -349,8 +349,9 @@ export function showAccessHints(): void {
   if (document.body.classList.contains('show-access-keys')) {
     return
   }
-  // Nav bar items 1..N (mirrors the Alt+N targets; single digits only).
-  navLinks().slice(0, 9).forEach((link, index) => link.setAttribute(ACCESS_HINT_ATTR, String(index + 1)))
+  // Nav bar items 1..7 only — that's the range the Alt+N handler binds
+  // (/^Digit[1-7]$/), so a badge never advertises a shortcut that won't fire.
+  navLinks().slice(0, 7).forEach((link, index) => link.setAttribute(ACCESS_HINT_ATTR, String(index + 1)))
   document.querySelectorAll<HTMLElement>('[aria-keyshortcuts]').forEach((el) => {
     const key = accessKeyOf(el.getAttribute('aria-keyshortcuts'))
     if (key !== null) {

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -331,12 +331,62 @@ export function handleShortcut(event: KeyboardEvent): void {
   }
 }
 
+// ── Access-key overlay ───────────────────────────────────────────────────────
+// Holding Alt reveals the keyboard shortcuts as small badges: 1..N on the nav
+// bar items (Alt+1..N) and the modifier key on anything advertising an
+// aria-keyshortcuts (Alt+A on Add, Alt+C on Continue, …). The page just sets a
+// data-access-hint attribute + a body class; the badge itself is CSS.
+const ACCESS_HINT_ATTR = 'data-access-hint'
+
+/** "Alt+C" → "C", "Alt+1" → "1", "?" → "?"; the part after the last "+". */
+function accessKeyOf(shortcut: string | null): string | null {
+  const key = (shortcut ?? '').split('+').pop()?.trim() ?? ''
+
+  return key === '' ? null : key.toUpperCase()
+}
+
+export function showAccessHints(): void {
+  if (document.body.classList.contains('show-access-keys')) {
+    return
+  }
+  // Nav bar items 1..N (mirrors the Alt+N targets; single digits only).
+  navLinks().slice(0, 9).forEach((link, index) => link.setAttribute(ACCESS_HINT_ATTR, String(index + 1)))
+  document.querySelectorAll<HTMLElement>('[aria-keyshortcuts]').forEach((el) => {
+    const key = accessKeyOf(el.getAttribute('aria-keyshortcuts'))
+    if (key !== null) {
+      el.setAttribute(ACCESS_HINT_ATTR, key)
+    }
+  })
+  document.body.classList.add('show-access-keys')
+}
+
+export function hideAccessHints(): void {
+  if (!document.body.classList.contains('show-access-keys')) {
+    return
+  }
+  document.querySelectorAll(`[${ACCESS_HINT_ATTR}]`).forEach((el) => el.removeAttribute(ACCESS_HINT_ATTR))
+  document.body.classList.remove('show-access-keys')
+}
+
 function initShortcuts(): void {
   if (shortcutsWired) {
     return
   }
   shortcutsWired = true
   document.addEventListener('keydown', handleShortcut)
+  // Alt-hold shows the shortcut badges; Alt-up (or losing the window — so a
+  // missed keyup can't strand them) hides them.
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Alt' && !event.repeat) {
+      showAccessHints()
+    }
+  })
+  document.addEventListener('keyup', (event) => {
+    if (event.key === 'Alt') {
+      hideAccessHints()
+    }
+  })
+  window.addEventListener('blur', hideAccessHints)
 }
 
 function pollLoginStatus(config: AppConfig): void {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1348,6 +1348,34 @@ th[aria-sort='descending'] .th-sort-glyph {
   color: var(--color-warning-text);
 }
 
+/* Access-key overlay: while Alt is held (body.show-access-keys, set by
+   header.ts), each shortcut target shows a small corner badge with its key —
+   1..N on the nav items, the letter on the toolbar actions. */
+.show-access-keys [data-access-hint] {
+  position: relative;
+}
+
+.show-access-keys [data-access-hint]::after {
+  content: attr(data-access-hint);
+  align-items: center;
+  background: var(--color-accent);
+  border-radius: 4px;
+  color: light-dark(#ffffff, #10171a);
+  display: inline-flex;
+  font-size: 0.68rem;
+  font-weight: 700;
+  height: 1.05rem;
+  inset-block-start: -0.4rem;
+  inset-inline-end: -0.4rem;
+  justify-content: center;
+  line-height: 1;
+  min-width: 1.05rem;
+  padding: 0 0.2rem;
+  pointer-events: none;
+  position: absolute;
+  z-index: 6;
+}
+
 .modal-backdrop {
   background: rgba(0, 0, 0, 0.45);
   inset: 0;


### PR DESCRIPTION
Holding **Alt** overlays the available shortcuts as small corner badges — **1…N** on the main-nav items (Alt+1..N) and the key on anything with an `aria-keyshortcuts` (A=Add, C=Continue, P=Prolong, I=Info, X=Export). Makes the existing shortcuts discoverable without a cheatsheet.

Implementation: the handler sets a `data-access-hint` attribute + a `show-access-keys` body class; the badge is pure CSS (`::after`). Cleared on Alt-up or window blur (so a missed keyup can't strand the badges). SPA-scoped (header.ts).

209 vitest pass (added an overlay test); lint + typecheck clean; badges verified visually.