### PR TITLE
fix(ui): make Ctrl+C/V work on a focused grid cell, not only while editing

### DIFF
--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -7,7 +7,7 @@ import { createWorklogEntry, rowByStamp } from './helpers/worklog';
 /**
  * Spreadsheet-style keyboard + clipboard editing on the SolidJS worklog grid:
  * Tab walks to the next editable cell staying in edit mode, and Ctrl+C / Ctrl+V
- * copy the focused cell / paste into it.
+ * copy the focused (non-edit) cell / paste into another via the async clipboard API.
  */
 test.describe('Worklog grid — keyboard & clipboard editing', () => {
   test.beforeEach(async ({ page, context }) => {
@@ -30,31 +30,28 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
     await expect(page.locator('td[data-col-key="end"][data-inline-editing] input.inline-editor')).toBeVisible();
   });
 
-  test('copy writes the focused cell text; paste seeds the editor', async ({ page }) => {
-    // The copy/paste handlers use the clipboard EVENTS (clipboardData), which work
-    // over plain HTTP — unlike navigator.clipboard, which needs a secure context.
+  test('Ctrl+C copies the focused cell; Ctrl+V pastes into another, seeding the editor', async ({ page }) => {
+    // Ctrl+C/V on a focused (non-edit) cell drive the async clipboard API, which needs
+    // a secure context. CI serves the app over plain HTTP on a container hostname, so
+    // navigator.clipboard is unavailable there — skip rather than fail. Runs locally
+    // (localhost is a secure context) and on prod (HTTPS).
+    const secure = await page.evaluate(() => navigator.clipboard?.readText !== undefined);
+    test.skip(!secure, 'async clipboard API needs a secure context (CI serves plain HTTP)');
+
     const stamp = await createWorklogEntry(page);
     const row = rowByStamp(page, stamp);
 
-    // Copy: the handler fills the copy event's clipboardData with the cell text.
-    const copied = await row.locator('td[data-col-key="description"]').evaluate((cell) => {
-      (cell as HTMLElement).focus();
-      const data = new DataTransfer();
-      cell.dispatchEvent(new ClipboardEvent('copy', { clipboardData: data, bubbles: true, cancelable: true }));
+    // Copy the description cell (its text contains the unique stamp) with the cursor on
+    // the cell — not in edit mode.
+    await row.locator('td[data-col-key="description"]').focus();
+    await page.keyboard.press('Control+c');
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(stamp);
 
-      return data.getData('text/plain');
-    });
-    expect(copied).toContain(stamp);
-
-    // Paste: a paste event with known text opens the editor seeded with it.
-    await row.locator('td[data-col-key="ticket"]').evaluate((cell) => {
-      (cell as HTMLElement).focus();
-      const data = new DataTransfer();
-      data.setData('text/plain', 'pasted-text');
-      cell.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }));
-    });
+    // Paste into the ticket cell → opens the editor seeded with the clipboard text.
+    await row.locator('td[data-col-key="ticket"]').focus();
+    await page.keyboard.press('Control+v');
     const ticketEditor = page.locator('td[data-col-key="ticket"][data-inline-editing] input.inline-editor');
     await expect(ticketEditor).toBeVisible();
-    await expect(ticketEditor).toHaveValue('pasted-text');
+    await expect(ticketEditor).toHaveValue(stamp);
   });
 });

--- a/frontend/src/lib/gridNavigation.test.ts
+++ b/frontend/src/lib/gridNavigation.test.ts
@@ -123,7 +123,7 @@ describe('enableGridNavigation', () => {
     cleanup()
   })
 
-  it('Ctrl+C copies the focused cell text; paste seeds the editor (onActivate type)', () => {
+  it('Ctrl+C writes the focused cell text; Ctrl+V reads the clipboard to seed the editor', async () => {
     grid.cleanup()
     document.body.innerHTML = '<table class="data-table"><tbody><tr><td data-col-key="a" data-row-id="1">Gamma</td></tr></tbody></table>'
     const table = document.querySelector('table') as HTMLTableElement
@@ -132,24 +132,26 @@ describe('enableGridNavigation', () => {
     const cell = table.querySelector('td') as HTMLElement
     cell.focus()
 
-    // jsdom has no DataTransfer — stub clipboardData on a plain event.
-    const clip = (type: string, text = ''): Event => {
-      const store: Record<string, string> = { 'text/plain': text }
-      const event = new Event(type, { bubbles: true, cancelable: true })
-      Object.defineProperty(event, 'clipboardData', {
-        value: { getData: (t: string) => store[t] ?? '', setData: (t: string, v: string) => { store[t] = v } },
-      })
+    // A focused, non-editable cell never receives copy/paste events — the grid drives
+    // them off the keystroke through the async clipboard API. Mock it here.
+    const writeText = vi.fn(() => Promise.resolve())
+    const readText = vi.fn(() => Promise.resolve('hello world'))
+    const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText, readText }, configurable: true })
 
-      return event
-    }
+    key(cell, 'c', { ctrlKey: true })
+    expect(writeText).toHaveBeenCalledWith('Gamma')
 
-    const copyEvent = clip('copy')
-    cell.dispatchEvent(copyEvent)
-    expect((copyEvent as unknown as { clipboardData: DataTransfer }).clipboardData.getData('text/plain')).toBe('Gamma')
-    expect(copyEvent.defaultPrevented).toBe(true)
-
-    cell.dispatchEvent(clip('paste', 'hello world'))
+    key(cell, 'v', { ctrlKey: true })
+    await Promise.resolve()
+    await Promise.resolve()
     expect(onActivate).toHaveBeenCalledWith(cell, 'type', 'hello world')
+
+    if (original) {
+      Object.defineProperty(navigator, 'clipboard', original)
+    } else {
+      Reflect.deleteProperty(navigator, 'clipboard')
+    }
     cleanup()
   })
 

--- a/frontend/src/lib/gridNavigation.test.ts
+++ b/frontend/src/lib/gridNavigation.test.ts
@@ -155,6 +155,31 @@ describe('enableGridNavigation', () => {
     cleanup()
   })
 
+  it('Ctrl+C with an active text selection copies natively, not the whole cell', () => {
+    grid.cleanup()
+    document.body.innerHTML = '<table class="data-table"><tbody><tr><td data-col-key="a">Gamma</td></tr></tbody></table>'
+    const table = document.querySelector('table') as HTMLTableElement
+    const cleanup = enableGridNavigation(table)
+    const cell = table.querySelector('td') as HTMLElement
+    cell.focus()
+
+    const writeText = vi.fn(() => Promise.resolve())
+    const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    const getSelection = vi.spyOn(window, 'getSelection').mockReturnValue({ toString: () => 'amm' } as Selection)
+
+    key(cell, 'c', { ctrlKey: true })
+    expect(writeText).not.toHaveBeenCalled() // a real selection → native copy, not synthesized
+
+    getSelection.mockRestore()
+    if (original) {
+      Object.defineProperty(navigator, 'clipboard', original)
+    } else {
+      Reflect.deleteProperty(navigator, 'clipboard')
+    }
+    cleanup()
+  })
+
   it('PageDown jumps down a page, clamped to the last row', () => {
     const firstHeader = grid.table.querySelector('th') as HTMLElement
     firstHeader.focus()

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -315,6 +315,24 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     const [r, c] = currentPos()
     const lastRow = table.rows.length - 1 // live count, no per-keystroke allocation
 
+    // Clipboard from a focused cell (non-edit mode): Ctrl/Cmd+C copies the cell's
+    // text; Ctrl/Cmd+V opens the editor seeded with the clipboard text.
+    if ((event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey) {
+      const lower = event.key.toLowerCase()
+      if (lower === 'c') {
+        event.preventDefault()
+        copyCellText(cell)
+
+        return
+      }
+      if (lower === 'v' && options.onActivate !== undefined) {
+        event.preventDefault()
+        void pasteIntoCell(cell)
+
+        return
+      }
+    }
+
     switch (event.key) {
       case 'ArrowRight':
         focusAt(r, c + 1)
@@ -419,42 +437,42 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     }
   }
 
-  // Spreadsheet-style clipboard. With a cell (not one of its controls) focused
-  // and nothing selected, Ctrl/Cmd+C copies the cell's text and Ctrl/Cmd+V pastes
-  // into it by opening the editor seeded with the pasted text (like typing the
-  // string). The inline editor owns the clipboard while a cell is being edited.
-  function focusedCell(): Cell | null {
-    const el = document.activeElement
-    if (el instanceof HTMLElement && (el.tagName === 'TD' || el.tagName === 'TH') && table.contains(el) && !el.hasAttribute('data-inline-editing')) {
-      return el as Cell
-    }
+  // Spreadsheet clipboard from a FOCUSED CELL (non-edit mode). The copy/paste DOM
+  // events only fire on an editable element or a text selection, so a focused cell
+  // never receives them — Ctrl/Cmd+C/V are driven from the keystroke (see onKeydown)
+  // via the async clipboard API, with an execCommand fallback for copy in non-secure
+  // contexts. In edit mode the focused input handles copy/paste natively.
+  function copyCellText(cell: Cell): void {
+    const text = (cell.textContent ?? '').trim()
+    if (navigator.clipboard?.writeText !== undefined) {
+      void navigator.clipboard.writeText(text)
 
-    return null
+      return
+    }
+    const area = document.createElement('textarea')
+    area.value = text
+    area.style.cssText = 'position:fixed;top:0;opacity:0'
+    document.body.appendChild(area)
+    area.select()
+    try { document.execCommand('copy') } catch { /* best effort */ }
+    area.remove()
+    cell.focus()
   }
 
-  function onCopy(event: ClipboardEvent): void {
-    if ((window.getSelection()?.toString() ?? '') !== '') {
-      return // a real text selection copies normally
+  async function pasteIntoCell(cell: Cell): Promise<void> {
+    if (navigator.clipboard?.readText === undefined) {
+      return // no async clipboard (non-secure context) → can't read the clipboard
     }
-    const cell = focusedCell()
-    if (cell !== null && event.clipboardData) {
-      event.clipboardData.setData('text/plain', (cell.textContent ?? '').trim())
-      event.preventDefault()
-    }
-  }
-
-  function onPaste(event: ClipboardEvent): void {
-    const cell = focusedCell()
-    const text = event.clipboardData?.getData('text/plain') ?? ''
-    if (cell !== null && text !== '' && options.onActivate?.(cell, 'type', text) === true) {
-      event.preventDefault()
-    }
+    try {
+      const text = await navigator.clipboard.readText()
+      if (text !== '') {
+        options.onActivate?.(cell, 'type', text)
+      }
+    } catch { /* permission denied / empty clipboard */ }
   }
 
   table.addEventListener('keydown', onKeydown)
   table.addEventListener('focusin', onFocusin)
-  table.addEventListener('copy', onCopy)
-  table.addEventListener('paste', onPaste)
 
   // Hand the inline-edit owner a roving handle so it can move the active cell
   // (after committing an edit) through setActive — the single writer of the
@@ -474,8 +492,6 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     dispose: () => {
       table.removeEventListener('keydown', onKeydown)
       table.removeEventListener('focusin', onFocusin)
-      table.removeEventListener('copy', onCopy)
-      table.removeEventListener('paste', onPaste)
       options.moveRef?.(null)
     },
   }

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -320,6 +320,11 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
     if ((event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey) {
       const lower = event.key.toLowerCase()
       if (lower === 'c') {
+        // A real text selection copies natively (the browser's own copy of the
+        // selection) — only synthesize a copy for a bare, unselected focused cell.
+        if ((window.getSelection()?.toString() ?? '') !== '') {
+          return
+        }
         event.preventDefault()
         copyCellText(cell)
 


### PR DESCRIPTION
## Problem

Ctrl+C / Ctrl+V on the worklog grid only worked **while a cell was being edited** — once the inline editor's `<input>` had focus, the browser handled copy/paste natively. With a cell merely **focused** (cursor on the cell, not editing), nothing happened.

Root cause: the previous handlers listened for the `copy`/`paste` **DOM events**, which only fire on an editable element or when there's a text selection. A focused, non-editable `<td>` never receives them.

## Fix

Drive Ctrl/Cmd+C/V from the **keystroke** in `gridNavigation`, when a cell (not one of its controls) is focused:

- **Ctrl/Cmd+C** → writes the focused cell's text via the async clipboard API (`navigator.clipboard.writeText`), with an `execCommand` fallback for copy in non-secure contexts.
- **Ctrl/Cmd+V** → reads the clipboard and opens the inline editor seeded with the text — identical to typing the value into the cell.

In edit mode the focused input still owns copy/paste natively (the grid yields entirely on `data-inline-editing`), so this only adds the non-edit-mode path. Paste has no non-secure fallback because `readText` cannot be polyfilled.

## Tests

- **Unit** (`gridNavigation.test.ts`): replaced the event-based stub with a keydown + mocked `navigator.clipboard` test — Ctrl+C writes the cell text, Ctrl+V reads and seeds the editor.
- **e2e** (`worklog-grid-editing.spec.ts`): real `Control+c` / `Control+v` keypresses across two cells; skips on non-secure contexts (CI serves plain HTTP, where `navigator.clipboard` is unavailable). Runs locally (localhost) and on prod (HTTPS).

## Verification

`bun run typecheck` ✓ · `bun run lint` ✓ · `bun run test` (247) ✓ · `bun run build` ✓
