### PR TITLE
ci: track the root npm lockfile with Dependabot (#118/#102/#415)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,13 @@ updates:
       frontend:
         patterns:
           - "*"
+  # Root npm lockfile (the Symfony Encore/webpack build toolchain). Was unmonitored,
+  # so dev-tooling advisories (http-proxy-middleware, uuid) never produced a bump PR.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
The root `package-lock.json` (Symfony Encore/webpack build toolchain) had **no Dependabot ecosystem entry** — only `github-actions` (/) and `bun` (/frontend) — so dev-tooling advisories never produced a bump PR. Adds a weekly grouped `npm` ecosystem for `/`.

Fixes the coverage gap behind **#118** (http-proxy-middleware, dev-only, Host-header proxy bypass) and **#102** (uuid, dev-only, buffer bounds), and Scorecard **#415** (Vulnerabilities) once Dependabot bumps the parents. No hand-bump / `overrides`: both are dev-only transitive build tooling and major-version-blocked by their parents (webpack-dev-server pins http-proxy-middleware ^2; sockjs/node-notifier pin uuid ^8), so forcing the patched majors would break the dev toolchain — Dependabot will move the parents when fixed lines ship.

> Note: I dropped the base-image digest-pin (Scorecard #407) from this PR — the php base flows through a `docker-bake.hcl` var → `ARG` → `FROM \${PHP_BASE_IMAGE}`, which Dependabot can't parse, so a pinned digest couldn't auto-bump; and `docker-publish` rebuilds daily off the floating `php:8.5-fpm` tag (which pulls base CVE patches each build), so pinning would *freeze* patching. Accepting #407 as risk is the better call.