### PR TITLE
fix(worklog): hide inactive customers/projects from the picker, keep them editable

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -45,6 +45,9 @@ export function holidaysQuery(year: number, month: number) {
 export interface NamedOption {
   id: number
   label: string
+  /** Bookable flag where the source carries one (e.g. customers); undefined means
+   *  "always bookable" (sources with no active concept). Drives the active-only picker. */
+  active?: boolean
 }
 
 // Reference dropdown sources (customers/projects/users/teams/presets/ticket
@@ -64,7 +67,7 @@ export function optionSourceKey(entity: string): readonly [string] {
   return [`all-${entity}`] as const
 }
 
-type OptionRow = Record<string, { id: number; name?: string; username?: string }>
+type OptionRow = Record<string, { id: number; name?: string; username?: string; active?: boolean }>
 
 function optionSourceQuery(
   entity: string,
@@ -79,7 +82,7 @@ function optionSourceQuery(
       records
         .map((record) => record?.[rowKey])
         .filter((inner): inner is NonNullable<typeof inner> => inner != null)
-        .map((inner) => ({ id: inner.id, label: String(inner[nameField] ?? '') })),
+        .map((inner) => ({ id: inner.id, label: String(inner[nameField] ?? ''), active: inner.active })),
     staleTime: REFERENCE_STALE_TIME,
   })
 }
@@ -160,6 +163,7 @@ export interface TrackingProject {
   id: number
   name: string
   customer: number
+  active: boolean
   jiraId: string
   ticketSystem: number
 }
@@ -176,6 +180,8 @@ export function trackingProjectsQuery() {
           id: Number(project.id ?? 0),
           name: String(project.name ?? ''),
           customer: Number(project.customer ?? 0),
+          // Default to bookable unless the backend explicitly says inactive.
+          active: project.active !== false && project.active !== 0,
           jiraId: String(project.jiraId ?? project.jira_id ?? ''),
           ticketSystem: Number(project.ticket_system ?? project.ticketSystem ?? 0),
         })),

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -67,7 +67,14 @@ export function optionSourceKey(entity: string): readonly [string] {
   return [`all-${entity}`] as const
 }
 
-type OptionRow = Record<string, { id: number; name?: string; username?: string; active?: boolean }>
+type OptionRow = Record<string, { id: number; name?: string; username?: string; active?: boolean | number | string }>
+
+// The backend serializes `active` via a PHP (bool) cast → JSON true/false, but be
+// defensive about drivers/serializers that emit 1/0 or "1"/"0": treat only the
+// explicit falsy forms as inactive, everything else (incl. absent) as bookable.
+function coerceActive(raw: unknown): boolean {
+  return raw !== false && raw !== 0 && raw !== '0' && raw !== 'false'
+}
 
 function optionSourceQuery(
   entity: string,
@@ -82,7 +89,7 @@ function optionSourceQuery(
       records
         .map((record) => record?.[rowKey])
         .filter((inner): inner is NonNullable<typeof inner> => inner != null)
-        .map((inner) => ({ id: inner.id, label: String(inner[nameField] ?? ''), active: inner.active })),
+        .map((inner) => ({ id: inner.id, label: String(inner[nameField] ?? ''), active: inner.active === undefined ? undefined : coerceActive(inner.active) })),
     staleTime: REFERENCE_STALE_TIME,
   })
 }
@@ -181,7 +188,7 @@ export function trackingProjectsQuery() {
           name: String(project.name ?? ''),
           customer: Number(project.customer ?? 0),
           // Default to bookable unless the backend explicitly says inactive.
-          active: project.active !== false && project.active !== 0,
+          active: coerceActive(project.active),
           jiraId: String(project.jiraId ?? project.jira_id ?? ''),
           ticketSystem: Number(project.ticket_system ?? project.ticketSystem ?? 0),
         })),

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -608,4 +608,50 @@ describe('Tracking (Worklog grid)', () => {
 
     unmount()
   })
+
+  it('the picker offers only active customers (inactive ones are hidden)', async () => {
+    mockTracking({
+      entries: [{ entry: DEFAULT_ENTRY }],
+      customers: [
+        { customer: { id: 1, name: 'ACME', active: true } },
+        { customer: { id: 7, name: 'OldCo', active: false } },
+      ],
+      projects: [{ project: { id: 4, name: 'Site', customer: 1, active: true } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
+    const { getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    // Add opens the customer picker on the new row.
+    fireEvent.click(getByRole('button', { name: 'Add entry' }))
+    await waitFor(() => expect(document.querySelectorAll('.combobox-content .combobox-item').length).toBeGreaterThan(0))
+    const labels = [...document.querySelectorAll('.combobox-content .combobox-item')].map((el) => el.textContent ?? '')
+    expect(labels.some((label) => label.includes('ACME'))).toBe(true)
+    expect(labels.some((label) => label.includes('OldCo'))).toBe(false)
+
+    unmount()
+  })
+
+  it('keeps an existing entry\'s deactivated project selectable in its picker', async () => {
+    mockTracking({
+      entries: [{ entry: { ...DEFAULT_ENTRY, customer: 1, project: 9 } }],
+      customers: [{ customer: { id: 1, name: 'ACME', active: true } }],
+      projects: [
+        { project: { id: 4, name: 'Site', customer: 1, active: true } },
+        { project: { id: 9, name: 'Legacy', customer: 1, active: false } }, // the entry's now-inactive project
+      ],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    // The existing entry's project picker shows active projects PLUS its current (inactive) one.
+    editCell(container, 'project')
+    await waitFor(() => expect(document.querySelectorAll('.combobox-content .combobox-item').length).toBeGreaterThan(0))
+    const labels = [...document.querySelectorAll('.combobox-content .combobox-item')].map((el) => el.textContent ?? '')
+    expect(labels.some((label) => label.includes('Site'))).toBe(true)
+    expect(labels.some((label) => label.includes('Legacy'))).toBe(true)
+
+    unmount()
+  })
 })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -188,31 +188,50 @@ export default function Tracking() {
   const activityLabels = createMemo(() => toLabelMap(activities.data))
   const labelFrom = (map: Map<number, string>, id: number): string => (id > 0 ? (map.get(id) ?? String(id)) : '')
 
+  // The PICKER offers only bookable (active) customers/projects, plus the row's
+  // CURRENT value even if it's since been deactivated — so editing an existing
+  // entry whose customer/project was deactivated keeps it visible/selectable and
+  // never silently drops it. Activities have no active concept.
   const optionLookup: OptionLookup = (source: OptionSource) => {
+    const cell = editor.editCell()
+    const currentOf = (field: string): number => (cell !== null ? num(editor.draftValue(cell.rowId, field)) : 0)
+    const bookable = <T extends { id: number; active?: boolean }>(list: T[], keepId: number): T[] =>
+      list.filter((option) => option.active !== false || option.id === keepId)
+
     switch (source) {
       case 'customers':
-        return customers.data ?? []
+        return bookable(customers.data ?? [], currentOf('customer'))
       case 'activities':
         return activities.data ?? []
       case 'projects': {
         // Cascade: while editing, show only the projects for the row's customer
         // (prod has ~1000 projects, so an unfiltered list is unusable).
-        const cell = editor.editCell()
-        const customerId = cell !== null ? num(editor.draftValue(cell.rowId, 'customer')) : 0
+        const customerId = currentOf('customer')
         const list = projects.data ?? []
         const scoped = customerId > 0 ? list.filter((project) => project.customer === customerId) : list
 
-        return scoped.map((project) => ({ id: project.id, label: project.name }))
+        return bookable(scoped, currentOf('project')).map((project) => ({ id: project.id, label: project.name }))
       }
       default:
         return []
     }
   }
 
-  // Read-mode chip labels resolve against the FULL option set: the cascade in
-  // optionLookup narrows only the OPEN editor's project list — it must never
-  // mislabel another row's project chip while a customer is being edited.
-  const readOptionLookup: OptionLookup = (source: OptionSource) => (source === 'projects' ? allProjectOptions() : optionLookup(source))
+  // Read-mode chip labels resolve against the FULL option set (incl. inactive), so
+  // an existing entry's deactivated customer/project still renders its name — the
+  // active-only filtering above applies ONLY to the open editor's picker.
+  const readOptionLookup: OptionLookup = (source: OptionSource) => {
+    switch (source) {
+      case 'projects':
+        return allProjectOptions()
+      case 'customers':
+        return customers.data ?? []
+      case 'activities':
+        return activities.data ?? []
+      default:
+        return []
+    }
+  }
 
   // Suggested start for a fresh row / empty start cell: continue from the latest
   // entry's end ONLY if that entry is from TODAY; otherwise a fresh day starts at

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -118,7 +118,12 @@ final class SaveEntryAction extends BaseTrackingController
             return $populateError;
         }
 
-        if (!$project->getActive()) {
+        // Only block an inactive project when it is newly assigned or changed — an
+        // existing entry that KEEPS its (since-deactivated) project must still save,
+        // so editing its other fields (start/end/description) never fails. The UI
+        // also hides inactive projects from the picker, so a fresh pick is active.
+        $projectChanged = !$previousEntry instanceof Entry || $previousEntry->getProjectId() !== $project->getId();
+        if ($projectChanged && !$project->getActive()) {
             return new Error('Project is no longer active.', Response::HTTP_BAD_REQUEST);
         }
 


### PR DESCRIPTION
## Problem

Deactivated customers/projects were still offered in the new-entry picker — sometimes the *only* option for a customer — so a user could pick an inactive project and the save then failed with **"Project is no longer active."** Worse, the backend rejected that project on **every** save, so editing *any* field of an old entry whose project was since deactivated **also failed** — old entries could get stuck.

## Fix

- **Frontend** — the editor picker now offers **only active** customers/projects, **plus the row's current value** even if it was since deactivated (so an existing entry keeps its value visible/selectable and never silently drops it). Read-mode chips still resolve against the full set, so inactive names still render. The `active` flag now flows through (the query selects dropped it before): `NamedOption.active` + `TrackingProject.active`.
- **Backend** (`SaveEntryAction`) — only reject an inactive project when it is **newly assigned or changed**; keeping an entry's existing (now-inactive) project saves fine, so editing old entries never fails.

This matches the intent: inactive customers/projects disappear from selection but stay available for existing entries.

## Tests

- Unit: the picker hides inactive customers; an existing entry's deactivated project stays selectable in its own picker.
- Verified manually on a local dev stack (deactivated a project used by 8 entries → hidden from the new-entry picker, those 8 entries still edit + save fine).
- Pre-commit gate green: phpstan, php-cs-fixer, phpunit unit + api-contract.

## Verification

`typecheck` ✓ · `lint` ✓ · `256` frontend unit ✓ · PHP unit + api-contract ✓
