### PR TITLE
feat(ui): edit-mode cue + auto-open the list when editing a select cell

### DIFF
--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -108,6 +108,17 @@ export function InlineEditor(props: {
       setValue(props.seed)
     }
     control?.focus()
+    // A select editor auto-opens its option list, so Enter-to-edit visibly reveals
+    // the dropdown rather than looking identical to read mode (the Enter keydown is
+    // a transient user activation). Progressive — browsers without showPicker fall
+    // back to the user pressing Space / Alt+Down.
+    if (control instanceof HTMLSelectElement) {
+      try {
+        control.showPicker()
+      } catch {
+        // showPicker unsupported or no user activation — ignore.
+      }
+    }
   })
 
   return (

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -112,11 +112,11 @@ export function InlineEditor(props: {
     // the dropdown rather than looking identical to read mode (the Enter keydown is
     // a transient user activation). Progressive — browsers without showPicker fall
     // back to the user pressing Space / Alt+Down.
-    if (control instanceof HTMLSelectElement) {
+    if (control instanceof HTMLSelectElement && typeof control.showPicker === 'function') {
       try {
         control.showPicker()
       } catch {
-        // showPicker unsupported or no user activation — ignore.
+        // no transient user activation (or blocked) — ignore; Space/Alt+Down still works.
       }
     }
   })

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1211,6 +1211,11 @@ kbd {
    (inset:0) and re-applies the cell's x-padding so the text stays exactly where
    the value was; a single-line input centres vertically like the static text. */
 .data-table td[data-inline-editing] {
+  /* A subtle accent wash marks the cell as IN edit mode — the read↔edit cue a
+     select cell otherwise lacks (a text editor has its caret). Layered via
+     color-mix so it tints over whatever the row already paints, in both themes,
+     with no layout shift (the seamless-border contract is untouched). */
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
   position: relative;
 }
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1215,7 +1215,7 @@ kbd {
      select cell otherwise lacks (a text editor has its caret). Layered via
      color-mix so it tints over whatever the row already paints, in both themes,
      with no layout shift (the seamless-border contract is untouched). */
-  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  background-color: color-mix(in srgb, var(--color-accent) 14%, transparent);
   position: relative;
 }
 


### PR DESCRIPTION
## Summary

Addresses the immediate half of your inline-select feedback (the "quick cues", part 1 of 2):

- **Can't tell read vs edit mode** → a subtle accent wash now marks the cell that's *in* edit mode. That's the read↔edit indicator a select cell lacks (a text editor has its blinking caret). It's `color-mix`-layered over whatever the row already paints, theme-aware, and adds **no** layout shift — the seamless-border contract from #386 is untouched.
- **Enter doesn't reveal the dropdown** → the select editor now auto-opens its native option list on edit (`HTMLSelectElement.showPicker()`). Progressive enhancement — browsers without it fall back to the user pressing Space / Alt+Down, exactly as today.

Both grids (shared `InlineEditor`).

## What this is *not*

This is the interim cue fix. The bigger ask — **type-ahead filtering + chips for single & multi select, unifying the worklog and admin editors** — is part 2, coming as a separate PR after we pick the editor approach (I'm preparing an interactive side-by-side of the two candidates).

## Test plan

- `typecheck` / `lint` / unit (60 on the two grids) — green.
- e2e `worklog-crud` + `admin-inline-edit` (18, select-heavy) — green on a fresh German stack.
