### PR TITLE
fix(ui): redesign the inline (multi)select editor — visible "type to search"

### DIFF
--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -73,7 +73,7 @@ test.describe('Admin inline cell editing', () => {
 
     // The teams column opens an inline filterable combobox (a text input + an
     // option list), with the selection rendered as chips — not the modal.
-    await expect(page.locator('td[data-inline-editing] .combobox-input')).toBeVisible();
+    await expect(page.locator('.combobox-input')).toBeVisible();
     await expect(page.locator('[role="dialog"]')).toHaveCount(0);
     await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
 

--- a/e2e/helpers/worklog.ts
+++ b/e2e/helpers/worklog.ts
@@ -22,7 +22,7 @@ export async function pickFirstOption(page: Page, row: Locator, colKey: string, 
     await row.locator(`td[data-col-key="${colKey}"]`).focus();
     await page.keyboard.press('Enter');
   }
-  await expect(page.locator('td[data-inline-editing] .combobox-input').first()).toBeVisible();
+  await expect(page.locator('.combobox-input').first()).toBeVisible();
   const option = page.locator('.combobox-content .combobox-item').first();
   await expect(option).toBeVisible({ timeout: 8000 });
   await option.click();

--- a/e2e/worklog-crud.spec.ts
+++ b/e2e/worklog-crud.spec.ts
@@ -103,7 +103,7 @@ test.describe('Worklog CRUD', () => {
     // Edit mode: a combobox opens with a filter input and an option list.
     await cell.focus();
     await page.keyboard.press('Enter');
-    await expect(page.locator('td[data-inline-editing] .combobox-input')).toBeVisible();
+    await expect(page.locator('.combobox-input')).toBeVisible();
     await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
 
     // The single-select editor overlays the cell — opening it must not widen the

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -16,6 +16,8 @@
   "app_no": "Nein",
   "app_no_results": "Keine Treffer",
   "app_select_none": "— Keine",
+  "app_type_to_search": "Tippen zum Suchen…",
+  "app_type_to_add": "Tippen zum Hinzufügen…",
   "app_save": "Speichern",
   "app_saving": "Speichert…",
   "login_username": "Benutzername",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -16,6 +16,8 @@
   "app_no": "No",
   "app_no_results": "No matches",
   "app_select_none": "— None",
+  "app_type_to_search": "Type to search…",
+  "app_type_to_add": "Type to add…",
   "app_save": "Save",
   "app_saving": "Saving…",
   "login_username": "Username",

--- a/frontend/src/lib/chipSelect.test.tsx
+++ b/frontend/src/lib/chipSelect.test.tsx
@@ -72,8 +72,8 @@ describe('ChipSelect (jsdom)', () => {
     render(() => <ChipSelect field={typeField} label="Type" initial="DEV" options={noOptions} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
     await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
 
-    // The existing value is shown (as the input's placeholder), not an empty editor.
-    expect(screen.getByRole('combobox')).toHaveAttribute('placeholder', 'DEV')
+    // The existing value is preserved and shown as the checked option (not lost to NaN).
+    expect(screen.getByRole('option', { name: 'DEV' })).toHaveAttribute('data-state', 'checked')
     fireEvent.click(screen.getByRole('option', { name: 'PL' }))
     await waitFor(() => expect(onCommit).toHaveBeenCalledWith('PL', expect.anything()))
   })

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -1,5 +1,5 @@
 import { Combobox, createListCollection } from '@ark-ui/solid/combobox'
-import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
+import { createMemo, createSignal, For, type JSX, onMount, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
 import type { FieldDef, FormValues, OptionLookup } from '../admin/types'
@@ -15,17 +15,19 @@ type Item = { value: string; label: string }
 const CLEAR_VALUE = '__clear__'
 
 /**
- * Filterable chip combobox for an inline relation cell — one component for single
- * (input + value, overlays the cell) and multi select (removable chips, in flow),
- * replacing the native-<select> editor and the hand-rolled InlineMultiSelect across
- * both grids. Built on Ark UI Combobox: type to filter, keyboard-navigable listbox.
+ * Filterable chip combobox for an inline relation cell, built on Ark UI Combobox.
+ *
+ * Two layouts that share all the logic:
+ * - MULTI: removable chips + a leading magnifier + the search input, all IN the
+ *   cell (admin cells are wide enough).
+ * - SINGLE: the cell stays compact — just the current value + a ▾ — and the search
+ *   field lives at the top of the (roomy, body-portalled) dropdown, so it is never
+ *   constrained by a narrow column. The current value is the checked list item.
  *
  * Boundary: Ark deals in string[] and our option values are *either* numeric ids
- * (relations) or strings (e.g. user `type`, `locale`). The selection is carried
- * verbatim as the option's string value and converted back to the field's payload
- * type only in coerced() — so a string-valued select round-trips as its string,
- * never as `Number('DEV')` → NaN. Every commit funnels through the controller's
- * onCommit so the grid's cascade / auto-save still fire.
+ * (relations) or strings (e.g. user `type`/`locale`); the selection is carried
+ * verbatim as the option's string value and converted to the field's payload type
+ * only in coerced() — so a string select round-trips as its string, never NaN.
  */
 export function ChipSelect(props: {
   field: FieldDef
@@ -36,9 +38,6 @@ export function ChipSelect(props: {
   onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
   onCancel: () => void
 }) {
-  // Selection is the list of selected option values, as strings (Ark's native
-  // shape). 0 / '' / null read as "nothing selected"; a numeric id is kept only
-  // when > 0 (0 is the relation "unset" sentinel — see chipValues()).
   const initialValues = (): string[] => {
     const raw = props.initial
     if (Array.isArray(raw)) {
@@ -66,9 +65,7 @@ export function ChipSelect(props: {
 
   const allItems = createMemo<Item[]>(() => fieldSelectOptions(props.field, props.options).map((option) => ({ value: String(option.value), label: option.label })))
   const labelOf = (value: string): string => allItems().find((item) => item.value === value)?.label ?? value
-  // Offer an explicit "none" only for an optional, numeric (relation) single select
-  // — the editor the native <select>'s empty <option> used to provide. String-valued
-  // selects (locale/type) always carry a value and are not cleared to ''.
+  // Offer an explicit "none" only for an optional, numeric (relation) single select.
   const showClear = (): boolean => !props.multiple && props.field.required !== true && props.field.stringValue !== true
   const filteredItems = createMemo<Item[]>(() => {
     const query = inputValue().trim().toLowerCase()
@@ -76,7 +73,6 @@ export function ChipSelect(props: {
 
     return showClear() && query === '' ? [{ value: CLEAR_VALUE, label: m.app_select_none() }, ...base] : base
   })
-  // Ark requires a collection; rebuild it from the filtered items (we filter, not zag).
   const collection = createMemo(() => createListCollection<Item>({ items: filteredItems(), itemToValue: (item) => item.value, itemToString: (item) => item.label }))
 
   const coerced = (): FormValues[string] => {
@@ -108,16 +104,61 @@ export function ChipSelect(props: {
 
   onMount(() => {
     inputEl?.focus()
+    // The single-select input lives in the body-portalled popup; if it isn't ready
+    // on the first tick, focus it on the next frame so typing starts immediately.
+    if (document.activeElement !== inputEl) {
+      requestAnimationFrame(() => inputEl?.focus())
+    }
   })
+
+  const onInputKeyDown = (event: KeyboardEvent): void => {
+    // The listbox owns Arrow/Enter while open; the cell owns Tab (always), Enter when
+    // the list is closed, and Backspace to drop the last chip when the filter is empty.
+    // Escape with the list open is handled in onOpenChange (zag consumes it first);
+    // this branch covers the closed list and environments where zag doesn't.
+    if (event.key === 'Tab') {
+      event.preventDefault()
+      event.stopPropagation()
+      finish(event.shiftKey ? 'left' : 'right')
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      cancel()
+    } else if (event.key === 'Enter' && !open()) {
+      event.preventDefault()
+      event.stopPropagation()
+      finish(getEnterBehavior())
+    } else if (event.key === 'Backspace' && props.multiple && inputValue() === '' && selected().length > 0) {
+      event.preventDefault()
+      setSelected(selected().slice(0, -1))
+    }
+  }
+
+  const magnifier = (): JSX.Element => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true">
+      <circle cx="10.5" cy="10.5" r="6.5" />
+      <line x1="15.6" y1="15.6" x2="21" y2="21" />
+    </svg>
+  )
+
+  const searchInput = (): JSX.Element => (
+    <Combobox.Input
+      ref={(element) => { inputEl = element }}
+      class="combobox-input"
+      aria-label={props.label}
+      placeholder={props.multiple && selected().length === 0 ? m.app_type_to_add() : m.app_type_to_search()}
+      onKeyDown={onInputKeyDown}
+    />
+  )
 
   return (
     <div
       ref={(element) => { rootEl = element }}
       class={`inline-editor chip-select${props.multiple ? ' inline-tags' : ''}`}
       onFocusOut={() => {
-        // Commit only once focus has actually left the whole widget — including
-        // the body-portalled popup (data-chipselect-popup) — checked after focus
-        // settles, so moving into the listbox doesn't commit/close the editor.
+        // Commit once focus leaves the whole widget — including the body-portalled
+        // popup (data-chipselect-popup) — checked after focus settles so moving into
+        // the listbox/search doesn't commit/close the editor.
         // eslint-disable-next-line solid/reactivity -- deferred commit after focus settles
         queueMicrotask(() => {
           const active = document.activeElement
@@ -128,12 +169,19 @@ export function ChipSelect(props: {
         })
       }}
     >
+      {/* Multi: a leading magnifier in the cell. Single's search lives in the popup. */}
       <Show when={props.multiple}>
-        <span class="tag-list" role="list">
-          <For each={selected()}>
-            {(value) => (
-              <span class="tag" role="listitem">
-                <span class="tag-label">{labelOf(value)}</span>
+        <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
+      </Show>
+
+      {/* Selection chips in the cell: multi = removable; single = the current value
+          (no ×) so the cell stays a compact value display. */}
+      <span class="tag-list" role="list">
+        <For each={selected()}>
+          {(value) => (
+            <span class="tag" role="listitem">
+              <span class="tag-label">{labelOf(value)}</span>
+              <Show when={props.multiple}>
                 <button
                   type="button"
                   class="tag-remove"
@@ -142,25 +190,24 @@ export function ChipSelect(props: {
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => { setSelected(selected().filter((current) => current !== value)); inputEl?.focus() }}
                 >×</button>
-              </span>
-            )}
-          </For>
-        </span>
-      </Show>
+              </Show>
+            </span>
+          )}
+        </For>
+      </span>
 
-      {/* Announce selection changes (add / remove / single replace) — Ark's own
-          live region only narrates the highlighted option during navigation. */}
+      {/* Announce selection changes — Ark's own live region only narrates the
+          highlighted option during navigation. */}
       <span class="visually-hidden" role="status" aria-live="polite">
         {selected().map(labelOf).join(', ')}
       </span>
 
       <Combobox.Root
+        class="chip-select-root"
         collection={collection()}
         multiple={props.multiple}
         value={selected()}
         onValueChange={(details) => {
-          // State only; single-select commit is driven by onSelect (which fires even
-          // when the same value is re-picked, where onValueChange would not).
           if (props.multiple) {
             setSelected(details.value)
           }
@@ -177,11 +224,10 @@ export function ChipSelect(props: {
         defaultOpen
         onOpenChange={(details) => {
           setOpen(details.open)
-          // A single Escape cancels the whole cell edit. zag consumes Escape on a
-          // document listener to close ITS list before any element-level handler
-          // runs, so we hook the close itself (reason 'escape-key') rather than the
-          // keydown. Other close reasons (item-select, interact-outside) must not
-          // cancel — those commit via onSelect / focus-out.
+          // A single Escape cancels the whole cell edit: zag consumes Escape on a
+          // document listener to close ITS list before any element-level handler runs,
+          // so we hook the close itself (reason 'escape-key'). Other close reasons
+          // (item-select, interact-outside) must not cancel.
           if (!details.open && details.reason === 'escape-key') {
             cancel()
           }
@@ -190,54 +236,38 @@ export function ChipSelect(props: {
         closeOnSelect={!props.multiple}
         allowCustomValue={false}
         inputBehavior="autohighlight"
-        positioning={{ sameWidth: true, gutter: 2, flip: true, fitViewport: true }}
+        // Multi tethers the popup to the (wide) cell; single lets the popup size to
+        // its own content so the search field is never bound to a narrow column.
+        positioning={{ sameWidth: props.multiple, gutter: 2, flip: true, fitViewport: true }}
         onInteractOutside={(event) => {
-          // Keep the popup open while focus/clicks stay within the editing cell.
           const target = event.target as Node | null
           if (target !== null && rootEl?.contains(target)) {
-            event.preventDefault()
+            event.preventDefault() // a click within the cell keeps editing
+          } else {
+            finish() // a genuine outside interaction commits (covers single's popup input)
           }
         }}
       >
         <Combobox.Label class="visually-hidden">{props.label}</Combobox.Label>
         <Combobox.Control class="combobox-control">
-          <Combobox.Input
-            ref={(element) => { inputEl = element }}
-            class="combobox-input"
-            aria-label={props.label}
-            placeholder={!props.multiple && selected().length > 0 ? labelOf(selected()[0]!) : ''}
-            onKeyDown={(event) => {
-              // The listbox owns Arrow/Enter while open; the cell owns Tab (always),
-              // Enter when the list is closed, and Backspace to drop the last chip when
-              // the filter input is empty. Escape cancels: when the list is open in a
-              // real browser zag consumes it first (handled in onOpenChange); this
-              // branch covers the closed list and environments where zag doesn't.
-              if (event.key === 'Tab') {
-                event.preventDefault()
-                event.stopPropagation()
-                finish(event.shiftKey ? 'left' : 'right')
-              } else if (event.key === 'Escape') {
-                event.preventDefault()
-                event.stopPropagation()
-                cancel()
-              } else if (event.key === 'Enter' && !open()) {
-                event.preventDefault()
-                event.stopPropagation()
-                finish(getEnterBehavior())
-              } else if (event.key === 'Backspace' && props.multiple && inputValue() === '' && selected().length > 0) {
-                event.preventDefault()
-                setSelected(selected().slice(0, -1))
-              }
-            }}
-          />
+          {/* Multi: the search input sits in the cell, next to the chips. */}
+          <Show when={props.multiple}>{searchInput()}</Show>
           <Combobox.Trigger class="combobox-trigger" tabindex="-1" aria-label={props.label}>▾</Combobox.Trigger>
         </Combobox.Control>
-        {/* Body-portal so the popup floats above the grid and is never clipped by
-            the .table-scroll overflow; data-chipselect-popup whitelists it in the
-            grid's focus-out logic so opening it doesn't save/close the row. */}
+        {/* Body-portal so the popup floats above the grid and is never clipped by the
+            .table-scroll overflow; data-chipselect-popup whitelists it in the grid's
+            focus-out logic so opening it doesn't save/close the row. */}
         <Portal>
           <Combobox.Positioner class="combobox-positioner" data-chipselect-popup>
             <Combobox.Content class="combobox-content">
+              {/* Single: a roomy, sticky search field at the TOP of the dropdown —
+                  not constrained by the narrow cell. */}
+              <Show when={!props.multiple}>
+                <div class="combobox-search-row">
+                  <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
+                  {searchInput()}
+                </div>
+              </Show>
               <For each={filteredItems()}>
                 {(item) => (
                   <Combobox.Item item={item} class="combobox-item">

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -107,7 +107,7 @@ export function ChipSelect(props: {
     // The single-select input lives in the body-portalled popup; if it isn't ready
     // on the first tick, focus it on the next frame so typing starts immediately.
     if (document.activeElement !== inputEl) {
-      requestAnimationFrame(() => inputEl?.focus())
+      requestAnimationFrame(() => { if (inputEl?.isConnected) inputEl.focus() })
     }
   })
 
@@ -130,6 +130,7 @@ export function ChipSelect(props: {
       finish(getEnterBehavior())
     } else if (event.key === 'Backspace' && props.multiple && inputValue() === '' && selected().length > 0) {
       event.preventDefault()
+      event.stopPropagation() // don't let the grid/global shortcuts also see the Backspace
       setSelected(selected().slice(0, -1))
     }
   }

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -105,7 +105,10 @@ function editCell(container: HTMLElement, colKey: string): HTMLInputElement {
   }
   cell.focus()
   fireEvent.keyDown(cell, { key: 'Enter' })
+  // The editor's input is in the cell (text / multi-select) or body-portalled in the
+  // combobox popup (single-select search field lives at the top of the dropdown).
   const control = cell.querySelector<HTMLInputElement>('input, select')
+    ?? document.querySelector<HTMLInputElement>('.combobox-input')
   if (control === null) {
     throw new Error(`no editor for ${colKey}`)
   }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1262,7 +1262,7 @@ kbd {
    with the magnifier, chips and input on one (wrapping) row. */
 .data-table td[data-inline-editing] .chip-select.inline-tags {
   align-items: center;
-  background: var(--color-surface);
+  background-color: var(--color-surface);
   border-radius: 5px;
   box-shadow: inset 0 0 0 1.5px var(--color-accent);
   column-gap: 0.3rem;
@@ -1354,7 +1354,7 @@ kbd {
    input, sticky so it stays while options scroll, bled to the popup's edges. */
 .combobox-search-row {
   align-items: center;
-  background: var(--color-surface);
+  background-color: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
   display: flex;
   gap: 0.45rem;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1242,38 +1242,92 @@ kbd {
   gap: 0.25rem;
 }
 
-/* ---- Ark Combobox inline chip editor (single + multi) ---- */
+/* ---- Ark Combobox inline chip editor (single + multi) ----
+   In edit mode the cell LIFTS into an obviously typeable search field: a surface
+   fill + an accent inner border + a focus ring, a leading magnifier, an italic
+   "type to search" placeholder and an accent caret. The field reads STRONGER than
+   the read-mode chips (fixing the inverted hierarchy) and the three converging cues
+   (magnifier + placeholder + caret) announce that you can type. */
 .chip-select {
   width: 100%;
+}
+
+/* Root is display:contents so the magnifier, chips and input share ONE flex row
+   (the field) rather than the input sitting in its own separate box. */
+.chip-select-root {
+  display: contents;
+}
+
+/* MULTI: the cell IS the search field — surface fill + accent border + focus ring,
+   with the magnifier, chips and input on one (wrapping) row. */
+.data-table td[data-inline-editing] .chip-select.inline-tags {
+  align-items: center;
+  background: var(--color-surface);
+  border-radius: 5px;
+  box-shadow: inset 0 0 0 1.5px var(--color-accent);
+  column-gap: 0.3rem;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.1rem 0.35rem;
+  row-gap: 0.2rem;
+}
+
+.data-table td[data-inline-editing] .chip-select.inline-tags:focus-within {
+  box-shadow:
+    inset 0 0 0 1.5px var(--color-accent),
+    0 0 0 3px color-mix(in srgb, var(--color-accent) 22%, transparent);
+}
+
+/* SINGLE: the cell stays a compact value + ▾ — the search field is at the top of the
+   (roomy) popup, so a narrow column never constrains it. */
+.data-table td[data-inline-editing] .chip-select:not(.inline-tags) {
+  align-items: center;
+  column-gap: 0.3rem;
+  display: flex;
+}
+
+.combobox-search {
+  align-items: center;
+  color: var(--color-accent);
+  display: inline-flex;
+  flex: none;
 }
 
 .combobox-control {
   align-items: center;
   display: flex;
   flex: 1;
-  /* min-width:0 so a single-select overlay (absolute, clamped to the cell width)
-     can't force the cell wider than its read-mode content. */
-  min-width: 0;
+  min-width: 4ch;
 }
 
 .combobox-input {
   background: transparent;
   border: 0;
-  color: inherit;
+  caret-color: var(--color-accent);
+  color: var(--color-text);
   flex: 1;
   font: inherit;
-  min-width: 0;
+  min-width: 4ch;
   outline: 0;
   padding: 0;
+}
+
+/* The placeholder is now an instruction ("Tippen zum Suchen…") — make it read as a
+   hint, not a value. */
+.combobox-input::placeholder {
+  color: var(--color-text-muted);
+  font-style: italic;
+  opacity: 1;
 }
 
 .combobox-trigger {
   background: none;
   border: 0;
-  color: var(--color-text-muted);
+  color: var(--color-accent);
   cursor: pointer;
-  font-size: 0.7rem;
-  padding: 0 0.2rem;
+  flex: none;
+  font-size: 0.8rem;
+  padding: 0 0.15rem;
 }
 
 .combobox-positioner {
@@ -1291,9 +1345,28 @@ kbd {
   /* Clamp the content (min-width 11rem can exceed a narrow cell's sameWidth
      positioner) so it never runs off the viewport's right edge. */
   max-width: min(90vw, 18rem);
-  min-width: 11rem;
+  min-width: 14rem;
   overflow-y: auto;
   padding: 0.2rem;
+}
+
+/* SINGLE: a roomy search field pinned to the top of the dropdown — magnifier +
+   input, sticky so it stays while options scroll, bled to the popup's edges. */
+.combobox-search-row {
+  align-items: center;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  gap: 0.45rem;
+  margin: -0.2rem -0.2rem 0.25rem;
+  padding: 0.5rem 0.6rem;
+  position: sticky;
+  top: -0.2rem;
+  z-index: 1;
+}
+
+.combobox-search-row .combobox-input {
+  font-size: 0.95rem;
 }
 
 .combobox-item {
@@ -1325,7 +1398,8 @@ kbd {
   padding: 0.5rem;
 }
 
-.inline-tags .tag {
+.chip-select .tag,
+.inline-tags.is-readonly .tag {
   align-items: center;
   background: var(--color-accent-soft);
   border: 1px solid var(--color-accent);
@@ -1337,7 +1411,7 @@ kbd {
 }
 
 /* Chips are roving-tabindex focusable in the editor (Left/Right + Delete). */
-.inline-tags .tag:focus-visible {
+.chip-select .tag:focus-visible {
   outline: 2px solid var(--color-focus);
   outline-offset: 1px;
 }
@@ -1355,7 +1429,7 @@ kbd {
   padding: 0 0.4rem;
 }
 
-.inline-tags .tag-remove {
+.chip-select .tag-remove {
   align-items: center;
   background: none;
   border: 0;


### PR DESCRIPTION
## Why
The product owner reported the inline (multi)select editing still didn't *look/feel* right — and crucially **you couldn't tell you could type to filter**. An independent **5-lens UX review panel** (visual / discoverability / interaction-flow / mental-model / micro-interaction), run over real screenshots, confirmed two perception problems with strong consensus (4/5):
1. the edit state looked **weaker** than read mode (muted placeholder vs bordered chips), and
2. **no 'type here' affordance** — the input was chromeless; the multi-select input was an invisible dead gap.

## What changed
- **Multi-select:** the cell is now an obvious search field — surface fill + accent border + focus ring, a leading **🔍 magnifier**, removable chips, and an italic **"Tippen zum Suchen…"** placeholder filling the former dead gap, plus an accent caret.
- **Single-select:** the cell stays compact (the value + a ▾) and the **search field moves to the top of the roomy, body-portalled dropdown** — a sticky "🔍 Tippen zum Suchen…" row — so a narrow column never constrains it (command-palette pattern; the owner's idea). The current value is the checked list item. zag anchors the popup to the *control* (not the input), so moving the input into the popup keeps positioning correct.

Three converging cues (magnifier + instructive placeholder + caret) now announce typeability, and the active editor reads **stronger** than the read chips.

## Scope / safety
Functionality (type-to-filter, keyboard nav, Escape-cancel, customer→project cascade) is unchanged — **visual/perception only**, scoped to `.chip-select` so the seamless text/number/date editors are untouched. The single-select cell stays absolutely overlaid on its `.inline-ghost` → **no column reflow** (asserted in e2e). Adds `app_type_to_search`/`app_type_to_add`. e2e relation-cell selectors target `.combobox-input` (single-select's input is in the popup).

## Tests
244 unit + typecheck + lint + build green; worklog + admin inline-edit e2e green (create / edit / commit / Escape-cancel / no-reflow / multiselect-persist).