### PR TITLE
fix(ui): polish inline editing — no flicker, seamless border, honest dirty state

### DIFF
--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -78,10 +78,63 @@ test.describe('Admin inline cell editing', () => {
 
     // Clicking Edit commits the in-progress value and opens the modal seeded from
     // it (the complete row also auto-saves in the background), so the modal shows
-    // the edit, not stale list data. Target Edit by name — a dirty row leads with
-    // the disk (force-save) button, so .first() would be the wrong control.
+    // the edit, not stale list data. Target Edit by name — the cell also has the
+    // Delete and the (reserved) disk force-save button, so .first() could be the
+    // wrong control.
     await row.getByRole('button', { name: /^(Bearbeiten|Edit)$/i }).click();
     await expect(page.locator('.modal input[type="text"]').first()).toHaveValue('Inline-Draft-X');
+  });
+
+  test('opening and closing the editor neither resizes the cell nor moves its border', async ({ page }) => {
+    const cell = page.locator('td[data-col-key="name"]').first();
+    const before = await cell.boundingBox();
+
+    await cell.focus();
+    await page.keyboard.press('Enter');
+    const editor = page.locator('td[data-inline-editing] input.inline-editor').first();
+    await expect(editor).toBeVisible();
+    const during = await cell.boundingBox();
+    const inputBox = await editor.boundingBox();
+    const editingTd = page.locator('td[data-inline-editing]').first();
+    const tdOutline = await editingTd.evaluate((el) => parseFloat(getComputedStyle(el).outlineWidth));
+    const ed = await editor.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { outline: s.outlineStyle, border: parseFloat(s.borderTopWidth), radius: parseFloat(s.borderTopLeftRadius) };
+    });
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('td[data-inline-editing]')).toHaveCount(0);
+    const after = await cell.boundingBox();
+
+    // No resize — width AND height — when the editor opens or closes. (Width
+    // catches an editor that overflows and widens the column.)
+    expect(Math.round(during!.width)).toBe(Math.round(before!.width));
+    expect(Math.round(during!.height)).toBe(Math.round(before!.height));
+    expect(Math.round(after!.width)).toBe(Math.round(before!.width));
+    expect(Math.round(after!.height)).toBe(Math.round(before!.height));
+    // The current-cell border is the cell's OWN 2px outline, kept while editing,
+    // so it can't jump or round — and the editor draws no border/radius/outline.
+    expect(tdOutline).toBe(2);
+    expect(ed.outline).toBe('none');
+    expect(ed.border).toBe(0);
+    expect(ed.radius).toBe(0);
+    // The editor stays within the cell (never overflows it).
+    expect(inputBox!.x).toBeGreaterThanOrEqual(before!.x - 1);
+    expect(inputBox!.x + inputBox!.width).toBeLessThanOrEqual(before!.x + before!.width + 1);
+  });
+
+  test('revealing the disk (force-save) icon shifts neither the Edit icon nor the cell width', async ({ page }) => {
+    const actionsCell = page.locator('td.admin-row-actions').first();
+    const editBtn = actionsCell.getByRole('button', { name: /^(Bearbeiten|Edit)$/i });
+    const editX = (await editBtn.boundingBox())!.x;
+    const cellWidth = (await actionsCell.boundingBox())!.width;
+
+    // The disk button always occupies a reserved slot; revealing it (as a dirty
+    // row would) must move neither the leading icons nor the cell's width.
+    await actionsCell.locator('.is-unsaved').evaluate((el) => el.classList.remove('action-slot-hidden'));
+
+    expect(Math.round((await editBtn.boundingBox())!.x)).toBe(Math.round(editX));
+    expect(Math.round((await actionsCell.boundingBox())!.width)).toBe(Math.round(cellWidth));
   });
 });
 

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -6,7 +6,7 @@ import { Portal } from 'solid-js/web'
 
 import { apiErrorMessage, getJson, postJson } from '../api/client'
 import { optionSourceKey } from '../api/queries'
-import { createInlineGridEdit, fieldSelectOptions, InlineEditor, InlineMultiSelect, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { createInlineGridEdit, fieldSelectOptions, InlineEditor, InlineMultiSelect, INLINE_OVERLAY_TYPES, INLINE_TYPES } from '../lib/inlineGridEdit'
 import { gridNav } from '../lib/gridNavigation'
 import { DiskIcon, DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
 import { m } from '../paraglide/messages.js'
@@ -510,6 +510,10 @@ export function AdminCrudShell(props: {
                         // A column whose field is modal-only (multiselect / locked
                         // relation) still opens the full form on double-click.
                         const modalOnly = !editable && fieldFor(col.key) !== undefined
+                        const fieldType = fieldFor(col.key)?.type
+                        // Single-line editors overlay a hidden ghost of the value (below)
+                        // so opening one can't re-flow the auto-layout column.
+                        const overlayEditor = fieldType !== undefined && INLINE_OVERLAY_TYPES.has(fieldType)
 
                         return (
                           <td
@@ -527,6 +531,11 @@ export function AdminCrudShell(props: {
                             }}
                           >
                             <Show when={editor.isEditing(rowId, col.key)} fallback={displayText(row, col)}>
+                              {/* Hidden ghost holds the column width so the overlaying
+                                  single-line editor can't make the table re-flow. */}
+                              <Show when={overlayEditor}>
+                                <span class="inline-ghost" aria-hidden="true">{displayText(row, col)}</span>
+                              </Show>
                               <Switch
                                 fallback={
                                   <InlineEditor
@@ -560,12 +569,6 @@ export function AdminCrudShell(props: {
                         focusing the row's action buttons "inside the row", so
                         clicking Edit doesn't read as a row-leave and flush. */}
                     <td class="admin-row-actions" data-row-id={String(Number(row.id))}>
-                      {/* Only while unsaved: force a full save (shows the full error if it fails). */}
-                      <Show when={editor.isDirty(Number(row.id))}>
-                        <button type="button" class="link-button is-icon is-unsaved" aria-label={m.app_save()} title={m.app_save()} onClick={() => void editor.flushRow(Number(row.id), 'force')}>
-                          <DiskIcon />
-                        </button>
-                      </Show>
                       <Show when={props.descriptor.editable !== false}>
                         <button type="button" class="link-button is-icon" aria-label={m.admin_edit()} title={m.admin_edit()} onClick={() => openForm(row)}>
                           <EditIcon />
@@ -573,6 +576,12 @@ export function AdminCrudShell(props: {
                       </Show>
                       <button type="button" class="link-button is-icon is-danger" aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => void remove(row)}>
                         <TrashIcon />
+                      </button>
+                      {/* Force a full save (shows the full error if it fails). Always rendered as
+                          the last action in a reserved slot — only its visibility toggles — so the
+                          Edit/Delete icons never shift when a row becomes dirty. */}
+                      <button type="button" class="link-button is-icon is-unsaved" classList={{ 'action-slot-hidden': !editor.isDirty(Number(row.id)) }} aria-label={m.app_save()} title={m.app_save()} onClick={() => void editor.flushRow(Number(row.id), 'force')}>
+                        <DiskIcon />
                       </button>
                     </td>
                   </tr>

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -12,6 +12,12 @@ export type Row = Record<string, unknown>
 // locked relation columns) stays modal-only.
 export const INLINE_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date', 'checkbox', 'select', 'multiselect'])
 
+// Single-line editors that overlay the cell (absolutely positioned over a hidden
+// "ghost" of the value, which holds the column width) so opening them can't make
+// the auto-layout table re-flow the column. Checkbox and multiselect editors stay
+// in flow (they aren't single-line text and size differently).
+export const INLINE_OVERLAY_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date', 'select'])
+
 /** Shared option resolution for both the modal FieldControl and the inline
  *  editor, so relation/static dropdowns stay identical in either surface. */
 export function fieldSelectOptions(field: FieldDef, options: OptionLookup): { value: string | number; label: string }[] {
@@ -338,7 +344,31 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
   }
 
   const draftValue = (id: number, colKey: string): FormValues[string] | undefined => drafts[id]?.[colKey]
-  const isDirty = (id: number): boolean => drafts[id] !== undefined
+
+  // A draft is only "dirty" when it actually differs from the row it was seeded
+  // from. Entering a cell seeds a draft (so the editor + overlay work), but that
+  // alone is not a change — comparing against a fresh seed keeps the dirty cues
+  // (warning tint, disk button) and the save off until the user really edits.
+  const rowDirty = (id: number): boolean => {
+    const draft = drafts[id]
+    if (draft === undefined) {
+      return false
+    }
+    const row = rowById(id)
+    return row !== undefined && JSON.stringify(draft) !== JSON.stringify(config.seedDraft(row))
+  }
+  const isDirty = rowDirty
+
+  // Drop a draft that ended up identical to its original row (opened a cell and
+  // left without changing it, or edited a value back) so the row shows no dirty
+  // state and never triggers a no-op save.
+  function discardIfClean(id: number): void {
+    if (drafts[id] !== undefined && !rowDirty(id)) {
+      setDrafts(produce((store) => { delete store[id] }))
+      setFieldHints(produce((store) => { delete store[id] }))
+      originalRows.delete(id)
+    }
+  }
 
   function beginEdit(id: number, colKey: string, char?: string): boolean {
     if (!config.isInlineEditable(colKey)) {
@@ -394,6 +424,10 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     config.onCommit?.(cell.rowId, cell.colKey, value)
     seedChar = undefined
     setEditCell(null)
+    // If the net result equals the original row (no real change, or a value
+    // edited back), drop the draft so the row stays clean — and refreshHints
+    // then sees no draft and skips the (pointless) auto-save.
+    discardIfClean(cell.rowId)
     refreshHints(cell.rowId)
     // All focus moves go through the grid's setActive (the single roving-tabindex
     // writer); landing on a different row triggers that row's save via focusin.
@@ -424,8 +458,14 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
   }
 
   function cancelCell(): void {
+    const id = editCell()?.rowId
     seedChar = undefined
     setEditCell(null)
+    // Cancelling the current cell leaves the draft untouched; if that draft only
+    // ever held the seeded (unchanged) values, drop it so the row stays clean.
+    if (id !== undefined) {
+      discardIfClean(id)
+    }
     moveHandle?.focusActive()
   }
 
@@ -450,6 +490,13 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     const draft = drafts[id]
     const row = rowById(id)
     if (draft === undefined || row === undefined || savingRows[id]) {
+      return
+    }
+    // Nothing actually changed (e.g. the row was only navigated through) — drop
+    // the no-op draft instead of POSTing an identical row.
+    if (!rowDirty(id)) {
+      discardIfClean(id)
+
       return
     }
     setSavingRows(id, true)
@@ -526,7 +573,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     for (const key of Object.keys(drafts)) {
       const id = Number(key)
       const row = rowById(id)
-      if (drafts[id] !== undefined && row !== undefined && !savingRows[id]) {
+      if (rowDirty(id) && row !== undefined && !savingRows[id]) {
         // Best-effort flush on unmount; the component is gone, so swallow a
         // failure (nowhere to surface it) rather than leak an unhandled rejection.
         void config.saveRow({ ...drafts[id]! }, row).catch(() => { /* discarded */ })

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -329,6 +329,50 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
+  it('committing a cell without changing it leaves the row clean (no save, no dirty cues)', async () => {
+    mockEndpoints()
+    const { getByRole, unmount } = renderAdmin()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
+
+    const cell = getByRole('gridcell', { name: 'ACME' })
+    const row = cell.closest('tr') as HTMLTableRowElement
+    cell.focus()
+    fireEvent.keyDown(cell, { key: 'Enter' }) // open the editor (seeds a draft)
+    const editor = (await screen.findByRole('textbox')) as HTMLInputElement
+    fireEvent.keyDown(editor, { key: 'Enter' }) // commit the unchanged value
+
+    await waitFor(() => expect(screen.queryByRole('textbox')).not.toBeInTheDocument())
+    // No real change → no save, no warning tint, and the disk (force-save) stays
+    // hidden in its reserved slot.
+    expect(postJson).not.toHaveBeenCalled()
+    expect(row.classList.contains('is-dirty')).toBe(false)
+    const disk = row.querySelector('.is-unsaved') as HTMLElement
+    expect(disk).not.toBeNull()
+    expect(disk.classList.contains('action-slot-hidden')).toBe(true)
+
+    unmount()
+  })
+
+  it('does not mark the row dirty or save when a cell is opened then cancelled (Escape)', async () => {
+    mockEndpoints()
+    const { getByRole, unmount } = renderAdmin()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
+
+    const cell = getByRole('gridcell', { name: 'ACME' })
+    const row = cell.closest('tr') as HTMLTableRowElement
+    cell.focus()
+    fireEvent.keyDown(cell, { key: 'Enter' })
+    const editor = (await screen.findByRole('textbox')) as HTMLInputElement
+    fireEvent.keyDown(editor, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('textbox')).not.toBeInTheDocument())
+    expect(postJson).not.toHaveBeenCalled()
+    expect(row.classList.contains('is-dirty')).toBe(false)
+    expect((row.querySelector('.is-unsaved') as HTMLElement).classList.contains('action-slot-hidden')).toBe(true)
+
+    unmount()
+  })
+
   it('seeds the editor with the printable key that opened it', async () => {
     mockEndpoints()
     const { getByRole, unmount } = renderAdmin()

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -329,7 +329,10 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
-  it('committing a cell without changing it leaves the row clean (no save, no dirty cues)', async () => {
+  // Opening the ACME name cell, then leaving it via `exitKey` without changing
+  // the value, must leave the row clean: no save, no warning tint, and the disk
+  // (force-save) stays hidden in its reserved slot.
+  async function expectRowStaysCleanAfter(exitKey: 'Enter' | 'Escape') {
     mockEndpoints()
     const { getByRole, unmount } = renderAdmin()
     await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
@@ -339,11 +342,9 @@ describe('Admin inline cell editing', () => {
     cell.focus()
     fireEvent.keyDown(cell, { key: 'Enter' }) // open the editor (seeds a draft)
     const editor = (await screen.findByRole('textbox')) as HTMLInputElement
-    fireEvent.keyDown(editor, { key: 'Enter' }) // commit the unchanged value
+    fireEvent.keyDown(editor, { key: exitKey })
 
     await waitFor(() => expect(screen.queryByRole('textbox')).not.toBeInTheDocument())
-    // No real change → no save, no warning tint, and the disk (force-save) stays
-    // hidden in its reserved slot.
     expect(postJson).not.toHaveBeenCalled()
     expect(row.classList.contains('is-dirty')).toBe(false)
     const disk = row.querySelector('.is-unsaved') as HTMLElement
@@ -351,27 +352,13 @@ describe('Admin inline cell editing', () => {
     expect(disk.classList.contains('action-slot-hidden')).toBe(true)
 
     unmount()
-  })
+  }
 
-  it('does not mark the row dirty or save when a cell is opened then cancelled (Escape)', async () => {
-    mockEndpoints()
-    const { getByRole, unmount } = renderAdmin()
-    await waitFor(() => expect(getByRole('gridcell', { name: 'ACME' })).toBeInTheDocument())
+  it('committing a cell without changing it leaves the row clean (no save, no dirty cues)', () =>
+    expectRowStaysCleanAfter('Enter'))
 
-    const cell = getByRole('gridcell', { name: 'ACME' })
-    const row = cell.closest('tr') as HTMLTableRowElement
-    cell.focus()
-    fireEvent.keyDown(cell, { key: 'Enter' })
-    const editor = (await screen.findByRole('textbox')) as HTMLInputElement
-    fireEvent.keyDown(editor, { key: 'Escape' })
-
-    await waitFor(() => expect(screen.queryByRole('textbox')).not.toBeInTheDocument())
-    expect(postJson).not.toHaveBeenCalled()
-    expect(row.classList.contains('is-dirty')).toBe(false)
-    expect((row.querySelector('.is-unsaved') as HTMLElement).classList.contains('action-slot-hidden')).toBe(true)
-
-    unmount()
-  })
+  it('does not mark the row dirty or save when a cell is opened then cancelled (Escape)', () =>
+    expectRowStaysCleanAfter('Escape'))
 
   it('seeds the editor with the printable key that opened it', async () => {
     mockEndpoints()

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -8,7 +8,7 @@ import { activitiesQuery, trackingCustomersQuery, trackingEntriesQuery, tracking
 import { appConfig } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { gridNav } from '../lib/gridNavigation'
-import { createInlineGridEdit, InlineEditor, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { createInlineGridEdit, InlineEditor, INLINE_OVERLAY_TYPES, INLINE_TYPES } from '../lib/inlineGridEdit'
 import { DiskIcon, DownloadIcon, PlusIcon, TrashIcon } from '../lib/icons'
 import { BulkEntryForm } from '../components/BulkEntryForm'
 import { parseTime, toIsoDate } from '../lib/timeParse'
@@ -569,6 +569,10 @@ export default function Tracking() {
                       <For each={COLUMNS}>
                         {(col) => {
                           const editable = FIELD_BY_KEY.has(col.key)
+                          const fieldType = FIELD_BY_KEY.get(col.key)?.type
+                          // Single-line editors overlay a hidden ghost of the value
+                          // (below) so opening one can't re-flow the auto-layout column.
+                          const overlayEditor = fieldType !== undefined && INLINE_OVERLAY_TYPES.has(fieldType)
 
                           return (
                             <td
@@ -583,6 +587,11 @@ export default function Tracking() {
                                 when={editor.isEditing(id, col.key)}
                                 fallback={cellContent(entry, col.key)}
                               >
+                                {/* Hidden ghost holds the column width so the overlaying
+                                    single-line editor can't make the table re-flow. */}
+                                <Show when={overlayEditor}>
+                                  <span class="inline-ghost" aria-hidden="true">{cellContent(entry, col.key)}</span>
+                                </Show>
                                 <InlineEditor
                                   field={FIELD_BY_KEY.get(col.key)!}
                                   label={col.label()}
@@ -601,14 +610,14 @@ export default function Tracking() {
                           "inside the row" so clicking Delete isn't read as a row-leave. */}
                       <td class="tracking-row-actions" data-row-id={String(id)}>
                         <div class="row-actions">
-                          {/* Only while unsaved: force a full save (shows the full error if it fails). */}
-                          <Show when={editor.isDirty(id)}>
-                            <button type="button" class="link-button is-icon is-unsaved" aria-label={m.app_save()} title={m.app_save()} onClick={() => void editor.flushRow(id, 'force')}>
-                              <DiskIcon />
-                            </button>
-                          </Show>
                           <button type="button" class="link-button is-icon is-danger" aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => void removeEntry(entry)}>
                             <TrashIcon />
+                          </button>
+                          {/* Force a full save (shows the full error if it fails). Always rendered as
+                              the last action in a reserved slot — only its visibility toggles — so the
+                              Delete icon never shifts when a row becomes dirty. */}
+                          <button type="button" class="link-button is-icon is-unsaved" classList={{ 'action-slot-hidden': !editor.isDirty(id) }} aria-label={m.app_save()} title={m.app_save()} onClick={() => void editor.flushRow(id, 'force')}>
+                            <DiskIcon />
                           </button>
                         </div>
                       </td>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -957,8 +957,12 @@ kbd {
 }
 
 .data-table tbody td {
+  /* Exposed so the in-cell editor can cancel exactly this padding and fill the
+     cell with zero layout shift, at any density (see .inline-editor). */
+  --cell-pad-y: 0.55rem;
+  --cell-pad-x: 0.9rem;
   border-top: 1px solid var(--color-border);
-  padding: 0.55rem 0.9rem;
+  padding: var(--cell-pad-y) var(--cell-pad-x);
   vertical-align: middle;
 }
 
@@ -975,9 +979,13 @@ kbd {
    :focus (not :focus-visible) on purpose — gridNav makes a cell "current" the
    same way whether reached by arrow keys or a mouse click (setActive + focus),
    so the indicator must be modality-independent. :focus-visible would suppress
-   the outline on pointer focus, leaving clicked cells current-but-invisible. */
+   the outline on pointer focus, leaving clicked cells current-but-invisible.
+   The editing cell ([data-inline-editing]) keeps the SAME outline even though
+   focus has moved into its child editor — so the current-cell border never
+   jumps, rounds, or resizes when the inline editor opens or closes. */
 .data-table [role='gridcell']:focus,
-.data-table [role='columnheader']:focus {
+.data-table [role='columnheader']:focus,
+.data-table td[data-inline-editing] {
   outline: 2px solid var(--color-focus);
   outline-offset: -2px;
 }
@@ -1074,24 +1082,52 @@ kbd {
   cursor: text;
 }
 
+/* The editor sits seamlessly inside the cell: no border, radius, background or
+   outline of its own. The cell's own focus outline (kept while
+   [data-inline-editing]) is the single current-cell indicator, so it can't jump
+   or round when the editor opens/closes. */
 .inline-editor {
-  background: var(--color-bg);
-  border: 1px solid var(--color-accent);
-  border-radius: 4px;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
   box-sizing: border-box;
   font: inherit;
-  margin: -0.3rem -0.4rem;
-  padding: 0.25rem 0.5rem;
-  width: calc(100% + 0.8rem);
+  margin: 0;
+  outline: none;
+  padding: 0;
+  width: 100%;
 }
 
+/* Single-line editors (text/number/date/select) overlay the cell absolutely on
+   top of a hidden "ghost" copy of the value (.inline-ghost). The ghost stays in
+   flow and holds the column's width, so swapping the text for an input never
+   re-flows the auto-layout table (no horizontal jump). The editor fills the cell
+   (inset:0) and re-applies the cell's x-padding so the text stays exactly where
+   the value was; a single-line input centres vertically like the static text. */
+.data-table td[data-inline-editing] {
+  position: relative;
+}
+
+.inline-ghost {
+  visibility: hidden;
+}
+
+.data-table td[data-inline-editing] .inline-editor:not(.inline-check):not(.inline-tags) {
+  inset: 0;
+  padding: 0 var(--cell-pad-x);
+  position: absolute;
+  width: auto;
+}
+
+/* A checkbox isn't single-line text — don't stretch it to fill the cell width. */
 .inline-editor.inline-check {
   margin: 0;
   padding: 0;
   width: auto;
 }
 
-/* Inline multiselect: selected options as removable chips + an "add" dropdown. */
+/* Inline multiselect: selected options as removable chips + an "add" dropdown.
+   Fills the cell like the text editor but may wrap to more than one line. */
 .inline-editor.inline-tags {
   align-items: center;
   display: flex;
@@ -1394,6 +1430,13 @@ th[aria-sort='descending'] .th-sort-glyph {
   color: var(--color-warning-text);
 }
 
+/* The disk button keeps its slot reserved (it's the last action) and only
+   toggles visibility, so showing/hiding it never shifts the other action icons.
+   visibility:hidden also drops it from the tab order and the a11y tree. */
+.action-slot-hidden {
+  visibility: hidden;
+}
+
 /* Access-key overlay: while Alt is held (body.show-access-keys, set by
    header.ts), each shortcut target shows a small corner badge with its key —
    1..N on the nav items, the letter on the toolbar actions. */
@@ -1610,7 +1653,8 @@ th[aria-sort='descending'] .th-sort-glyph {
 }
 
 :root[data-density='compact'] .data-table tbody td {
-  padding: 0.25rem 0.6rem;
+  --cell-pad-y: 0.25rem;
+  --cell-pad-x: 0.6rem;
 }
 
 :root[data-density='compact'] .tracking-toolbar,


### PR DESCRIPTION
Polish for inline (spreadsheet-style) cell editing on **both** the Worklog
(`/ui/tracking`) and Admin grids, addressing four reported issues.

### 1. No cell resize / flicker on open & close
The editor is rendered over a hidden **ghost** copy of the value that stays in
flow and holds the column width, so swapping the static text for an input can't
re-flow the auto-layout table. The cell keeps its row-driven height; the editor
centres in it like the static value.

### 2. Seamless, pixel-matched border (no jump, no rounding)
The current-cell indicator is now the **cell's own** focus outline, kept while
`[data-inline-editing]` even though focus moves into the child editor — so it's
the *same* 2px outline whether you arrow to a cell or edit it. The editor itself
has no border, radius, background or outline of its own.

### 3. Disk (force-save) icon no longer shifts the other icons
It moved to a **reserved last slot** whose visibility toggles, instead of being
inserted before the Edit/Delete icons. Revealing it shifts neither the leading
icons nor the cell width.

### 4. Honest dirty state — no false "unsaved" on no-op
A row is "dirty" only when its draft actually differs from the original. Merely
opening a cell (which seeds a draft) and leaving it — or editing a value back —
no longer shows the warning tint / disk icon or fires a no-op save. `isDirty`
compares against a fresh seed; clean drafts are discarded on commit/cancel;
`flushRow`/`onCleanup` skip non-dirty rows.

Cell padding is exposed via `--cell-pad-*` custom properties so the editor stays
aligned at comfort **and** compact density.

### Verification
- 212 unit tests (incl. new no-change dirty-state cases), ESLint, tsc — green.
- e2e (clean DB): full `admin-inline-edit` suite 11/11 — including new tests
  asserting **zero** cell resize (width + height), the seamless border
  (`outline:none / border:0 / radius:0`, cell keeps its 2px outline), and the
  reserved disk slot (revealing it moves neither the Edit icon nor the cell);
  plus `worklog` + `keyboard` 14/14 for the Worklog grid.
- Frontend-only; no backend or DB changes.
