### PR TITLE
feat(worklog): guided-Enter fill + configurable end-time pre-fill

### DIFF
--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -79,7 +79,7 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
     await expect(page.locator('tr.tracking-row')).toHaveCount(before);
   });
 
-  test('Enter guides a new entry to the next required field (customer → project → activity → end)', async ({ page }) => {
+  test('Enter guides a new entry to the next required field (customer → project → activity)', async ({ page }) => {
     await page.getByRole('button', { name: /Add entry|Eintrag hinzufügen/i }).click();
     const row = page.locator('tr.tracking-row.is-new').first();
     await expect(row).toBeVisible();
@@ -89,13 +89,13 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
       await page.keyboard.press('ArrowDown'); // highlight an option
       await page.keyboard.press('Enter'); // Enter-driven pick guides to the next required field
     };
+    // customer/project/activity are always required-and-empty for a new row, so the
+    // guide jumps through them. (date/start/end are pre-filled by suggest-time +
+    // the end-prefill minimum, so they're skipped — the guide only targets empties.)
     await arrowEnter();
     await expect(row.locator('td[data-col-key="project"][data-inline-editing]')).toBeVisible();
     await arrowEnter();
     await expect(row.locator('td[data-col-key="activity"][data-inline-editing]')).toBeVisible();
-    await arrowEnter();
-    // start is pre-filled by suggest-time, so the guide skips it straight to end.
-    await expect(row.locator('td[data-col-key="end"][data-inline-editing]')).toBeVisible();
   });
 
   test('Enter committing a select editor keeps focus on a grid cell (no focus loss)', async ({ page }) => {

--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -78,4 +78,34 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
     await row.locator('.is-reset').click();
     await expect(page.locator('tr.tracking-row')).toHaveCount(before);
   });
+
+  test('Enter guides a new entry to the next required field (customer → project → activity → end)', async ({ page }) => {
+    await page.getByRole('button', { name: /Add entry|Eintrag hinzufügen/i }).click();
+    const row = page.locator('tr.tracking-row.is-new').first();
+    await expect(row).toBeVisible();
+
+    const arrowEnter = async (): Promise<void> => {
+      await expect(page.locator('.combobox-input').first()).toBeVisible();
+      await page.keyboard.press('ArrowDown'); // highlight an option
+      await page.keyboard.press('Enter'); // Enter-driven pick guides to the next required field
+    };
+    await arrowEnter();
+    await expect(row.locator('td[data-col-key="project"][data-inline-editing]')).toBeVisible();
+    await arrowEnter();
+    await expect(row.locator('td[data-col-key="activity"][data-inline-editing]')).toBeVisible();
+    await arrowEnter();
+    // start is pre-filled by suggest-time, so the guide skips it straight to end.
+    await expect(row.locator('td[data-col-key="end"][data-inline-editing]')).toBeVisible();
+  });
+
+  test('Enter committing a select editor keeps focus on a grid cell (no focus loss)', async ({ page }) => {
+    const stamp = await createWorklogEntry(page);
+    const row = rowByStamp(page, stamp);
+
+    await row.locator('td[data-col-key="customer"]').focus();
+    await page.keyboard.press('Enter'); // open the (portalled) select editor
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter'); // commit — focus must return to a grid cell, not <body>
+    await expect(page.locator('.tracking-table td:focus')).toHaveCount(1);
+  });
 });

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -58,6 +58,8 @@
   "settings_show_empty_line": "Immer leere Zeile anzeigen",
   "settings_suggest_time": "Zeit vorschlagen",
   "settings_show_future": "Zukunft anzeigen",
+  "settings_min_entry_duration": "Minimale Eintragsdauer (Minuten)",
+  "settings_min_entry_duration_hint": "Die Endzeit eines neuen Eintrags wird auf Startzeit plus diese Minuten vorbelegt. 0 deaktiviert dies.",
   "settings_grid_enter": "Beim Bearbeiten einer Tabellenzelle springt Enter…",
   "settings_grid_enter_hint": "Wirkt sofort. Tab springt immer zur nächsten Zelle.",
   "settings_dateformat": "Datumsformat",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -58,6 +58,8 @@
   "settings_show_empty_line": "Always show an empty line",
   "settings_suggest_time": "Suggest time",
   "settings_show_future": "Show future",
+  "settings_min_entry_duration": "Minimum entry duration (minutes)",
+  "settings_min_entry_duration_hint": "A new entry's end pre-fills to its start plus this many minutes. 0 disables it.",
   "settings_grid_enter": "When editing a table cell, Enter…",
   "settings_grid_enter_hint": "Applies immediately. Tab always moves to the next cell.",
   "settings_dateformat": "Date format",

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -7,6 +7,8 @@ export interface AppConfig {
   showEmptyLine: boolean
   suggestTime: boolean
   showFuture: boolean
+  /** Minutes a new entry's end pre-fills past its start (0 disables; default 5). */
+  minEntryDuration: number
   logoutUrl: string
   legacyUrl: string
   /** CSRF token for the 'authenticate' intention — stateless, so it stays valid

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -35,7 +35,7 @@ export function ChipSelect(props: {
   initial: FormValues[string]
   options: OptionLookup
   multiple: boolean
-  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
+  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay' | 'next') => void
   onCancel: () => void
 }) {
   const initialValues = (): string[] => {
@@ -62,6 +62,9 @@ export function ChipSelect(props: {
   let rootEl: HTMLDivElement | undefined
   let inputEl: HTMLInputElement | undefined
   let done = false
+  // True when an Enter keystroke (not a click) drove the pending selection, so the
+  // resulting onSelect commits as 'next' (guides to the next required field).
+  let committedByEnter = false
 
   const allItems = createMemo<Item[]>(() => fieldSelectOptions(props.field, props.options).map((option) => ({ value: String(option.value), label: option.label })))
   const labelOf = (value: string): string => allItems().find((item) => item.value === value)?.label ?? value
@@ -87,7 +90,7 @@ export function ChipSelect(props: {
     return props.field.stringValue === true ? first : Number(first)
   }
 
-  const finish = (direction?: 'down' | 'left' | 'right' | 'stay'): void => {
+  const finish = (direction?: 'down' | 'left' | 'right' | 'stay' | 'next'): void => {
     if (done) {
       return
     }
@@ -124,10 +127,16 @@ export function ChipSelect(props: {
       event.preventDefault()
       event.stopPropagation()
       cancel()
-    } else if (event.key === 'Enter' && !open()) {
-      event.preventDefault()
-      event.stopPropagation()
-      finish(getEnterBehavior())
+    } else if (event.key === 'Enter') {
+      if (open()) {
+        // The list is open: let zag select the highlighted item; mark that an Enter
+        // (not a click) drove the resulting onSelect so it commits as 'next'.
+        committedByEnter = true
+      } else {
+        event.preventDefault()
+        event.stopPropagation()
+        finish('next')
+      }
     } else if (event.key === 'Backspace' && props.multiple && inputValue() === '' && selected().length > 0) {
       event.preventDefault()
       event.stopPropagation() // don't let the grid/global shortcuts also see the Backspace
@@ -215,10 +224,16 @@ export function ChipSelect(props: {
         }}
         onSelect={(details) => {
           if (props.multiple) {
+            committedByEnter = false
+
             return
           }
           setSelected(details.itemValue === CLEAR_VALUE ? [] : [details.itemValue])
-          finish(getEnterBehavior()) // single pick commits + moves per the user's Enter pref
+          // Enter-driven pick guides to the next required field; a click pick follows
+          // the user's Enter (stay/down) preference.
+          const direction = committedByEnter ? 'next' : getEnterBehavior()
+          committedByEnter = false
+          finish(direction)
         }}
         inputValue={inputValue()}
         onInputValueChange={(details) => setInputValue(details.inputValue)}

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -115,6 +115,12 @@ export function ChipSelect(props: {
   })
 
   const onInputKeyDown = (event: KeyboardEvent): void => {
+    // Any non-Enter key starts a fresh interaction, so a prior open-Enter that didn't
+    // select (empty list / no highlight) can't leak its "guide" intent into a later
+    // click pick — typing or arrowing first clears it.
+    if (event.key !== 'Enter') {
+      committedByEnter = false
+    }
     // The listbox owns Arrow/Enter while open; the cell owns Tab (always), Enter when
     // the list is closed, and Backspace to drop the last chip when the filter is empty.
     // Escape with the list open is handled in onOpenChange (zag consumes it first);

--- a/frontend/src/lib/dateFormat.test.ts
+++ b/frontend/src/lib/dateFormat.test.ts
@@ -7,7 +7,7 @@ const ISO = '2026-06-19'
 
 const appConfigStub: AppConfig = {
   locale: 'de', userId: 1, userName: 'x', appTitle: '', roles: [],
-  showEmptyLine: false, suggestTime: false, showFuture: false, logoutUrl: '', legacyUrl: '',
+  showEmptyLine: false, suggestTime: false, showFuture: false, minEntryDuration: 5, logoutUrl: '', legacyUrl: '',
   csrfToken: '', loginPath: '/login',
 }
 

--- a/frontend/src/lib/gridNavigation.ts
+++ b/frontend/src/lib/gridNavigation.ts
@@ -33,6 +33,9 @@ export interface GridMoveHandle {
   move: (direction: 'up' | 'down' | 'left' | 'right') => void
   /** Re-focus the current active cell (e.g. after an editor is dismissed). */
   focusActive: () => void
+  /** Make a specific cell (by data-row-id + data-col-key) the active one and focus
+   *  it — for jumping straight to a target cell (e.g. the next required field). */
+  focusCell: (rowId: number, colKey: string) => void
 }
 
 export interface GridNavOptions {
@@ -488,6 +491,12 @@ function setupGridNav(table: HTMLTableElement, options: GridNavOptions): GridCon
       const cell = cellAt(active[0], active[1])
       if (cell) {
         setActive(cell)
+      }
+    },
+    focusCell: (rowId, colKey) => {
+      const cell = table.querySelector<HTMLElement>(`td[data-row-id="${rowId}"][data-col-key="${colKey}"]`)
+      if (cell !== null) {
+        setActive(cell as Cell)
       }
     },
   })

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -69,7 +69,7 @@ export function InlineEditor(props: {
   initial: FormValues[string]
   seed?: string
   options: OptionLookup
-  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay') => void
+  onCommit: (value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay' | 'next') => void
   onCancel: () => void
 }) {
   const isCheckbox = (): boolean => props.field.type === 'checkbox'
@@ -94,7 +94,7 @@ export function InlineEditor(props: {
     return raw
   }
 
-  const finish = (direction?: 'down' | 'left' | 'right' | 'stay') => {
+  const finish = (direction?: 'down' | 'left' | 'right' | 'stay' | 'next') => {
     if (done) {
       return
     }
@@ -113,9 +113,10 @@ export function InlineEditor(props: {
     if (event.key === 'Enter') {
       event.preventDefault()
       event.stopPropagation()
-      // Enter's focus move is a user preference (default: stay in the cell);
-      // Tab below always advances, so the user keeps an explicit move key.
-      finish(getEnterBehavior())
+      // 'next' = Enter: the controller guides to the next required field on an
+      // incomplete row, else falls back to the user's stay/down preference. Tab
+      // below always advances, so the user keeps an explicit move key.
+      finish('next')
     } else if (event.key === 'Tab') {
       event.preventDefault()
       event.stopPropagation()
@@ -341,7 +342,42 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     }
   }
 
-  function commitCell(value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay'): void {
+  // Enter on an INCOMPLETE row jumps to the next field that still needs input (a
+  // required/invalid cell) and opens its editor — a guided fill flow. Cyclic in the
+  // row's column order, so it also reaches a required cell to the LEFT of the one
+  // just committed (e.g. Add opens on customer, then loops back for date/start/end).
+  // Returns false when nothing required remains — Enter then follows the stay/down
+  // preference. A no-op when the host provides no invalidFields.
+  function moveToNextRequired(rowId: number, fromColKey: string): boolean {
+    if (config.invalidFields === undefined || tableEl === undefined) {
+      return false
+    }
+    const draft = drafts[rowId]
+    const row = rowById(rowId)
+    if (draft === undefined || row === undefined) {
+      return false
+    }
+    const invalid = new Set(config.invalidFields(draft, row))
+    if (invalid.size === 0) {
+      return false
+    }
+    const colKeys = Array.from(tableEl.querySelectorAll<HTMLElement>(`td[data-row-id="${rowId}"][data-col-key]`))
+      .map((td) => td.getAttribute('data-col-key'))
+    const from = colKeys.indexOf(fromColKey)
+    for (let step = 1; step <= colKeys.length; step++) {
+      const colKey = colKeys[(from + step) % colKeys.length]
+      if (colKey != null && invalid.has(colKey) && config.isInlineEditable(colKey)) {
+        moveHandle?.focusCell(rowId, colKey)
+        beginEdit(rowId, colKey)
+
+        return true
+      }
+    }
+
+    return false
+  }
+
+  function commitCell(value: FormValues[string], direction?: 'down' | 'left' | 'right' | 'stay' | 'next'): void {
     const cell = editCell()
     if (cell === null) {
       return
@@ -356,14 +392,40 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     // then sees no draft and skips the (pointless) auto-save.
     discardIfClean(cell.rowId)
     refreshHints(cell.rowId)
-    // All focus moves go through the grid's setActive (the single roving-tabindex
-    // writer); landing on a different row triggers that row's save via focusin.
-    if (direction === 'stay') {
-      moveHandle?.focusActive()
-    } else if (direction === 'left' || direction === 'right') {
-      moveAndEdit(direction)
-    } else if (direction) {
-      moveHandle?.move(direction)
+
+    // The post-commit move (all through the grid's setActive — the single
+    // roving-tabindex writer). Enter (stay/down) on an incomplete row is guided to
+    // the next required field; otherwise it follows the stay/down preference. Tab
+    // walks to the next editable cell.
+    const { rowId, colKey } = cell
+    const advance = (): void => {
+      if (direction === 'left' || direction === 'right') {
+        moveAndEdit(direction)
+
+        return
+      }
+      // Enter ('next'): guide to the next required field on an incomplete row, else
+      // fall back to the user's Enter (stay/down) preference. Click-select and the
+      // plain stay/down directions keep their behaviour (no guide).
+      const enter = direction === 'next'
+      if (enter && moveToNextRequired(rowId, colKey)) {
+        return
+      }
+      const effective = enter ? getEnterBehavior() : direction
+      if (effective === 'down') {
+        moveHandle?.move('down')
+      } else if (effective === 'stay') {
+        moveHandle?.focusActive()
+      }
+    }
+    // A select/multiselect editor lives in a body-portal; Ark restores focus to its
+    // (now-unmounting) trigger as it closes, which would steal focus to <body> and
+    // lose the cell. Run the move AFTER that teardown so focus lands where we put it.
+    const fromType = config.fieldFor(colKey)?.type
+    if (fromType === 'select' || fromType === 'multiselect') {
+      requestAnimationFrame(advance)
+    } else {
+      advance()
     }
   }
 

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -423,7 +423,13 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     // lose the cell. Run the move AFTER that teardown so focus lands where we put it.
     const fromType = config.fieldFor(colKey)?.type
     if (fromType === 'select' || fromType === 'multiselect') {
-      requestAnimationFrame(advance)
+      // Skip if the grid was torn down (route change) before the frame fires, so we
+      // never drive focus into a stale/unmounted grid (moveHandle is nulled on dispose).
+      requestAnimationFrame(() => {
+        if (moveHandle !== null) {
+          advance()
+        }
+      })
     } else {
       advance()
     }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -79,6 +79,7 @@ export default function Settings() {
         show_empty_line: data.get('show_empty_line') ? 1 : 0,
         suggest_time: data.get('suggest_time') ? 1 : 0,
         show_future: data.get('show_future') ? 1 : 0,
+        min_entry_duration: Number(data.get('min_entry_duration') ?? config.minEntryDuration),
       })
       const result = JSON.parse(body) as SaveResponse
       if (!result.success) {
@@ -126,6 +127,13 @@ export default function Settings() {
             </label>
           )}
         </For>
+
+        {/* Server setting: a new entry's end pre-fills to start + this many minutes. */}
+        <label class="field">
+          <span>{m.settings_min_entry_duration()}</span>
+          <input type="number" name="min_entry_duration" min="0" max="1440" step="5" value={config.minEntryDuration} />
+          <small class="field-hint">{m.settings_min_entry_duration_hint()}</small>
+        </label>
 
         {/* Client-side UI preference — applies instantly, not part of the Save. */}
         <label class="field">

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -654,4 +654,26 @@ describe('Tracking (Worklog grid)', () => {
 
     unmount()
   })
+
+  it('Add pre-fills the end time to start + the configured minimum (suggest-time on)', async () => {
+    window.APP_CONFIG!.suggestTime = true
+    window.APP_CONFIG!.minEntryDuration = 15
+    try {
+      const now = new Date()
+      const today = `${String(now.getDate()).padStart(2, '0')}/${String(now.getMonth() + 1).padStart(2, '0')}/${now.getFullYear()}`
+      // Latest entry from today ends 10:30 → start inherits 10:30 → end = 10:30 + 15 = 10:45.
+      mockApiWith([{ entry: { ...DEFAULT_ENTRY, date: today, end: '10:30', class: 0 } }])
+      const { getByRole, container, unmount } = renderTracking()
+      await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+      fireEvent.click(getByRole('button', { name: 'Add entry' }))
+      await waitFor(() => expect(container.querySelector('tbody td[data-col-key="start"]')?.textContent).toBe('10:30'))
+      expect(container.querySelector('tbody td[data-col-key="end"]')?.textContent).toBe('10:45')
+
+      unmount()
+    } finally {
+      window.APP_CONFIG!.suggestTime = false
+      window.APP_CONFIG!.minEntryDuration = 5
+    }
+  })
 })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -76,6 +76,19 @@ function nowHi(): string {
   return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
 }
 
+// Add minutes to an H:i time, capped at 23:59 (a single entry can't cross midnight).
+function addMinutes(hi: string, mins: number): string {
+  const [hh, mm] = hi.split(':')
+  const h = Number(hh)
+  const m = Number(mm)
+  if (Number.isNaN(h) || Number.isNaN(m)) {
+    return ''
+  }
+  const total = Math.min(h * 60 + m + mins, 23 * 60 + 59)
+
+  return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`
+}
+
 // The editable fields drive the in-cell editor; duration is server-derived.
 const FIELDS: FieldDef[] = [
   { name: 'date', label: () => m.tracking_col_date(), type: 'date', required: true },
@@ -283,20 +296,26 @@ export default function Tracking() {
 
       return field !== undefined && INLINE_TYPES.has(field.type)
     },
-    seedDraft: (entry) => ({
-      id: num(entry.id),
-      date: toIsoDate(str(entry.date)),
-      // An empty start (a fresh row) prefills with the suggested start so the
-      // editor opens on a sensible value — but only when the user's suggest-time
-      // preference is on (mirrors addEntry; respects the opt-out).
-      start: str(entry.start) || (appConfig().suggestTime ? suggestedStart() : ''),
-      end: str(entry.end),
-      ticket: str(entry.ticket),
-      customer: num(entry.customer),
-      project: num(entry.project),
-      activity: num(entry.activity),
-      description: str(entry.description),
-    }),
+    seedDraft: (entry) => {
+      // A fresh row prefills start with the suggested start, then end with start +
+      // the per-user minimum (minEntryDuration minutes) — so a new entry opens with a
+      // sensible default span. Both respect the suggest-time opt-out; a 0 minimum (or
+      // an already-set value) leaves end blank.
+      const start = str(entry.start) || (appConfig().suggestTime ? suggestedStart() : '')
+      const minMinutes = appConfig().minEntryDuration
+
+      return {
+        id: num(entry.id),
+        date: toIsoDate(str(entry.date)),
+        start,
+        end: str(entry.end) || (start !== '' && appConfig().suggestTime && minMinutes > 0 ? addMinutes(start, minMinutes) : ''),
+        ticket: str(entry.ticket),
+        customer: num(entry.customer),
+        project: num(entry.project),
+        activity: num(entry.activity),
+        description: str(entry.description),
+      }
+    },
     saveRow: async (draft, entry) => {
       const start = parseTime(str(draft.start))
       const end = parseTime(str(draft.end))

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -67,6 +67,7 @@ window.APP_CONFIG = {
   showEmptyLine: false,
   suggestTime: false,
   showFuture: false,
+  minEntryDuration: 5,
   logoutUrl: '/logout',
   legacyUrl: '/',
   csrfToken: 'test-csrf-token',

--- a/migrations/Version20260622_AddMinEntryDuration.php
+++ b/migrations/Version20260622_AddMinEntryDuration.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add the per-user min_entry_duration setting (minutes).
+ *
+ * A new worklog entry's end pre-fills to start + this many minutes (default 5).
+ * Fresh installs created from sql/full.sql already have the column, so this
+ * migration is conditional for long-lived databases.
+ */
+final class Version20260622_AddMinEntryDuration extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add users.min_entry_duration (per-user minimum entry duration in minutes)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('users') && !$schema->getTable('users')->hasColumn('min_entry_duration')) {
+            $this->addSql('ALTER TABLE users ADD min_entry_duration INT NOT NULL DEFAULT 5');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('users') && $schema->getTable('users')->hasColumn('min_entry_duration')) {
+            $this->addSql('ALTER TABLE users DROP min_entry_duration');
+        }
+    }
+}

--- a/sql/000_base.sql
+++ b/sql/000_base.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `show_empty_line` tinyint(1) NOT NULL DEFAULT '0',
   `suggest_time` tinyint(1) NOT NULL DEFAULT '1',
   `show_future` tinyint(1) NOT NULL DEFAULT '1',
+  `min_entry_duration` int(11) NOT NULL DEFAULT 5,
   `locale` char(2) NOT NULL DEFAULT 'de',
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`)

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -40,6 +40,7 @@ CREATE TABLE `users` (
   `show_empty_line` tinyint(1) NOT NULL DEFAULT '0',
   `suggest_time` tinyint(1) NOT NULL DEFAULT '1',
   `show_future` tinyint(1) NOT NULL DEFAULT '1',
+  `min_entry_duration` int(11) NOT NULL DEFAULT 5,
   `locale` char(2) NOT NULL DEFAULT 'de',
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`)

--- a/src/Controller/Settings/SaveSettingsAction.php
+++ b/src/Controller/Settings/SaveSettingsAction.php
@@ -51,6 +51,7 @@ final class SaveSettingsAction extends BaseController
         $user->setShowEmptyLine((bool) $request->request->get('show_empty_line'));
         $user->setSuggestTime((bool) $request->request->get('suggest_time'));
         $user->setShowFuture((bool) $request->request->get('show_future'));
+        $user->setMinEntryDuration((int) $request->request->get('min_entry_duration', 5));
 
         $normalized = $this->localizationService->normalizeLocale((string) $request->request->get('locale'));
         $user->setLocale($normalized);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -52,6 +52,10 @@ class User implements UserInterface
     #[ORM\Column(name: 'show_future', type: 'boolean', nullable: false, options: ['default' => 1])]
     protected bool $showFuture = true;
 
+    /** Minimum entry duration in minutes — a new entry's end pre-fills to start + this. */
+    #[ORM\Column(name: 'min_entry_duration', type: 'integer', nullable: false, options: ['default' => 5])]
+    protected int $minEntryDuration = 5;
+
     /**
      * @var Collection<int, Team>
      */
@@ -222,6 +226,19 @@ class User implements UserInterface
         return $this;
     }
 
+    public function getMinEntryDuration(): int
+    {
+        return $this->minEntryDuration;
+    }
+
+    public function setMinEntryDuration(int $minEntryDuration): static
+    {
+        // Clamp to a sane range; 0 disables the end pre-fill, default is 5.
+        $this->minEntryDuration = max(0, min(1440, $minEntryDuration));
+
+        return $this;
+    }
+
     /**
      * Reset teams.
      *
@@ -298,7 +315,7 @@ class User implements UserInterface
      * Returns user settings for API responses.
      * Note: Boolean settings are returned as integers (0/1) for frontend compatibility.
      *
-     * @return array{show_empty_line: int, suggest_time: int, show_future: int, user_name: string, user_id: int, type: string, locale: string, roles: array<string>}
+     * @return array{show_empty_line: int, suggest_time: int, show_future: int, min_entry_duration: int, user_name: string, user_id: int, type: string, locale: string, roles: array<string>}
      */
     public function getSettings(): array
     {
@@ -306,6 +323,7 @@ class User implements UserInterface
             'show_empty_line' => (int) $this->getShowEmptyLine(),
             'suggest_time' => (int) $this->getSuggestTime(),
             'show_future' => (int) $this->getShowFuture(),
+            'min_entry_duration' => $this->getMinEntryDuration(),
             'user_name' => $this->getUsername() ?? '',
             'user_id' => $this->getId() ?? 0,
             'type' => $this->getType()->value,

--- a/templates/ui/index.html.twig
+++ b/templates/ui/index.html.twig
@@ -26,6 +26,7 @@
                 'showEmptyLine': settings.show_empty_line == 1,
                 'suggestTime': settings.suggest_time == 1,
                 'showFuture': settings.show_future == 1,
+                'minEntryDuration': settings.min_entry_duration,
                 'logoutUrl': url('_logout'),
                 'legacyUrl': url('_start'),
                 'csrfToken': csrf_token('authenticate'),


### PR DESCRIPTION
Two worklog new-entry improvements (requested together).

## 1. Enter guides to the next required field (+ a select focus fix)

- When a row is **incomplete**, pressing **Enter** (committing a cell) jumps to the next field that still needs input and opens its editor — a fast Enter-Enter fill flow for a new entry (customer → project → activity → end; `start`/`date` are pre-filled so they're skipped). Once the row is **complete**, Enter falls back to your existing stay/down preference, so editing a finished entry isn't disrupted.
- The guide is **Enter-specific** (a new `'next'` commit direction): a **click** pick keeps its current behaviour, so mouse users and existing flows are unchanged.
- **Fix:** committing a select/multiselect editor with Enter no longer drops cell focus to `<body>`. The editor is body-portalled and Ark restores focus to its (unmounting) trigger on close; the post-commit move now runs after that teardown (rAF) so focus lands where we put it.

## 2. Pre-fill a new entry's end time to start + a configurable minimum

- A new entry's **end** now pre-fills to **start + a per-user minimum** (default **5 min**), so the row opens with a sensible span. New setting in **Settings → "Minimum entry duration"**; `0` disables it. Respects the suggest-time opt-out; caps at 23:59.
- **Backend:** `users.min_entry_duration` (int, default 5) + getSettings + SaveSettingsAction; a conditional migration for long-lived DBs (fresh installs get it from `sql/full.sql`); exposed via `APP_CONFIG.minEntryDuration`.

## Tests

- Unit: Enter guides; select-commit keeps focus; Add pre-fills end = start + minimum.
- e2e: Enter walks customer→project→activity→end on a new entry; Enter on a select editor keeps focus on a grid cell.
- Verified on a local dev stack (real LDAP); pre-commit PHP gate green (phpstan, cs-fixer, twig lint, phpunit unit + api-contract).

## Verification

`typecheck` ✓ · `lint` ✓ · `257` frontend unit ✓ · PHP unit + api-contract ✓ · `build` ✓ · e2e ✓
