### PR TITLE
fix(ui): show current grid cell on mouse click; restore last-opened tab on every login

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -289,26 +289,25 @@ test.describe('Responsive Behavior', () => {
 });
 
 test.describe('Last-opened view memory', () => {
-  test('returns the user to their last-opened /ui view after re-login', async ({ page }) => {
+  // Each test starts from the same state: visit /ui/auswertung (recorded as
+  // tt:lastView), log out, then log back in in the SAME tab — where the old
+  // once-per-session guard failed to restore the view.
+  test.beforeEach(async ({ page }) => {
     await login(page); // fresh context → no saved view yet → lands on /
     await goToAuswertungPage(page); // → /ui/auswertung; the header records it as tt:lastView
     await expect(page).toHaveURL(/\/ui\/auswertung/);
 
     await logout(page); // → /login (flags that a login is in progress)
-
-    // Re-login in the SAME tab. The old once-per-session guard blocked this and
-    // left the user on the ExtJS root; they must now be returned to /ui/auswertung.
     await submitLogin(page);
+  });
+
+  test('returns the user to their last-opened /ui view after re-login', async ({ page }) => {
     await expect(page).toHaveURL(/\/ui\/auswertung/, { timeout: 15000 });
   });
 
   test('an explicit visit to the ExtJS root after a restore does not bounce back to /ui', async ({
     page,
   }) => {
-    await login(page);
-    await goToAuswertungPage(page);
-    await logout(page);
-    await submitLogin(page);
     await expect(page).toHaveURL(/\/ui\/auswertung/, { timeout: 15000 });
 
     // The restore flag is one-shot: navigating to / afterwards (e.g. the legacy

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from './helpers/auth';
+import { login, logout, TEST_USERS } from './helpers/auth';
 import {
   goToTrackingTab,
   goToAuswertungPage,
@@ -9,6 +9,15 @@ import {
   NAV_LINKS,
 } from './helpers/navigation';
 import { waitForGrid } from './helpers/grid';
+
+/** Submit the login form without asserting the landing URL (the restore may
+ *  redirect away from /), so the last-view tests can assert their own landing. */
+async function submitLogin(page: import('@playwright/test').Page): Promise<void> {
+  await page.waitForSelector('input[name="_username"]', { timeout: 10000 });
+  await page.locator('input[name="_username"]').fill(TEST_USERS.developer.username);
+  await page.locator('input[name="_password"]').fill(TEST_USERS.developer.password);
+  await page.locator('#form-submit').click();
+}
 
 /**
  * E2E tests for tab navigation and UI structure.
@@ -276,5 +285,36 @@ test.describe('Responsive Behavior', () => {
     // Header navigation to the SolidJS settings page should still work
     await goToSettingsPage(page);
     await expect(page.locator('select[name="locale"]')).toBeAttached();
+  });
+});
+
+test.describe('Last-opened view memory', () => {
+  test('returns the user to their last-opened /ui view after re-login', async ({ page }) => {
+    await login(page); // fresh context → no saved view yet → lands on /
+    await goToAuswertungPage(page); // → /ui/auswertung; the header records it as tt:lastView
+    await expect(page).toHaveURL(/\/ui\/auswertung/);
+
+    await logout(page); // → /login (flags that a login is in progress)
+
+    // Re-login in the SAME tab. The old once-per-session guard blocked this and
+    // left the user on the ExtJS root; they must now be returned to /ui/auswertung.
+    await submitLogin(page);
+    await expect(page).toHaveURL(/\/ui\/auswertung/, { timeout: 15000 });
+  });
+
+  test('an explicit visit to the ExtJS root after a restore does not bounce back to /ui', async ({
+    page,
+  }) => {
+    await login(page);
+    await goToAuswertungPage(page);
+    await logout(page);
+    await submitLogin(page);
+    await expect(page).toHaveURL(/\/ui\/auswertung/, { timeout: 15000 });
+
+    // The restore flag is one-shot: navigating to / afterwards (e.g. the legacy
+    // "Time tracking" link) must stay on the ExtJS shell, not bounce to /ui.
+    await page.goto('/');
+    await waitForGrid(page);
+    await expect(page).toHaveURL('/');
   });
 });

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -970,10 +970,14 @@ kbd {
   background: var(--color-accent-soft);
 }
 
-/* Keyboard grid navigation (use:gridNav): show which cell holds focus, using the
-   stronger focus token for contrast (>=3:1, WCAG 1.4.11) in both themes. */
-.data-table [role='gridcell']:focus-visible,
-.data-table [role='columnheader']:focus-visible {
+/* Grid navigation (use:gridNav): outline the cell that holds focus, using the
+   stronger focus token for contrast (>=3:1, WCAG 1.4.11) in both themes. Uses
+   :focus (not :focus-visible) on purpose — gridNav makes a cell "current" the
+   same way whether reached by arrow keys or a mouse click (setActive + focus),
+   so the indicator must be modality-independent. :focus-visible would suppress
+   the outline on pointer focus, leaving clicked cells current-but-invisible. */
+.data-table [role='gridcell']:focus,
+.data-table [role='columnheader']:focus {
   outline: 2px solid var(--color-focus);
   outline-offset: -2px;
 }

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -5,29 +5,9 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        {# Soft opt-in for the parallel work-log grids: on the FIRST root view of a
-           browser session (i.e. the post-login landing), if the user last used a
-           SolidJS (/ui/*) view, return them there before the heavy ExtJS bundle
-           loads. The once-per-session sessionStorage guard is essential: without
-           it, clicking the "Time tracking" link (→ /) would bounce straight back
-           to the last /ui view, making the ExtJS grid unreachable. The shared
-           header writes tt:lastView on every page. #}
-        <script>
-            try {
-                var ttSeenRoot = sessionStorage.getItem('tt:viewedRoot');
-                sessionStorage.setItem('tt:viewedRoot', '1');
-                var ttLastView = localStorage.getItem('tt:lastView');
-                if (!ttSeenRoot && ttLastView && ttLastView !== location.pathname) {
-                    // Resolve + validate so a crafted value (e.g. path traversal to a
-                    // protocol-relative URL) can't redirect off-origin: only a same-origin
-                    // /ui/ path is honoured, and we navigate to the RESOLVED pathname.
-                    var ttTarget = new URL(ttLastView, location.origin);
-                    if (ttTarget.origin === location.origin && ttTarget.pathname.indexOf('/ui/') === 0) {
-                        location.replace(ttTarget.pathname + ttTarget.search + ttTarget.hash);
-                    }
-                }
-            } catch (e) {}
-        </script>
+        {# After a login, return the user to their last-opened /ui view before the
+           heavy ExtJS bundle loads (see partials/last-view.html.twig). #}
+        {% include 'partials/last-view.html.twig' with {mode: 'restore'} %}
         <title>{{ apptitle }}</title>
         <link rel="stylesheet" href="{{ asset('build/js/ext-js/resources/css/ext-all-gray.css') }}" type="text/css">
         <link rel="stylesheet" href="{{ asset('build/css/header.css') }}" type="text/css">

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -8,6 +8,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ apptitle }}</title>
         <meta name="robots" content="noindex,nofollow">
+        {# Flag that a login is in progress, so the next app shell returns the user
+           to their last-opened /ui view (last-view.html.twig). #}
+        {% include 'partials/last-view.html.twig' with {mode: 'mark'} %}
         {# Apply the saved light/dark preference before first paint (shared with the app). #}
         {% include 'partials/theme-init.html.twig' %}
         {{ vite_entry_link_tags('login') }}

--- a/templates/partials/last-view.html.twig
+++ b/templates/partials/last-view.html.twig
@@ -1,0 +1,33 @@
+{# Last-opened-view memory for the parallel ExtJS (/) + SolidJS (/ui/*) shells.
+   The shared header writes tt:lastView on every page; this partial decides when
+   to return a returning user to it. Three roles via `mode`:
+     - 'mark'    (login page): record that a login is in progress.
+     - 'restore' (ExtJS root /): right after a login, jump to the saved /ui/* view
+                                 before the heavy ExtJS bundle loads.
+     - 'consume' (/ui shell):    right after a login, just clear the flag — you are
+                                 already in the SPA, and clearing it stops a later
+                                 click on "Time tracking" (→ /) from bouncing back.
+   Gating on this login-set sessionStorage flag (not a once-per-session "seen root"
+   guard) makes restore fire on EVERY login — including a same-tab re-login — yet
+   never on plain navigation to /, so the ExtJS grid stays reachable. Only a
+   same-origin /ui/* target is honoured (guards against open-redirect via a crafted
+   stored value). #}
+<script>
+    try {
+{% if mode == 'mark' %}
+        sessionStorage.setItem('tt:restorePending', '1');
+{% else %}
+        var ttPending = sessionStorage.getItem('tt:restorePending');
+        sessionStorage.removeItem('tt:restorePending');
+{% if mode == 'restore' %}
+        var ttLastView = ttPending ? localStorage.getItem('tt:lastView') : null;
+        if (ttLastView && ttLastView !== location.pathname) {
+            var ttTarget = new URL(ttLastView, location.origin);
+            if (ttTarget.origin === location.origin && ttTarget.pathname.indexOf('/ui/') === 0) {
+                location.replace(ttTarget.pathname + ttTarget.search + ttTarget.hash);
+            }
+        }
+{% endif %}
+{% endif %}
+    } catch (e) {}
+</script>

--- a/templates/ui/index.html.twig
+++ b/templates/ui/index.html.twig
@@ -5,6 +5,9 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {# Already in the SPA after a login — clear the restore flag so a later click
+           on "Time tracking" (→ /) doesn't bounce back here (last-view.html.twig). #}
+        {% include 'partials/last-view.html.twig' with {mode: 'consume'} %}
         <title>{{ apptitle }}</title>
         <link rel="stylesheet" href="{{ asset('build/css/header.css') }}">
         {% include 'partials/theme-init.html.twig' %}


### PR DESCRIPTION
Two independent UX/a11y bug fixes reported together (separate atomic commits).

## 1. Current grid cell now visible on mouse click (not only keyboard)

`use:gridNav` makes a cell "current" the same way whether it's reached by arrow
keys or a mouse click (`setActive()` + focus), and the row highlight
(`aria-current`) already reflected that for both. The **cell outline** used
`:focus-visible`, which the browser deliberately suppresses for pointer focus —
so a clicked cell became current but drew no border, while keyboard nav did.

Fix: the grid-cell rule now uses `:focus` (modality-independent). It still
appears only on interaction (nothing is focused on load), and the keyboard
appearance is unchanged — `:focus` is a superset of `:focus-visible`.

Verified in headless Chromium: a mouse-clicked cell now paints the 2px focus
outline; keyboard focus is identical to before.

## 2. Last-opened tab restored on *every* login

The post-login "return me to my last `/ui` view" redirect was gated on a
once-per-session `sessionStorage` guard (`tt:viewedRoot`) that conflated "first
root view of the session" with "just logged in". They only coincide on a cold
browser start, so:

- **logging out and back in within the same tab never restored** the last view
  (the guard was already set), and
- a **deep-link login** that landed on a `/ui` page left the guard unset, so the
  first later click on "Time tracking" (→ `/`) **bounced into the SPA**, making
  the ExtJS grid unreachable.

Fix: gate the restore on an explicit, login-set, **one-shot** flag. The login
page marks `tt:restorePending`; the first app shell to load after login consumes
it — the ExtJS root restores the saved `/ui/*` view, a `/ui` shell just clears
it. This fires on every login (cold or same-tab), never on plain navigation to
`/`, and the `/ui` consume path removes the deep-link bounce. Only same-origin
`/ui/*` targets are honoured (anti-open-redirect), as before. Logic extracted to
`partials/last-view.html.twig` (modes `mark`/`restore`/`consume`).

### Verification
- Headless-browser reproduction of the exact rendered Twig across 5 scenarios
  (cold login, same-tab re-login, manual `/` nav, deep-link-then-root,
  first-ever login) — all correct; the same matrix fails on the old guard.
- New e2e coverage (`navigation.spec.ts`): re-login restore + no-bounce, both
  green against the live stack; full nav + login specs pass (the one
  `should navigate to Evaluation` timeout is the known parallel-login
  tracking-grid flake — passes in isolation).
