### PR TITLE
feat(ui): filterable chip combobox (Ark UI) for inline relation cells

### DIFF
--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -57,17 +57,49 @@ test.describe('Admin inline cell editing', () => {
     await expect(page.locator('td[data-col-key="name"]').first()).toHaveText(original);
   });
 
-  test('inline-edits a multiselect column as a chip combobox', async ({ page }) => {
-    const teamsCell = page.locator('td[data-col-key="teams"]').first();
-    await teamsCell.focus();
+  test('inline-edits a multiselect column as a chip combobox and persists the pick', async ({ page }) => {
+    // The teams column lives on the Users entity. Target sandy.supporter and TOGGLE
+    // a team — add an unselected one if there's room, else remove a selected one —
+    // so the test is idempotent across re-runs (teams is required, so ≥1 remains).
+    await page.goto('/ui/admin/users');
+    await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
+    await page.locator('input.admin-filter').fill('sandy');
+    const row = page.locator('table.admin-table tbody tr').filter({ hasText: /sandy/i }).first();
+    await expect(row).toBeVisible();
+    const before = await row.locator('td[data-col-key="teams"] .tag').count();
+
+    await row.locator('td[data-col-key="teams"]').focus();
     await page.keyboard.press('Enter');
 
     // The teams column opens an inline filterable combobox (a text input + an
     // option list), with the selection rendered as chips — not the modal.
     await expect(page.locator('td[data-inline-editing] .combobox-input')).toBeVisible();
-    await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
     await expect(page.locator('[role="dialog"]')).toHaveCount(0);
-    await page.keyboard.press('Escape');
+    await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
+
+    const unselected = page.locator('.combobox-content .combobox-item:not([data-state="checked"])');
+    let expected: number;
+    if ((await unselected.count()) > 0) {
+      await unselected.first().click(); // add a team → one more chip
+      expected = before + 1;
+    } else {
+      await page.locator('.combobox-content .combobox-item[data-state="checked"]').first().click(); // remove one → one fewer (still ≥1)
+      expected = before - 1;
+    }
+    await expect(page.locator('td[data-inline-editing] .tag')).toHaveCount(expected);
+
+    // Leaving the row saves the whole user — exercising the body-portal multi-commit
+    // path (the picked array must survive focus-out and reach /user/save).
+    const saved = page.waitForResponse((r) => /\/user\/save$/.test(r.url()) && r.request().method() === 'POST');
+    await page.locator('input.admin-filter').focus();
+    await saved;
+
+    // The change survives a full reload (persisted, not just optimistic).
+    await page.reload();
+    await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
+    await page.locator('input.admin-filter').fill('sandy');
+    await expect(page.locator('table.admin-table tbody tr').filter({ hasText: /sandy/i }).first()
+      .locator('td[data-col-key="teams"] .tag')).toHaveCount(expected);
   });
 
   test('the Status sub-page shows read-only diagnostics', async ({ page }) => {

--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -57,17 +57,17 @@ test.describe('Admin inline cell editing', () => {
     await expect(page.locator('td[data-col-key="name"]').first()).toHaveText(original);
   });
 
-  test('inline-edits a multiselect column as tag chips', async ({ page }) => {
+  test('inline-edits a multiselect column as a chip combobox', async ({ page }) => {
     const teamsCell = page.locator('td[data-col-key="teams"]').first();
     await teamsCell.focus();
     await page.keyboard.press('Enter');
 
-    // The teams column opens an inline tag editor (chips + an add button that
-    // opens a listbox menu), not the modal. (Add/remove behaviour is unit-tested
-    // in Admin.test.tsx; here we just confirm the inline editor mounts.)
-    const addBtn = teamsCell.locator('button.tag-add');
-    await expect(addBtn).toBeVisible();
+    // The teams column opens an inline filterable combobox (a text input + an
+    // option list), with the selection rendered as chips — not the modal.
+    await expect(page.locator('td[data-inline-editing] .combobox-input')).toBeVisible();
+    await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
     await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+    await page.keyboard.press('Escape');
   });
 
   test('the Status sub-page shows read-only diagnostics', async ({ page }) => {

--- a/e2e/helpers/worklog.ts
+++ b/e2e/helpers/worklog.ts
@@ -2,17 +2,31 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
  * Shared Worklog-grid helpers. The seeded entries predate the default day range,
- * so tests create their own entry for *today* via the Add flow — picking the
- * first seed customer that actually has projects, then the first project/activity
- * — and locate it by a unique description stamp.
+ * so tests create their own entry for *today* via the Add flow. Relation cells
+ * (customer/project/activity) are Ark Combobox chip editors — picked by opening
+ * the cell, optionally filtering, and clicking the first option.
  */
 
-export async function openEditor(page: Page, row: Locator, colKey: string): Promise<Locator> {
+export async function openTextEditor(page: Page, row: Locator, colKey: string): Promise<Locator> {
   await row.locator(`td[data-col-key="${colKey}"]`).focus();
   await page.keyboard.press('Enter');
-  const editor = page.locator('td[data-inline-editing] input.inline-editor, td[data-inline-editing] select.inline-editor').first();
+  const editor = page.locator('td[data-inline-editing] input.inline-editor').first();
   await expect(editor).toBeVisible();
   return editor;
+}
+
+// Open a relation cell's combobox (Add already opens the first one) and pick its
+// first available option, committing it.
+export async function pickFirstOption(page: Page, row: Locator, colKey: string, alreadyOpen = false): Promise<void> {
+  if (!alreadyOpen) {
+    await row.locator(`td[data-col-key="${colKey}"]`).focus();
+    await page.keyboard.press('Enter');
+  }
+  await expect(page.locator('td[data-inline-editing] .combobox-input').first()).toBeVisible();
+  const option = page.locator('.combobox-content .combobox-item').first();
+  await expect(option).toBeVisible({ timeout: 8000 });
+  await option.click();
+  await expect(page.locator('.combobox-content')).toBeHidden({ timeout: 4000 });
 }
 
 export function rowByStamp(page: Page, stamp: string): Locator {
@@ -26,49 +40,22 @@ export async function createWorklogEntry(page: Page): Promise<string> {
   const row = page.locator('tr.tracking-row.is-new').first();
   await expect(row).toBeVisible();
 
-  // Add opens the customer editor automatically. Pick the first real customer
-  // that actually has projects, so the cascade-filtered project editor isn't
-  // empty (some seed customers have none).
-  let projectValue = '';
-  for (let attempt = 0; attempt < 6 && projectValue === ''; attempt += 1) {
-    const customer = page.locator('td[data-inline-editing] select.inline-editor').first();
-    await expect(customer).toBeVisible();
-    const options = customer.locator('option[value]:not([value=""])');
-    await expect(options.first()).toBeAttached({ timeout: 10000 });
-    const value = await options.nth(attempt).getAttribute('value');
-    if (value === null) {
-      break;
-    }
-    await customer.selectOption(value);
-    await page.keyboard.press('Enter');
+  // Add opens the customer combobox; pick the first bookable customer, then its
+  // first (cascade-filtered) project, then the first activity.
+  await pickFirstOption(page, row, 'customer', true);
+  await pickFirstOption(page, row, 'project');
+  await pickFirstOption(page, row, 'activity');
 
-    const project = await openEditor(page, row, 'project');
-    const realProject = project.locator('option[value]:not([value=""])').first();
-    if (await realProject.count() > 0 && (await realProject.getAttribute('value')) !== null) {
-      projectValue = (await realProject.getAttribute('value')) ?? '';
-      await project.selectOption(projectValue);
-      await page.keyboard.press('Enter');
-      break;
-    }
-    await page.keyboard.press('Escape');
-    await openEditor(page, row, 'customer');
-  }
-  expect(projectValue).not.toBe('');
-
-  const activity = await openEditor(page, row, 'activity');
-  await activity.selectOption((await activity.locator('option[value]:not([value=""])').first().getAttribute('value')));
-  await page.keyboard.press('Enter');
-
-  const description = await openEditor(page, row, 'description');
+  const description = await openTextEditor(page, row, 'description');
   await description.fill(stamp);
   await page.keyboard.press('Enter');
 
-  const start = await openEditor(page, row, 'start');
+  const start = await openTextEditor(page, row, 'start');
   await start.fill('08:00');
   await page.keyboard.press('Enter');
 
   const saved = page.waitForResponse((r) => /\/tracking\/save$/.test(r.url()) && r.request().method() === 'POST');
-  const end = await openEditor(page, row, 'end');
+  const end = await openTextEditor(page, row, 'end');
   await end.fill('09:00');
   await page.keyboard.press('Enter');
   await saved;

--- a/e2e/worklog-crud.spec.ts
+++ b/e2e/worklog-crud.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from './helpers/auth';
 import { goToWorklogPage } from './helpers/navigation';
-import { createWorklogEntry, openEditor, rowByStamp } from './helpers/worklog';
+import { createWorklogEntry, openTextEditor, rowByStamp } from './helpers/worklog';
 
 /**
  * End-to-end coverage of the SolidJS Worklog CRUD journey (create / edit / save /
@@ -34,7 +34,7 @@ test.describe('Worklog CRUD', () => {
 
     // EDIT: change the description; a complete row auto-saves on commit.
     const edited = `${stamp}-edited`;
-    const editor = await openEditor(page, rowByStamp(page, stamp), 'description');
+    const editor = await openTextEditor(page, rowByStamp(page, stamp), 'description');
     const resaved = page.waitForResponse(isSave);
     await editor.fill(edited);
     await page.keyboard.press('Enter');
@@ -92,30 +92,17 @@ test.describe('Worklog CRUD', () => {
     await expect(page.getByRole('link', { name: /Export CSV|CSV-Export/i })).toHaveAttribute('href', '/export/35');
   });
 
-  test('a select cell shows a dropdown chevron and opening its editor does not shift the cell', async ({ page }) => {
+  test('a relation cell edits via a filterable combobox and resolves to a chip', async ({ page }) => {
     const stamp = await createEntry(page);
+    // Read mode: the customer cell renders its value as a chip (not free text).
     const cell = rowByStamp(page, stamp).locator('td[data-col-key="customer"]');
+    await expect(cell.locator('.inline-tags .tag')).toHaveCount(1);
 
-    // The chevron affordance marks a select cell (distinct from a text cell) in
-    // STATIC mode — a rendered ::after with a visible border-triangle.
-    await expect(cell).toHaveClass(/is-select/);
-    const staticCaret = await cell.evaluate((el) => parseFloat(getComputedStyle(el, '::after').borderTopWidth));
-    expect(staticCaret).toBeGreaterThan(0);
-
-    // Opening the inline editor must not reflow the cell (the caret gutter is
-    // reserved identically on the cell and the overlaying select editor).
-    const before = await cell.boundingBox();
+    // Edit mode: a combobox opens with a filter input and an option list.
     await cell.focus();
     await page.keyboard.press('Enter');
-    await expect(cell.locator('select.inline-editor')).toBeVisible();
-    const during = await cell.boundingBox();
-    // The chevron is still painted in edit mode (same affordance, same spot).
-    const editCaret = await cell.evaluate((el) => parseFloat(getComputedStyle(el, '::after').borderTopWidth));
-    expect(editCaret).toBeGreaterThan(0);
-
+    await expect(page.locator('td[data-inline-editing] .combobox-input')).toBeVisible();
+    await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
     await page.keyboard.press('Escape');
-    const after = await cell.boundingBox();
-    expect(Math.round(during!.width)).toBe(Math.round(before!.width));
-    expect(Math.round(after!.width)).toBe(Math.round(before!.width));
   });
 });

--- a/e2e/worklog-crud.spec.ts
+++ b/e2e/worklog-crud.spec.ts
@@ -92,17 +92,32 @@ test.describe('Worklog CRUD', () => {
     await expect(page.getByRole('link', { name: /Export CSV|CSV-Export/i })).toHaveAttribute('href', '/export/35');
   });
 
-  test('a relation cell edits via a filterable combobox and resolves to a chip', async ({ page }) => {
+  test('a relation cell edits via a filterable combobox, without reflow, and Escape cancels', async ({ page }) => {
     const stamp = await createEntry(page);
-    // Read mode: the customer cell renders its value as a chip (not free text).
+    // Read mode: the customer cell renders its value as a single chip (not free text).
     const cell = rowByStamp(page, stamp).locator('td[data-col-key="customer"]');
     await expect(cell.locator('.inline-tags .tag')).toHaveCount(1);
+    const original = ((await cell.locator('.inline-tags .tag').textContent()) ?? '').trim();
+    const before = await cell.boundingBox();
 
     // Edit mode: a combobox opens with a filter input and an option list.
     await cell.focus();
     await page.keyboard.press('Enter');
     await expect(page.locator('td[data-inline-editing] .combobox-input')).toBeVisible();
     await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
+
+    // The single-select editor overlays the cell — opening it must not widen the
+    // column (the no-reflow contract the native-select editor used to uphold).
+    const during = await cell.boundingBox();
+    expect(Math.abs(during!.width - before!.width)).toBeLessThanOrEqual(1);
+
+    // Escape cancels: the editor closes, the chip is unchanged, and nothing is saved.
+    let saveFired = false;
+    page.on('request', (r) => { if (isSave(r)) saveFired = true; });
     await page.keyboard.press('Escape');
+    await expect(page.locator('td[data-inline-editing]')).toHaveCount(0);
+    await expect(cell.locator('.inline-tags .tag')).toHaveCount(1);
+    await expect(cell.locator('.inline-tags .tag')).toHaveText(original);
+    expect(saveFired).toBe(false);
   });
 });

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -14,6 +14,7 @@
   "app_retry": "Erneut versuchen",
   "app_yes": "Ja",
   "app_no": "Nein",
+  "app_no_results": "Keine Treffer",
   "app_save": "Speichern",
   "app_saving": "Speichert…",
   "login_username": "Benutzername",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -15,6 +15,7 @@
   "app_yes": "Ja",
   "app_no": "Nein",
   "app_no_results": "Keine Treffer",
+  "app_select_none": "— Keine",
   "app_save": "Speichern",
   "app_saving": "Speichert…",
   "login_username": "Benutzername",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -14,6 +14,7 @@
   "app_retry": "Retry",
   "app_yes": "Yes",
   "app_no": "No",
+  "app_no_results": "No matches",
   "app_save": "Save",
   "app_saving": "Saving…",
   "login_username": "Username",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -15,6 +15,7 @@
   "app_yes": "Yes",
   "app_no": "No",
   "app_no_results": "No matches",
+  "app_select_none": "— None",
   "app_save": "Save",
   "app_saving": "Saving…",
   "login_username": "Username",

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -572,6 +572,11 @@ export function AdminCrudShell(props: {
                                   </>
                                 }
                               >
+                                {/* Ghost holds the column width so the overlaying single-select
+                                    editor can't re-flow the table (multi-select wraps in flow). */}
+                                <Show when={fieldType === 'select'}>
+                                  <span class="inline-ghost" aria-hidden="true"><ReadonlyChips values={chipValues(editor.overlayRow(row)[col.key])} options={fieldSelectOptions(fieldFor(col.key)!, props.options)} /></span>
+                                </Show>
                                 <ChipSelect
                                   field={fieldFor(col.key)!}
                                   label={col.label()}

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -4,7 +4,8 @@ import { createStore, reconcile } from 'solid-js/store'
 
 import { apiErrorMessage, getJson, postJson } from '../api/client'
 import { optionSourceKey } from '../api/queries'
-import { createInlineGridEdit, fieldSelectOptions, InlineEditor, InlineMultiSelect, INLINE_OVERLAY_TYPES, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { chipValues, createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_OVERLAY_TYPES, INLINE_TYPES, ReadonlyChips } from '../lib/inlineGridEdit'
+import { ChipSelect } from '../lib/chipSelect'
 import { gridNav } from '../lib/gridNavigation'
 import { DiskIcon, DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
 import { PageDialog } from './PageDialog'
@@ -29,33 +30,6 @@ function csvCell(value: string): string {
   return /[",\r\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe
 }
 
-// A select/multiselect cell value → the list of chip values to render. A single
-// select is one chip; "none" (0 / '' / null) is no chips.
-function chipValues(raw: unknown): (string | number)[] {
-  if (Array.isArray(raw)) {
-    return raw as (string | number)[]
-  }
-  if (raw === undefined || raw === null || raw === '' || raw === 0) {
-    return []
-  }
-
-  return [raw as string | number]
-}
-
-/** Read-only chips for a select/multiselect column in display mode, so reference
- *  columns read as chips (visually distinct from free-text) whether or not the
- *  cell is being edited. */
-function ReadonlyChips(props: Readonly<{ values: (string | number)[]; options: { value: string | number; label: string }[] }>) {
-  const labelOf = (value: string | number): string => props.options.find((option) => String(option.value) === String(value))?.label ?? String(value)
-
-  return (
-    <span class="inline-tags is-readonly">
-      <For each={props.values}>
-        {(value) => <span class="tag"><span class="tag-label">{labelOf(value)}</span></span>}
-      </For>
-    </span>
-  )
-}
 
 /** On/off indicator for a boolean column: a green dot for true, empty for false,
  *  with visually-hidden Yes/No so it isn't colour-only (WCAG 1.4.1). */
@@ -554,7 +528,7 @@ export function AdminCrudShell(props: {
 
                         return (
                           <td
-                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable, 'is-invalid': editor.fieldInvalid(rowId, col.key), 'is-select': editable && fieldType === 'select' }}
+                            classList={{ numeric: col.align === 'right', boolean: col.align === 'center', 'is-editable': editable, 'is-invalid': editor.fieldInvalid(rowId, col.key) }}
                             data-row-id={String(rowId)}
                             data-col-key={col.key}
                             data-inline-editing={editor.isEditing(rowId, col.key) ? '' : undefined}
@@ -577,35 +551,37 @@ export function AdminCrudShell(props: {
                                     : displayText(row, col)
                               }
                             >
-                              {/* Hidden ghost holds the column width so the overlaying
-                                  single-line editor can't make the table re-flow. */}
-                              <Show when={overlayEditor}>
-                                <span class="inline-ghost" aria-hidden="true">{displayText(row, col)}</span>
-                              </Show>
-                              <Switch
+                              <Show
+                                when={fieldType === 'select' || fieldType === 'multiselect'}
                                 fallback={
-                                  <InlineEditor
-                                    field={fieldFor(col.key)!}
-                                    label={col.label()}
-                                    initial={editor.draftValue(rowId, col.key) ?? ''}
-                                    seed={editor.seedChar()}
-                                    options={props.options}
-                                    onCommit={editor.commitCell}
-                                    onCancel={editor.cancelCell}
-                                  />
+                                  <>
+                                    {/* Hidden ghost holds the column width so the overlaying
+                                        single-line editor can't make the table re-flow. */}
+                                    <Show when={overlayEditor}>
+                                      <span class="inline-ghost" aria-hidden="true">{displayText(row, col)}</span>
+                                    </Show>
+                                    <InlineEditor
+                                      field={fieldFor(col.key)!}
+                                      label={col.label()}
+                                      initial={editor.draftValue(rowId, col.key) ?? ''}
+                                      seed={editor.seedChar()}
+                                      options={props.options}
+                                      onCommit={editor.commitCell}
+                                      onCancel={editor.cancelCell}
+                                    />
+                                  </>
                                 }
                               >
-                                <Match when={fieldFor(col.key)?.type === 'multiselect'}>
-                                  <InlineMultiSelect
-                                    field={fieldFor(col.key)!}
-                                    label={col.label()}
-                                    initial={editor.draftValue(rowId, col.key) ?? []}
-                                    options={props.options}
-                                    onCommit={editor.commitCell}
-                                    onCancel={editor.cancelCell}
-                                  />
-                                </Match>
-                              </Switch>
+                                <ChipSelect
+                                  field={fieldFor(col.key)!}
+                                  label={col.label()}
+                                  initial={editor.draftValue(rowId, col.key) ?? (fieldType === 'multiselect' ? [] : '')}
+                                  options={props.options}
+                                  multiple={fieldType === 'multiselect'}
+                                  onCommit={editor.commitCell}
+                                  onCancel={editor.cancelCell}
+                                />
+                              </Show>
                             </Show>
                           </td>
                         )

--- a/frontend/src/lib/chipSelect.test.tsx
+++ b/frontend/src/lib/chipSelect.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { FieldDef, OptionLookup } from '../admin/types'
+import { ChipSelect } from './chipSelect'
+
+const customers = [
+  { id: 7, label: 'Apollo' },
+  { id: 8, label: 'Zeus' },
+  { id: 9, label: 'Atlas' },
+]
+const options: OptionLookup = (source) => (source === 'customers' ? customers : [])
+const field: FieldDef = { name: 'customer', label: () => 'Customer', type: 'select', source: 'customers' }
+
+afterEach(() => { cleanup(); vi.restoreAllMocks() })
+
+describe('ChipSelect (jsdom)', () => {
+  it('renders the options and filters as you type', async () => {
+    render(() => <ChipSelect field={field} label="Customer" initial={0} options={options} multiple={false} onCommit={vi.fn()} onCancel={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+    fireEvent.input(screen.getByRole('combobox'), { target: { value: 'Ap' } })
+    await waitFor(() => {
+      const labels = screen.getAllByRole('option').map((o) => o.textContent)
+      expect(labels.some((l) => l?.includes('Apollo'))).toBe(true)
+      expect(labels.some((l) => l?.includes('Zeus'))).toBe(false)
+    })
+  })
+
+  it('picking an option commits its numeric id', async () => {
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={field} label="Customer" initial={0} options={options} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    fireEvent.click(screen.getByRole('option', { name: 'Zeus' }))
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith(8, expect.anything()))
+  })
+
+  const teamsField: FieldDef = { name: 'teams', label: () => 'Teams', type: 'multiselect', source: 'teams' }
+  const teams = [{ id: 1, label: 'Backend' }, { id: 2, label: 'Frontend' }, { id: 3, label: 'Design' }]
+  const teamOptions: OptionLookup = (source) => (source === 'teams' ? teams : [])
+
+  it('multi: shows the initial selection as chips and adds another on pick', async () => {
+    render(() => <ChipSelect field={teamsField} label="Teams" initial={[1]} options={teamOptions} multiple onCommit={vi.fn()} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    expect(screen.getAllByRole('listitem').length).toBe(1) // initial chip (id 1 = Backend)
+    fireEvent.click(screen.getByRole('option', { name: 'Design' })) // add id 3 (stays open for multi)
+    await waitFor(() => expect(screen.getAllByRole('listitem').length).toBe(2))
+  })
+
+  it('multi: removing a chip with its × drops it from the selection', async () => {
+    render(() => <ChipSelect field={teamsField} label="Teams" initial={[1, 2]} options={teamOptions} multiple onCommit={vi.fn()} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('listitem').length).toBe(2))
+
+    fireEvent.click(screen.getByRole('button', { name: /Backend/ })) // the × on the Backend chip
+    await waitFor(() => expect(screen.getAllByRole('listitem').length).toBe(1))
+  })
+})

--- a/frontend/src/lib/chipSelect.test.tsx
+++ b/frontend/src/lib/chipSelect.test.tsx
@@ -10,7 +10,8 @@ const customers = [
   { id: 9, label: 'Atlas' },
 ]
 const options: OptionLookup = (source) => (source === 'customers' ? customers : [])
-const field: FieldDef = { name: 'customer', label: () => 'Customer', type: 'select', source: 'customers' }
+// Required (like the worklog customer cell) → no "clear" pseudo-option.
+const field: FieldDef = { name: 'customer', label: () => 'Customer', type: 'select', source: 'customers', required: true }
 
 afterEach(() => { cleanup(); vi.restoreAllMocks() })
 
@@ -36,6 +37,59 @@ describe('ChipSelect (jsdom)', () => {
     await waitFor(() => expect(onCommit).toHaveBeenCalledWith(8, expect.anything()))
   })
 
+  it('Enter on the freshly-opened list never commits the empty value', async () => {
+    // Regression: `open` seeded false made the first Enter read the open list as
+    // closed and commit selected()=0 instead of selecting the highlighted option.
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={field} label="Customer" initial={0} options={options} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' })
+    await Promise.resolve()
+    expect(onCommit).not.toHaveBeenCalledWith(0, expect.anything())
+  })
+
+  it('Escape cancels the edit without committing', async () => {
+    const onCommit = vi.fn()
+    const onCancel = vi.fn()
+    render(() => <ChipSelect field={field} label="Customer" initial={7} options={options} multiple={false} onCommit={onCommit} onCancel={onCancel} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('a string-valued single select round-trips its string, never NaN', async () => {
+    // Regression: forcing the value through Number() turned 'DEV' into NaN and
+    // committed the literal 'NaN' for the user `type` / `locale` columns.
+    const typeField: FieldDef = {
+      name: 'type', label: () => 'Type', type: 'select', stringValue: true,
+      staticOptions: [{ value: 'DEV', label: () => 'DEV' }, { value: 'PL', label: () => 'PL' }, { value: 'CTL', label: () => 'CTL' }],
+    }
+    const noOptions: OptionLookup = () => []
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={typeField} label="Type" initial="DEV" options={noOptions} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    // The existing value is shown (as the input's placeholder), not an empty editor.
+    expect(screen.getByRole('combobox')).toHaveAttribute('placeholder', 'DEV')
+    fireEvent.click(screen.getByRole('option', { name: 'PL' }))
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith('PL', expect.anything()))
+  })
+
+  it('an optional single relation offers a "none" option that commits 0', async () => {
+    const tsField: FieldDef = { name: 'ticket_system', label: () => 'Ticket system', type: 'select', source: 'ticketSystems' }
+    const tsOptions: OptionLookup = (source) => (source === 'ticketSystems' ? [{ id: 5, label: 'Jira' }, { id: 6, label: 'GitHub' }] : [])
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={tsField} label="Ticket system" initial={5} options={tsOptions} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
+    // 2 real options + the prepended clear option.
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    fireEvent.click(screen.getByRole('option', { name: /None/ }))
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith(0, expect.anything()))
+  })
+
   const teamsField: FieldDef = { name: 'teams', label: () => 'Teams', type: 'multiselect', source: 'teams' }
   const teams = [{ id: 1, label: 'Backend' }, { id: 2, label: 'Frontend' }, { id: 3, label: 'Design' }]
   const teamOptions: OptionLookup = (source) => (source === 'teams' ? teams : [])
@@ -55,5 +109,29 @@ describe('ChipSelect (jsdom)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Backend/ })) // the × on the Backend chip
     await waitFor(() => expect(screen.getAllByRole('listitem').length).toBe(1))
+  })
+
+  it('multi: commits the selected ids as a number[] on Tab (add)', async () => {
+    // The committed-array path the deleted InlineMultiSelect tests used to guard:
+    // multi commits not on pick but on the deferred finish (Tab / blur / Enter-closed).
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={teamsField} label="Teams" initial={[1]} options={teamOptions} multiple onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    fireEvent.click(screen.getByRole('option', { name: 'Design' })) // add id 3
+    await waitFor(() => expect(screen.getAllByRole('listitem').length).toBe(2))
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Tab' })
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith([1, 3], expect.anything()))
+  })
+
+  it('multi: removing the last chip commits an empty array on Tab', async () => {
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={teamsField} label="Teams" initial={[1]} options={teamOptions} multiple onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('listitem').length).toBe(1))
+
+    fireEvent.click(screen.getByRole('button', { name: /Backend/ }))
+    await waitFor(() => expect(screen.queryAllByRole('listitem').length).toBe(0))
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Tab' })
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith([], expect.anything()))
   })
 })

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -9,16 +9,23 @@ import { m } from '../paraglide/messages.js'
 
 type Item = { value: string; label: string }
 
+// The "clear to none" pseudo-option for an optional single relation select. A
+// sentinel (never a real option value — relation values stringify to digits) so
+// it can't collide with a genuine option and never enters the committed value.
+const CLEAR_VALUE = '__clear__'
+
 /**
  * Filterable chip combobox for an inline relation cell — one component for single
- * (max one chip) and multi select, replacing the native-<select> editor and the
- * hand-rolled InlineMultiSelect across both grids. Built on Ark UI Combobox:
- * type to filter, chips for the selection, keyboard-navigable listbox.
+ * (input + value, overlays the cell) and multi select (removable chips, in flow),
+ * replacing the native-<select> editor and the hand-rolled InlineMultiSelect across
+ * both grids. Built on Ark UI Combobox: type to filter, keyboard-navigable listbox.
  *
- * Boundary: Ark deals in string[]; our option ids are numbers — coerced at the
- * edges. Selected chips resolve through the FULL label map, so a value filtered
- * out of the live list keeps its chip label. Every commit funnels through the
- * controller's onCommit so the grid's cascade / auto-save still fire.
+ * Boundary: Ark deals in string[] and our option values are *either* numeric ids
+ * (relations) or strings (e.g. user `type`, `locale`). The selection is carried
+ * verbatim as the option's string value and converted back to the field's payload
+ * type only in coerced() — so a string-valued select round-trips as its string,
+ * never as `Number('DEV')` → NaN. Every commit funnels through the controller's
+ * onCommit so the grid's cascade / auto-save still fire.
  */
 export function ChipSelect(props: {
   field: FieldDef
@@ -29,42 +36,59 @@ export function ChipSelect(props: {
   onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
   onCancel: () => void
 }) {
-  const initialIds = (): number[] => {
-    if (Array.isArray(props.initial)) {
-      return (props.initial as unknown[]).map((value) => Number(value)).filter((value) => value > 0)
+  // Selection is the list of selected option values, as strings (Ark's native
+  // shape). 0 / '' / null read as "nothing selected"; a numeric id is kept only
+  // when > 0 (0 is the relation "unset" sentinel — see chipValues()).
+  const initialValues = (): string[] => {
+    const raw = props.initial
+    if (Array.isArray(raw)) {
+      return (raw as unknown[]).map((value) => Number(value)).filter((value) => value > 0).map(String)
     }
-    const single = Number(props.initial ?? 0)
+    if (props.field.stringValue === true) {
+      const value = raw === undefined || raw === null ? '' : String(raw)
 
-    return single > 0 ? [single] : []
+      return value === '' ? [] : [value]
+    }
+    const single = Number(raw ?? 0)
+
+    return single > 0 ? [String(single)] : []
   }
 
-  const [selected, setSelected] = createSignal<number[]>(initialIds())
+  const [selected, setSelected] = createSignal<string[]>(initialValues())
   const [inputValue, setInputValue] = createSignal('')
-  const [open, setOpen] = createSignal(false)
+  // Seed to match `defaultOpen`: Ark enters the open state as the machine's initial
+  // state without firing onOpenChange, so a signal seeded false would mis-read the
+  // open list as closed and route the first Enter to commit-the-cell.
+  const [open, setOpen] = createSignal(true)
   let rootEl: HTMLDivElement | undefined
   let inputEl: HTMLInputElement | undefined
   let done = false
 
   const allItems = createMemo<Item[]>(() => fieldSelectOptions(props.field, props.options).map((option) => ({ value: String(option.value), label: option.label })))
-  const labelOf = (id: number): string => allItems().find((item) => item.value === String(id))?.label ?? String(id)
+  const labelOf = (value: string): string => allItems().find((item) => item.value === value)?.label ?? value
+  // Offer an explicit "none" only for an optional, numeric (relation) single select
+  // — the editor the native <select>'s empty <option> used to provide. String-valued
+  // selects (locale/type) always carry a value and are not cleared to ''.
+  const showClear = (): boolean => !props.multiple && props.field.required !== true && props.field.stringValue !== true
   const filteredItems = createMemo<Item[]>(() => {
     const query = inputValue().trim().toLowerCase()
+    const base = query === '' ? allItems() : allItems().filter((item) => item.label.toLowerCase().includes(query))
 
-    return query === '' ? allItems() : allItems().filter((item) => item.label.toLowerCase().includes(query))
+    return showClear() && query === '' ? [{ value: CLEAR_VALUE, label: m.app_select_none() }, ...base] : base
   })
   // Ark requires a collection; rebuild it from the filtered items (we filter, not zag).
   const collection = createMemo(() => createListCollection<Item>({ items: filteredItems(), itemToValue: (item) => item.value, itemToString: (item) => item.label }))
 
   const coerced = (): FormValues[string] => {
     if (props.multiple) {
-      return selected()
+      return selected().map(Number)
     }
     const first = selected()[0]
     if (first === undefined) {
       return props.field.stringValue === true ? '' : 0
     }
 
-    return props.field.stringValue === true ? String(first) : first
+    return props.field.stringValue === true ? first : Number(first)
   }
 
   const finish = (direction?: 'down' | 'left' | 'right' | 'stay'): void => {
@@ -89,7 +113,7 @@ export function ChipSelect(props: {
   return (
     <div
       ref={(element) => { rootEl = element }}
-      class="inline-editor inline-tags chip-select"
+      class={`inline-editor chip-select${props.multiple ? ' inline-tags' : ''}`}
       onFocusOut={() => {
         // Commit only once focus has actually left the whole widget — including
         // the body-portalled popup (data-chipselect-popup) — checked after focus
@@ -104,48 +128,69 @@ export function ChipSelect(props: {
         })
       }}
     >
-      <span class="tag-list" role="list">
-        <For each={selected()}>
-          {(id) => (
-            <span class="tag" role="listitem">
-              <span class="tag-label">{labelOf(id)}</span>
-              <Show when={props.multiple}>
+      <Show when={props.multiple}>
+        <span class="tag-list" role="list">
+          <For each={selected()}>
+            {(value) => (
+              <span class="tag" role="listitem">
+                <span class="tag-label">{labelOf(value)}</span>
                 <button
                   type="button"
                   class="tag-remove"
                   tabindex="-1"
-                  aria-label={`${m.admin_delete()}: ${labelOf(id)}`}
+                  aria-label={`${m.admin_delete()}: ${labelOf(value)}`}
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => { setSelected(selected().filter((value) => value !== id)); inputEl?.focus() }}
+                  onClick={() => { setSelected(selected().filter((current) => current !== value)); inputEl?.focus() }}
                 >×</button>
-              </Show>
-            </span>
-          )}
-        </For>
+              </span>
+            )}
+          </For>
+        </span>
+      </Show>
+
+      {/* Announce selection changes (add / remove / single replace) — Ark's own
+          live region only narrates the highlighted option during navigation. */}
+      <span class="visually-hidden" role="status" aria-live="polite">
+        {selected().map(labelOf).join(', ')}
       </span>
 
       <Combobox.Root
         collection={collection()}
         multiple={props.multiple}
-        value={selected().map(String)}
+        value={selected()}
         onValueChange={(details) => {
+          // State only; single-select commit is driven by onSelect (which fires even
+          // when the same value is re-picked, where onValueChange would not).
           if (props.multiple) {
-            setSelected(details.value.map(Number))
-          } else {
-            const picked = details.value.at(-1)
-            setSelected(picked !== undefined ? [Number(picked)] : [])
-            finish(getEnterBehavior()) // single pick commits + moves per the user's Enter pref
+            setSelected(details.value)
           }
+        }}
+        onSelect={(details) => {
+          if (props.multiple) {
+            return
+          }
+          setSelected(details.itemValue === CLEAR_VALUE ? [] : [details.itemValue])
+          finish(getEnterBehavior()) // single pick commits + moves per the user's Enter pref
         }}
         inputValue={inputValue()}
         onInputValueChange={(details) => setInputValue(details.inputValue)}
         defaultOpen
-        onOpenChange={(details) => setOpen(details.open)}
+        onOpenChange={(details) => {
+          setOpen(details.open)
+          // A single Escape cancels the whole cell edit. zag consumes Escape on a
+          // document listener to close ITS list before any element-level handler
+          // runs, so we hook the close itself (reason 'escape-key') rather than the
+          // keydown. Other close reasons (item-select, interact-outside) must not
+          // cancel — those commit via onSelect / focus-out.
+          if (!details.open && details.reason === 'escape-key') {
+            cancel()
+          }
+        }}
         openOnClick
         closeOnSelect={!props.multiple}
         allowCustomValue={false}
         inputBehavior="autohighlight"
-        positioning={{ sameWidth: true, gutter: 2, flip: true }}
+        positioning={{ sameWidth: true, gutter: 2, flip: true, fitViewport: true }}
         onInteractOutside={(event) => {
           // Keep the popup open while focus/clicks stay within the editing cell.
           const target = event.target as Node | null
@@ -154,6 +199,7 @@ export function ChipSelect(props: {
           }
         }}
       >
+        <Combobox.Label class="visually-hidden">{props.label}</Combobox.Label>
         <Combobox.Control class="combobox-control">
           <Combobox.Input
             ref={(element) => { inputEl = element }}
@@ -161,20 +207,26 @@ export function ChipSelect(props: {
             aria-label={props.label}
             placeholder={!props.multiple && selected().length > 0 ? labelOf(selected()[0]!) : ''}
             onKeyDown={(event) => {
-              // The listbox owns Arrow/Enter/Escape while open; the cell owns
-              // Tab (always) and Enter/Escape only when the list is closed.
+              // The listbox owns Arrow/Enter while open; the cell owns Tab (always),
+              // Enter when the list is closed, and Backspace to drop the last chip when
+              // the filter input is empty. Escape cancels: when the list is open in a
+              // real browser zag consumes it first (handled in onOpenChange); this
+              // branch covers the closed list and environments where zag doesn't.
               if (event.key === 'Tab') {
                 event.preventDefault()
                 event.stopPropagation()
                 finish(event.shiftKey ? 'left' : 'right')
+              } else if (event.key === 'Escape') {
+                event.preventDefault()
+                event.stopPropagation()
+                cancel()
               } else if (event.key === 'Enter' && !open()) {
                 event.preventDefault()
                 event.stopPropagation()
                 finish(getEnterBehavior())
-              } else if (event.key === 'Escape' && !open()) {
+              } else if (event.key === 'Backspace' && props.multiple && inputValue() === '' && selected().length > 0) {
                 event.preventDefault()
-                event.stopPropagation()
-                cancel()
+                setSelected(selected().slice(0, -1))
               }
             }}
           />

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -1,0 +1,204 @@
+import { Combobox, createListCollection } from '@ark-ui/solid/combobox'
+import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
+import { Portal } from 'solid-js/web'
+
+import type { FieldDef, FormValues, OptionLookup } from '../admin/types'
+import { getEnterBehavior } from './gridEditPref'
+import { fieldSelectOptions } from './inlineGridEdit'
+import { m } from '../paraglide/messages.js'
+
+type Item = { value: string; label: string }
+
+/**
+ * Filterable chip combobox for an inline relation cell — one component for single
+ * (max one chip) and multi select, replacing the native-<select> editor and the
+ * hand-rolled InlineMultiSelect across both grids. Built on Ark UI Combobox:
+ * type to filter, chips for the selection, keyboard-navigable listbox.
+ *
+ * Boundary: Ark deals in string[]; our option ids are numbers — coerced at the
+ * edges. Selected chips resolve through the FULL label map, so a value filtered
+ * out of the live list keeps its chip label. Every commit funnels through the
+ * controller's onCommit so the grid's cascade / auto-save still fire.
+ */
+export function ChipSelect(props: {
+  field: FieldDef
+  label: string
+  initial: FormValues[string]
+  options: OptionLookup
+  multiple: boolean
+  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
+  onCancel: () => void
+}) {
+  const initialIds = (): number[] => {
+    if (Array.isArray(props.initial)) {
+      return (props.initial as unknown[]).map((value) => Number(value)).filter((value) => value > 0)
+    }
+    const single = Number(props.initial ?? 0)
+
+    return single > 0 ? [single] : []
+  }
+
+  const [selected, setSelected] = createSignal<number[]>(initialIds())
+  const [inputValue, setInputValue] = createSignal('')
+  const [open, setOpen] = createSignal(false)
+  let rootEl: HTMLDivElement | undefined
+  let inputEl: HTMLInputElement | undefined
+  let done = false
+
+  const allItems = createMemo<Item[]>(() => fieldSelectOptions(props.field, props.options).map((option) => ({ value: String(option.value), label: option.label })))
+  const labelOf = (id: number): string => allItems().find((item) => item.value === String(id))?.label ?? String(id)
+  const filteredItems = createMemo<Item[]>(() => {
+    const query = inputValue().trim().toLowerCase()
+
+    return query === '' ? allItems() : allItems().filter((item) => item.label.toLowerCase().includes(query))
+  })
+  // Ark requires a collection; rebuild it from the filtered items (we filter, not zag).
+  const collection = createMemo(() => createListCollection<Item>({ items: filteredItems(), itemToValue: (item) => item.value, itemToString: (item) => item.label }))
+
+  const coerced = (): FormValues[string] => {
+    if (props.multiple) {
+      return selected()
+    }
+    const first = selected()[0]
+    if (first === undefined) {
+      return props.field.stringValue === true ? '' : 0
+    }
+
+    return props.field.stringValue === true ? String(first) : first
+  }
+
+  const finish = (direction?: 'down' | 'left' | 'right' | 'stay'): void => {
+    if (done) {
+      return
+    }
+    done = true
+    props.onCommit(coerced(), direction)
+  }
+  const cancel = (): void => {
+    if (done) {
+      return
+    }
+    done = true
+    props.onCancel()
+  }
+
+  onMount(() => {
+    inputEl?.focus()
+  })
+
+  return (
+    <div
+      ref={(element) => { rootEl = element }}
+      class="inline-editor inline-tags chip-select"
+      onFocusOut={() => {
+        // Commit only once focus has actually left the whole widget — including
+        // the body-portalled popup (data-chipselect-popup) — checked after focus
+        // settles, so moving into the listbox doesn't commit/close the editor.
+        // eslint-disable-next-line solid/reactivity -- deferred commit after focus settles
+        queueMicrotask(() => {
+          const active = document.activeElement
+          const inPopup = active instanceof HTMLElement && active.closest('[data-chipselect-popup]') !== null
+          if (!done && rootEl !== undefined && !rootEl.contains(active) && !inPopup) {
+            finish()
+          }
+        })
+      }}
+    >
+      <span class="tag-list" role="list">
+        <For each={selected()}>
+          {(id) => (
+            <span class="tag" role="listitem">
+              <span class="tag-label">{labelOf(id)}</span>
+              <Show when={props.multiple}>
+                <button
+                  type="button"
+                  class="tag-remove"
+                  tabindex="-1"
+                  aria-label={`${m.admin_delete()}: ${labelOf(id)}`}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => { setSelected(selected().filter((value) => value !== id)); inputEl?.focus() }}
+                >×</button>
+              </Show>
+            </span>
+          )}
+        </For>
+      </span>
+
+      <Combobox.Root
+        collection={collection()}
+        multiple={props.multiple}
+        value={selected().map(String)}
+        onValueChange={(details) => {
+          if (props.multiple) {
+            setSelected(details.value.map(Number))
+          } else {
+            const picked = details.value.at(-1)
+            setSelected(picked !== undefined ? [Number(picked)] : [])
+            finish(getEnterBehavior()) // single pick commits + moves per the user's Enter pref
+          }
+        }}
+        inputValue={inputValue()}
+        onInputValueChange={(details) => setInputValue(details.inputValue)}
+        defaultOpen
+        onOpenChange={(details) => setOpen(details.open)}
+        openOnClick
+        closeOnSelect={!props.multiple}
+        allowCustomValue={false}
+        inputBehavior="autohighlight"
+        positioning={{ sameWidth: true, gutter: 2, flip: true }}
+        onInteractOutside={(event) => {
+          // Keep the popup open while focus/clicks stay within the editing cell.
+          const target = event.target as Node | null
+          if (target !== null && rootEl?.contains(target)) {
+            event.preventDefault()
+          }
+        }}
+      >
+        <Combobox.Control class="combobox-control">
+          <Combobox.Input
+            ref={(element) => { inputEl = element }}
+            class="combobox-input"
+            aria-label={props.label}
+            placeholder={!props.multiple && selected().length > 0 ? labelOf(selected()[0]!) : ''}
+            onKeyDown={(event) => {
+              // The listbox owns Arrow/Enter/Escape while open; the cell owns
+              // Tab (always) and Enter/Escape only when the list is closed.
+              if (event.key === 'Tab') {
+                event.preventDefault()
+                event.stopPropagation()
+                finish(event.shiftKey ? 'left' : 'right')
+              } else if (event.key === 'Enter' && !open()) {
+                event.preventDefault()
+                event.stopPropagation()
+                finish(getEnterBehavior())
+              } else if (event.key === 'Escape' && !open()) {
+                event.preventDefault()
+                event.stopPropagation()
+                cancel()
+              }
+            }}
+          />
+          <Combobox.Trigger class="combobox-trigger" tabindex="-1" aria-label={props.label}>▾</Combobox.Trigger>
+        </Combobox.Control>
+        {/* Body-portal so the popup floats above the grid and is never clipped by
+            the .table-scroll overflow; data-chipselect-popup whitelists it in the
+            grid's focus-out logic so opening it doesn't save/close the row. */}
+        <Portal>
+          <Combobox.Positioner class="combobox-positioner" data-chipselect-popup>
+            <Combobox.Content class="combobox-content">
+              <For each={filteredItems()}>
+                {(item) => (
+                  <Combobox.Item item={item} class="combobox-item">
+                    <Combobox.ItemText>{item.label}</Combobox.ItemText>
+                    <Combobox.ItemIndicator class="combobox-indicator">✓</Combobox.ItemIndicator>
+                  </Combobox.Item>
+                )}
+              </For>
+              <Combobox.Empty class="combobox-empty">{m.app_no_results()}</Combobox.Empty>
+            </Combobox.Content>
+          </Combobox.Positioner>
+        </Portal>
+      </Combobox.Root>
+    </div>
+  )
+}

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, createUniqueId, For, Match, onCleanup, onMount, Show, Switch, type Accessor } from 'solid-js'
+import { createSignal, createUniqueId, For, Match, onCleanup, onMount, Show, Switch, type Accessor } from 'solid-js'
 import { createStore, produce } from 'solid-js/store'
 
 import type { FieldDef, FormValues, OptionLookup } from '../admin/types'
@@ -16,7 +16,7 @@ export const INLINE_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date',
 // "ghost" of the value, which holds the column width) so opening them can't make
 // the auto-layout table re-flow the column. Checkbox and multiselect editors stay
 // in flow (they aren't single-line text and size differently).
-export const INLINE_OVERLAY_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date', 'select'])
+export const INLINE_OVERLAY_TYPES = new Set<FieldDef['type']>(['text', 'number', 'date'])
 
 /** Shared option resolution for both the modal FieldControl and the inline
  *  editor, so relation/static dropdowns stay identical in either surface. */
@@ -26,6 +26,33 @@ export function fieldSelectOptions(field: FieldDef, options: OptionLookup): { va
   }
 
   return field.source ? options(field.source).map((option) => ({ value: option.id, label: option.label })) : []
+}
+
+/** A select/multiselect cell value → the list of chip values to render. A single
+ *  select is one chip; "none" (0 / '' / null) is no chips. */
+export function chipValues(raw: unknown): (string | number)[] {
+  if (Array.isArray(raw)) {
+    return raw as (string | number)[]
+  }
+  if (raw === undefined || raw === null || raw === '' || raw === 0) {
+    return []
+  }
+
+  return [raw as string | number]
+}
+
+/** Read-only chips for a select/multiselect column in display mode, so reference
+ *  columns read as chips (visually distinct from free text) in both grids. */
+export function ReadonlyChips(props: Readonly<{ values: (string | number)[]; options: { value: string | number; label: string }[] }>) {
+  const labelOf = (value: string | number): string => props.options.find((option) => String(option.value) === String(value))?.label ?? String(value)
+
+  return (
+    <span class="inline-tags is-readonly">
+      <For each={props.values}>
+        {(value) => <span class="tag"><span class="tag-label">{labelOf(value)}</span></span>}
+      </For>
+    </span>
+  )
 }
 
 /**
@@ -47,9 +74,6 @@ export function InlineEditor(props: {
 }) {
   const isCheckbox = (): boolean => props.field.type === 'checkbox'
   const [value, setValue] = createSignal<string | boolean>(isCheckbox() ? Boolean(props.initial) : String(props.initial ?? ''))
-  // Memoized so the <For> below sees a stable array (recreated only when the
-  // option source changes), not a fresh one on every render.
-  const selectOptions = createMemo(() => fieldSelectOptions(props.field, props.options))
   let control: HTMLInputElement | HTMLSelectElement | undefined
   // Stable id linking the date input to its visually-hidden format hint, so the
   // required YYYY-MM-DD format is announced (a placeholder alone is not reliable).
@@ -108,17 +132,6 @@ export function InlineEditor(props: {
       setValue(props.seed)
     }
     control?.focus()
-    // A select editor auto-opens its option list, so Enter-to-edit visibly reveals
-    // the dropdown rather than looking identical to read mode (the Enter keydown is
-    // a transient user activation). Progressive — browsers without showPicker fall
-    // back to the user pressing Space / Alt+Down.
-    if (control instanceof HTMLSelectElement && typeof control.showPicker === 'function') {
-      try {
-        control.showPicker()
-      } catch {
-        // no transient user activation (or blocked) — ignore; Space/Alt+Down still works.
-      }
-    }
   })
 
   return (
@@ -134,22 +147,6 @@ export function InlineEditor(props: {
           onKeyDown={onKeyDown}
           onBlur={() => finish()}
         />
-      </Match>
-      <Match when={props.field.type === 'select'}>
-        <select
-          ref={(el) => { control = el }}
-          class="inline-editor"
-          aria-label={props.label}
-          value={value() as string}
-          onInput={(e) => setValue(e.currentTarget.value)}
-          onKeyDown={onKeyDown}
-          onBlur={() => finish()}
-        >
-          <option value="">—</option>
-          <For each={selectOptions()}>
-            {(option) => <option value={String(option.value)}>{option.label}</option>}
-          </For>
-        </select>
       </Match>
       <Match when={true}>
         <input
@@ -172,247 +169,6 @@ export function InlineEditor(props: {
         </Show>
       </Match>
     </Switch>
-  )
-}
-
-/**
- * In-cell multiselect editor: the selected options render as removable tag chips
- * with an "add" dropdown of the remaining options (Teams: [DEV ×] [PL ×] +). The
- * value is the selected ids (number[]). Commit moves through the same onCommit
- * as the single-cell editor: Enter commits in place, Escape cancels, and tabbing
- * or clicking out of the whole widget commits (checked after the focus settles,
- * so moving between chips/the dropdown — incl. removing one — doesn't commit).
- */
-export function InlineMultiSelect(props: {
-  field: FieldDef
-  label: string
-  initial: FormValues[string]
-  options: OptionLookup
-  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
-  onCancel: () => void
-}) {
-  const allOptions = createMemo(() => fieldSelectOptions(props.field, props.options))
-  const [selected, setSelected] = createSignal<number[]>(Array.isArray(props.initial) ? [...(props.initial as number[])] : [])
-  const unselected = createMemo(() => allOptions().filter((option) => !selected().includes(Number(option.value))))
-  // id→label map (rebuilt only when the options change) so resolving a chip's
-  // name is O(1) rather than an O(n) .find on each of its (re)renders.
-  const optionLabels = createMemo(() => new Map(allOptions().map((option) => [Number(option.value), option.label])))
-  const labelOf = (id: number): string => optionLabels().get(id) ?? String(id)
-  // The "add" control is a popup MENU OF BUTTONS, not a native <select> (which
-  // fired change on every arrow keypress, adding a chip per keystroke) and not a
-  // role=listbox + aria-activedescendant (invalid ARIA on a <button>). Real,
-  // focusable <button> options are keyboard-native and accessible.
-  const [menuOpen, setMenuOpen] = createSignal(false)
-  let container: HTMLDivElement | undefined
-  let addBtn: HTMLButtonElement | undefined
-  let menuEl: HTMLDivElement | undefined
-  let done = false
-
-  function add(id: number): void {
-    if (id > 0 && !selected().includes(id)) {
-      setSelected([...selected(), id])
-    }
-  }
-  function remove(id: number): void {
-    setSelected(selected().filter((value) => value !== id))
-  }
-  // Focusable items, in DOM order: each chip, then the add button. Chips carry a
-  // roving tabindex so Left/Right can move between them (and the add button).
-  const navItems = (): HTMLElement[] => Array.from(container?.querySelectorAll<HTMLElement>('.tag, .tag-add') ?? [])
-  function moveFocus(delta: number): void {
-    const items = navItems()
-    const current = items.indexOf(document.activeElement as HTMLElement)
-    const from = current === -1 ? items.length - 1 : current
-    items[Math.max(0, Math.min(items.length - 1, from + delta))]?.focus()
-  }
-  // Remove the focused chip, then keep focus inside the widget (the chip now in
-  // its place, or the add button) so the removal doesn't read as a commit.
-  function removeFocusedChip(): void {
-    const active = document.activeElement
-    if (!(active instanceof HTMLElement) || !active.classList.contains('tag')) {
-      return
-    }
-    const index = navItems().indexOf(active)
-    const id = Number(active.dataset.tagId)
-    if (!Number.isInteger(id) || id <= 0) {
-      return
-    }
-    remove(id)
-    // Re-focus the next item SYNCHRONOUSLY (Solid has already re-rendered the
-    // removed chip away): the focus-out check is deferred to a microtask, so
-    // focus must be back inside the widget before it runs, or the removal would
-    // read as "focus left" and commit/close the editor.
-    const after = navItems()
-    ;(after[Math.min(index, after.length - 1)] ?? addBtn)?.focus()
-  }
-  const focusFirstItem = (): void => {
-    queueMicrotask(() => menuEl?.querySelector<HTMLButtonElement>('.tag-menu-item')?.focus())
-  }
-  function openMenu(): void {
-    if (unselected().length > 0) {
-      setMenuOpen(true)
-      focusFirstItem()
-    }
-  }
-  function closeMenu(refocusAddBtn = true): void {
-    setMenuOpen(false)
-    if (refocusAddBtn) {
-      addBtn?.focus()
-    }
-  }
-  // Add an option, keeping the menu usable for adding several in a row (it closes
-  // once nothing is left to add).
-  function addOption(id: number): void {
-    add(id)
-    if (unselected().length === 0) {
-      closeMenu()
-    } else {
-      focusFirstItem()
-    }
-  }
-  // Takes the value so the signal is read in the (tracked) event handler, not in
-  // the deferred focusout microtask.
-  const finish = (value: number[], direction?: 'down' | 'left' | 'right' | 'stay') => {
-    if (done) {
-      return
-    }
-    done = true
-    props.onCommit([...value], direction)
-  }
-  const cancel = () => {
-    if (!done) {
-      done = true
-      props.onCancel()
-    }
-  }
-
-  onMount(() => addBtn?.focus())
-
-  return (
-    <div
-      ref={(el) => { container = el }}
-      class="inline-editor inline-tags"
-      role="group"
-      aria-label={props.label}
-      onKeyDown={(event) => {
-        // While the add-menu is open it owns the arrow/enter/escape keys (handled
-        // on the button below); don't let them commit/cancel the whole edit.
-        if (menuOpen()) {
-          return
-        }
-        const onChip = document.activeElement instanceof HTMLElement && document.activeElement.classList.contains('tag')
-        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-          // Move between chips and the add button.
-          event.preventDefault()
-          event.stopPropagation()
-          moveFocus(event.key === 'ArrowLeft' ? -1 : 1)
-        } else if (event.key === 'Enter') {
-          event.preventDefault()
-          event.stopPropagation()
-          finish(selected(), 'stay')
-        } else if (event.key === 'Tab') {
-          // Keep spreadsheet cell-to-cell nav: commit and move to the adjacent
-          // cell rather than tabbing focus out of the grid entirely.
-          event.preventDefault()
-          event.stopPropagation()
-          finish(selected(), event.shiftKey ? 'left' : 'right')
-        } else if (event.key === 'Escape') {
-          event.preventDefault()
-          event.stopPropagation()
-          cancel()
-        } else if (event.key === 'Delete' || event.key === 'Backspace') {
-          event.preventDefault()
-          if (onChip) {
-            removeFocusedChip() // remove the chip the user navigated to
-          } else if (event.key === 'Backspace' && selected().length > 0) {
-            remove(selected()[selected().length - 1]!) // tag-input convention: Backspace removes the last
-            addBtn?.focus()
-          }
-        }
-      }}
-      onFocusOut={() => {
-        // Capture the value now (tracked handler), then commit only when focus
-        // has actually left the whole widget — checked after it settles, so
-        // moving between chips/the menu (incl. removing one) doesn't commit.
-        const value = selected()
-        // eslint-disable-next-line solid/reactivity -- intentional deferred commit of the captured value after focus settles
-        queueMicrotask(() => {
-          if (!done && container !== undefined && !container.contains(document.activeElement)) {
-            finish(value)
-          }
-        })
-      }}
-    >
-      {/* role=list over the selected tags gives each chip a name+role+position for
-          AT (display:contents keeps the chips in the parent's flex flow). */}
-      <span class="tag-list" role="list">
-        <For each={selected()}>
-          {(id) => (
-            // Focusable (roving tabindex) so Left/Right reach it and Delete/Backspace
-            // removes it; aria-label names the tag for screen readers.
-            <span class="tag" role="listitem" tabindex="-1" data-tag-id={id} aria-label={labelOf(id)}>
-              <span class="tag-label">{labelOf(id)}</span>
-              {/* preventDefault on mousedown so clicking × doesn't blur the widget
-                  (which would commit + unmount before the click removes the chip). */}
-              <button type="button" class="tag-remove" tabindex="-1" aria-label={`${m.admin_delete()}: ${labelOf(id)}`} onMouseDown={(event) => event.preventDefault()} onClick={() => { remove(id); addBtn?.focus() }}>×</button>
-            </span>
-          )}
-        </For>
-      </span>
-      <span class="tag-add-wrap">
-        <button
-          ref={(el) => { addBtn = el }}
-          type="button"
-          class="tag-add"
-          aria-haspopup="true"
-          aria-expanded={menuOpen()}
-          aria-label={`${m.admin_add()} — ${props.label}`}
-          onClick={() => (menuOpen() ? closeMenu() : openMenu())}
-          onKeyDown={(event) => {
-            // Closed: Down/Space open the menu; Enter/Tab/Escape/Backspace bubble
-            // to the container (commit / move / cancel / remove last).
-            if (!menuOpen() && (event.key === 'ArrowDown' || event.key === ' ')) {
-              event.preventDefault()
-              event.stopPropagation()
-              openMenu()
-            }
-          }}
-        >+</button>
-        <Show when={menuOpen()}>
-          <div
-            ref={(el) => { menuEl = el }}
-            class="tag-menu"
-            role="menu"
-            aria-label={props.label}
-            onKeyDown={(event) => {
-              const items = Array.from(menuEl?.querySelectorAll<HTMLButtonElement>('.tag-menu-item') ?? [])
-              const i = items.indexOf(document.activeElement as HTMLButtonElement)
-              if (event.key === 'ArrowDown') {
-                event.preventDefault()
-                event.stopPropagation()
-                items[Math.min(items.length - 1, i + 1)]?.focus()
-              } else if (event.key === 'ArrowUp') {
-                event.preventDefault()
-                event.stopPropagation()
-                items[Math.max(0, i - 1)]?.focus()
-              } else if (event.key === 'Escape') {
-                event.preventDefault()
-                event.stopPropagation()
-                closeMenu()
-              } else if (event.key === 'Tab') {
-                closeMenu(false) // close, then let the container's Tab move to the next cell
-              }
-            }}
-          >
-            <For each={unselected()}>
-              {(option) => (
-                <button type="button" role="menuitem" class="tag-menu-item" onClick={() => addOption(Number(option.value))}>{option.label}</button>
-              )}
-            </For>
-          </div>
-        </Show>
-      </span>
-    </div>
   )
 }
 
@@ -682,7 +438,15 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     return cell ? Number(cell.getAttribute('data-row-id')) : null
   }
 
+  // A ChipSelect editor body-portals its listbox outside the table; focus inside
+  // it must read as "still editing the row", not "left the table".
+  const inChipSelectPopup = (node: EventTarget | null): boolean =>
+    node instanceof HTMLElement && node.closest('[data-chipselect-popup]') !== null
+
   function onTableFocusIn(event: FocusEvent): void {
+    if (inChipSelectPopup(event.target)) {
+      return // focusing the portalled popup doesn't leave the current row
+    }
     const id = rowIdOf(event.target)
     if (id === lastFocusedRowId) {
       return
@@ -694,7 +458,8 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
   }
 
   function flushIfFocusLeftTable(): void {
-    if (tableEl === undefined || (document.activeElement !== null && tableEl.contains(document.activeElement))) {
+    const active = document.activeElement
+    if (tableEl === undefined || (active !== null && (tableEl.contains(active) || inChipSelectPopup(active)))) {
       return
     }
     if (lastFocusedRowId !== null) {

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -1,6 +1,6 @@
 import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
@@ -65,8 +65,8 @@ function renderAdmin(path = '/admin') {
 }
 
 // Renders the customer grid (customer 1 has team 2) with the given team
-// catalogue, then opens the inline tag editor on the "Backend" teams cell.
-async function openTeamsTagEditor(teams: { id: number; name: string }[]) {
+// catalogue, then opens the inline chip-combobox editor on the "Backend" teams cell.
+async function openTeamsCombobox(teams: { id: number; name: string }[]) {
   getJson.mockImplementation((path: string) =>
     path === '/getAllCustomers'
       ? Promise.resolve([{ customer: { id: 1, name: 'ACME', active: true, global: false, teams: [2] } }])
@@ -80,17 +80,13 @@ async function openTeamsTagEditor(teams: { id: number; name: string }[]) {
   const teamsCell = utils.getByRole('gridcell', { name: 'Backend' })
   teamsCell.focus()
   fireEvent.keyDown(teamsCell, { key: 'Enter' })
-  const addBtn = await waitFor(() => {
-    const el = teamsCell.querySelector<HTMLButtonElement>('button.tag-add')
-    if (el === null) throw new Error('inline tag editor not mounted')
+  await waitFor(() => expect(teamsCell.querySelector('.combobox-input')).not.toBeNull())
 
-    return el
-  })
-
-  return { ...utils, teamsCell, addBtn }
+  return { ...utils, teamsCell }
 }
 
 afterEach(() => {
+  cleanup() // unmount even after a throwing test, so a body-portalled combobox + body-inert can't leak into the next test
   getJson.mockReset()
   postJson.mockReset()
   vi.restoreAllMocks()
@@ -422,104 +418,22 @@ describe('Admin inline cell editing', () => {
     unmount()
   })
 
-  it('adds a tag via the menu — one option per pick, not one per keystroke', async () => {
-    postJson.mockResolvedValue([1, 'ACME', true, false, [2, 3]])
-    const { teamsCell, addBtn, unmount } = await openTeamsTagEditor([
+  it('inline-edits the teams multiselect as a chip combobox (not the modal)', async () => {
+    const { teamsCell, unmount } = await openTeamsCombobox([
       { id: 2, name: 'Backend' },
       { id: 3, name: 'Frontend' },
     ])
 
-    // An inline tag editor opened (chip for the current team + an add button),
-    // not the modal — and no menu until it's opened.
+    // The teams cell opens an inline filterable combobox, not the modal; the
+    // current team renders as a chip and the option list shows the catalogue.
+    // (add/remove/commit behaviour is unit-tested in chipSelect.test.tsx + e2e.)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-    expect(within(teamsCell).getByText('Backend')).toBeInTheDocument() // existing team is a chip
-    expect(teamsCell.querySelector('[role="menu"]')).toBeNull()
-
-    // Opening the menu adds nothing (the old <select> added on every arrow key).
-    fireEvent.click(addBtn)
-    expect(teamsCell.querySelector('[role="menu"]')).not.toBeNull()
-    expect(teamsCell.querySelectorAll('.tag')).toHaveLength(1)
-
-    // Picking the option (Frontend, the only unselected one) adds exactly one chip.
-    fireEvent.click(within(teamsCell).getByRole('menuitem', { name: 'Frontend' }))
-    await waitFor(() => expect(teamsCell.querySelectorAll('.tag')).toHaveLength(2))
-
-    // Menu auto-closed (no options left); Enter on the add button commits → [2, 3].
-    fireEvent.keyDown(addBtn, { key: 'Enter' })
-    await waitFor(() =>
-      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ teams: [2, 3] })),
-    )
+    expect(within(teamsCell).getByRole('listitem')).toHaveTextContent('Backend')
+    expect(await screen.findByRole('option', { name: 'Frontend' })).toBeInTheDocument()
 
     unmount()
   })
 
-  it('opens the add menu from the keyboard (ArrowDown), without adding', async () => {
-    const { teamsCell, addBtn, unmount } = await openTeamsTagEditor([
-      { id: 2, name: 'Backend' },
-      { id: 3, name: 'Frontend' },
-    ])
-
-    fireEvent.keyDown(addBtn, { key: 'ArrowDown' })
-    expect(teamsCell.querySelector('[role="menu"]')).not.toBeNull()
-    expect(within(teamsCell).getByRole('menuitem', { name: 'Frontend' })).toBeInTheDocument()
-    expect(teamsCell.querySelectorAll('.tag')).toHaveLength(1) // opening added nothing
-
-    unmount()
-  })
-
-  it('removes a chip by clicking its × with the mouse, then commits', async () => {
-    postJson.mockResolvedValue([1, 'ACME', true, false, []])
-    const { teamsCell, addBtn, unmount } = await openTeamsTagEditor([{ id: 2, name: 'Backend' }])
-
-    const removeBtn = teamsCell.querySelector('.tag-remove') as HTMLElement
-    expect(removeBtn).not.toBeNull()
-    fireEvent.mouseDown(removeBtn) // preventDefault keeps focus → no premature commit
-    fireEvent.click(removeBtn) // removes the only chip
-    await waitFor(() => expect(teamsCell.querySelector('.tag')).toBeNull())
-
-    fireEvent.keyDown(addBtn, { key: 'Enter' }) // commit → auto-save with no teams
-    await waitFor(() =>
-      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ teams: [] })),
-    )
-
-    unmount()
-  })
-
-  it('removes the last tag with Backspace in the inline multiselect (keyboard path)', async () => {
-    postJson.mockResolvedValue([1, 'ACME', true, false, []])
-    const { teamsCell, addBtn, unmount } = await openTeamsTagEditor([{ id: 2, name: 'Backend' }])
-
-    // Backspace removes the last chip (no .tag chips remain); Enter commits →
-    // auto-saves with no teams.
-    fireEvent.keyDown(addBtn, { key: 'Backspace' })
-    await waitFor(() => expect(teamsCell.querySelector('.tag')).toBeNull())
-    fireEvent.keyDown(addBtn, { key: 'Enter' })
-    await waitFor(() =>
-      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ teams: [] })),
-    )
-
-    unmount()
-  })
-
-  it('navigates to a chip with the keyboard (ArrowLeft) and removes it with Delete', async () => {
-    postJson.mockResolvedValue([1, 'ACME', true, false, []])
-    const { teamsCell, addBtn, unmount } = await openTeamsTagEditor([{ id: 2, name: 'Backend' }])
-
-    // Focus starts on the add button; ArrowLeft moves to the Backend chip.
-    addBtn.focus()
-    fireEvent.keyDown(addBtn, { key: 'ArrowLeft' })
-    const chip = teamsCell.querySelector('.tag') as HTMLElement
-    expect(document.activeElement).toBe(chip)
-
-    fireEvent.keyDown(chip, { key: 'Delete' }) // removes the focused chip
-    await waitFor(() => expect(teamsCell.querySelector('.tag')).toBeNull())
-    fireEvent.keyDown(addBtn, { key: 'Enter' }) // commit
-    await waitFor(() =>
-      expect(postJson).toHaveBeenCalledWith('/customer/save', expect.objectContaining({ teams: [] })),
-    )
-
-    unmount()
-  })
 
   it('renders selected teams as read-only chips in display mode (not just when editing)', async () => {
     getJson.mockImplementation((path: string) =>

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
@@ -74,6 +74,7 @@ function renderTracking() {
 }
 
 afterEach(() => {
+  cleanup() // unmount even after a throwing test, so a body-portalled combobox + body-inert can't leak into the next test
   getJson.mockReset()
   postJson.mockReset()
   postForm.mockReset()
@@ -252,10 +253,10 @@ describe('Tracking (Worklog grid)', () => {
     const { getByRole, container, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
 
-    const select = editCell(container, 'project')
-    const labels = Array.from(select.querySelectorAll('option')).map((option) => option.textContent)
-    expect(labels).toContain('Apollo') // customer 7's project
-    expect(labels).not.toContain('Zeus') // customer 8's project is filtered out
+    editCell(container, 'project') // opens the combobox (options portal to body)
+    // The cascade filters the combobox to the row customer's projects.
+    expect(await screen.findByRole('option', { name: 'Apollo' })).toBeInTheDocument() // customer 7's project
+    expect(screen.queryByRole('option', { name: 'Zeus' })).not.toBeInTheDocument() // customer 8's is filtered out
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -9,7 +9,8 @@ import { num, str } from '../lib/coerce'
 import { formatUserDate } from '../lib/dateFormat'
 import { formatMinutes } from '../lib/format'
 import { gridNav, type GridMoveHandle } from '../lib/gridNavigation'
-import { createInlineGridEdit, InlineEditor, INLINE_OVERLAY_TYPES, INLINE_TYPES } from '../lib/inlineGridEdit'
+import { chipValues, createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_OVERLAY_TYPES, INLINE_TYPES, ReadonlyChips } from '../lib/inlineGridEdit'
+import { ChipSelect } from '../lib/chipSelect'
 import { ContinueIcon, DiskIcon, DownloadIcon, InfoIcon, PlusIcon, ProlongIcon, TrashIcon } from '../lib/icons'
 import { BulkEntryForm } from '../components/BulkEntryForm'
 import { PageDialog } from '../components/PageDialog'
@@ -368,6 +369,11 @@ export default function Tracking() {
         </>
       )
     }
+    // Relation columns read as chips (matching the admin grid), not free text.
+    const field = FIELD_BY_KEY.get(colKey)
+    if (field !== undefined && (field.type === 'select' || field.type === 'multiselect')) {
+      return <ReadonlyChips values={chipValues(num((editor.overlayRow(entry) as unknown as Record<string, unknown>)[colKey]))} options={fieldSelectOptions(field, optionLookup)} />
+    }
 
     return displayCell(entry, colKey)
   }
@@ -642,7 +648,7 @@ export default function Tracking() {
 
                           return (
                             <td
-                              classList={{ numeric: col.numeric, 'is-editable': editable, 'is-invalid': editor.fieldInvalid(id, col.key), 'is-select': editable && fieldType === 'select' }}
+                              classList={{ numeric: col.numeric, 'is-editable': editable, 'is-invalid': editor.fieldInvalid(id, col.key) }}
                               data-row-id={String(id)}
                               data-col-key={col.key}
                               data-inline-editing={editor.isEditing(id, col.key) ? '' : undefined}
@@ -652,20 +658,37 @@ export default function Tracking() {
                                 when={editor.isEditing(id, col.key)}
                                 fallback={cellContent(entry, col.key)}
                               >
-                                {/* Hidden ghost holds the column width so the overlaying
-                                    single-line editor can't make the table re-flow. */}
-                                <Show when={overlayEditor}>
-                                  <span class="inline-ghost" aria-hidden="true">{cellContent(entry, col.key)}</span>
+                                <Show
+                                  when={fieldType === 'select' || fieldType === 'multiselect'}
+                                  fallback={
+                                    <>
+                                      {/* Hidden ghost holds the column width so the overlaying
+                                          single-line editor can't make the table re-flow. */}
+                                      <Show when={overlayEditor}>
+                                        <span class="inline-ghost" aria-hidden="true">{cellContent(entry, col.key)}</span>
+                                      </Show>
+                                      <InlineEditor
+                                        field={FIELD_BY_KEY.get(col.key)!}
+                                        label={col.label()}
+                                        initial={editor.draftValue(id, col.key) ?? ''}
+                                        seed={editor.seedChar()}
+                                        options={optionLookup}
+                                        onCommit={editor.commitCell}
+                                        onCancel={editor.cancelCell}
+                                      />
+                                    </>
+                                  }
+                                >
+                                  <ChipSelect
+                                    field={FIELD_BY_KEY.get(col.key)!}
+                                    label={col.label()}
+                                    initial={editor.draftValue(id, col.key) ?? (fieldType === 'multiselect' ? [] : '')}
+                                    options={optionLookup}
+                                    multiple={fieldType === 'multiselect'}
+                                    onCommit={editor.commitCell}
+                                    onCancel={editor.cancelCell}
+                                  />
                                 </Show>
-                                <InlineEditor
-                                  field={FIELD_BY_KEY.get(col.key)!}
-                                  label={col.label()}
-                                  initial={editor.draftValue(id, col.key) ?? ''}
-                                  seed={editor.seedChar()}
-                                  options={optionLookup}
-                                  onCommit={editor.commitCell}
-                                  onCancel={editor.cancelCell}
-                                />
                               </Show>
                             </td>
                           )

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -81,9 +81,9 @@ const FIELDS: FieldDef[] = [
   { name: 'start', label: () => m.tracking_col_start(), type: 'text', required: true },
   { name: 'end', label: () => m.tracking_col_end(), type: 'text', required: true },
   { name: 'ticket', label: () => m.tracking_col_ticket(), type: 'text' },
-  { name: 'customer', label: () => m.tracking_col_customer(), type: 'select', source: 'customers' },
-  { name: 'project', label: () => m.tracking_col_project(), type: 'select', source: 'projects' },
-  { name: 'activity', label: () => m.tracking_col_activity(), type: 'select', source: 'activities' },
+  { name: 'customer', label: () => m.tracking_col_customer(), type: 'select', source: 'customers', required: true },
+  { name: 'project', label: () => m.tracking_col_project(), type: 'select', source: 'projects', required: true },
+  { name: 'activity', label: () => m.tracking_col_activity(), type: 'select', source: 'activities', required: true },
   { name: 'description', label: () => m.tracking_col_description(), type: 'text' },
 ]
 const FIELD_BY_KEY = new Map(FIELDS.map((field) => [field.name, field]))
@@ -208,6 +208,11 @@ export default function Tracking() {
         return []
     }
   }
+
+  // Read-mode chip labels resolve against the FULL option set: the cascade in
+  // optionLookup narrows only the OPEN editor's project list — it must never
+  // mislabel another row's project chip while a customer is being edited.
+  const readOptionLookup: OptionLookup = (source: OptionSource) => (source === 'projects' ? allProjectOptions() : optionLookup(source))
 
   // Suggested start for a fresh row / empty start cell: the latest entry's end,
   // else the current wall-clock time (so a new entry continues from the last one).
@@ -372,7 +377,7 @@ export default function Tracking() {
     // Relation columns read as chips (matching the admin grid), not free text.
     const field = FIELD_BY_KEY.get(colKey)
     if (field !== undefined && (field.type === 'select' || field.type === 'multiselect')) {
-      return <ReadonlyChips values={chipValues(num((editor.overlayRow(entry) as unknown as Record<string, unknown>)[colKey]))} options={fieldSelectOptions(field, optionLookup)} />
+      return <ReadonlyChips values={chipValues(num((editor.overlayRow(entry) as unknown as Record<string, unknown>)[colKey]))} options={fieldSelectOptions(field, readOptionLookup)} />
     }
 
     return displayCell(entry, colKey)
@@ -679,6 +684,11 @@ export default function Tracking() {
                                     </>
                                   }
                                 >
+                                  {/* Ghost holds the column width so the overlaying single-select
+                                      editor can't re-flow the table (multi-select wraps in flow). */}
+                                  <Show when={fieldType === 'select'}>
+                                    <span class="inline-ghost" aria-hidden="true">{cellContent(entry, col.key)}</span>
+                                  </Show>
                                   <ChipSelect
                                     field={FIELD_BY_KEY.get(col.key)!}
                                     label={col.label()}

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -377,7 +377,7 @@ export default function Tracking() {
     // Relation columns read as chips (matching the admin grid), not free text.
     const field = FIELD_BY_KEY.get(colKey)
     if (field !== undefined && (field.type === 'select' || field.type === 'multiselect')) {
-      return <ReadonlyChips values={chipValues(num((editor.overlayRow(entry) as unknown as Record<string, unknown>)[colKey]))} options={fieldSelectOptions(field, readOptionLookup)} />
+      return <ReadonlyChips values={chipValues((editor.overlayRow(entry) as unknown as Record<string, unknown>)[colKey])} options={fieldSelectOptions(field, readOptionLookup)} />
     }
 
     return displayCell(entry, colKey)

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -989,10 +989,6 @@ kbd {
      cell with zero layout shift, at any density (see .inline-editor). */
   --cell-pad-y: 0.55rem;
   --cell-pad-x: 0.9rem;
-  /* Right-gutter reserved for a select cell's dropdown chevron; 0 elsewhere. It
-     inherits into the overlaying editor (custom props cascade), so the cell and
-     its editor reserve the same gutter and the text origin can't shift on open. */
-  --caret-w: 0px;
   border-top: 1px solid var(--color-border);
   padding: var(--cell-pad-y) var(--cell-pad-x);
   vertical-align: middle;
@@ -1225,43 +1221,9 @@ kbd {
 
 .data-table td[data-inline-editing] .inline-editor:not(.inline-check):not(.inline-tags) {
   inset: 0;
-  /* Re-apply the cell's x-padding; the right side also reserves the select caret
-     gutter (--caret-w inherited from the cell — 0 for non-select). */
-  padding-block: 0;
-  padding-inline: var(--cell-pad-x) calc(var(--cell-pad-x) + var(--caret-w));
+  padding: 0 var(--cell-pad-x);
   position: absolute;
   width: auto;
-}
-
-/* A <select> editor: drop the native chrome (dropdown arrow) so the overlay reads
-   as the value it sits on — the native arrow would shift the text and flicker on
-   open. The cell paints its own non-reflowing chevron instead (.is-select below). */
-.data-table td[data-inline-editing] select.inline-editor {
-  appearance: none;
-}
-
-/* A select cell is a chooser, not free text. Mark it with a chevron in the right
-   gutter, present in BOTH static and edit mode (identical position), so a select
-   reads as editable and the static→edit transition stays a visual no-op. The
-   gutter is reserved on the cell (here) and on the overlaying editor (above, via
-   the inherited --caret-w), so the text origin never moves when editing opens. */
-.data-table td.is-select {
-  --caret-w: 1.1rem;
-  padding-inline-end: calc(var(--cell-pad-x) + var(--caret-w));
-  position: relative;
-}
-
-.data-table td.is-select::after {
-  border-inline: 0.28rem solid transparent;
-  border-top: 0.34rem solid currentColor;
-  content: "";
-  inset-inline-end: var(--cell-pad-x);
-  opacity: 0.55;
-  pointer-events: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-25%);
-  z-index: 1;
 }
 
 /* A checkbox isn't single-line text — don't stretch it to fill the cell width. */
@@ -1278,6 +1240,82 @@ kbd {
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
+}
+
+/* ---- Ark Combobox inline chip editor (single + multi) ---- */
+.chip-select {
+  width: 100%;
+}
+
+.combobox-control {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  min-width: 5rem;
+}
+
+.combobox-input {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  flex: 1;
+  font: inherit;
+  min-width: 4rem;
+  outline: 0;
+  padding: 0;
+}
+
+.combobox-trigger {
+  background: none;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0 0.2rem;
+}
+
+.combobox-positioner {
+  z-index: 40;
+}
+
+.combobox-content {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px light-dark(rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.5));
+  max-height: 14rem;
+  min-width: 11rem;
+  overflow-y: auto;
+  padding: 0.2rem;
+}
+
+.combobox-item {
+  align-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  font-size: 0.9rem;
+  gap: 0.5rem;
+  justify-content: space-between;
+  padding: 0.35rem 0.5rem;
+}
+
+.combobox-item[data-highlighted] {
+  background: var(--color-accent-soft);
+}
+
+.combobox-item[data-state="checked"] {
+  font-weight: 600;
+}
+
+.combobox-indicator {
+  color: var(--color-accent);
+}
+
+.combobox-empty {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  padding: 0.5rem;
 }
 
 .inline-tags .tag {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1251,7 +1251,9 @@ kbd {
   align-items: center;
   display: flex;
   flex: 1;
-  min-width: 5rem;
+  /* min-width:0 so a single-select overlay (absolute, clamped to the cell width)
+     can't force the cell wider than its read-mode content. */
+  min-width: 0;
 }
 
 .combobox-input {
@@ -1260,7 +1262,7 @@ kbd {
   color: inherit;
   flex: 1;
   font: inherit;
-  min-width: 4rem;
+  min-width: 0;
   outline: 0;
   padding: 0;
 }
@@ -1275,7 +1277,9 @@ kbd {
 }
 
 .combobox-positioner {
-  z-index: 40;
+  /* Above every incidental fixed overlay (modal 100/101, first-run hint 1100):
+     the popup is body-portalled and only present while a cell is being edited. */
+  z-index: 1200;
 }
 
 .combobox-content {
@@ -1284,6 +1288,9 @@ kbd {
   border-radius: 8px;
   box-shadow: 0 8px 24px light-dark(rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.5));
   max-height: 14rem;
+  /* Clamp the content (min-width 11rem can exceed a narrow cell's sameWidth
+     positioner) so it never runs off the viewport's right edge. */
+  max-width: min(90vw, 18rem);
   min-width: 11rem;
   overflow-y: auto;
   padding: 0.2rem;
@@ -1360,59 +1367,6 @@ kbd {
   /* Discrete inline control: >=24px (WCAG 2.2 AA 2.5.8); flex-centred glyph. */
   min-height: 1.5rem;
   min-width: 1.5rem;
-}
-
-/* The add control is a button that opens a listbox menu of unselected options. */
-.inline-tags .tag-add-wrap {
-  position: relative;
-}
-
-.inline-tags .tag-add {
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  color: var(--color-text);
-  cursor: pointer;
-  font: inherit;
-  line-height: 1;
-  min-height: 1.7rem;
-  min-width: 1.7rem;
-}
-
-.inline-tags .tag-menu {
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  box-shadow: 0 6px 18px light-dark(rgba(0, 0, 0, 0.18), rgba(0, 0, 0, 0.5));
-  display: flex;
-  flex-direction: column;
-  inset-inline-start: 0;
-  inset-block-start: calc(100% + 0.2rem);
-  max-height: 14rem;
-  max-width: min(90vw, 16rem); /* never run off the screen edge on narrow viewports */
-  min-width: 10rem;
-  overflow-y: auto;
-  padding: 0.2rem;
-  position: absolute;
-  z-index: 20;
-}
-
-.inline-tags .tag-menu-item {
-  background: none;
-  border: 0;
-  border-radius: 4px;
-  color: var(--color-text);
-  cursor: pointer;
-  font: inherit;
-  padding: 0.35rem 0.6rem;
-  text-align: start;
-  white-space: nowrap;
-}
-
-.inline-tags .tag-menu-item:hover,
-.inline-tags .tag-menu-item:focus-visible {
-  background: var(--color-accent-soft);
-  outline: none;
 }
 
 /* A saving row dims slightly and blocks pointer interaction until it settles. */


### PR DESCRIPTION
## Summary

PR 2 of the inline-relation-editor rework (PR 1 was #395's edit-mode cue). Replaces the native `<select>` editor **and** the hand-rolled `InlineMultiSelect` with **one filterable chip combobox** built on **Ark UI Combobox**, used by the worklog **and** admin grids — and renders relation cells as chips in read mode in both (the admin/worklog divergence you flagged).

You picked **B (Ark Combobox)** after the interactive side-by-side, and the design came from a judged 6-agent workflow.

## What you get
- **Type-to-filter** single- and multi-select, with the selection shown as chips.
- **Auto-opens** on edit; keyboard-navigable listbox.
- **Worklog + admin unified** — one `ChipSelect`, one read-mode `ReadonlyChips`, shared.
- The customer→project **cascade** survives (the combobox's options stay filtered by the row's customer).

## The one hard problem, and how it's solved
The blueprint's linchpin was to portal the popup *into the editing `<td>>` — but in a real browser that **clipped** (`.table-scroll`'s `overflow-x:auto` makes `overflow-y` compute to `auto`) and **mis-positioned** (the input overlapped the popup, eating clicks). So this uses the escape hatch: a **body-portal** (never clipped) + a **focus-out whitelist** — the popup is marked `data-chipselect-popup`, and the controller's `onTableFocusIn`/`flushIfFocusLeftTable` treat focus inside it as "still editing the row", so **opening the popup never saves or closes the row**. Every selection still funnels through `commitCell` (so the cascade + auto-save fire).

## Notable
- **Bundle +~84KB** (Ark Combobox + zag) — a conscious cost for the filtering/a11y, flagged for sign-off.
- The `is-select` chevron + select-overlay machinery from #394/#395 is now superseded by chips and removed; the `[data-inline-editing]` edit-mode accent wash stays.

## Test plan
- typecheck / lint / unit (**232**, incl. a new `chipSelect.test.tsx` — render/filter, single-pick→numeric id, multi add/remove chips; the cascade + admin multiselect tests rewritten for the combobox; added `cleanup()` so a body-portalled popup can't leak `inert` across tests).
- e2e: full suite green on a fresh German stack — `worklog-crud` (create via combobox type-and-pick, read-mode chips, edit/delete/prolong/continue), `admin-inline-edit` (multiselect combobox), `date-format`, `interpretation`.


---

## Review hardening (follow-up, commits `5f77985`, `0a217c0`)

An independent 5-lens adversarial review panel (find → verify) was run over the diff; it confirmed **17 findings the unit tests and CI all passed over**, since corroborated by gemini. Fixed in this PR:

- **Data-loss (high):** string-valued single selects (user `type`/`locale`) committed the literal `'NaN'` — the selection is now carried as the option's string value and converted to the field's payload type only at the boundary.
- **Wrong-commit (high):** the first Enter on a freshly-opened list committed the empty value instead of the highlighted option (the local `open` signal now seeds to match `defaultOpen`).
- **Coverage (high):** the deleted `InlineMultiSelect` persistence assertions are restored (multi-commit `Tab → number[] → onCommit`, and reaching `/save`).
- **UX/a11y:** re-pick-same now commits (via `onSelect`); single-select regains its no-reflow overlay; read-mode chips resolve against the full (non-cascade) option set; single-press Escape cancels; optional relations are clearable ("none"); keyboard chip removal (Backspace); visually-hidden combobox label + polite live region; popup z-index/viewport clamp; dead CSS removed.

**Tests now:** 238 unit (+ stringValue / multi-commit / clear / cancel / Enter-at-mount cases); e2e picks+persists a multiselect (idempotent), asserts no-reflow on a select cell, and that Escape cancels. Full e2e green on a fresh stack.

> Note: the red **Lint & Static Analysis** check is a repo-wide `composer audit` failure on newly-disclosed guzzle/psr7 CVEs (not a required check, unrelated to this PR) — tracked separately for a composer bump.
