### PR TITLE
feat(ui): visible non-reflowing dropdown chevron on inline select cells

### DIFF
--- a/e2e/worklog-crud.spec.ts
+++ b/e2e/worklog-crud.spec.ts
@@ -172,4 +172,31 @@ test.describe('Worklog CRUD', () => {
 
     await expect(page.getByRole('link', { name: /Export CSV|CSV-Export/i })).toHaveAttribute('href', '/export/35');
   });
+
+  test('a select cell shows a dropdown chevron and opening its editor does not shift the cell', async ({ page }) => {
+    const stamp = await createEntry(page);
+    const cell = rowByStamp(page, stamp).locator('td[data-col-key="customer"]');
+
+    // The chevron affordance marks a select cell (distinct from a text cell) in
+    // STATIC mode — a rendered ::after with a visible border-triangle.
+    await expect(cell).toHaveClass(/is-select/);
+    const staticCaret = await cell.evaluate((el) => parseFloat(getComputedStyle(el, '::after').borderTopWidth));
+    expect(staticCaret).toBeGreaterThan(0);
+
+    // Opening the inline editor must not reflow the cell (the caret gutter is
+    // reserved identically on the cell and the overlaying select editor).
+    const before = await cell.boundingBox();
+    await cell.focus();
+    await page.keyboard.press('Enter');
+    await expect(cell.locator('select.inline-editor')).toBeVisible();
+    const during = await cell.boundingBox();
+    // The chevron is still painted in edit mode (same affordance, same spot).
+    const editCaret = await cell.evaluate((el) => parseFloat(getComputedStyle(el, '::after').borderTopWidth));
+    expect(editCaret).toBeGreaterThan(0);
+
+    await page.keyboard.press('Escape');
+    const after = await cell.boundingBox();
+    expect(Math.round(during!.width)).toBe(Math.round(before!.width));
+    expect(Math.round(after!.width)).toBe(Math.round(before!.width));
+  });
 });

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -554,7 +554,7 @@ export function AdminCrudShell(props: {
 
                         return (
                           <td
-                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable, 'is-invalid': editor.fieldInvalid(Number(row.id), col.key), 'is-select': fieldType === 'select' }}
+                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable, 'is-invalid': editor.fieldInvalid(rowId, col.key), 'is-select': editable && fieldType === 'select' }}
                             data-row-id={String(rowId)}
                             data-col-key={col.key}
                             data-inline-editing={editor.isEditing(rowId, col.key) ? '' : undefined}

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -554,7 +554,7 @@ export function AdminCrudShell(props: {
 
                         return (
                           <td
-                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable, 'is-invalid': editor.fieldInvalid(Number(row.id), col.key) }}
+                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable, 'is-invalid': editor.fieldInvalid(Number(row.id), col.key), 'is-select': fieldType === 'select' }}
                             data-row-id={String(rowId)}
                             data-col-key={col.key}
                             data-inline-editing={editor.isEditing(rowId, col.key) ? '' : undefined}

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -639,7 +639,7 @@ export default function Tracking() {
 
                           return (
                             <td
-                              classList={{ numeric: col.numeric, 'is-editable': editable, 'is-invalid': editor.fieldInvalid(id, col.key), 'is-select': fieldType === 'select' }}
+                              classList={{ numeric: col.numeric, 'is-editable': editable, 'is-invalid': editor.fieldInvalid(id, col.key), 'is-select': editable && fieldType === 'select' }}
                               data-row-id={String(id)}
                               data-col-key={col.key}
                               data-inline-editing={editor.isEditing(id, col.key) ? '' : undefined}

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -639,7 +639,7 @@ export default function Tracking() {
 
                           return (
                             <td
-                              classList={{ numeric: col.numeric, 'is-editable': editable, 'is-invalid': editor.fieldInvalid(id, col.key) }}
+                              classList={{ numeric: col.numeric, 'is-editable': editable, 'is-invalid': editor.fieldInvalid(id, col.key), 'is-select': fieldType === 'select' }}
                               data-row-id={String(id)}
                               data-col-key={col.key}
                               data-inline-editing={editor.isEditing(id, col.key) ? '' : undefined}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -989,6 +989,10 @@ kbd {
      cell with zero layout shift, at any density (see .inline-editor). */
   --cell-pad-y: 0.55rem;
   --cell-pad-x: 0.9rem;
+  /* Right-gutter reserved for a select cell's dropdown chevron; 0 elsewhere. It
+     inherits into the overlaying editor (custom props cascade), so the cell and
+     its editor reserve the same gutter and the text origin can't shift on open. */
+  --caret-w: 0px;
   border-top: 1px solid var(--color-border);
   padding: var(--cell-pad-y) var(--cell-pad-x);
   vertical-align: middle;
@@ -1216,15 +1220,43 @@ kbd {
 
 .data-table td[data-inline-editing] .inline-editor:not(.inline-check):not(.inline-tags) {
   inset: 0;
-  padding: 0 var(--cell-pad-x);
+  /* Re-apply the cell's x-padding; the right side also reserves the select caret
+     gutter (--caret-w inherited from the cell — 0 for non-select). */
+  padding-block: 0;
+  padding-inline: var(--cell-pad-x) calc(var(--cell-pad-x) + var(--caret-w));
   position: absolute;
   width: auto;
 }
 
-/* A <select> editor: drop the native chrome (dropdown arrow) so it reads as the
-   plain text it overlays — the arrow would shift the text and flicker on open. */
+/* A <select> editor: drop the native chrome (dropdown arrow) so the overlay reads
+   as the value it sits on — the native arrow would shift the text and flicker on
+   open. The cell paints its own non-reflowing chevron instead (.is-select below). */
 .data-table td[data-inline-editing] select.inline-editor {
   appearance: none;
+}
+
+/* A select cell is a chooser, not free text. Mark it with a chevron in the right
+   gutter, present in BOTH static and edit mode (identical position), so a select
+   reads as editable and the static→edit transition stays a visual no-op. The
+   gutter is reserved on the cell (here) and on the overlaying editor (above, via
+   the inherited --caret-w), so the text origin never moves when editing opens. */
+.data-table td.is-select {
+  --caret-w: 1.1rem;
+  padding-inline-end: calc(var(--cell-pad-x) + var(--caret-w));
+  position: relative;
+}
+
+.data-table td.is-select::after {
+  border-inline: 0.28rem solid transparent;
+  border-top: 0.34rem solid currentColor;
+  content: "";
+  inset-inline-end: var(--cell-pad-x);
+  opacity: 0.55;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-25%);
+  z-index: 1;
 }
 
 /* A checkbox isn't single-line text — don't stretch it to fill the cell width. */


### PR DESCRIPTION
## Summary

Closes the discoverability half of the inline-select feedback: a select cell was visually indistinguishable from a text cell, so users couldn't tell it was a chooser (and it *felt* mouse-only).

**Myth-busted in the code first:** the native `<select>` editor is already fully keyboard-operable — `gridNavigation.ts` early-returns the moment focus is inside a `td[data-inline-editing]`, so Alt+Down / Space / arrows / type-ahead / Esc all reach the focused control and open/navigate the list. So this PR does **not** touch keyboard behaviour or rip out the native control. The only real defect was the missing affordance: `appearance:none` (which kills the open/close flicker) also strips the native arrow.

## What changed

- An `is-select` class on select grid cells paints a chevron in the right gutter, present in **both** static and edit mode at the same position → the cell reads as editable and the static→edit transition is a visual no-op.
- The caret gutter is reserved on the cell **and** inherited (`--caret-w` custom prop) into the overlaying `<select>` editor, so the text origin can't shift when editing opens.
- Applies to the worklog **and** admin grids (shared editor).

This is the **native-fixed** approach (chosen over a custom-listbox fork and Ark UI Select after a judged design pass).

## Test plan

- `typecheck` / `lint` / unit (60 tests on the two grids) — green.
- e2e `worklog-crud` (incl. a new "chevron present in both modes + no horizontal shift on open" assertion) + `admin-inline-edit` — green on the German stack.

> Supersedes #392 (auto-closed when its stacked base branch was deleted on #391's merge). Part 2 (the date-format setting, #393) stacks on this.
