### PR TITLE
fix(ui): worklog/admin grid refinements — dates, chips, delete, row actions

### DIFF
--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -30,6 +30,34 @@ function csvCell(value: string): string {
   return /[",\r\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe
 }
 
+// A select/multiselect cell value → the list of chip values to render. A single
+// select is one chip; "none" (0 / '' / null) is no chips.
+function chipValues(raw: unknown): (string | number)[] {
+  if (Array.isArray(raw)) {
+    return raw as (string | number)[]
+  }
+  if (raw === undefined || raw === null || raw === '' || raw === 0) {
+    return []
+  }
+
+  return [raw as string | number]
+}
+
+/** Read-only chips for a select/multiselect column in display mode, so reference
+ *  columns read as chips (visually distinct from free-text) whether or not the
+ *  cell is being edited. */
+function ReadonlyChips(props: Readonly<{ values: (string | number)[]; options: { value: string | number; label: string }[] }>) {
+  const labelOf = (value: string | number): string => props.options.find((option) => String(option.value) === String(value))?.label ?? String(value)
+
+  return (
+    <span class="inline-tags is-readonly">
+      <For each={props.values}>
+        {(value) => <span class="tag"><span class="tag-label">{labelOf(value)}</span></span>}
+      </For>
+    </span>
+  )
+}
+
 /** On/off indicator for a boolean column: a green dot for true, empty for false,
  *  with visually-hidden Yes/No so it isn't colour-only (WCAG 1.4.1). */
 function BoolDot(props: Readonly<{ on: boolean }>) {
@@ -542,7 +570,13 @@ export function AdminCrudShell(props: {
                           >
                             <Show
                               when={editor.isEditing(rowId, col.key)}
-                              fallback={col.boolean ? <BoolDot on={Boolean(editor.overlayRow(row)[col.key])} /> : displayText(row, col)}
+                              fallback={
+                                col.boolean
+                                  ? <BoolDot on={Boolean(editor.overlayRow(row)[col.key])} />
+                                  : fieldType === 'select' || fieldType === 'multiselect'
+                                    ? <ReadonlyChips values={chipValues(editor.overlayRow(row)[col.key])} options={fieldSelectOptions(fieldFor(col.key)!, props.options)} />
+                                    : displayText(row, col)
+                              }
                             >
                               {/* Hidden ghost holds the column width so the overlaying
                                   single-line editor can't make the table re-flow. */}

--- a/frontend/src/lib/icons.tsx
+++ b/frontend/src/lib/icons.tsx
@@ -40,3 +40,18 @@ export function DiskIcon(): JSX.Element {
     </Icon>
   )
 }
+
+// Continue: a play triangle — clone this entry into a fresh row.
+export function ContinueIcon(): JSX.Element {
+  return <Icon><path d="M7 5v14l11-7z" /></Icon>
+}
+
+// Prolong: a clock — set this entry's end to now.
+export function ProlongIcon(): JSX.Element {
+  return <Icon><circle cx="12" cy="12" r="8" /><path d="M12 8v4l3 2" /></Icon>
+}
+
+// Info: an "i" in a circle — show the summary for this entry's ticket.
+export function InfoIcon(): JSX.Element {
+  return <Icon><circle cx="12" cy="12" r="9" /><path d="M12 11v5" /><path d="M12 7.5h.01" /></Icon>
+}

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -140,7 +140,12 @@ export function InlineEditor(props: {
       <Match when={true}>
         <input
           ref={(el) => { control = el }}
-          type={props.field.type === 'number' ? 'number' : props.field.type === 'date' ? 'date' : 'text'}
+          // Dates use a text input with the ISO value, not type="date": a native
+          // date control renders in the browser's locale (mm/dd/yyyy, dd.mm.yyyy),
+          // which changes the format on edit. Text keeps it yyyy-mm-dd throughout.
+          type={props.field.type === 'number' ? 'number' : 'text'}
+          inputmode={props.field.type === 'date' ? 'numeric' : undefined}
+          placeholder={props.field.type === 'date' ? 'YYYY-MM-DD' : undefined}
           class="inline-editor"
           aria-label={props.label}
           value={value() as string}
@@ -190,7 +195,35 @@ export function InlineMultiSelect(props: {
   }
   function remove(id: number): void {
     setSelected(selected().filter((value) => value !== id))
-    addBtn?.focus() // the chip's × unmounts — keep focus inside so it isn't a commit
+  }
+  // Focusable items, in DOM order: each chip, then the add button. Chips carry a
+  // roving tabindex so Left/Right can move between them (and the add button).
+  const navItems = (): HTMLElement[] => Array.from(container?.querySelectorAll<HTMLElement>('.tag, .tag-add') ?? [])
+  function moveFocus(delta: number): void {
+    const items = navItems()
+    const current = items.indexOf(document.activeElement as HTMLElement)
+    const from = current === -1 ? items.length - 1 : current
+    items[Math.max(0, Math.min(items.length - 1, from + delta))]?.focus()
+  }
+  // Remove the focused chip, then keep focus inside the widget (the chip now in
+  // its place, or the add button) so the removal doesn't read as a commit.
+  function removeFocusedChip(): void {
+    const active = document.activeElement
+    if (!(active instanceof HTMLElement) || !active.classList.contains('tag')) {
+      return
+    }
+    const index = navItems().indexOf(active)
+    const id = Number(active.dataset.tagId)
+    if (!Number.isInteger(id) || id <= 0) {
+      return
+    }
+    remove(id)
+    // Re-focus the next item SYNCHRONOUSLY (Solid has already re-rendered the
+    // removed chip away): the focus-out check is deferred to a microtask, so
+    // focus must be back inside the widget before it runs, or the removal would
+    // read as "focus left" and commit/close the editor.
+    const after = navItems()
+    ;(after[Math.min(index, after.length - 1)] ?? addBtn)?.focus()
   }
   const focusFirstItem = (): void => {
     queueMicrotask(() => menuEl?.querySelector<HTMLButtonElement>('.tag-menu-item')?.focus())
@@ -247,7 +280,13 @@ export function InlineMultiSelect(props: {
         if (menuOpen()) {
           return
         }
-        if (event.key === 'Enter') {
+        const onChip = document.activeElement instanceof HTMLElement && document.activeElement.classList.contains('tag')
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+          // Move between chips and the add button.
+          event.preventDefault()
+          event.stopPropagation()
+          moveFocus(event.key === 'ArrowLeft' ? -1 : 1)
+        } else if (event.key === 'Enter') {
           event.preventDefault()
           event.stopPropagation()
           finish(selected(), 'stay')
@@ -261,11 +300,14 @@ export function InlineMultiSelect(props: {
           event.preventDefault()
           event.stopPropagation()
           cancel()
-        } else if (event.key === 'Backspace' && selected().length > 0) {
-          // Tag-input convention: Backspace removes the last chip (the × buttons
-          // are out of the Tab order, so this is the keyboard removal path).
+        } else if (event.key === 'Delete' || event.key === 'Backspace') {
           event.preventDefault()
-          remove(selected()[selected().length - 1]!)
+          if (onChip) {
+            removeFocusedChip() // remove the chip the user navigated to
+          } else if (event.key === 'Backspace' && selected().length > 0) {
+            remove(selected()[selected().length - 1]!) // tag-input convention: Backspace removes the last
+            addBtn?.focus()
+          }
         }
       }}
       onFocusOut={() => {
@@ -283,11 +325,13 @@ export function InlineMultiSelect(props: {
     >
       <For each={selected()}>
         {(id) => (
-          <span class="tag">
+          // Focusable (roving tabindex) so Left/Right reach it and Delete/Backspace
+          // removes it; aria-label names the tag for screen readers.
+          <span class="tag" tabindex="-1" data-tag-id={id} aria-label={labelOf(id)}>
             <span class="tag-label">{labelOf(id)}</span>
             {/* preventDefault on mousedown so clicking × doesn't blur the widget
                 (which would commit + unmount before the click removes the chip). */}
-            <button type="button" class="tag-remove" tabindex="-1" aria-label={`${props.label}: ${labelOf(id)} ✕`} onMouseDown={(event) => event.preventDefault()} onClick={() => remove(id)}>×</button>
+            <button type="button" class="tag-remove" tabindex="-1" aria-label={`${m.admin_delete()}: ${labelOf(id)}`} onMouseDown={(event) => event.preventDefault()} onClick={() => { remove(id); addBtn?.focus() }}>×</button>
           </span>
         )}
       </For>

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -144,7 +144,6 @@ export function InlineEditor(props: {
           // date control renders in the browser's locale (mm/dd/yyyy, dd.mm.yyyy),
           // which changes the format on edit. Text keeps it yyyy-mm-dd throughout.
           type={props.field.type === 'number' ? 'number' : 'text'}
-          inputmode={props.field.type === 'date' ? 'numeric' : undefined}
           placeholder={props.field.type === 'date' ? 'YYYY-MM-DD' : undefined}
           class="inline-editor"
           aria-label={props.label}

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -501,6 +501,45 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
+  it('navigates to a chip with the keyboard (ArrowLeft) and removes it with Delete', async () => {
+    postJson.mockResolvedValue([1, 'ACME', true, false, []])
+    const { teamsCell, addBtn, unmount } = await openTeamsTagEditor([{ id: 2, name: 'Backend' }])
+
+    // Focus starts on the add button; ArrowLeft moves to the Backend chip.
+    addBtn.focus()
+    fireEvent.keyDown(addBtn, { key: 'ArrowLeft' })
+    const chip = teamsCell.querySelector('.tag') as HTMLElement
+    expect(document.activeElement).toBe(chip)
+
+    fireEvent.keyDown(chip, { key: 'Delete' }) // removes the focused chip
+    await waitFor(() => expect(teamsCell.querySelector('.tag')).toBeNull())
+    fireEvent.keyDown(addBtn, { key: 'Enter' }) // commit
+    await waitFor(() =>
+      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ teams: [] })),
+    )
+
+    unmount()
+  })
+
+  it('renders selected teams as read-only chips in display mode (not just when editing)', async () => {
+    getJson.mockImplementation((path: string) =>
+      path === '/getAllCustomers'
+        ? Promise.resolve([{ customer: { id: 1, name: 'ACME', active: true, global: false, teams: [2] } }])
+        : path === '/getAllTeams'
+          ? Promise.resolve([{ team: { id: 2, name: 'Backend' } }])
+          : Promise.resolve([]),
+    )
+    const { getByRole, unmount } = renderAdmin()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Backend' })).toBeInTheDocument())
+
+    // The teams cell shows a chip without being edited (no editor mounted).
+    const cell = getByRole('gridcell', { name: 'Backend' })
+    expect(cell.querySelector('.inline-tags.is-readonly .tag')).not.toBeNull()
+    expect(cell.querySelector('input, select, button')).toBeNull()
+
+    unmount()
+  })
+
   it('keeps focus on the cell after Enter by default (stay, does not move down)', async () => {
     getJson.mockImplementation((path: string) =>
       path === '/getAllCustomers'

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -206,7 +206,9 @@ describe('Tracking (Worklog grid)', () => {
 
     fireEvent.click(getByRole('button', { name: 'Delete' }))
 
-    await waitFor(() => expect(postJson).toHaveBeenCalledWith('/tracking/delete', { id: 1 }))
+    // /tracking/delete is form-encoded (reads $request->request, shared with the
+    // ExtJS shell), so it goes out via postForm — not postJson.
+    await waitFor(() => expect(postForm).toHaveBeenCalledWith('/tracking/delete', { id: 1 }))
 
     unmount()
   })
@@ -393,8 +395,9 @@ describe('Tracking (Worklog grid)', () => {
     const { container, getByRole, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'Newest' })).toBeInTheDocument())
 
+    // Dates render in ISO (yyyy-mm-dd), one consistent format everywhere.
     const dates = Array.from(container.querySelectorAll('tbody tr td[data-col-key="date"]')).map((td) => td.textContent)
-    expect(dates).toEqual(['16/06/2026', '15/06/2026', '14/06/2026'])
+    expect(dates).toEqual(['2026-06-16', '2026-06-15', '2026-06-14'])
 
     unmount()
   })
@@ -412,9 +415,10 @@ describe('Tracking (Worklog grid)', () => {
     const { container, getByRole, getAllByRole, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'BroCorp' })).toBeInTheDocument())
 
-    // Cursor on the 2nd (older, XYZ-9/BroCorp) row, then Continue.
+    // Cursor on the 2nd (older, XYZ-9/BroCorp) row, then Continue via Alt+C
+    // (the cursor-row shortcut; the per-row icons clone their own row instead).
     focusBodyRow(container, 1)
-    fireEvent.click(getByRole('button', { name: 'Continue' }))
+    fireEvent.keyDown(document.body, { key: 'c', altKey: true })
 
     // The cloned new row carries the cursor row's customer + ticket (not ABC-1/ACME).
     await waitFor(() => expect(getAllByRole('gridcell', { name: 'BroCorp' }).length).toBe(2))

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -9,7 +9,7 @@ import { appConfig, canBulkEnter } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { gridNav } from '../lib/gridNavigation'
 import { createInlineGridEdit, InlineEditor, INLINE_OVERLAY_TYPES, INLINE_TYPES } from '../lib/inlineGridEdit'
-import { DiskIcon, DownloadIcon, PlusIcon, TrashIcon } from '../lib/icons'
+import { ContinueIcon, DiskIcon, DownloadIcon, InfoIcon, PlusIcon, ProlongIcon, TrashIcon } from '../lib/icons'
 import { BulkEntryForm } from '../components/BulkEntryForm'
 import { parseTime, toIsoDate } from '../lib/timeParse'
 import { m } from '../paraglide/messages.js'
@@ -126,11 +126,12 @@ function nameOf(list: NamedOption[] | undefined, id: number): string {
   return list.find((option) => option.id === id)?.label ?? String(id)
 }
 
-// d/m/Y (list rows) or Y-m-d (date-input draft) → d/m/Y for display.
+// d/m/Y (list rows) or Y-m-d (draft) → Y-m-d (ISO) for display — one consistent
+// date format everywhere, matching the inline editor.
 function displayDate(value: string): string {
-  const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  const dmy = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value.trim())
 
-  return iso !== null ? `${iso[3]}/${iso[2]}/${iso[1]}` : value
+  return dmy !== null ? `${dmy[3]}-${dmy[2]}-${dmy[1]}` : value
 }
 
 /**
@@ -363,8 +364,8 @@ export default function Tracking() {
   // the latest entry). /getSummary is a legacy endpoint that reads form params
   // ($request->request->get('id')), so it must be POSTed as form-encoded — a
   // JSON body leaves `id` null and the server answers all-zero totals.
-  async function showInfo(): Promise<void> {
-    const target = activeOrLatestEntry()
+  async function showInfo(entry?: TrackingEntry): Promise<void> {
+    const target = entry ?? activeOrLatestEntry()
     if (target === undefined) {
       return
     }
@@ -381,7 +382,9 @@ export default function Tracking() {
       return
     }
     try {
-      await postJson('/tracking/delete', { id: num(entry.id) })
+      // /tracking/delete reads form params ($request->request, shared with the
+      // ExtJS shell), so it must be posted as a form — not a JSON body.
+      await postForm('/tracking/delete', { id: num(entry.id) })
       // Drop any pending inline draft for the now-deleted entry.
       editor.takeDraft(num(entry.id))
       await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
@@ -423,8 +426,8 @@ export default function Tracking() {
 
   // Continue: clone the cursor row's (or, with no cursor, the latest entry's)
   // customer/project/activity/ticket/description into a fresh blank-time row.
-  function continueEntry(): void {
-    const source = activeOrLatestEntry()
+  function continueEntry(entry?: TrackingEntry): void {
+    const source = entry ?? activeOrLatestEntry()
     if (source === undefined) {
       addEntry()
 
@@ -443,8 +446,8 @@ export default function Tracking() {
   }
 
   // Prolong-last (Alt+P): set the latest entry's end to now and save it.
-  async function prolongLast(): Promise<void> {
-    const first = (entries.data ?? [])[0]
+  async function prolongLast(entry?: TrackingEntry): Promise<void> {
+    const first = entry ?? (entries.data ?? [])[0]
     if (first === undefined) {
       return
     }
@@ -520,9 +523,8 @@ export default function Tracking() {
         <Show when={canBulkEnter()}>
           <button type="button" class="action-button" onClick={() => setBulkOpen(true)}>{m.extras_title()}</button>
         </Show>
-        <button type="button" class="action-button" onClick={() => continueEntry()} aria-keyshortcuts="Alt+C">{m.tracking_continue()}</button>
-        <button type="button" class="action-button" onClick={() => void prolongLast()} aria-keyshortcuts="Alt+P">{m.tracking_prolong()}</button>
-        <button type="button" class="action-button" onClick={() => void showInfo()} aria-keyshortcuts="Alt+I">{m.tracking_info()}</button>
+        {/* Continue / Prolong / Info moved to per-row action icons; Alt+C/P/I
+            still act on the keyboard-cursor row via the global shortcut handler. */}
         <a class="action-button is-icon" href={exportHref()} aria-keyshortcuts="Alt+X" aria-label={m.tracking_export()} title={m.tracking_export()}><DownloadIcon /></a>
         <label class="tracking-days">
           <span>{m.tracking_days_label()}</span>
@@ -613,6 +615,18 @@ export default function Tracking() {
                           "inside the row" so clicking Delete isn't read as a row-leave. */}
                       <td class="tracking-row-actions" data-row-id={String(id)}>
                         <div class="row-actions">
+                          {/* Per-row Continue / Prolong / Info — only for saved entries. */}
+                          <Show when={id > 0}>
+                            <button type="button" class="link-button is-icon" aria-label={m.tracking_continue()} title={m.tracking_continue()} onClick={() => continueEntry(entry)}>
+                              <ContinueIcon />
+                            </button>
+                            <button type="button" class="link-button is-icon" aria-label={m.tracking_prolong()} title={m.tracking_prolong()} onClick={() => void prolongLast(entry)}>
+                              <ProlongIcon />
+                            </button>
+                            <button type="button" class="link-button is-icon" aria-label={m.tracking_info()} title={m.tracking_info()} onClick={() => void showInfo(entry)}>
+                              <InfoIcon />
+                            </button>
+                          </Show>
                           <button type="button" class="link-button is-icon is-danger" aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => void removeEntry(entry)}>
                             <TrashIcon />
                           </button>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1111,6 +1111,9 @@ kbd {
   margin: 0;
   outline: none;
   padding: 0;
+  /* Inherit the cell's alignment so editing a right-aligned (numeric) cell keeps
+     the value right-aligned instead of jumping left. */
+  text-align: inherit;
   width: 100%;
 }
 
@@ -1133,6 +1136,12 @@ kbd {
   padding: 0 var(--cell-pad-x);
   position: absolute;
   width: auto;
+}
+
+/* A <select> editor: drop the native chrome (dropdown arrow) so it reads as the
+   plain text it overlays — the arrow would shift the text and flicker on open. */
+.data-table td[data-inline-editing] select.inline-editor {
+  appearance: none;
 }
 
 /* A checkbox isn't single-line text — don't stretch it to fill the cell width. */
@@ -1160,6 +1169,25 @@ kbd {
   font-size: 0.85rem;
   gap: 0.1rem;
   padding: 0 0.1rem 0 0.4rem;
+}
+
+/* Chips are roving-tabindex focusable in the editor (Left/Right + Delete). */
+.inline-tags .tag:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 1px;
+}
+
+/* Read-only chips: the same chip styling shown in the cell when NOT editing, so
+   a multiselect column reads as chips throughout (no ×, symmetric padding). */
+.inline-tags.is-readonly {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.inline-tags.is-readonly .tag {
+  padding: 0 0.4rem;
 }
 
 .inline-tags .tag-remove {


### PR DESCRIPTION
A second round of Worklog/Admin inline-grid refinements from your feedback.

### Dates
Render `yyyy-mm-dd` everywhere (display + editor). The editor is now an ISO text
field, not a native `type=date` picker — which rendered in the browser locale
(mm/dd/yyyy, dd.mm.yyyy) and switched format on edit.

### Editor alignment & select flicker
- Inline editors inherit the cell's `text-align`, so editing a right-aligned
  (numeric) cell keeps the value right-aligned.
- A `<select>` editor drops its native dropdown arrow (`appearance:none`) so it
  sits seamlessly over the value instead of flickering when it opens.

### Reference columns as chips
Both **select and multiselect** columns render their value(s) as chips in display
mode, so a relation/reference reads as a token, not free text.

### Multiselect keyboard nav
Chips are roving-tabindex focusable: **Left/Right** move between chips and the add
button, **Delete/Backspace** removes the focused chip. Removal re-focuses
synchronously, which also fixes a latent bug where deleting a chip closed the
editor.

### Fix: deleting a work-log entry did nothing
`/tracking/delete` reads form params (`$request->request`, shared with the ExtJS
shell), but the SPA POSTed a JSON body, so the id was never read — the call
returned `{"success":true}` and deleted nothing. Now sent as a form (`postForm`),
like `/getSummary`. Verified live: a row actually deletes.

### Continue / Prolong / Info → per-row action icons
Moved off the toolbar into each saved row's action column (play / clock / info).
**Alt+C / Alt+P / Alt+I** still act on the keyboard-cursor row via the global
shortcut handler.

### Verification
218 unit tests (incl. new chip-display, keyboard chip-delete, ISO-date and
delete-via-postForm cases), ESLint, tsc, build — all green. Verified in a real
browser: ISO dates + ISO editor, right-aligned numeric editor, select/multiselect
chips, per-row Continue/Prolong/Info icons, and a live row delete (11→12 clone via
Continue; delete removes a row).
