### PR TITLE
ci: scope GITHUB_TOKEN permissions to jobs (least-privilege)

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -3,10 +3,11 @@ name: Auto-merge dependency PRs
 on:
   pull_request:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@53469ad0d1024265804184e214318b9895559cc9 # main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,16 @@ on:
     - cron: '30 2 * * 1' # Weekly on Monday
 
 permissions:
-  security-events: write
   contents: read
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,11 +14,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,8 +6,12 @@ on:
   push:
     branches: [main, master]
 
+permissions: {}
+
 jobs:
   node-audit:
+    permissions:
+      contents: read
     uses: netresearch/.github/.github/workflows/node-audit.yml@53469ad0d1024265804184e214318b9895559cc9 # main
     with:
       package-manager: npm


### PR DESCRIPTION
Clears 4 Scorecard **Token-Permissions (High)** alerts (#434, #398, #421, #418) by moving each elevated `GITHUB_TOKEN` scope from the workflow top level down to the single job that needs it (top level left read-only):

| Workflow | Was (top-level) | Now (job-scoped) |
|---|---|---|
| docker-publish.yml | `packages: write` | on the `docker` job |
| codeql.yml | `security-events: write` | on `analyze` (+ `actions: read`) |
| auto-merge-deps.yml | `contents/pull-requests: write` | on `auto-merge` |
| security.yml | *(none — implicit default)* | explicit `permissions: {}` + `contents: read` on node-audit |

No functional change — the same scopes are still granted to the jobs that use them. Org reusable workflows keep their `@<sha> # main` pin (the caller job sets least-privilege). YAML validated.