### PR TITLE
test(frontend): shared renderWithProviders helper + test:watch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "i18n:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide",
     "lint": "eslint .",
     "typecheck": "bun run i18n:compile && tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@ark-ui/solid": "^5.37.1",

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -1,10 +1,9 @@
-import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
+import { cleanup, fireEvent, screen, waitFor, within } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import { ApiError } from '../api/client'
+import { renderWithProviders } from '../test/renderWithProviders'
 import Admin from './Admin'
 
 const getJson = vi.fn()
@@ -51,17 +50,9 @@ function mockEndpoints() {
 }
 
 function renderAdmin(path = '/admin') {
-  const history = createMemoryHistory()
-  history.set({ value: path })
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-
-  return render(() => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter history={history}>
-        <Route path="/admin/:entity?" component={Admin} />
-      </MemoryRouter>
-    </QueryClientProvider>
-  ))
+  return renderWithProviders(undefined, {
+    route: { initialPath: path, path: '/admin/:entity?', component: Admin },
+  })
 }
 
 // Renders the customer grid (customer 1 has team 2) with the given team

--- a/frontend/src/pages/Auswertung.test.tsx
+++ b/frontend/src/pages/Auswertung.test.tsx
@@ -1,9 +1,8 @@
-import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { fireEvent, render, waitFor } from '@solidjs/testing-library'
+import { fireEvent, waitFor } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
+import { renderWithProviders } from '../test/renderWithProviders'
 import Auswertung from './Auswertung'
 
 const getJson = vi.fn()
@@ -36,17 +35,9 @@ function mockEndpoints() {
 }
 
 function renderPage() {
-  const history = createMemoryHistory()
-  history.set({ value: '/auswertung' })
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-
-  return render(() => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter history={history}>
-        <Route path="/auswertung" component={Auswertung} />
-      </MemoryRouter>
-    </QueryClientProvider>
-  ))
+  return renderWithProviders(undefined, {
+    route: { initialPath: '/auswertung', component: Auswertung },
+  })
 }
 
 afterEach(() => getJson.mockReset())

--- a/frontend/src/pages/Month.test.tsx
+++ b/frontend/src/pages/Month.test.tsx
@@ -1,10 +1,9 @@
-import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { fireEvent, render, waitFor } from '@solidjs/testing-library'
+import { fireEvent, waitFor } from '@solidjs/testing-library'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import type { HolidayRecord, WorktimeRecord } from '../api/queries'
+import { renderWithProviders } from '../test/renderWithProviders'
 import Month, { resolveDayTokens } from './Month'
 
 // One booking in the past, one in the future (Fri 2026-06-19) relative to the
@@ -25,17 +24,9 @@ vi.mock('../api/client', () => ({
 }))
 
 function renderMonth() {
-  const history = createMemoryHistory()
-  history.set({ value: '/month?year=2026&month=6' })
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-
-  return render(() => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter history={history}>
-        <Route path="/month" component={Month} />
-      </MemoryRouter>
-    </QueryClientProvider>
-  ))
+  return renderWithProviders(undefined, {
+    route: { initialPath: '/month?year=2026&month=6', path: '/month', component: Month },
+  })
 }
 
 describe('Month page', () => {

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -1,8 +1,8 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
+import { cleanup, fireEvent, screen, waitFor, within } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
+import { renderWithProviders } from '../test/renderWithProviders'
 import Tracking from './Tracking'
 
 const getJson = vi.fn()
@@ -69,13 +69,7 @@ function mockApi(): void {
 }
 
 function renderTracking() {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-
-  return render(() => (
-    <QueryClientProvider client={queryClient}>
-      <Tracking />
-    </QueryClientProvider>
-  ))
+  return renderWithProviders(() => <Tracking />)
 }
 
 afterEach(() => {

--- a/frontend/src/pages/tabs.test.tsx
+++ b/frontend/src/pages/tabs.test.tsx
@@ -1,9 +1,9 @@
-import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { fireEvent, render, waitFor } from '@solidjs/testing-library'
+import type { Component } from 'solid-js'
+import { fireEvent, waitFor } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
+import { renderWithProviders } from '../test/renderWithProviders'
 import Billing from './Billing'
 import { BulkEntryForm } from '../components/BulkEntryForm'
 import Help from './Help'
@@ -24,17 +24,9 @@ vi.mock('../api/client', () => ({
 }))
 
 function renderPage(path: string, component: () => unknown) {
-  const history = createMemoryHistory()
-  history.set({ value: path })
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-
-  return render(() => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter history={history}>
-        <Route path={path} component={component as never} />
-      </MemoryRouter>
-    </QueryClientProvider>
-  ))
+  return renderWithProviders(undefined, {
+    route: { initialPath: path, component: component as Component },
+  })
 }
 
 afterEach(() => {

--- a/frontend/src/test/renderWithProviders.tsx
+++ b/frontend/src/test/renderWithProviders.tsx
@@ -59,7 +59,7 @@ function renderRoute(route: RouteOptions): JSX.Element {
 
   return (
     <MemoryRouter history={history}>
-      <Route path={route.path ?? route.initialPath} component={route.component} />
+      <Route path={route.path ?? route.initialPath.split('?')[0]} component={route.component} />
     </MemoryRouter>
   )
 }

--- a/frontend/src/test/renderWithProviders.tsx
+++ b/frontend/src/test/renderWithProviders.tsx
@@ -1,0 +1,65 @@
+import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
+import { render } from '@solidjs/testing-library'
+import type { Component, JSX } from 'solid-js'
+
+// A QueryClient tuned for tests: retries off so a rejected fetch surfaces at once
+// (no exponential backoff stalling waitFor). Mirrors the per-file config the page
+// tests used before this helper existed, so behaviour is unchanged.
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+interface RouteOptions {
+  // The path the in-memory history starts on, e.g. '/admin/users' — this is what
+  // the component sees as the active URL (params, query string, …).
+  initialPath: string
+  // The Route's path pattern. Defaults to initialPath when the route is a plain
+  // page; pass a pattern (e.g. '/admin/:entity?') when it differs from the URL.
+  path?: string
+  // The page component mounted at `path`.
+  component: Component
+}
+
+interface RenderWithProvidersOptions {
+  // Reuse a specific client (e.g. to pre-seed the cache via setQueryData before
+  // rendering). Omitted → a fresh createTestQueryClient() is used and returned.
+  queryClient?: QueryClient
+  // Mount the UI under a MemoryRouter + Route. Omitted → no router (the `ui`
+  // accessor is rendered directly inside the QueryClientProvider).
+  route?: RouteOptions
+}
+
+type RenderResult = ReturnType<typeof render>
+
+// Wrap a page render in the providers its tests need: a QueryClientProvider
+// always, and a MemoryRouter + Route only when `route` is given. Pass `ui` for a
+// routerless page; pass `route` (and omit `ui`) for a routed one — the Route's
+// component is what gets mounted. Returns the @solidjs/testing-library result
+// plus the queryClient so a test can seed or inspect the cache.
+export function renderWithProviders(
+  ui: (() => JSX.Element) | undefined,
+  options: RenderWithProvidersOptions = {},
+): RenderResult & { queryClient: QueryClient } {
+  const queryClient = options.queryClient ?? createTestQueryClient()
+  const { route } = options
+
+  const result = render(() => (
+    <QueryClientProvider client={queryClient}>
+      {route !== undefined ? renderRoute(route) : ui?.()}
+    </QueryClientProvider>
+  ))
+
+  return { ...result, queryClient }
+}
+
+function renderRoute(route: RouteOptions): JSX.Element {
+  const history = createMemoryHistory()
+  history.set({ value: route.initialPath })
+
+  return (
+    <MemoryRouter history={history}>
+      <Route path={route.path ?? route.initialPath} component={route.component} />
+    </MemoryRouter>
+  )
+}


### PR DESCRIPTION
## What

Two testing-review follow-ups, both frontend, both locally verified:

1. **Dedup the page-test render harness** (framework-fit / duplication finding). The 5 SolidJS page tests (`Admin`, `Auswertung`, `Month`, `Tracking`, `tabs`) each hand-rolled the same `QueryClient` (+ `MemoryRouter`/`Route`) wrapper. Extracted one helper `src/test/renderWithProviders.tsx`:
   - `createTestQueryClient()` — the exact `{ queries: { retry: false } }` config all 5 used.
   - `renderWithProviders(ui, options?)` — `QueryClientProvider` always; an optional `MemoryRouter`+`Route` (via `options.route`); returns the testing-library result **plus the `queryClient`** so a test can seed/inspect the cache.

   Behaviour-preserving (**−65/+24** across the 5 files, **266 tests unchanged**). `Settings.test.tsx` renders bare and was correctly left out.

2. **Add a `test:watch` script** — the inner loop only had `vitest run` (no watch); the review flagged the missing fast feedback loop.

## Verification
`bun run typecheck`, `bun run lint`, `bun run test` (**266 passed**), `bun run build` — all green. No behaviour change (pure dedup + a script).
