### PR TITLE
fix(deps): re-pin webpack-cli to ^6 (match webpack-encore 6 peer; fixes Encore CI build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "sass-embedded": "^1.100.0",
         "sass-loader": "^17.0.0",
         "webpack": "^5.107.2",
-        "webpack-cli": "^7.0.3",
+        "webpack-cli": "^6.0.0",
         "webpack-dev-server": "^5.2.5",
         "webpack-notifier": "^1.15.0"
       },
@@ -1587,9 +1587,9 @@
       "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
-      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3286,6 +3286,53 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -9001,16 +9048,21 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.3.tgz",
-      "integrity": "sha512-2E2C6A1e2El7791zQgTH7LPIuwLjRliow9OHS/qlJc9pwhZlCoL/uiwqd/1WSlXT83wJfmfDbkcqHXuXoPJZ3g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^1.1.0",
-        "commander": "^14.0.3",
-        "cross-spawn": "^7.0.6",
+        "@discoveryjs/json-ext": "^0.6.1",
+        "@webpack-cli/configtest": "^3.0.1",
+        "@webpack-cli/info": "^3.0.1",
+        "@webpack-cli/serve": "^3.0.1",
+        "colorette": "^2.0.14",
+        "commander": "^12.1.0",
+        "cross-spawn": "^7.0.3",
         "envinfo": "^7.14.0",
+        "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
@@ -9020,16 +9072,14 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=20.9.0"
+        "node": ">=18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.101.0",
-        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
-        "webpack-dev-server": "^5.0.0"
+        "webpack": "^5.82.0"
       },
       "peerDependenciesMeta": {
         "webpack-bundle-analyzer": {
@@ -9041,13 +9091,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sass-embedded": "^1.100.0",
     "sass-loader": "^17.0.0",
     "webpack": "^5.107.2",
-    "webpack-cli": "^7.0.3",
+    "webpack-cli": "^6.0.0",
     "webpack-dev-server": "^5.2.5",
     "webpack-notifier": "^1.15.0"
   },


### PR DESCRIPTION
webpack-encore 6.0.0 peer-requires `webpack-cli ^6.0.0`, but `ff659f4d` (2026-06-12 deps bump) moved it to **7.0.3**, breaking the legacy ExtJS Encore build in CI fresh installs:
```
[webpack-cli] Failed to load '/var/www/html/webpack.config.js' config
Encore.isRuntimeEnvironmentConfigured is not a function
```
This pin was applied once before (`7640505a fix(deps): align webpack-cli with encore 6 peer requirement`) and regressed. It's **masked on `main` by Docker layer caching** but surfaces on any cache-invalidating PR (#427, dependabot #405, the next merge). Re-pin to `^6.0.0` (resolves 6.0.1); dev-server 5 has no cli peer, so no conflict.

Encore build verified locally (`webpack compiled successfully`). **This PR's own CI run is the validation** — if its Encore build is green, the fix holds and #427 + the e2e teardown can rebase onto it.