### PR TITLE
fix(admin): render bookTime / needsTicket as boolean dots, not ✓/— text

### DIFF
--- a/frontend/src/admin/entities.test.ts
+++ b/frontend/src/admin/entities.test.ts
@@ -43,11 +43,25 @@ describe('admin entity descriptors', () => {
     expect(byKey('contracts').toForm(null)).toMatchObject({ hours_1: 8, hours_5: 8, hours_6: 0, hours_0: 0 })
   })
 
-  it('boolean columns render ✓/—', () => {
+  it('boolean columns render ✓/— as the sort key', () => {
     const active = col(byKey('customers'), 'active')
     expect(active.render?.({ active: true }, noOptions)).toBe('✓')
     expect(active.render?.({ active: false }, noOptions)).toBe('—')
     expect(active.align).toBe('center')
+  })
+
+  // The `render` above is only the (hidden) sort key; `boolean: true` is what makes
+  // the cell paint the BoolDot. Every boolean-backed column must set it, or it
+  // renders the raw ✓/— text instead of the dot (inconsistent with active/global).
+  it.each([
+    ['customers', 'active'],
+    ['customers', 'global'],
+    ['projects', 'active'],
+    ['projects', 'global'],
+    ['ticketsystems', 'bookTime'],
+    ['activities', 'needsTicket'],
+  ])('%s.%s is a boolean (dot) column', (entityKey, colKey) => {
+    expect(col(byKey(entityKey), colKey).boolean).toBe(true)
   })
 
   it('relation columns resolve id→label, fall back to the id, and blank on 0', () => {

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -268,7 +268,7 @@ export function adminEntities(): EntityDescriptor[] {
       columns: [
         { key: 'name', label: () => m.admin_f_name() },
         { key: 'type', label: () => m.admin_f_type() },
-        { key: 'bookTime', label: () => m.admin_f_book_time(), render: (row) => mark(pick(row, 'bookTime', 'book_time')), align: 'center' },
+        { key: 'bookTime', label: () => m.admin_f_book_time(), render: (row) => mark(pick(row, 'bookTime', 'book_time')), align: 'center', boolean: true },
         { key: 'url', label: () => m.admin_f_url() },
       ],
       fields: [
@@ -313,7 +313,7 @@ export function adminEntities(): EntityDescriptor[] {
       deleteEndpoint: '/activity/delete',
       columns: [
         { key: 'name', label: () => m.admin_f_name() },
-        { key: 'needsTicket', label: () => m.admin_f_needs_ticket(), render: (row) => mark(pick(row, 'needsTicket', 'needs_ticket')), align: 'center' },
+        { key: 'needsTicket', label: () => m.admin_f_needs_ticket(), render: (row) => mark(pick(row, 'needsTicket', 'needs_ticket')), align: 'center', boolean: true },
         { key: 'factor', label: () => m.admin_f_factor(), align: 'right' },
       ],
       fields: [


### PR DESCRIPTION
## Problem
In **Admin → Ticket Systems**, the *time booking* (`bookTime`) column, and in **Admin → Activities** the *needs ticket* (`needsTicket`) column, render the raw `✓`/`—` text instead of the green **BoolDot** (Yes/No) that `active`/`global` use.

## Cause
Both columns used `render: (row) => mark(...)` but were **missing `boolean: true`** in their `ColumnDef`. For a boolean column, `render` is only the hidden sort key — `boolean: true` is what paints the dot.

## Fix
Add `boolean: true` to both columns. The list rows carry the camelCase keys the BoolDot reads (`Base::toArray()` emits both casings; `ActivityRepository` emits `needsTicket`), so the dot reflects the correct value.

## Test
The existing `entities.test.ts` only asserted the `render` ✓/— sort-key — the exact blind spot that let this slip. Added an `it.each` asserting **every** boolean-backed column (active/global ×2, bookTime, needsTicket) sets `boolean: true`. typecheck / lint / unit / build green; no e2e (config-only, dot-rendering already e2e-covered via active/global).