### PR TITLE
test(e2e): add a real-browser accessibility gate (axe-core)

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,68 @@
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { login, loginIsolated } from './helpers/auth';
+import { goToWorklogPage, goToAuswertungPage, goToAdminPage, hideDebugToolbar } from './helpers/navigation';
+
+/**
+ * First real-browser accessibility gate for the SolidJS UI: axe-core (WCAG 2.0/2.1
+ * A + AA) against the key pages, asserting zero serious/critical violations.
+ * Until now a11y stopped at jsdom vitest-axe component tests, which can't catch
+ * computed-contrast, focus-order or live-region issues that only exist once the
+ * page is actually rendered and styled in a browser.
+ *
+ * Each test navigates with the existing goTo* helpers (which already
+ * waitForSelector on the page's settled marker) BEFORE analyzing — no fixed
+ * sleeps. The scan is read-only: no entry creation, no teardown.
+ */
+
+/**
+ * Run axe against `page`, optionally scoped to `scopeSelector`, and assert no
+ * serious/critical WCAG-A/AA violations. We exclude two regions that are not part
+ * of the shipped SolidJS code:
+ *   - .sf-toolbar: the Symfony web debug toolbar APP_ENV=test injects; not shipped.
+ *   - .x-grid: legacy ExtJS markup that runs alongside the SPA and is being removed.
+ * Moderate/minor violations are intentionally not asserted on (this is a serious/
+ * critical gate); the JSON summary is attached to the failure message so a real
+ * regression names the rule, impact and node count.
+ */
+async function expectNoSeriousA11y(page: Page, scopeSelector?: string): Promise<void> {
+  await hideDebugToolbar(page).catch(() => undefined); // APP_ENV=test injects .sf-toolbar
+  let builder = new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .exclude('.sf-toolbar')   // Symfony web debug toolbar — not shipped code
+    .exclude('.x-grid');      // legacy ExtJS markup — being removed
+  if (scopeSelector) builder = builder.include(scopeSelector);
+  const { violations } = await builder.analyze();
+  const serious = violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
+  const summary = serious.map((v) => ({ id: v.id, impact: v.impact, nodes: v.nodes.length }));
+  expect(serious, JSON.stringify(summary, null, 2)).toEqual([]);
+}
+
+test.describe('Accessibility (axe-core, WCAG 2.1 AA, serious/critical)', () => {
+  test('/login has no serious/critical a11y violations', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForSelector('#form-submit');
+    await expectNoSeriousA11y(page);
+  });
+
+  test('/ui/tracking has no serious/critical a11y violations', async ({ page }) => {
+    await loginIsolated(page);
+    await goToWorklogPage(page);
+    await expectNoSeriousA11y(page, 'main');
+  });
+
+  test('/ui/auswertung has no serious/critical a11y violations', async ({ page }) => {
+    await loginIsolated(page);
+    await goToAuswertungPage(page);
+    await expectNoSeriousA11y(page, 'main');
+  });
+
+  test('/ui/admin has no serious/critical a11y violations', async ({ page }) => {
+    // The admin page is ROLE_ADMIN-only; the per-worker 'developer' isolation slot
+    // can't reach it, so log in explicitly as the admin user (i.myself).
+    await login(page, 'i.myself', 'myself123');
+    await goToAdminPage(page);
+    await expectNoSeriousA11y(page, 'section.admin-page');
+  });
+});

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
-import { login, loginIsolated } from './helpers/auth';
+import { loginAs, loginIsolated } from './helpers/auth';
 import { goToWorklogPage, goToAuswertungPage, goToAdminPage, hideDebugToolbar } from './helpers/navigation';
 
 /**
@@ -60,8 +60,9 @@ test.describe('Accessibility (axe-core, WCAG 2.1 AA, serious/critical)', () => {
 
   test('/ui/admin has no serious/critical a11y violations', async ({ page }) => {
     // The admin page is ROLE_ADMIN-only; the per-worker 'developer' isolation slot
-    // can't reach it, so log in explicitly as the admin user (i.myself).
-    await login(page, 'i.myself', 'myself123');
+    // can't reach it, so log in explicitly as the admin user. loginAs pulls the
+    // password from TEST_USERS (env-var-backed, no credential literal in the spec).
+    await loginAs(page, 'myself');
     await goToAdminPage(page);
     await expectNoSeriousA11y(page, 'section.admin-page');
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "license": "UNLICENSED",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "@hotwired/stimulus": "^3.2.2",
@@ -24,6 +25,19 @@
       },
       "engines": {
         "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3501,6 +3515,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-loader": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "@hotwired/stimulus": "^3.2.2",


### PR DESCRIPTION
## What

First real-browser accessibility gate for the SolidJS UI. Adds `@axe-core/playwright` and `e2e/accessibility.spec.ts` running axe-core (WCAG 2.0/2.1 A + AA) against **/login**, **/ui/tracking**, **/ui/auswertung**, and **/ui/admin**, asserting **zero serious/critical** violations.

Until now a11y stopped at jsdom `vitest-axe` component tests, which can't catch computed-contrast, focus-order, or live-region issues that only exist once a page is actually rendered and styled in a browser.

## Notes
- Read-only: no entry creation, no teardown; each test navigates via the existing `goTo*` helpers (web-first waits, no fixed sleeps).
- `/ui/admin` is scanned as `i.myself` (ROLE_ADMIN) since the per-worker `developer` isolation slot can't reach it.
- Excludes `.sf-toolbar` (Symfony debug toolbar injected under `APP_ENV=test`, not shipped) and `.x-grid` (legacy ExtJS markup being removed), justified inline.
- Asserts serious/critical only (moderate/minor are not gated). The failure message attaches the rule id + impact + node count so a regression is self-describing.

## Result
All four pages pass with **zero serious/critical violations** (verified locally against the live e2e stack). Two axe `incomplete` items (need-manual-review, not violations) are intentionally not asserted on: `th-has-data-cells` on the empty-state tables and `color-contrast` on 4 admin elements axe can't compute — worth a manual confirmation against a data-populated run.
