### PR TITLE
ci: pin the :e2e image by an immutable e2e-<sha> tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Pull or build E2E image
         run: |
           # Try to pull pre-built image, fall back to building
-          docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
+          docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
       - name: Prepare directories
         run: |
@@ -121,7 +121,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Pull E2E image
-        run: docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
+        run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
       - name: Download dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -197,7 +197,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Pull E2E image
-        run: docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
+        run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
       - name: Download dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -247,7 +247,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Pull E2E image
-        run: docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
+        run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
       - name: Download dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -313,7 +313,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Pull E2E image
-        run: docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
+        run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
       - name: Download dependencies
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Build and push E2E image
         uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
+        env:
+          GIT_SHA: ${{ github.sha }}
         with:
           source: .
           targets: app-e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,7 @@ USER app
 FROM deps AS dev
 
 ARG XDEBUG_VERSION
+ARG PCOV_VERSION
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
@@ -168,6 +169,14 @@ RUN set -ex \
 # Install Xdebug (debugging and coverage driver; enable coverage via XDEBUG_MODE=coverage)
 RUN pecl install xdebug-${XDEBUG_VERSION} \
     && docker-php-ext-enable xdebug
+
+# Install pcov as a faster coverage driver, ALONGSIDE Xdebug (does not replace it).
+# Inert by default (pcov.enabled=0) so it never collides with the e2e job's
+# Xdebug-based coverage path (public/coverage.php). Activate per-run via
+# `php -d pcov.enabled=1`.
+RUN pecl install pcov-${PCOV_VERSION} \
+    && docker-php-ext-enable pcov \
+    && echo 'pcov.enabled=0' > /usr/local/etc/php/conf.d/pcov.ini
 
 COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -176,7 +176,7 @@ RUN pecl install xdebug-${XDEBUG_VERSION} \
 # `php -d pcov.enabled=1`.
 RUN pecl install pcov-${PCOV_VERSION} \
     && docker-php-ext-enable pcov \
-    && echo 'pcov.enabled=0' > /usr/local/etc/php/conf.d/pcov.ini
+    && echo 'pcov.enabled=0' >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 
 COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,6 @@ USER app
 FROM deps AS dev
 
 ARG XDEBUG_VERSION
-ARG PCOV_VERSION
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
@@ -169,14 +168,6 @@ RUN set -ex \
 # Install Xdebug (debugging and coverage driver; enable coverage via XDEBUG_MODE=coverage)
 RUN pecl install xdebug-${XDEBUG_VERSION} \
     && docker-php-ext-enable xdebug
-
-# Install pcov as a faster coverage driver, ALONGSIDE Xdebug (does not replace it).
-# Inert by default (pcov.enabled=0) so it never collides with the e2e job's
-# Xdebug-based coverage path (public/coverage.php). Activate per-run via
-# `php -d pcov.enabled=1`.
-RUN pecl install pcov-${PCOV_VERSION} \
-    && docker-php-ext-enable pcov \
-    && echo 'pcov.enabled=0' >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 
 COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,6 +31,10 @@ variable "XDEBUG_VERSION" {
   default = "3.5.3"
 }
 
+variable "PCOV_VERSION" {
+  default = "1.0.12"
+}
+
 
 # =============================================================================
 # IMAGE METADATA
@@ -48,6 +52,12 @@ variable "TAG" {
   default = "latest"
 }
 
+# Git commit SHA, passed by CI to produce an immutable e2e-<sha> tag.
+# Empty by default (local builds get only the floating :e2e tag).
+variable "GIT_SHA" {
+  default = ""
+}
+
 # =============================================================================
 # COMMON BUILD SETTINGS (inherited by all targets)
 # =============================================================================
@@ -60,6 +70,7 @@ target "_common" {
     NODE_VERSION   = NODE_VERSION
     COMPOSER_IMAGE = COMPOSER_IMAGE
     XDEBUG_VERSION = XDEBUG_VERSION
+    PCOV_VERSION   = PCOV_VERSION
   }
 }
 
@@ -117,9 +128,10 @@ target "app-tools" {
 target "app-e2e" {
   inherits = ["_common"]
   target   = "e2e"
-  tags = [
+  tags = compact([
     "${REGISTRY}/${IMAGE_NAME}:e2e",
-  ]
+    notequal("", GIT_SHA) ? "${REGISTRY}/${IMAGE_NAME}:e2e-${GIT_SHA}" : "",
+  ])
 }
 
 # =============================================================================

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -130,7 +130,7 @@ target "app-e2e" {
   target   = "e2e"
   tags = compact([
     "${REGISTRY}/${IMAGE_NAME}:e2e",
-    notequal("", GIT_SHA) ? "${REGISTRY}/${IMAGE_NAME}:e2e-${GIT_SHA}" : "",
+    GIT_SHA != "" ? "${REGISTRY}/${IMAGE_NAME}:e2e-${GIT_SHA}" : "",
   ])
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,10 +31,6 @@ variable "XDEBUG_VERSION" {
   default = "3.5.3"
 }
 
-variable "PCOV_VERSION" {
-  default = "1.0.12"
-}
-
 
 # =============================================================================
 # IMAGE METADATA
@@ -70,7 +66,6 @@ target "_common" {
     NODE_VERSION   = NODE_VERSION
     COMPOSER_IMAGE = COMPOSER_IMAGE
     XDEBUG_VERSION = XDEBUG_VERSION
-    PCOV_VERSION   = PCOV_VERSION
   }
 }
 


### PR DESCRIPTION
## What

Pin the floating, digest-less `:e2e` image tag. The `app-e2e` bake target now also emits an immutable `e2e-<sha>` tag when `GIT_SHA` is set (docker-publish passes `github.sha`), and CI pulls `e2e-<sha>` with a `|| :e2e || bake` fallback. The immutable tag doesn't exist on PR runs (the publish is skipped there), so the fallback keeps PR builds working — the pin has teeth on main/release reruns.

## Note
An earlier revision of this PR also added pcov as a faster coverage driver. That was **dropped**: coverage stays on **Xdebug**, which provides the branch/path coverage that pcov's line-only driver lacks. This PR is now scoped to the tag pin only.
