### PR TITLE
fix(ldap): drop the stale hardcoded LDAP host default (#436/#424)

### DIFF
--- a/src/Service/Ldap/LdapClientService.php
+++ b/src/Service/Ldap/LdapClientService.php
@@ -33,8 +33,8 @@ use function strlen;
 
 class LdapClientService
 {
-    /** @var string LDAP host name or IP. */
-    protected $host = '192.168.1.2';
+    /** @var string LDAP host name or IP (always set from the ldap_host env via setHost() before use). */
+    protected $host = '';
 
     /** @var int LDAP host port. */
     protected $port = 389;

--- a/tests/Service/Ldap/LdapClientServiceTest.php
+++ b/tests/Service/Ldap/LdapClientServiceTest.php
@@ -817,7 +817,7 @@ final class LdapClientServiceTest extends TestCase
         $reflection = new ReflectionClass($service);
 
         $hostProp = $reflection->getProperty('host');
-        self::assertSame('192.168.1.2', $hostProp->getValue($service));
+        self::assertSame('', $hostProp->getValue($service));
 
         $portProp = $reflection->getProperty('port');
         self::assertSame(389, $portProp->getValue($service));


### PR DESCRIPTION
`LdapClientService::$host` defaulted to the hardcoded IP `192.168.1.2` (SonarCloud **#436**). The host is **always** set from the `ldap_host` env parameter via `setHost()` before any connect (`LdapAuthenticator:163`), so the default is never used at runtime — it's just misleading. Blank it to `''`, and update `testDefaultValues` to assert `''` in lockstep (**#424**, the test mirroring the same default).

Trivial, runtime-safe. phpstan / cs-fixer / phpunit (unit + api-contract) green via CaptainHook.