### PR TITLE
feat(ui): inline-edit multiselect columns as removable tag chips

### DIFF
--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -57,13 +57,15 @@ test.describe('Admin inline cell editing', () => {
     await expect(page.locator('td[data-col-key="name"]').first()).toHaveText(original);
   });
 
-  test('does not inline-edit a modal-only (multiselect) column', async ({ page }) => {
+  test('inline-edits a multiselect column as tag chips', async ({ page }) => {
     const teamsCell = page.locator('td[data-col-key="teams"]').first();
     await teamsCell.focus();
     await page.keyboard.press('Enter');
 
-    // The teams column maps to a multiselect field → no inline editor opens.
-    await expect(page.locator('td[data-inline-editing]')).toHaveCount(0);
+    // The teams column opens an inline tag editor (chips + an add dropdown),
+    // not the modal.
+    await expect(teamsCell.locator('select.tag-add')).toBeVisible();
+    await expect(page.locator('[role="dialog"]')).toHaveCount(0);
   });
 
   test('the Edit button opens the modal seeded with the in-progress inline value', async ({ page }) => {

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -527,8 +527,7 @@ export function AdminCrudShell(props: {
                             }}
                           >
                             <Show when={editor.isEditing(rowId, col.key)} fallback={displayText(row, col)}>
-                              <Show
-                                when={fieldFor(col.key)?.type === 'multiselect'}
+                              <Switch
                                 fallback={
                                   <InlineEditor
                                     field={fieldFor(col.key)!}
@@ -541,15 +540,17 @@ export function AdminCrudShell(props: {
                                   />
                                 }
                               >
-                                <InlineMultiSelect
-                                  field={fieldFor(col.key)!}
-                                  label={col.label()}
-                                  initial={editor.draftValue(rowId, col.key) ?? []}
-                                  options={props.options}
-                                  onCommit={editor.commitCell}
-                                  onCancel={editor.cancelCell}
-                                />
-                              </Show>
+                                <Match when={fieldFor(col.key)?.type === 'multiselect'}>
+                                  <InlineMultiSelect
+                                    field={fieldFor(col.key)!}
+                                    label={col.label()}
+                                    initial={editor.draftValue(rowId, col.key) ?? []}
+                                    options={props.options}
+                                    onCommit={editor.commitCell}
+                                    onCancel={editor.cancelCell}
+                                  />
+                                </Match>
+                              </Switch>
                             </Show>
                           </td>
                         )

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -6,7 +6,7 @@ import { Portal } from 'solid-js/web'
 
 import { apiErrorMessage, getJson, postJson } from '../api/client'
 import { optionSourceKey } from '../api/queries'
-import { createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { createInlineGridEdit, fieldSelectOptions, InlineEditor, InlineMultiSelect, INLINE_TYPES } from '../lib/inlineGridEdit'
 import { gridNav } from '../lib/gridNavigation'
 import { DiskIcon, DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
 import { m } from '../paraglide/messages.js'
@@ -527,15 +527,29 @@ export function AdminCrudShell(props: {
                             }}
                           >
                             <Show when={editor.isEditing(rowId, col.key)} fallback={displayText(row, col)}>
-                              <InlineEditor
-                                field={fieldFor(col.key)!}
-                                label={col.label()}
-                                initial={editor.draftValue(rowId, col.key) ?? ''}
-                                seed={editor.seedChar()}
-                                options={props.options}
-                                onCommit={editor.commitCell}
-                                onCancel={editor.cancelCell}
-                              />
+                              <Show
+                                when={fieldFor(col.key)?.type === 'multiselect'}
+                                fallback={
+                                  <InlineEditor
+                                    field={fieldFor(col.key)!}
+                                    label={col.label()}
+                                    initial={editor.draftValue(rowId, col.key) ?? ''}
+                                    seed={editor.seedChar()}
+                                    options={props.options}
+                                    onCommit={editor.commitCell}
+                                    onCancel={editor.cancelCell}
+                                  />
+                                }
+                              >
+                                <InlineMultiSelect
+                                  field={fieldFor(col.key)!}
+                                  label={col.label()}
+                                  initial={editor.draftValue(rowId, col.key) ?? []}
+                                  options={props.options}
+                                  onCommit={editor.commitCell}
+                                  onCancel={editor.cancelCell}
+                                />
+                              </Show>
                             </Show>
                           </td>
                         )

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -210,10 +210,21 @@ export function InlineMultiSelect(props: {
           event.preventDefault()
           event.stopPropagation()
           finish(selected(), 'stay')
+        } else if (event.key === 'Tab') {
+          // Keep spreadsheet cell-to-cell nav: commit and move to the adjacent
+          // cell rather than tabbing focus out of the grid entirely.
+          event.preventDefault()
+          event.stopPropagation()
+          finish(selected(), event.shiftKey ? 'left' : 'right')
         } else if (event.key === 'Escape') {
           event.preventDefault()
           event.stopPropagation()
           cancel()
+        } else if (event.key === 'Backspace' && selected().length > 0) {
+          // Tag-input convention: Backspace removes the last chip (the × buttons
+          // are out of the Tab order, so this is the keyboard removal path).
+          event.preventDefault()
+          remove(selected()[selected().length - 1]!)
         }
       }}
       onFocusOut={() => {
@@ -233,7 +244,7 @@ export function InlineMultiSelect(props: {
         {(id) => (
           <span class="tag">
             <span class="tag-label">{labelOf(id)}</span>
-            <button type="button" class="tag-remove" aria-label={`${props.label}: ${labelOf(id)} ✕`} onClick={() => remove(id)}>×</button>
+            <button type="button" class="tag-remove" tabindex="-1" aria-label={`${props.label}: ${labelOf(id)} ✕`} onClick={() => remove(id)}>×</button>
           </span>
         )}
       </For>

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -10,7 +10,7 @@ export type Row = Record<string, unknown>
 
 // Field types that get a compact in-cell editor; everything else (multiselect,
 // locked relation columns) stays modal-only.
-export const INLINE_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date', 'checkbox', 'select'])
+export const INLINE_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date', 'checkbox', 'select', 'multiselect'])
 
 /** Shared option resolution for both the modal FieldControl and the inline
  *  editor, so relation/static dropdowns stay identical in either surface. */
@@ -144,6 +144,112 @@ export function InlineEditor(props: {
         />
       </Match>
     </Switch>
+  )
+}
+
+/**
+ * In-cell multiselect editor: the selected options render as removable tag chips
+ * with an "add" dropdown of the remaining options (Teams: [DEV ×] [PL ×] +). The
+ * value is the selected ids (number[]). Commit moves through the same onCommit
+ * as the single-cell editor: Enter commits in place, Escape cancels, and tabbing
+ * or clicking out of the whole widget commits (checked after the focus settles,
+ * so moving between chips/the dropdown — incl. removing one — doesn't commit).
+ */
+export function InlineMultiSelect(props: {
+  field: FieldDef
+  label: string
+  initial: FormValues[string]
+  options: OptionLookup
+  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
+  onCancel: () => void
+}) {
+  const allOptions = createMemo(() => fieldSelectOptions(props.field, props.options))
+  const [selected, setSelected] = createSignal<number[]>(Array.isArray(props.initial) ? [...(props.initial as number[])] : [])
+  const unselected = createMemo(() => allOptions().filter((option) => !selected().includes(Number(option.value))))
+  const labelOf = (id: number): string => allOptions().find((option) => Number(option.value) === id)?.label ?? String(id)
+  let container: HTMLDivElement | undefined
+  let addSelect: HTMLSelectElement | undefined
+  let done = false
+
+  function add(id: number): void {
+    if (id > 0 && !selected().includes(id)) {
+      setSelected([...selected(), id])
+    }
+    addSelect?.focus() // keep focus in the widget so the add reads as one action
+  }
+  function remove(id: number): void {
+    setSelected(selected().filter((value) => value !== id))
+    addSelect?.focus() // the chip's × unmounts — keep focus inside so it isn't a commit
+  }
+  // Takes the value so the signal is read in the (tracked) event handler, not in
+  // the deferred focusout microtask.
+  const finish = (value: number[], direction?: 'down' | 'left' | 'right' | 'stay') => {
+    if (done) {
+      return
+    }
+    done = true
+    props.onCommit([...value], direction)
+  }
+  const cancel = () => {
+    if (!done) {
+      done = true
+      props.onCancel()
+    }
+  }
+
+  onMount(() => addSelect?.focus())
+
+  return (
+    <div
+      ref={(el) => { container = el }}
+      class="inline-editor inline-tags"
+      role="group"
+      aria-label={props.label}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          event.stopPropagation()
+          finish(selected(), 'stay')
+        } else if (event.key === 'Escape') {
+          event.preventDefault()
+          event.stopPropagation()
+          cancel()
+        }
+      }}
+      onFocusOut={() => {
+        // Capture the value now (tracked handler), then commit only when focus
+        // has actually left the whole widget — checked after it settles, so
+        // moving between chips/the dropdown (incl. removing one) doesn't commit.
+        const value = selected()
+        // eslint-disable-next-line solid/reactivity -- intentional deferred commit of the captured value after focus settles
+        queueMicrotask(() => {
+          if (!done && container !== undefined && !container.contains(document.activeElement)) {
+            finish(value)
+          }
+        })
+      }}
+    >
+      <For each={selected()}>
+        {(id) => (
+          <span class="tag">
+            <span class="tag-label">{labelOf(id)}</span>
+            <button type="button" class="tag-remove" aria-label={`${props.label}: ${labelOf(id)} ✕`} onClick={() => remove(id)}>×</button>
+          </span>
+        )}
+      </For>
+      <select
+        ref={(el) => { addSelect = el }}
+        class="tag-add"
+        aria-label={props.label}
+        value=""
+        onInput={(event) => { add(Number(event.currentTarget.value)); event.currentTarget.value = '' }}
+      >
+        <option value="">+</option>
+        <For each={unselected()}>
+          {(option) => <option value={String(option.value)}>{option.label}</option>}
+        </For>
+      </select>
+    </div>
   )
 }
 

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -365,20 +365,40 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
-  it('opens the edit modal (not an inline editor) when activating a modal-only column', async () => {
-    mockEndpoints()
+  it('inline-edits a multiselect column as tag chips (add commits + auto-saves)', async () => {
+    getJson.mockImplementation((path: string) =>
+      path === '/getAllCustomers'
+        ? Promise.resolve([{ customer: { id: 1, name: 'ACME', active: true, global: false, teams: [2] } }])
+        : path === '/getAllTeams'
+          ? Promise.resolve([{ team: { id: 2, name: 'Backend' } }, { team: { id: 3, name: 'Frontend' } }])
+          : Promise.resolve([]),
+    )
+    postJson.mockResolvedValue([1, 'ACME', true, false, [2, 3]])
     const { getByRole, unmount } = renderAdmin()
-    await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Backend' })).toBeInTheDocument())
 
-    // The "Backend" cell is the teams (multiselect) column — not inline-editable.
     const teamsCell = getByRole('gridcell', { name: 'Backend' })
     teamsCell.focus()
     fireEvent.keyDown(teamsCell, { key: 'Enter' })
 
-    // No inline editor mounts in the cell; instead the full edit modal opens
-    // (portalled to document.body) so the field stays keyboard-reachable.
-    expect(teamsCell.querySelector('input')).toBeNull()
-    await screen.findByRole('dialog')
+    // An inline tag editor opens (chip for the current team + an add dropdown),
+    // not the modal.
+    const addSelect = await waitFor(() => {
+      const el = teamsCell.querySelector<HTMLSelectElement>('select.tag-add')
+      if (el === null) throw new Error('inline tag editor not mounted')
+
+      return el
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(within(teamsCell).getByText('Backend')).toBeInTheDocument() // existing team is a chip
+
+    // Add "Frontend" → Enter commits → the complete row auto-saves with [2, 3].
+    fireEvent.input(addSelect, { target: { value: '3' } })
+    fireEvent.keyDown(addSelect, { key: 'Enter' })
+    await waitFor(() =>
+      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ teams: [2, 3] })),
+    )
+
     unmount()
   })
 

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -402,6 +402,40 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
+  it('removes the last tag with Backspace in the inline multiselect (keyboard path)', async () => {
+    getJson.mockImplementation((path: string) =>
+      path === '/getAllCustomers'
+        ? Promise.resolve([{ customer: { id: 1, name: 'ACME', active: true, global: false, teams: [2] } }])
+        : path === '/getAllTeams'
+          ? Promise.resolve([{ team: { id: 2, name: 'Backend' } }])
+          : Promise.resolve([]),
+    )
+    postJson.mockResolvedValue([1, 'ACME', true, false, []])
+    const { getByRole, unmount } = renderAdmin()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Backend' })).toBeInTheDocument())
+
+    const teamsCell = getByRole('gridcell', { name: 'Backend' })
+    teamsCell.focus()
+    fireEvent.keyDown(teamsCell, { key: 'Enter' })
+    const addSelect = await waitFor(() => {
+      const el = teamsCell.querySelector<HTMLSelectElement>('select.tag-add')
+      if (el === null) throw new Error('inline tag editor not mounted')
+
+      return el
+    })
+
+    // Backspace removes the last chip (no .tag chips remain); Enter commits →
+    // auto-saves with no teams.
+    fireEvent.keyDown(addSelect, { key: 'Backspace' })
+    await waitFor(() => expect(teamsCell.querySelector('.tag')).toBeNull())
+    fireEvent.keyDown(addSelect, { key: 'Enter' })
+    await waitFor(() =>
+      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ teams: [] })),
+    )
+
+    unmount()
+  })
+
   it('keeps focus on the cell after Enter by default (stay, does not move down)', async () => {
     getJson.mockImplementation((path: string) =>
       path === '/getAllCustomers'

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -64,6 +64,32 @@ function renderAdmin(path = '/admin') {
   ))
 }
 
+// Renders the customer grid (customer 1 has team 2) with the given team
+// catalogue, then opens the inline tag editor on the "Backend" teams cell.
+async function openTeamsTagEditor(teams: { id: number; name: string }[]) {
+  getJson.mockImplementation((path: string) =>
+    path === '/getAllCustomers'
+      ? Promise.resolve([{ customer: { id: 1, name: 'ACME', active: true, global: false, teams: [2] } }])
+      : path === '/getAllTeams'
+        ? Promise.resolve(teams.map((team) => ({ team })))
+        : Promise.resolve([]),
+  )
+  const utils = renderAdmin()
+  await waitFor(() => expect(utils.getByRole('gridcell', { name: 'Backend' })).toBeInTheDocument())
+
+  const teamsCell = utils.getByRole('gridcell', { name: 'Backend' })
+  teamsCell.focus()
+  fireEvent.keyDown(teamsCell, { key: 'Enter' })
+  const addSelect = await waitFor(() => {
+    const el = teamsCell.querySelector<HTMLSelectElement>('select.tag-add')
+    if (el === null) throw new Error('inline tag editor not mounted')
+
+    return el
+  })
+
+  return { ...utils, teamsCell, addSelect }
+}
+
 afterEach(() => {
   getJson.mockReset()
   postJson.mockReset()
@@ -366,29 +392,14 @@ describe('Admin inline cell editing', () => {
   })
 
   it('inline-edits a multiselect column as tag chips (add commits + auto-saves)', async () => {
-    getJson.mockImplementation((path: string) =>
-      path === '/getAllCustomers'
-        ? Promise.resolve([{ customer: { id: 1, name: 'ACME', active: true, global: false, teams: [2] } }])
-        : path === '/getAllTeams'
-          ? Promise.resolve([{ team: { id: 2, name: 'Backend' } }, { team: { id: 3, name: 'Frontend' } }])
-          : Promise.resolve([]),
-    )
     postJson.mockResolvedValue([1, 'ACME', true, false, [2, 3]])
-    const { getByRole, unmount } = renderAdmin()
-    await waitFor(() => expect(getByRole('gridcell', { name: 'Backend' })).toBeInTheDocument())
+    const { teamsCell, addSelect, unmount } = await openTeamsTagEditor([
+      { id: 2, name: 'Backend' },
+      { id: 3, name: 'Frontend' },
+    ])
 
-    const teamsCell = getByRole('gridcell', { name: 'Backend' })
-    teamsCell.focus()
-    fireEvent.keyDown(teamsCell, { key: 'Enter' })
-
-    // An inline tag editor opens (chip for the current team + an add dropdown),
+    // An inline tag editor opened (chip for the current team + an add dropdown),
     // not the modal.
-    const addSelect = await waitFor(() => {
-      const el = teamsCell.querySelector<HTMLSelectElement>('select.tag-add')
-      if (el === null) throw new Error('inline tag editor not mounted')
-
-      return el
-    })
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(within(teamsCell).getByText('Backend')).toBeInTheDocument() // existing team is a chip
 
@@ -403,26 +414,8 @@ describe('Admin inline cell editing', () => {
   })
 
   it('removes the last tag with Backspace in the inline multiselect (keyboard path)', async () => {
-    getJson.mockImplementation((path: string) =>
-      path === '/getAllCustomers'
-        ? Promise.resolve([{ customer: { id: 1, name: 'ACME', active: true, global: false, teams: [2] } }])
-        : path === '/getAllTeams'
-          ? Promise.resolve([{ team: { id: 2, name: 'Backend' } }])
-          : Promise.resolve([]),
-    )
     postJson.mockResolvedValue([1, 'ACME', true, false, []])
-    const { getByRole, unmount } = renderAdmin()
-    await waitFor(() => expect(getByRole('gridcell', { name: 'Backend' })).toBeInTheDocument())
-
-    const teamsCell = getByRole('gridcell', { name: 'Backend' })
-    teamsCell.focus()
-    fireEvent.keyDown(teamsCell, { key: 'Enter' })
-    const addSelect = await waitFor(() => {
-      const el = teamsCell.querySelector<HTMLSelectElement>('select.tag-add')
-      if (el === null) throw new Error('inline tag editor not mounted')
-
-      return el
-    })
+    const { teamsCell, addSelect, unmount } = await openTeamsTagEditor([{ id: 2, name: 'Backend' }])
 
     // Backspace removes the last chip (no .tag chips remain); Enter commits →
     // auto-saves with no teams.

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1107,13 +1107,17 @@ kbd {
 }
 
 .inline-tags .tag-remove {
+  align-items: center;
   background: none;
   border: 0;
   color: var(--color-accent-text);
   cursor: pointer;
-  font-size: 1.05rem;
-  line-height: 1;
-  padding: 0 0.25rem;
+  display: inline-flex;
+  font-size: 1.1rem;
+  justify-content: center;
+  /* Discrete inline control: >=24px (WCAG 2.2 AA 2.5.8); flex-centred glyph. */
+  min-height: 1.5rem;
+  min-width: 1.5rem;
 }
 
 .inline-tags .tag-add {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1087,6 +1087,44 @@ kbd {
   width: auto;
 }
 
+/* Inline multiselect: selected options as removable chips + an "add" dropdown. */
+.inline-editor.inline-tags {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.inline-tags .tag {
+  align-items: center;
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent);
+  border-radius: 6px;
+  display: inline-flex;
+  font-size: 0.85rem;
+  gap: 0.1rem;
+  padding: 0 0.1rem 0 0.4rem;
+}
+
+.inline-tags .tag-remove {
+  background: none;
+  border: 0;
+  color: var(--color-accent-text);
+  cursor: pointer;
+  font-size: 1.05rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.inline-tags .tag-add {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text);
+  font: inherit;
+  min-height: 1.7rem;
+}
+
 /* A saving row dims slightly and blocks pointer interaction until it settles. */
 .data-table tbody tr[aria-busy='true'] {
   opacity: 0.6;


### PR DESCRIPTION
Makes multiselect columns (e.g. a customer's **Teams**) editable **inline** instead of modal-only — your `Teams: [(DEV ×)(PL ×) +]` sketch.

- New `InlineMultiSelect` editor: selected options as **removable chips** + an **add dropdown** of the rest. Commits through the same path as the other inline editors — Enter commits, Escape cancels, tabbing/clicking out of the whole widget commits (checked after focus settles, so moving between chips or removing one doesn't commit) — so a complete row still auto-saves.
- `'multiselect'` joins `INLINE_TYPES`; AdminCrudShell renders `InlineMultiSelect` for those cells (others keep `InlineEditor`).

## Verification
- 209 vitest pass — the unit + e2e "multiselect is modal-only" tests rewritten to verify inline chip editing (add → Enter → auto-save with the new ids).
- Lint + typecheck clean. Chip editor verified visually.