### PR TITLE
test(perf): make the performance suite actually runnable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
     "test:fast": "APP_ENV=test php -d memory_limit=512M bin/phpunit --testsuite=unit --do-not-cache-result && APP_ENV=test php -d memory_limit=512M bin/phpunit --testsuite=controller --do-not-cache-result",
     "test:coverage": "APP_ENV=test php -d memory_limit=512M bin/phpunit --coverage-html=var/coverage",
     "test:coverage-text": "APP_ENV=test php -d memory_limit=512M bin/phpunit --coverage-text",
-    "perf:export": "APP_ENV=test php -d memory_limit=1G -d max_execution_time=300 bin/phpunit --configuration=config/testing/phpunit-performance.xml --group=performance",
+    "perf:export": "APP_ENV=test php -d memory_limit=1G -d max_execution_time=300 bin/phpunit --configuration=config/testing/phpunit-performance.xml --testsuite=performance",
     "perf:unit": "APP_ENV=test php -d memory_limit=1G -d max_execution_time=300 bin/phpunit --configuration=config/testing/phpunit-performance.xml --testsuite=performance-unit",
     "perf:integration": "APP_ENV=test php -d memory_limit=1G -d max_execution_time=300 bin/phpunit --configuration=config/testing/phpunit-performance.xml --testsuite=performance-integration",
     "perf:benchmark": "APP_ENV=test php -d memory_limit=1G -d max_execution_time=600 tests/Performance/PerformanceBenchmarkRunner.php",

--- a/config/testing/phpunit-performance.xml
+++ b/config/testing/phpunit-performance.xml
@@ -18,9 +18,6 @@
         <exclude>
             <directory>../../src/Migrations</directory>
             <directory>../../src/DataFixtures</directory>
-            <directory>../../vendor</directory>
-            <directory>../../tests</directory>
-            <directory>../../var</directory>
         </exclude>
     </source>
     <testsuites>

--- a/config/testing/phpunit-performance.xml
+++ b/config/testing/phpunit-performance.xml
@@ -2,44 +2,39 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
-    bootstrap="tests/bootstrap.php"
+    bootstrap="../../tests/bootstrap.php"
     colors="true"
     stopOnFailure="false"
     executionOrder="depends,defects"
     beStrictAboutOutputDuringTests="false"
     beStrictAboutChangesToGlobalState="false"
-    cacheDirectory=".phpunit.cache"
+    cacheDirectory="../../.phpunit.cache"
 >
     <coverage/>
     <source>
         <include>
-            <directory suffix=".php">src</directory>
+            <directory suffix=".php">../../src</directory>
         </include>
         <exclude>
-            <directory>src/Migrations</directory>
-            <directory>src/DataFixtures</directory>
-            <directory>vendor</directory>
-            <directory>tests</directory>
-            <directory>var</directory>
+            <directory>../../src/Migrations</directory>
+            <directory>../../src/DataFixtures</directory>
+            <directory>../../vendor</directory>
+            <directory>../../tests</directory>
+            <directory>../../var</directory>
         </exclude>
     </source>
     <testsuites>
         <testsuite name="performance">
-            <directory>tests/Performance</directory>
+            <directory>../../tests/Performance</directory>
         </testsuite>
         <testsuite name="performance-unit">
-            <file>tests/Performance/ExportPerformanceTest.php</file>
-            <file>tests/Performance/ExportActionPerformanceTest.php</file>
+            <file>../../tests/Performance/ExportPerformanceTest.php</file>
+            <file>../../tests/Performance/ExportActionPerformanceTest.php</file>
         </testsuite>
         <testsuite name="performance-integration">
-            <file>tests/Performance/ExportWorkflowIntegrationTest.php</file>
+            <file>../../tests/Performance/ExportWorkflowIntegrationTest.php</file>
         </testsuite>
     </testsuites>
-    <groups>
-        <include>
-            <group>performance</group>
-        </include>
-    </groups>
     <php>
         <server name="APP_ENV" value="test" force="true"/>
         <server name="KERNEL_CLASS" value="App\Kernel"/>
@@ -49,8 +44,8 @@
         <!-- Increase memory and time limits for performance tests -->
         <ini name="memory_limit" value="512M"/>
         <ini name="max_execution_time" value="300"/>
-        <!-- Disable opcache for consistent benchmarking -->
+        <!-- Disable opcache for consistent benchmarking (enable_cli is PHP_INI_SYSTEM
+             and cannot be set at runtime, so it is left to the image's php.ini) -->
         <ini name="opcache.enable" value="0"/>
-        <ini name="opcache.enable_cli" value="0"/>
     </php>
 </phpunit>


### PR DESCRIPTION
The `config/testing/phpunit-performance.xml` config used config-dir-relative paths, so PHPUnit resolved `bootstrap` + the testsuites under `config/testing/` and the `perf:*` scripts silently ran **nothing**.

Fixes:
- `../../` prefix on every relative path (bootstrap, source include/exclude, testsuites) so they resolve from the repo root
- drop the global `<groups>performance` filter — it required `@group` docblock metadata PHPUnit 13 no longer honours, so testsuite runs matched 0 tests
- point `perf:export` at the `performance` testsuite instead of `--group=performance`
- drop the `opcache.enable_cli` ini (PHP_INI_SYSTEM, unsettable at runtime → a warning that made the scripts exit non-zero)

**Result:** `perf:unit` 15 tests, `perf:integration` 7, `perf:export` 22 — all green, exit 0 (verified in the e2e image's PHP 8.5.7). These are developer benchmark tools, not on the CI hot path.