### PR TITLE
feat(tracking): port v4 GET /tracking/entry/{id} (TIM-123) to v5

### DIFF
--- a/public/api.yml
+++ b/public/api.yml
@@ -1487,6 +1487,97 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
 
+  /tracking/entry/{id}:
+    get:
+      summary: Get a single entry by id
+      tags:
+        - Entries
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: The id of the entry
+          schema:
+            type: integer
+            example: 1
+      responses:
+        '401':
+          description: Error Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '403':
+          description: Forbidden — the entry belongs to another user and the requester is not an admin/PL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+              example:
+                message: You are not allowed to view this entry.
+        '404':
+          description: No entry for id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoEntryForId'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      date:
+                        type: string
+                        description: Day in d/m/Y format
+                        example: "15/01/2024"
+                      start:
+                        type: string
+                        example: "08:00"
+                      end:
+                        type: string
+                        example: "08:50"
+                      user:
+                        type: integer
+                        nullable: true
+                      customer:
+                        type: integer
+                        nullable: true
+                      project:
+                        type: integer
+                        nullable: true
+                      activity:
+                        type: integer
+                        nullable: true
+                      description:
+                        type: string
+                      ticket:
+                        type: string
+                      duration:
+                        type: string
+                        description: The duration in hh:mm format
+                        example: "00:50"
+                      durationMinutes:
+                        type: integer
+                        example: 50
+                      class:
+                        type: integer
+                        description: Day-rendering class (daybreak/pause/overlap/plain)
+                      worklog:
+                        type: integer
+                        nullable: true
+                        description: ID of the Jira work log entry
+                      extTicket:
+                        type: string
+                        nullable: true
+                        description: Original external Jira key of mirrored entries
+
   /preset/delete:
     post:
       summary: Delete a preset

--- a/src/Controller/Tracking/GetEntryAction.php
+++ b/src/Controller/Tracking/GetEntryAction.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Tracking;
+
+use App\Entity\Entry;
+use App\Entity\User;
+use App\Model\JsonResponse;
+use App\Model\Response;
+use App\Response\Error;
+use App\Util\RequestEntityHelper;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+final class GetEntryAction extends BaseTrackingController
+{
+    #[Route(path: '/tracking/entry/{id}', name: 'timetracking_get_attr', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(
+        int $id,
+        #[CurrentUser]
+        ?User $currentUser = null,
+    ): Response|JsonResponse|Error {
+        $entry = RequestEntityHelper::findById($this->managerRegistry, Entry::class, (string) $id);
+
+        if (!$entry instanceof Entry) {
+            return new Error(
+                $this->translate('No entry for id.'),
+                \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
+            );
+        }
+
+        // A normal developer may only view their own entries; admins and project
+        // leads (ROLE_ADMIN — PL carries it for v4 compatibility) may view any.
+        if ($entry->getUserId() !== $currentUser?->getId()
+            && !$this->isGranted('ROLE_ADMIN')
+            && (!$currentUser instanceof User || !$currentUser->getType()->isPl())
+        ) {
+            return new Error(
+                $this->translate('You are not allowed to view this entry.'),
+                \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN,
+            );
+        }
+
+        return new JsonResponse(['data' => $entry->toArray()]);
+    }
+}

--- a/tests/Controller/CrudControllerTest.php
+++ b/tests/Controller/CrudControllerTest.php
@@ -22,6 +22,47 @@ use function json_encode;
  */
 final class CrudControllerTest extends AbstractWebTestCase
 {
+    public function testGetAction(): void
+    {
+        // Default login is the unittest admin user (id 1), who owns entry 1.
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/tracking/entry/1');
+
+        $this->assertStatusCode(200);
+        // Native v5 Entry::toArray() shape: no *_id-suffixed keys, date as d/m/Y.
+        $this->assertJsonStructure([
+            'data' => [
+                'id' => 1,
+                'date' => '30/01/1000',
+                'start' => '08:00',
+                'end' => '08:50',
+                'user' => 1,
+                'customer' => 1,
+                'project' => 1,
+                'activity' => 1,
+                'ticket' => 'testGetLastEntriesAction',
+                'durationMinutes' => 50,
+            ],
+        ]);
+    }
+
+    public function testGetActionNoEntry(): void
+    {
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/tracking/entry/9999');
+
+        $this->assertStatusCode(404);
+        $this->assertJsonStructure(['message' => 'Kein Eintrag für ID.']);
+    }
+
+    public function testGetActionNotAllowed(): void
+    {
+        // 'developer' maps to user 2, a DEV who does not own entry 1.
+        $this->logInSession('developer');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/tracking/entry/1');
+
+        $this->assertStatusCode(403);
+        $this->assertJsonStructure(['message' => 'Sie sind nicht berechtigt, diesen Eintrag anzuzeigen.']);
+    }
+
     public function testSaveAction(): void
     {
         $parameter = [

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -50,6 +50,7 @@
 "There is already an ongoing contract with a start date in the future that overlaps with the new contract." : "Es besteht bereits ein laufender Vertrag mit einem Startdatum in der Zukunft, das sich mit dem neuen Vertrag überschneidet."
 "There is more than one open-ended contract for the user." : "Für den Nutzer besteht mehr als ein unbefristeter Vertrag."
 "No entry for id." : "Kein Eintrag für ID."
+"You are not allowed to view this entry." : "Sie sind nicht berechtigt, diesen Eintrag anzuzeigen."
 "Skip to main content": "Zum Hauptinhalt springen"
 "User status": "Benutzerstatus"
 "Logout": "Abmelden"


### PR DESCRIPTION
## What

The **last outstanding v4→v5 port**: re-implements v4's `GET /tracking/entry/{id}` single-entry read endpoint (TIM-123, v4 commit `326d1257`) as a v5 one-action-per-class controller. Attribution preserved (commit authored by **Timothy Elias**).

## Behaviour
- `GET /tracking/entry/{id}` (`id` constrained to `\d+`), `IS_AUTHENTICATED_FULLY`.
- **404** `"No entry for id."` when the entry doesn't exist (same `RequestEntityHelper::findById` + `Error` flow as `DeleteEntryAction`).
- **403** `"You are not allowed to view this entry."` when a plain developer requests another user's entry — admins and project leads may view any. The gate mirrors `GetAllEntriesAction` (`!isGranted('ROLE_ADMIN') && !user.type.isPl()`), plus an owner short-circuit.
- **200** returns the **native v5 `Entry::toArray()` shape** wrapped in `{ "data": … }` (the old v4 `*_id`-suffixed / `Y-m-d` hand-rolling is dropped — v5 is the source of truth).

## Why v5-native shape
v4 hand-rolled a bespoke response; v5 standardises on `Entry::toArray()`. Since nothing in v5 consumed the old contract, the clean choice is the native shape, documented accurately in `public/api.yml`.

## Verification
- `controller` suite **191 tests**, `api-contract` **11**, `api-functional` **55** — all green; PHPStan **no errors**; PHP-CS-Fixer **clean**.
- New tests: own-entry → 200 (asserts `toArray()` keys); missing id → 404 (German `Kein Eintrag für ID.` under the test locale); a DEV viewing another user's entry → 403.

With this, every functional v4 change is now in v5; the only v4 commits left out are the deliberately-obsolete PHP-7.4 build/lockfile + replaced-ExtJS ones.
