### PR TITLE
Fix the worklog grid e2e flake + #408 session-expiry data loss at their source

### DIFF
--- a/e2e/date-format.spec.ts
+++ b/e2e/date-format.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { login } from './helpers/auth';
+import { loginIsolated } from './helpers/auth';
 import { goToWorklogPage } from './helpers/navigation';
-import { createWorklogEntry, rowByStamp } from './helpers/worklog';
+import { cleanupWorklogEntries, createWorklogEntry, rowByStamp } from './helpers/worklog';
 
 /**
  * The client-side date-format preference (Settings → ISO / Automatic / Custom).
@@ -10,8 +10,12 @@ import { createWorklogEntry, rowByStamp } from './helpers/worklog';
  */
 test.describe('Date-format preference', () => {
   test.beforeEach(async ({ page }) => {
-    await login(page);
+    await loginIsolated(page);
     await goToWorklogPage(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupWorklogEntries(page);
   });
 
   test('a custom pattern reformats the worklog date cells, but editing stays ISO', async ({ page }) => {

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -26,12 +26,26 @@ export async function login(
   await page.addInitScript(() => {
     window.localStorage.setItem('tt-kbd-hint-seen', '1');
   });
-  await page.goto('/login');
-  await page.waitForSelector('input[name="_username"]', { timeout: 10000 });
-  await page.locator('input[name="_username"]').fill(username);
-  await page.locator('input[name="_password"]').fill(password);
-  await page.locator('#form-submit').click();
-  await expect(page).toHaveURL('/', { timeout: 15000 });
+  // Under concurrent CI-shard load the auth round-trip (10 shards hitting one LDAP +
+  // one MariaDB) occasionally fails and re-renders the login form, leaving us on
+  // /login — the long-standing parallel-login flake. Retry the submit a couple of
+  // times so a transient failure doesn't sink the whole spec.
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await page.goto('/login');
+    await page.waitForSelector('input[name="_username"]', { timeout: 10000 });
+    await page.locator('input[name="_username"]').fill(username);
+    await page.locator('input[name="_password"]').fill(password);
+    await page.locator('#form-submit').click();
+    try {
+      await expect(page).toHaveURL('/', { timeout: 10000 });
+
+      return;
+    } catch (error) {
+      if (attempt === 3) {
+        throw error;
+      }
+    }
+  }
 }
 
 /**

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 
 /**
  * Test credentials, defaulting to the values seeded in docker/ldap/dev-users.ldif
@@ -43,6 +43,26 @@ export async function loginAs(
 ): Promise<void> {
   const user = TEST_USERS[userKey];
   await login(page, user.username, user.password);
+}
+
+/**
+ * Per-worker users for specs that create/mutate worklog data. Both exist in the
+ * e2e DB *and* in LDAP *and* can book the global "Freizeit" customer. (unittest is
+ * in LDAP but absent from the e2e DB, so it can't be used here.)
+ */
+const ISOLATION_USERS = ['developer', 'myself'] as const;
+
+/**
+ * Log in as a user chosen by the running worker's slot, so specs that create
+ * worklog entries never share a backend account with a *concurrently* running
+ * spec — and therefore never see each other's rows. `parallelIndex` is the worker
+ * slot [0..workers-1]; two tests with the same slot never run at the same time, so
+ * concurrent specs always get distinct users for up to ISOLATION_USERS.length
+ * workers. CI runs exactly 2 workers, matching the two available users.
+ */
+export async function loginIsolated(page: Page): Promise<void> {
+  const userKey = ISOLATION_USERS[test.info().parallelIndex % ISOLATION_USERS.length];
+  await loginAs(page, userKey);
 }
 
 /**

--- a/e2e/helpers/worklog.ts
+++ b/e2e/helpers/worklog.ts
@@ -7,9 +7,18 @@ import { expect, type Locator, type Page } from '@playwright/test';
  * the cell, optionally filtering, and clicking the first option.
  */
 
-/** A successful POST to the worklog save endpoint (used to await an auto-save). */
-const isSaveResponse = (r: { url(): string; request(): { method(): string } }): boolean =>
-  /\/tracking\/save$/.test(r.url()) && r.request().method() === 'POST';
+/**
+ * A SUCCESSFUL (HTTP 200) POST to the worklog save endpoint. Picking the three
+ * required relations one by one fires a partial auto-save after each, so the
+ * endpoint answers 422 (incomplete) twice before the final 200 — matching on the
+ * method alone would resolve on the first 422 and let the helper return while the
+ * real save (and its reconciling refetch) is still in flight.
+ */
+const isSaveResponse = (r: { url(): string; status(): number; request(): { method(): string } }): boolean =>
+  /\/tracking\/save$/.test(r.url()) && r.request().method() === 'POST' && r.status() === 200;
+
+/** The reconciling GET the grid issues after a save lands (invalidate → refetch). */
+const isEntriesRefetch = (r: { url(): string }): boolean => /\/getData\/days\//.test(r.url());
 
 export async function openTextEditor(page: Page, row: Locator, colKey: string): Promise<Locator> {
   await row.locator(`td[data-col-key="${colKey}"]`).focus();
@@ -81,26 +90,34 @@ export async function createWorklogEntry(page: Page): Promise<string> {
   // relations and therefore can't auto-save — so nothing saves mid-helper and the
   // .is-new row never detaches under us (the historic tracking-grid flake). Fixed
   // early times, *overriding* the suggest-time default that starts entries at "now"
-  // and marches +minDuration each one, keep every entry at 08:00–09:00: no drift
-  // toward midnight (which saturated the day into invalid spans), and "now" is always
-  // past the start so Prolong/Continue are valid.
+  // and marches +minDuration each one, give a stable, non-drifting span. The window
+  // sits at the very start of the day so the wall-clock "now" is ALWAYS at or past
+  // the start (Prolong rewrites the end to "now" and aborts when now < start) — a
+  // later fixed start (e.g. 08:00) would silently no-op Prolong for any run before
+  // that hour, the time-of-day flake the earlier 08:00–09:00 span hid.
   const start = await openTextEditor(page, row, 'start');
-  await start.fill('08:00');
+  await start.fill('00:00');
   await page.keyboard.press('Enter');
   const end = await openTextEditor(page, row, 'end');
-  await end.fill('09:00');
+  await end.fill('00:15');
   await page.keyboard.press('Enter');
   const description = await openTextEditor(page, row, 'description');
   await description.fill(stamp);
   await page.keyboard.press('Enter');
 
-  // Complete the three required relations; the last one validates the row and fires a
-  // single save carrying every field set above.
+  // Complete the three required relations; the last one validates the row and fires
+  // the save (HTTP 200) carrying every field set above. Wait for that 200 AND the
+  // reconciling GET refetch the grid issues afterwards, so the row's <tr> has been
+  // rebuilt from the authoritative server list before we hand back — a caller that
+  // immediately opens an editor then can't have the cell detached under it by a
+  // late-landing refetch (the historic boundingBox-null flake).
   const saved = page.waitForResponse(isSaveResponse);
+  const refetched = page.waitForResponse(isEntriesRefetch);
   await pickFirstOption(page, row, 'customer');
   await pickFirstOption(page, row, 'project');
   await pickFirstOption(page, row, 'activity');
   await saved;
+  await refetched;
 
   await expect(rowByStamp(page, stamp)).toBeVisible();
   return stamp;

--- a/e2e/helpers/worklog.ts
+++ b/e2e/helpers/worklog.ts
@@ -50,28 +50,38 @@ export function rowByStamp(page: Page, stamp: string): Locator {
  * Delete every e2e-stamped entry the current user can see, via the same plain
  * form-POST the app uses (session cookie, same-origin → CSRF origin check passes).
  * Call it in an afterEach so the shared db-e2e doesn't accumulate the fixed-time
- * entries these tests create — left to pile up they overlap at 08:00–09:00 and
- * confuse cell-focus + clipboard targeting (the no-teardown pollution the testing
+ * entries these tests create — left to pile up they overlap at the same fixed time
+ * and confuse cell-focus + clipboard targeting (the no-teardown pollution the testing
  * review flagged). Best-effort: a failed delete is swallowed, never failing the test.
  */
 export async function cleanupWorklogEntries(page: Page): Promise<void> {
+  // A test may have ended on another page (e.g. Settings); the cleanup reads the
+  // grid DOM, so return to the worklog first or it would silently delete nothing
+  // and leave the shared DB polluted.
+  if (!page.url().includes('/ui/tracking')) {
+    await page.goto('/ui/tracking').catch(() => undefined);
+    await page.locator('table.tracking-table').first().waitFor({ timeout: 5000 }).catch(() => undefined);
+  }
   await page
     .evaluate(async () => {
       const ids = new Set<string>();
       document.querySelectorAll('tr.tracking-row').forEach((tr) => {
         if (tr.textContent?.includes('e2e-') === true) {
           const id = tr.querySelector('[data-row-id]')?.getAttribute('data-row-id');
-          if (id != null && Number(id) > 0) ids.add(id);
+          if (id != null && Number.isInteger(Number(id)) && Number(id) > 0) ids.add(id);
         }
       });
-      for (const id of ids) {
-        await fetch('/tracking/delete', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          credentials: 'same-origin',
-          body: `id=${encodeURIComponent(id)}`,
-        }).catch(() => undefined);
-      }
+      // Independent best-effort deletes — fire them concurrently.
+      await Promise.all(
+        Array.from(ids).map((id) =>
+          fetch('/tracking/delete', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            credentials: 'same-origin',
+            body: `id=${encodeURIComponent(id)}`,
+          }).catch(() => undefined),
+        ),
+      );
     })
     .catch(() => undefined);
 }

--- a/e2e/helpers/worklog.ts
+++ b/e2e/helpers/worklog.ts
@@ -7,6 +7,10 @@ import { expect, type Locator, type Page } from '@playwright/test';
  * the cell, optionally filtering, and clicking the first option.
  */
 
+/** A successful POST to the worklog save endpoint (used to await an auto-save). */
+const isSaveResponse = (r: { url(): string; request(): { method(): string } }): boolean =>
+  /\/tracking\/save$/.test(r.url()) && r.request().method() === 'POST';
+
 export async function openTextEditor(page: Page, row: Locator, colKey: string): Promise<Locator> {
   await row.locator(`td[data-col-key="${colKey}"]`).focus();
   await page.keyboard.press('Enter');
@@ -33,6 +37,36 @@ export function rowByStamp(page: Page, stamp: string): Locator {
   return page.locator('tr.tracking-row').filter({ hasText: stamp }).first();
 }
 
+/**
+ * Delete every e2e-stamped entry the current user can see, via the same plain
+ * form-POST the app uses (session cookie, same-origin → CSRF origin check passes).
+ * Call it in an afterEach so the shared db-e2e doesn't accumulate the fixed-time
+ * entries these tests create — left to pile up they overlap at 08:00–09:00 and
+ * confuse cell-focus + clipboard targeting (the no-teardown pollution the testing
+ * review flagged). Best-effort: a failed delete is swallowed, never failing the test.
+ */
+export async function cleanupWorklogEntries(page: Page): Promise<void> {
+  await page
+    .evaluate(async () => {
+      const ids = new Set<string>();
+      document.querySelectorAll('tr.tracking-row').forEach((tr) => {
+        if (tr.textContent?.includes('e2e-') === true) {
+          const id = tr.querySelector('[data-row-id]')?.getAttribute('data-row-id');
+          if (id != null && Number(id) > 0) ids.add(id);
+        }
+      });
+      for (const id of ids) {
+        await fetch('/tracking/delete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          credentials: 'same-origin',
+          body: `id=${encodeURIComponent(id)}`,
+        }).catch(() => undefined);
+      }
+    })
+    .catch(() => undefined);
+}
+
 /** Create one entry dated today and return its unique description stamp. */
 export async function createWorklogEntry(page: Page): Promise<string> {
   const stamp = `e2e-${Date.now()}`;
@@ -40,26 +74,34 @@ export async function createWorklogEntry(page: Page): Promise<string> {
   const row = page.locator('tr.tracking-row.is-new').first();
   await expect(row).toBeVisible();
 
-  // Add opens the customer combobox; pick the first bookable customer, then its
-  // first (cascade-filtered) project, then the first activity.
-  await pickFirstOption(page, row, 'customer', true);
-  await pickFirstOption(page, row, 'project');
-  await pickFirstOption(page, row, 'activity');
+  // Add opens the customer combobox; close it so we can set the plain fields first.
+  await page.keyboard.press('Escape');
 
+  // Set explicit start/end/description while the row still lacks its required
+  // relations and therefore can't auto-save — so nothing saves mid-helper and the
+  // .is-new row never detaches under us (the historic tracking-grid flake). Fixed
+  // early times, *overriding* the suggest-time default that starts entries at "now"
+  // and marches +minDuration each one, keep every entry at 08:00–09:00: no drift
+  // toward midnight (which saturated the day into invalid spans), and "now" is always
+  // past the start so Prolong/Continue are valid.
+  const start = await openTextEditor(page, row, 'start');
+  await start.fill('08:00');
+  await page.keyboard.press('Enter');
+  const end = await openTextEditor(page, row, 'end');
+  await end.fill('09:00');
+  await page.keyboard.press('Enter');
   const description = await openTextEditor(page, row, 'description');
   await description.fill(stamp);
   await page.keyboard.press('Enter');
 
-  const start = await openTextEditor(page, row, 'start');
-  await start.fill('08:00');
-  await page.keyboard.press('Enter');
-
-  const saved = page.waitForResponse((r) => /\/tracking\/save$/.test(r.url()) && r.request().method() === 'POST');
-  const end = await openTextEditor(page, row, 'end');
-  await end.fill('09:00');
-  await page.keyboard.press('Enter');
+  // Complete the three required relations; the last one validates the row and fires a
+  // single save carrying every field set above.
+  const saved = page.waitForResponse(isSaveResponse);
+  await pickFirstOption(page, row, 'customer');
+  await pickFirstOption(page, row, 'project');
+  await pickFirstOption(page, row, 'activity');
   await saved;
 
-  await expect(page.getByRole('gridcell', { name: stamp })).toBeVisible();
+  await expect(rowByStamp(page, stamp)).toBeVisible();
   return stamp;
 }

--- a/e2e/worklog-crud.spec.ts
+++ b/e2e/worklog-crud.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { login } from './helpers/auth';
+import { loginIsolated } from './helpers/auth';
 import { goToWorklogPage } from './helpers/navigation';
-import { createWorklogEntry, openTextEditor, rowByStamp } from './helpers/worklog';
+import { cleanupWorklogEntries, createWorklogEntry, openTextEditor, rowByStamp } from './helpers/worklog';
 
 /**
  * End-to-end coverage of the SolidJS Worklog CRUD journey (create / edit / save /
@@ -11,17 +11,25 @@ import { createWorklogEntry, openTextEditor, rowByStamp } from './helpers/worklo
  * default day range.
  */
 
-const isSave = (r: { url(): string; request(): { method(): string } }): boolean =>
-  /\/tracking\/save$/.test(r.url()) && r.request().method() === 'POST';
-const isDelete = (r: { url(): string; request(): { method(): string } }): boolean =>
-  /\/tracking\/delete$/.test(r.url()) && r.request().method() === 'POST';
+// Accept either a Playwright Request (from page.on('request')) or a Response (from
+// waitForResponse): a Request exposes method() directly; a Response only via request().
+type HttpLike = { url(): string; method(): string } | { url(): string; request(): { method(): string } };
+const reqMethod = (r: HttpLike): string => ('method' in r ? r.method() : r.request().method());
+const isSave = (r: HttpLike): boolean =>
+  /\/tracking\/save$/.test(r.url()) && reqMethod(r) === 'POST';
+const isDelete = (r: HttpLike): boolean =>
+  /\/tracking\/delete$/.test(r.url()) && reqMethod(r) === 'POST';
 
 const createEntry = createWorklogEntry;
 
 test.describe('Worklog CRUD', () => {
   test.beforeEach(async ({ page }) => {
-    await login(page);
+    await loginIsolated(page);
     await goToWorklogPage(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupWorklogEntries(page);
   });
 
   test('create → edit → delete journey, with a polite save announcement', async ({ page }) => {
@@ -107,7 +115,10 @@ test.describe('Worklog CRUD', () => {
     await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
 
     // The single-select editor overlays the cell — opening it must not widen the
-    // column (the no-reflow contract the native-select editor used to uphold).
+    // column (the no-reflow contract the native-select editor used to uphold). Wait
+    // for the cell to settle into edit mode before measuring, so a transient re-render
+    // during the combobox open doesn't yield a null box.
+    await expect(cell).toHaveAttribute('data-inline-editing', '');
     const during = await cell.boundingBox();
     expect(Math.abs(during!.width - before!.width)).toBeLessThanOrEqual(1);
 

--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 
-import { login } from './helpers/auth';
+import { loginIsolated } from './helpers/auth';
 import { goToWorklogPage } from './helpers/navigation';
-import { createWorklogEntry, rowByStamp } from './helpers/worklog';
+import { cleanupWorklogEntries, createWorklogEntry, rowByStamp } from './helpers/worklog';
 
 /**
  * Spreadsheet-style keyboard + clipboard editing on the SolidJS worklog grid:
@@ -12,18 +12,31 @@ import { createWorklogEntry, rowByStamp } from './helpers/worklog';
 test.describe('Worklog grid — keyboard & clipboard editing', () => {
   test.beforeEach(async ({ page, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await login(page);
+    await loginIsolated(page);
     await goToWorklogPage(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupWorklogEntries(page);
   });
 
   test('Tab walks to the next editable cell, staying in edit mode', async ({ page }) => {
     const stamp = await createWorklogEntry(page);
     const row = rowByStamp(page, stamp);
 
-    // Start typing on the start cell → it enters inline edit mode (seeded).
-    await row.locator('td[data-col-key="start"]').focus();
+    // Start typing on the start cell → it enters inline edit mode (seeded). Wait for
+    // the cell to actually hold focus before the keystroke, or under load the '9' can
+    // land before focus settles and never opens the editor.
+    const startCell = row.locator('td[data-col-key="start"]');
+    await startCell.focus();
+    await expect(startCell).toBeFocused();
     await page.keyboard.press('9');
-    await expect(page.locator('td[data-col-key="start"][data-inline-editing] input.inline-editor')).toBeVisible();
+    const startEditor = page.locator('td[data-col-key="start"][data-inline-editing] input.inline-editor');
+    await expect(startEditor).toBeVisible();
+    // The editor focuses itself on mount; wait for that before Tab, or the keystroke
+    // can land on the still-focused cell (which yields Tab to the browser) instead of
+    // the editor's own commit-and-walk handler.
+    await expect(startEditor).toBeFocused();
 
     // Tab commits and moves to the next editable cell (end), still in edit mode.
     await page.keyboard.press('Tab');

--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -99,6 +99,10 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
 
     const arrowEnter = async (): Promise<void> => {
       await expect(page.locator('.combobox-input').first()).toBeVisible();
+      // Wait for the option list to populate before navigating it — under shard load
+      // ArrowDown can fire before the (async) options arrive, highlighting nothing, so
+      // Enter then picks nothing and the guide never advances to the next field.
+      await expect(page.locator('.combobox-content .combobox-item').first()).toBeVisible({ timeout: 8000 });
       await page.keyboard.press('ArrowDown'); // highlight an option
       await page.keyboard.press('Enter'); // Enter-driven pick guides to the next required field
     };

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData } from '@tanstack/solid-query'
+import { keepPreviousData, type QueryClient } from '@tanstack/solid-query'
 
 import { getJson } from './client'
 import { dmyToIso } from '../lib/timeParse'
@@ -129,6 +129,75 @@ export interface TrackingEntry {
 
 interface TrackingEntryRow {
   entry: TrackingEntry
+}
+
+// The cache key prefix the work-log grid (and every save/delete/refresh) keys on;
+// the per-range query appends the day count. Exported so the page invalidates and
+// seeds the same key.
+export const ENTRIES_KEY = 'tracking-entries'
+
+// The /tracking/save response envelope: the persisted entry, with date as 'd/m/Y'
+// and start/end as 'H:i' (already the cache row shape), so it can seed the cache
+// directly. ticket/description/extTicket are present only when non-empty.
+export interface SavedEntryResult {
+  result: {
+    id: number
+    date: string
+    start: string
+    end: string
+    user: number
+    customer: number
+    project: number
+    activity: number
+    duration: string
+    durationMinutes: number
+    class: number
+    ticket?: string
+    description?: string
+    extTicket?: string
+  }
+}
+
+// Build a cache row from a save response. A created entry must land in entries.data
+// the instant its save returns 200 — not on a follow-up refetch — so it survives a
+// session-expiry (issue #408) or any other error on that refetch.
+function savedEntryToRow(saved: SavedEntryResult['result']): TrackingEntryRow {
+  return {
+    entry: {
+      id: saved.id,
+      date: saved.date,
+      start: saved.start,
+      end: saved.end,
+      user: saved.user,
+      customer: saved.customer,
+      project: saved.project,
+      activity: saved.activity,
+      description: saved.description ?? '',
+      ticket: saved.ticket ?? '',
+      duration: saved.duration,
+      durationMinutes: saved.durationMinutes,
+      class: saved.class,
+      worklog: null,
+      extTicket: saved.extTicket ?? null,
+    },
+  }
+}
+
+// Upsert a just-saved entry into every cached entries range (keyed by ENTRIES_KEY)
+// so the grid shows it immediately and keeps it even if the reconciling refetch
+// fails. The save response is authoritative for the saved row; neighbour rows
+// (re-classed server-side) are reconciled by the follow-up invalidate, but losing
+// that refetch must never drop the user's just-saved work.
+export function upsertSavedEntry(queryClient: QueryClient, saved: SavedEntryResult['result']): void {
+  const row = savedEntryToRow(saved)
+  queryClient.setQueriesData<TrackingEntryRow[]>({ queryKey: [ENTRIES_KEY] }, (existing) => {
+    if (existing === undefined) {
+      return existing
+    }
+    const without = existing.filter((candidate) => candidate?.entry?.id !== saved.id)
+
+    return [...without, row]
+  })
 }
 
 // A chronological sort key from the row format: date is 'd/m/Y', so reorder it

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -325,11 +325,18 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
   // and stopping at the row edge. Reads document.activeElement because the grid's
   // move handle is the single writer of focus + the roving tabindex.
   function moveAndEdit(direction: 'left' | 'right'): void {
+    // Track the roving tab stop (the single td[tabindex="0"] that setActive owns), NOT
+    // document.activeElement: committing a text editor unmounts its <input> and drops
+    // focus to <body>, so reading activeElement would see "no move" and bail at the
+    // first step. The roving cell is always current, so the walk stays reliable even
+    // while focus is momentarily on <body>; beginEdit's editor re-grabs focus on mount.
+    const rovingCell = (): HTMLElement | null =>
+      tableEl?.querySelector<HTMLElement>('td[tabindex="0"], th[tabindex="0"]') ?? null
     for (let i = 0; i < 30; i++) {
-      const before = document.activeElement
+      const before = rovingCell()
       moveHandle?.move(direction)
-      const cell = document.activeElement
-      if (!(cell instanceof HTMLElement) || cell === before) {
+      const cell = rovingCell()
+      if (cell === null || cell === before) {
         return // clamped at the row edge — no editable cell that way
       }
       const colKey = cell.getAttribute('data-col-key')

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, screen, waitFor, within } from '@solidjs/testing-library'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import { renderWithProviders } from '../test/renderWithProviders'
@@ -72,6 +72,17 @@ function renderTracking() {
   return renderWithProviders(() => <Tracking />)
 }
 
+beforeEach(() => {
+  // Freeze the clock (Date only — leave setTimeout/Interval real so waitFor still
+  // polls) to noon on the seeded test date. Several toolbar actions read the wall
+  // clock — Prolong sets the entry's end to "now" and aborts when now precedes the
+  // entry's start — so without a fixed clock the suite fails whenever it runs before
+  // the fixture's start time (e.g. an early-morning CI run). Noon keeps every seeded
+  // entry in the past.
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2024-01-15T12:00:00'))
+})
+
 afterEach(() => {
   cleanup() // unmount even after a throwing test, so a body-portalled combobox + body-inert can't leak into the next test
   // The day range now persists to localStorage — clear it so a range change in
@@ -81,6 +92,7 @@ afterEach(() => {
   postJson.mockReset()
   postForm.mockReset()
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 // Move the keyboard cursor to the Nth body row (0-based) so the active-row

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage, postForm, postJson } from '../api/client'
-import { activitiesQuery, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, type NamedOption, type SummaryScope, type TrackingEntry } from '../api/queries'
+import { activitiesQuery, ENTRIES_KEY, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, upsertSavedEntry, type NamedOption, type SavedEntryResult, type SummaryScope, type TrackingEntry } from '../api/queries'
 import { appConfig, canBulkEnter } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { num, str } from '../lib/coerce'
@@ -26,7 +26,6 @@ const DAYS_OPTIONS = [1, 3, 7, 35] as const
 const DEFAULT_DAYS = 3
 // Widen target for the range-aware empty state (the largest preset window).
 const WIDEN_DAYS = 35
-const ENTRIES_KEY = 'tracking-entries'
 
 // Server-computed EntryClass → row modifier, mirroring the ExtJS row borders.
 const CLASS_ROW: Record<number, string> = { 2: 'is-daybreak', 4: 'is-pause', 8: 'is-overlap' }
@@ -338,7 +337,7 @@ export default function Tracking() {
         throw new Error(m.tracking_invalid_time())
       }
       const isNew = num(entry.id) <= 0
-      await postJson('/tracking/save', savePayload({
+      const saved = await postJson<SavedEntryResult>('/tracking/save', savePayload({
         id: num(entry.id),
         date: str(draft.date),
         start,
@@ -350,6 +349,12 @@ export default function Tracking() {
         activity: draft.activity,
         extTicket: entry.extTicket, // preserve the mirrored-entry key (not editable inline)
       }))
+      // Land the saved entry in the cache from the 200 itself, so it's in the grid
+      // BEFORE — and independent of — the reconciling refetch below. A new row drops
+      // from newRows here; without the upsert, a refetch that errors (session expiry,
+      // issue #408) would leave the entry in neither newRows nor entries.data and the
+      // user's just-saved work would vanish.
+      upsertSavedEntry(queryClient, saved.result)
       if (isNew) {
         setNewRows((list) => list.filter((row) => num(row.id) !== num(entry.id)))
       }
@@ -610,7 +615,7 @@ export default function Tracking() {
     }
     const end = nowHi()
     try {
-      await postJson('/tracking/save', savePayload({
+      const saved = await postJson<SavedEntryResult>('/tracking/save', savePayload({
         id: num(base.id),
         date,
         start,
@@ -622,6 +627,7 @@ export default function Tracking() {
         activity: merged.activity,
         extTicket: base.extTicket,
       }))
+      upsertSavedEntry(queryClient, saved.result) // keep the prolonged row if the refetch fails
       editor.takeDraft(num(base.id)) // the draft is now persisted — clear it
       await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
       announce(m.tracking_prolonged())


### PR DESCRIPTION
## Why

The SolidJS worklog grid e2e specs (`worklog-crud`, `worklog-grid-editing`, `date-format`) were the long-standing "shard-10" flake, and `main` is currently red from it. The real cause was **not CSRF and not the stale local DB** — it was a stack of compounding issues across the test helpers, the grid frontend, and the in-place session-expiry feature.

## Root causes + fixes

**Worklog-grid flake (the original report):**
1. **`createWorklogEntry` raced the suggest-time auto-save** — a new row pre-fills start+end, so completing the three relation cells saved + detached the `.is-new` row before the helper finished. It now sets explicit fixed times *before* the relations (one save, no race), and waits for a **200** save + the **reconciling refetch** (the old predicate resolved on a partial-save `422`, and the missing refetch-wait caused a `boundingBox`-null flake).
2. **Concurrent specs shared `developer`**, so Prolong/Continue (latest-entry only) fought over whose entry was newest — `loginIsolated()` gives each worker a distinct user.
3. **No teardown** let entries accumulate — an `afterEach` now deletes them.
4. **`isSave`/`isDelete`** were Response-shaped but passed to `page.on('request')` — a deterministic `TypeError` the flake masked; they now accept either shape.
5. The fixed span moved to `00:00–00:15` so `now ≥ start` at any hour (Prolong aborts when `now < start`, so an `08:00` start silently no-opped before 8am).

**Frontend Tab-walk focus** — `moveAndEdit` read `document.activeElement` (→ `<body>` once the editor unmounts on commit); now tracks the roving `td[tabindex="0"]`.

**Session-expiry data loss (issue #408, surfaced in the same shard):** a freshly-created entry only reached `entries.data` via the save's *reconciling refetch*; when the in-place overlay clears the session, that refetch 302s and the entry was left in neither `newRows` nor `entries.data` → the grid blanked behind the overlay, losing the user's work. `upsertSavedEntry` now writes the saved row into the cache from the 200 itself (in `saveRow` + `prolongLast`), so it survives a failed refetch.

**Login robustness** — retry the login form on a transient auth failure under concurrent shard load (the parallel-login flake).

Also froze the clock in `Tracking.test.tsx` so the time-sensitive Prolong/Alt+P vitest specs don't fail before 09:00.

## Test plan

- `frontend`: typecheck + eslint clean; vitest **266 passing**.
- e2e (local, CI-exact: workers=2, retries=2): `session-expiry` + the three worklog specs → **15 passed, 0 flaky** (16s). Admin grids unaffected by the `moveAndEdit` change.
- CI here (10 shards on dedicated runners) is the arbiter.
