### PR TITLE
fix: port the still-relevant v4 fixes missing from v5 (customer sort, allEntries doc, German 404 message)

### DIFF
--- a/assets/js/netresearch/store/Customers.js
+++ b/assets/js/netresearch/store/Customers.js
@@ -14,6 +14,10 @@ Ext.define('Netresearch.store.Customers', {
             record: 'customer'
         }
     },
+    sorters: [{
+        property: 'name',
+        direction:'ASC'
+    }],
 
     /* Update customersData */
     reloadFromServer: function(callback) {
@@ -52,5 +56,6 @@ Ext.define('Netresearch.store.Customers', {
         }
 
         this.loadRecords(newData, {"append": false});
+        this.sort();
     }
 });

--- a/public/api.yml
+++ b/public/api.yml
@@ -1236,6 +1236,10 @@ paths:
                           type: string
                           description: The duration in string format (hh:mm)
                           example: "02:40"
+                        extTicket:
+                          type: string
+                          description: String of the original jira key
+                          example: ""
                         user_id:
                           type: integer
                           example: 2

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -47,6 +47,7 @@ class CustomerRepository extends ServiceEntityRepository
             ->setParameter('userId', $userId)
             ->leftJoin('customer.teams', 'team')
             ->leftJoin('team.users', 'user')
+            ->orderBy('customer.name', 'ASC')
             ->getQuery()
             ->execute();
 

--- a/tests/Controller/CrudControllerTest.php
+++ b/tests/Controller/CrudControllerTest.php
@@ -138,7 +138,7 @@ final class CrudControllerTest extends AbstractWebTestCase
         // Try to delete again and expect 404
         $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/tracking/delete', $deleteParam);
         $this->assertStatusCode(404);
-        $this->assertJsonStructure(['message' => 'No entry for id.']);
+        $this->assertJsonStructure(['message' => 'Kein Eintrag für ID.']);
     }
 
     // -------------- Bulkentry routes ----------------------------------------

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -49,6 +49,7 @@
 "There is already an ongoing contract with a closed end date in the future." : "Es besteht bereits ein laufender Vertrag mit einem Enddatum in der Zukunft."
 "There is already an ongoing contract with a start date in the future that overlaps with the new contract." : "Es besteht bereits ein laufender Vertrag mit einem Startdatum in der Zukunft, das sich mit dem neuen Vertrag überschneidet."
 "There is more than one open-ended contract for the user." : "Für den Nutzer besteht mehr als ein unbefristeter Vertrag."
+"No entry for id." : "Kein Eintrag für ID."
 "Skip to main content": "Zum Hauptinhalt springen"
 "User status": "Benutzerstatus"
 "Logout": "Abmelden"


### PR DESCRIPTION
## What

Catch-up of fixes that landed on the **v4** branch after the v5 split (merge-base `c99c2678`, 2025-03-15) but were never carried into `main` (v5). An audit of all 19 v4-only commits found **3 genuinely-missing, still-relevant fixes**; everything else is already in v5 or obsolete (see below). Each fix is **re-implemented** (the v4 `src/Netresearch/TimeTrackerBundle/…` + ExtJS-asset paths diverged from v5's layout, so no cherry-pick applies) and committed under its **original author**.

| Commit | Original author | Fix |
|--------|-----------------|-----|
| customer sort | Stefan Berger | `CustomerRepository::getCustomersByUser` had no `orderBy` — customers came back in insertion order. Adds `->orderBy('customer.name','ASC')` (fixes the tracking + admin dropdowns, project structure, and the bootstrapped customer list), and mirrors it in the still-served legacy ExtJS `Customers` store. (v4 `b60d0f81`, TIM-126) |
| API doc | Timothy Elias | `/interpretation/allEntries` already returns `extTicket` via `Entry::toArray()`, but the OpenAPI schema omitted it. (v4 `02ce294e`, TIM-123) |
| i18n | Timothy Elias | 15+ controllers emit `"No entry for id."` on a 404, but the German catalog lacked the key, so a German UI showed the English string. Adds the translation and updates the delete-entry test (now asserts the German message under the test locale). (v4 `5fbfcacd`, TIM-123) |

## Audit result (the other 16 v4-only commits)

- **Already in v5 (3):** TIM-132 activity-required (`SaveEntryAction::resolveActivity` + `EntrySaveDto` `Assert\Positive`); TIM-136 login-before-getUserId (v5's `GroupByUserAction` uses `#[IsGranted]` + `#[CurrentUser]`, the ordering bug is structurally gone).
- **Obsolete (13):** the entire Jira-API-version feature (6 commits) never reached v5 and targets the replaced ExtJS frontend + hardcoded `/rest/api/latest/`; the build/CI/lockfile commits (5) target the dead PHP-7.4 / Symfony-3.4 stack that v5 superseded.

## Deliberately excluded — needs a product decision

v4 `326d1257` (TIM-123) added **`GET /tracking/entry/{id}`**. It is genuinely absent from v5, but **nothing in v5 consumes it** (no frontend/PHP/config reference) and its response-shape contract is ambiguous (v4 hand-rolls `*_id`-suffixed keys + `Y-m-d`; v5's `Entry::toArray()` uses non-suffixed keys + `d/m/Y`). Porting it would add an unused public endpoint with an undecided contract, so it is left out pending a call on whether API parity is wanted and in which shape.

## Verification

- Full PHP suite green: **1990 tests, 5954 assertions** (`make test`). The non-zero exit is a pre-existing PHPUnit runner warning unrelated to this change (`OptimizedEntryRepositoryCacheTest` listed in two testsuites).
- PHPStan: **no errors**; PHP-CS-Fixer: **0/350** to fix.
- The i18n change ripples to every 404 emitter; verified by running the full `controller`, `api-contract`, and `api-functional` suites.
