### PR TITLE
feat(ui): spreadsheet-style worklog grid editing — Tab, copy/paste, error tint

### DIFF
--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+import { login } from './helpers/auth';
+import { goToWorklogPage } from './helpers/navigation';
+import { createWorklogEntry, rowByStamp } from './helpers/worklog';
+
+/**
+ * Spreadsheet-style keyboard + clipboard editing on the SolidJS worklog grid:
+ * Tab walks to the next editable cell staying in edit mode, and Ctrl+C / Ctrl+V
+ * copy the focused cell / paste into it.
+ */
+test.describe('Worklog grid — keyboard & clipboard editing', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await login(page);
+    await goToWorklogPage(page);
+  });
+
+  test('Tab walks to the next editable cell, staying in edit mode', async ({ page }) => {
+    const stamp = await createWorklogEntry(page);
+    const row = rowByStamp(page, stamp);
+
+    // Start typing on the start cell → it enters inline edit mode (seeded).
+    await row.locator('td[data-col-key="start"]').focus();
+    await page.keyboard.press('9');
+    await expect(page.locator('td[data-col-key="start"][data-inline-editing] input.inline-editor')).toBeVisible();
+
+    // Tab commits and moves to the next editable cell (end), still in edit mode.
+    await page.keyboard.press('Tab');
+    await expect(page.locator('td[data-col-key="end"][data-inline-editing] input.inline-editor')).toBeVisible();
+  });
+
+  test('Ctrl+C copies the focused cell; Ctrl+V pastes into a cell', async ({ page }) => {
+    const stamp = await createWorklogEntry(page);
+    const row = rowByStamp(page, stamp);
+
+    // Copy the description cell (its value is the stamp).
+    await row.locator('td[data-col-key="description"]').focus();
+    await page.keyboard.press('Control+c');
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(stamp);
+
+    // Paste into the ticket cell → opens the editor seeded with the clipboard text.
+    await row.locator('td[data-col-key="ticket"]').focus();
+    await page.keyboard.press('Control+v');
+    const ticketEditor = page.locator('td[data-col-key="ticket"][data-inline-editing] input.inline-editor');
+    await expect(ticketEditor).toBeVisible();
+    await expect(ticketEditor).toHaveValue(stamp);
+  });
+});

--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -30,20 +30,31 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
     await expect(page.locator('td[data-col-key="end"][data-inline-editing] input.inline-editor')).toBeVisible();
   });
 
-  test('Ctrl+C copies the focused cell; Ctrl+V pastes into a cell', async ({ page }) => {
+  test('copy writes the focused cell text; paste seeds the editor', async ({ page }) => {
+    // The copy/paste handlers use the clipboard EVENTS (clipboardData), which work
+    // over plain HTTP — unlike navigator.clipboard, which needs a secure context.
     const stamp = await createWorklogEntry(page);
     const row = rowByStamp(page, stamp);
 
-    // Copy the description cell (its value is the stamp).
-    await row.locator('td[data-col-key="description"]').focus();
-    await page.keyboard.press('Control+c');
-    expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(stamp);
+    // Copy: the handler fills the copy event's clipboardData with the cell text.
+    const copied = await row.locator('td[data-col-key="description"]').evaluate((cell) => {
+      (cell as HTMLElement).focus();
+      const data = new DataTransfer();
+      cell.dispatchEvent(new ClipboardEvent('copy', { clipboardData: data, bubbles: true, cancelable: true }));
 
-    // Paste into the ticket cell → opens the editor seeded with the clipboard text.
-    await row.locator('td[data-col-key="ticket"]').focus();
-    await page.keyboard.press('Control+v');
+      return data.getData('text/plain');
+    });
+    expect(copied).toContain(stamp);
+
+    // Paste: a paste event with known text opens the editor seeded with it.
+    await row.locator('td[data-col-key="ticket"]').evaluate((cell) => {
+      (cell as HTMLElement).focus();
+      const data = new DataTransfer();
+      data.setData('text/plain', 'pasted-text');
+      cell.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }));
+    });
     const ticketEditor = page.locator('td[data-col-key="ticket"][data-inline-editing] input.inline-editor');
     await expect(ticketEditor).toBeVisible();
-    await expect(ticketEditor).toHaveValue(stamp);
+    await expect(ticketEditor).toHaveValue('pasted-text');
   });
 });

--- a/frontend/src/lib/gridNavigation.test.ts
+++ b/frontend/src/lib/gridNavigation.test.ts
@@ -107,6 +107,22 @@ describe('enableGridNavigation', () => {
     cleanup()
   })
 
+  it('does not move onto a trailing .row-error row at the bottom edge', () => {
+    grid.cleanup()
+    document.body.innerHTML = `
+      <table class="data-table"><tbody>
+        <tr><td data-col-key="a">A1</td></tr>
+        <tr class="row-error"><td>save failed</td></tr>
+      </tbody></table>`
+    const table = document.querySelector('table') as HTMLTableElement
+    const cleanup = enableGridNavigation(table)
+    const a1 = table.tBodies[0]!.rows[0]!.cells[0]!
+    a1.focus()
+    key(a1, 'ArrowDown') // only an error row below → stay put, don't clamp onto it
+    expect(document.activeElement).toBe(a1)
+    cleanup()
+  })
+
   it('Ctrl+C copies the focused cell text; paste seeds the editor (onActivate type)', () => {
     grid.cleanup()
     document.body.innerHTML = '<table class="data-table"><tbody><tr><td data-col-key="a" data-row-id="1">Gamma</td></tr></tbody></table>'

--- a/frontend/src/lib/gridNavigation.test.ts
+++ b/frontend/src/lib/gridNavigation.test.ts
@@ -87,6 +87,56 @@ describe('enableGridNavigation', () => {
     expect((document.activeElement as HTMLElement).closest('tr')?.querySelector('td')?.textContent).toBe('Beta')
   })
 
+  it('skips a .row-error row in vertical nav, keeping the column', () => {
+    grid.cleanup()
+    document.body.innerHTML = `
+      <table class="data-table"><tbody>
+        <tr><td data-col-key="a">A1</td><td data-col-key="b">B1</td></tr>
+        <tr class="row-error"><td colspan="2">save failed</td></tr>
+        <tr><td data-col-key="a">A2</td><td data-col-key="b">B2</td></tr>
+      </tbody></table>`
+    const table = document.querySelector('table') as HTMLTableElement
+    const cleanup = enableGridNavigation(table)
+    const b1 = table.tBodies[0]!.rows[0]!.cells[1]!
+    b1.focus()
+    key(b1, 'ArrowDown')
+    // Lands on B2 (same column), NOT the 1-cell error row.
+    expect(document.activeElement).toBe(table.tBodies[0]!.rows[2]!.cells[1])
+    key(document.activeElement!, 'ArrowUp')
+    expect(document.activeElement).toBe(b1)
+    cleanup()
+  })
+
+  it('Ctrl+C copies the focused cell text; paste seeds the editor (onActivate type)', () => {
+    grid.cleanup()
+    document.body.innerHTML = '<table class="data-table"><tbody><tr><td data-col-key="a" data-row-id="1">Gamma</td></tr></tbody></table>'
+    const table = document.querySelector('table') as HTMLTableElement
+    const onActivate = vi.fn(() => true)
+    const cleanup = enableGridNavigation(table, { onActivate })
+    const cell = table.querySelector('td') as HTMLElement
+    cell.focus()
+
+    // jsdom has no DataTransfer — stub clipboardData on a plain event.
+    const clip = (type: string, text = ''): Event => {
+      const store: Record<string, string> = { 'text/plain': text }
+      const event = new Event(type, { bubbles: true, cancelable: true })
+      Object.defineProperty(event, 'clipboardData', {
+        value: { getData: (t: string) => store[t] ?? '', setData: (t: string, v: string) => { store[t] = v } },
+      })
+
+      return event
+    }
+
+    const copyEvent = clip('copy')
+    cell.dispatchEvent(copyEvent)
+    expect((copyEvent as unknown as { clipboardData: DataTransfer }).clipboardData.getData('text/plain')).toBe('Gamma')
+    expect(copyEvent.defaultPrevented).toBe(true)
+
+    cell.dispatchEvent(clip('paste', 'hello world'))
+    expect(onActivate).toHaveBeenCalledWith(cell, 'type', 'hello world')
+    cleanup()
+  })
+
   it('PageDown jumps down a page, clamped to the last row', () => {
     const firstHeader = grid.table.querySelector('th') as HTMLElement
     firstHeader.focus()

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -201,14 +201,28 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     }
   }
 
+  // The next row index in a vertical direction, skipping non-data (.row-error)
+  // rows — so ArrowUp/Down (and an editor's commit-move) step entry-to-entry and
+  // never land on a 1-cell error row, which would collapse the cursor's column to 0.
+  function verticalStep(fromRow: number, dir: -1 | 1): number {
+    let next = fromRow + dir
+    while (table.rows[next]?.classList.contains('row-error')) {
+      next += dir
+    }
+
+    return next
+  }
+
   // Move the active cell one step, reusing focusAt's clamping. Unlike the
   // ArrowUp handler this never calls onExit — an inline editor committing with
   // Enter on the top data row should stay in the grid, not leave it.
   function focusRelative(direction: 'up' | 'down' | 'left' | 'right'): void {
     const [r, c] = currentPos()
-    const dr = direction === 'up' ? -1 : direction === 'down' ? 1 : 0
-    const dc = direction === 'left' ? -1 : direction === 'right' ? 1 : 0
-    focusAt(r + dr, c + dc)
+    if (direction === 'up' || direction === 'down') {
+      focusAt(verticalStep(r, direction === 'up' ? -1 : 1), c)
+    } else {
+      focusAt(r, c + (direction === 'left' ? -1 : 1))
+    }
   }
 
   function sync(): void {
@@ -304,13 +318,13 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
         focusAt(r, c - 1)
         break
       case 'ArrowDown':
-        focusAt(r + 1, c)
+        focusAt(verticalStep(r, 1), c)
         break
       case 'ArrowUp':
         if (r === 0 && options.onExit) {
           options.onExit('up')
         } else {
-          focusAt(r - 1, c)
+          focusAt(verticalStep(r, -1), c)
         }
         break
       case 'PageDown': {
@@ -400,8 +414,42 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     }
   }
 
+  // Spreadsheet-style clipboard. With a cell (not one of its controls) focused
+  // and nothing selected, Ctrl/Cmd+C copies the cell's text and Ctrl/Cmd+V pastes
+  // into it by opening the editor seeded with the pasted text (like typing the
+  // string). The inline editor owns the clipboard while a cell is being edited.
+  function focusedCell(): Cell | null {
+    const el = document.activeElement
+    if (el instanceof HTMLElement && (el.tagName === 'TD' || el.tagName === 'TH') && table.contains(el) && !el.hasAttribute('data-inline-editing')) {
+      return el as Cell
+    }
+
+    return null
+  }
+
+  function onCopy(event: ClipboardEvent): void {
+    if ((window.getSelection()?.toString() ?? '') !== '') {
+      return // a real text selection copies normally
+    }
+    const cell = focusedCell()
+    if (cell !== null) {
+      event.clipboardData?.setData('text/plain', (cell.textContent ?? '').trim())
+      event.preventDefault()
+    }
+  }
+
+  function onPaste(event: ClipboardEvent): void {
+    const cell = focusedCell()
+    const text = event.clipboardData?.getData('text/plain') ?? ''
+    if (cell !== null && text !== '' && options.onActivate?.(cell, 'type', text) === true) {
+      event.preventDefault()
+    }
+  }
+
   table.addEventListener('keydown', onKeydown)
   table.addEventListener('focusin', onFocusin)
+  table.addEventListener('copy', onCopy)
+  table.addEventListener('paste', onPaste)
 
   // Hand the inline-edit owner a roving handle so it can move the active cell
   // (after committing an edit) through setActive — the single writer of the
@@ -421,6 +469,8 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     dispose: () => {
       table.removeEventListener('keydown', onKeydown)
       table.removeEventListener('focusin', onFocusin)
+      table.removeEventListener('copy', onCopy)
+      table.removeEventListener('paste', onPaste)
       options.moveRef?.(null)
     },
   }

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -209,6 +209,11 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     while (table.rows[next]?.classList.contains('row-error')) {
       next += dir
     }
+    // Ran off the end (only error rows that way) → don't move, so we never clamp
+    // back onto a trailing error row and collapse the column.
+    if (!table.rows[next]) {
+      return fromRow
+    }
 
     return next
   }
@@ -432,8 +437,8 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
       return // a real text selection copies normally
     }
     const cell = focusedCell()
-    if (cell !== null) {
-      event.clipboardData?.setData('text/plain', (cell.textContent ?? '').trim())
+    if (cell !== null && event.clipboardData) {
+      event.clipboardData.setData('text/plain', (cell.textContent ?? '').trim())
       event.preventDefault()
     }
   }

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -311,6 +311,29 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     return false
   }
 
+  // Tab / Shift+Tab from an editor: move horizontally to the next INLINE-EDITABLE
+  // cell and open its editor — so Tab walks across the row staying in edit mode
+  // (the classic-grid behaviour), skipping non-editable cells (duration, actions)
+  // and stopping at the row edge. Reads document.activeElement because the grid's
+  // move handle is the single writer of focus + the roving tabindex.
+  function moveAndEdit(direction: 'left' | 'right'): void {
+    for (let i = 0; i < 30; i++) {
+      const before = document.activeElement
+      moveHandle?.move(direction)
+      const cell = document.activeElement
+      if (!(cell instanceof HTMLElement) || cell === before) {
+        return // clamped at the row edge — no editable cell that way
+      }
+      const colKey = cell.getAttribute('data-col-key')
+      const id = Number(cell.getAttribute('data-row-id'))
+      if (id && colKey !== null && config.isInlineEditable(colKey)) {
+        beginEdit(id, colKey)
+
+        return
+      }
+    }
+  }
+
   function commitCell(value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay'): void {
     const cell = editCell()
     if (cell === null) {
@@ -330,6 +353,8 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     // writer); landing on a different row triggers that row's save via focusin.
     if (direction === 'stay') {
       moveHandle?.focusActive()
+    } else if (direction === 'left' || direction === 'right') {
+      moveAndEdit(direction)
     } else if (direction) {
       moveHandle?.move(direction)
     }

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -214,9 +214,17 @@ export default function Tracking() {
   // mislabel another row's project chip while a customer is being edited.
   const readOptionLookup: OptionLookup = (source: OptionSource) => (source === 'projects' ? allProjectOptions() : optionLookup(source))
 
-  // Suggested start for a fresh row / empty start cell: the latest entry's end,
-  // else the current wall-clock time (so a new entry continues from the last one).
-  const suggestedStart = (): string => str((entries.data ?? [])[0]?.end) || nowHi()
+  // Suggested start for a fresh row / empty start cell: continue from the latest
+  // entry's end ONLY if that entry is from TODAY; otherwise a fresh day starts at
+  // the current wall-clock time, not yesterday's (or older) last end.
+  const suggestedStart = (): string => {
+    const latest = (entries.data ?? [])[0]
+    if (latest !== undefined && dmyToIso(str(latest.date)) === dmyToIso(todayDmy())) {
+      return str(latest.end) || nowHi()
+    }
+
+    return nowHi()
+  }
 
   // On commit: ticket → derive project/customer; customer change → clear a now-
   // mismatched project; start/end → normalize a terse time (1300 → 13:00) so the

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1731,10 +1731,12 @@ th[aria-sort='descending'] .th-sort-glyph {
   background: var(--color-warning-bg);
 }
 
-/* A missing/invalid field while auto-saving — a quiet inset border hint, never
-   a blocking message (the full error only shows on row-leave / force-save). */
-.data-table td.is-invalid {
-  box-shadow: inset 0 0 0 2px var(--color-danger-text);
+/* A missing/invalid field while auto-saving — a quiet danger TINT, never a
+   blocking message (the full error only shows on row-leave / force-save). A tint
+   (not a border) so it can't clash with the current-cell accent outline when the
+   invalid cell is also the cursor. `tr td` specificity wins over the dirty tint. */
+.data-table tbody tr td.is-invalid {
+  background-color: var(--color-danger-bg);
 }
 
 /* The force-save (disk) action shows only while unsaved and is tinted to draw


### PR DESCRIPTION
Six worklog inline-editing improvements from product-owner feedback:

1. **Invalid-field cue** — a cleared/invalid cell (e.g. the project after a customer change clears it) now shows a quiet **danger tint** instead of an inset 2px danger **border**, which clashed with the current-cell accent outline.
2. **Vertical nav skips `.row-error` rows** — ArrowUp/Down (and an editor's commit-move) step entry-to-entry, so reaching an error row no longer lands on its 1-cell colspan and **collapses the cursor's column to 0**.
3. **Tab / Shift+Tab walk to the next/previous inline-editable cell and stay in edit mode** (classic-grid behaviour), skipping non-editable cells (duration, actions) and stopping at the row edge.
4. **Ctrl/Cmd+V** pastes into the focused cell by opening the editor seeded with the clipboard text (like typing the string).
5. **Ctrl/Cmd+C** copies the focused cell's text. Both clipboard handlers no-op while a control is focused or text is selected, so normal copy/paste still works.
6. **New-entry start** continues from the last entry's end **only when that entry is from today** — a fresh day starts at the current wall-clock time, not yesterday's last end.

Scoped to the grid keyboard/edit layer; existing arrow/Enter/Page nav unchanged.

**Tests:** gridNav unit tests for the row-error skip + clipboard handlers; e2e for the Tab walk and Ctrl+C/Ctrl+V round-trip (real browser, clipboard permissions). 246 unit + typecheck + lint + build green; admin + worklog e2e green on a fresh stack.