### PR TITLE
fix(month): base /ui/month "expected" hours on the user's contract

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -42,6 +42,27 @@ export function holidaysQuery(year: number, month: number) {
   }
 }
 
+// Response shape of GET /getContractHours (GetContractHoursAction): the current
+// user's per-weekday contract hours for the queried month, keyed hours_0 (Sunday)
+// … hours_6 (Saturday) to match JS Date.getDay(). The backend already falls back
+// to 8h per day when the user has no contract for that month.
+export interface ContractHoursRecord {
+  hours_0: number
+  hours_1: number
+  hours_2: number
+  hours_3: number
+  hours_4: number
+  hours_5: number
+  hours_6: number
+}
+
+export function contractHoursQuery(year: number, month: number) {
+  return {
+    queryKey: ['contract-hours', year, month] as const,
+    queryFn: () => getJson<ContractHoursRecord>('/getContractHours', { year, month }),
+  }
+}
+
 export interface NamedOption {
   id: number
   label: string

--- a/frontend/src/lib/month.test.ts
+++ b/frontend/src/lib/month.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+import type { ContractHoursRecord } from '../api/queries'
 import { computeMonth, type ComputeMonthInput, isoWeek, summarize } from './month'
+import { contractHoursPerWeekday } from './settings'
 
 const WEEKEND = { saturday: 'Saturday', sunday: 'Sunday' }
 
@@ -121,6 +123,26 @@ describe('computeMonth', () => {
     )
 
     expect(days[4]?.expected).toBe(240)
+    expect(days[3]?.expected).toBe(480)
+  })
+
+  it('derives expected from a contract-hours record (half-day Fridays)', () => {
+    // hours_0 = Sunday … hours_6 = Saturday; 4h Fridays via hours_5.
+    const contract: ContractHoursRecord = {
+      hours_0: 0, hours_1: 8, hours_2: 8, hours_3: 8, hours_4: 8, hours_5: 4, hours_6: 0,
+    }
+    const { days } = computeMonth(input({ hoursPerWeekday: contractHoursPerWeekday(contract) }))
+
+    // 2026-06-04 is a Thursday (8h), 2026-06-05 is a Friday (4h).
+    expect(days[3]?.expected).toBe(480)
+    expect(days[4]?.expected).toBe(240)
+  })
+
+  it('uses the 8h fallback when no contract record is available', () => {
+    const { days } = computeMonth(input({ hoursPerWeekday: contractHoursPerWeekday(undefined) }))
+
+    // Every working day defaults to 8h (480 min); 2026-06-01 is a Monday.
+    expect(days[0]?.expected).toBe(480)
     expect(days[3]?.expected).toBe(480)
   })
 })

--- a/frontend/src/lib/settings.test.ts
+++ b/frontend/src/lib/settings.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ContractHoursRecord } from '../api/queries'
+import { contractHoursPerWeekday, DEFAULT_HOURS_PER_DAY } from './settings'
+
+const CONTRACT: ContractHoursRecord = {
+  hours_0: 0, // Sunday
+  hours_1: 8, // Monday
+  hours_2: 8, // Tuesday
+  hours_3: 8, // Wednesday
+  hours_4: 8, // Thursday
+  hours_5: 4, // Friday (half day)
+  hours_6: 0, // Saturday
+}
+
+describe('contractHoursPerWeekday', () => {
+  it('maps JS getDay() (0=Sun … 6=Sat) directly onto hours_<weekday>', () => {
+    const hours = contractHoursPerWeekday(CONTRACT)
+
+    expect(hours(0)).toBe(0) // Sunday
+    expect(hours(1)).toBe(8) // Monday
+    expect(hours(5)).toBe(4) // Friday
+    expect(hours(6)).toBe(0) // Saturday
+  })
+
+  it('falls back to 8h per weekday when the record has not loaded yet', () => {
+    const hours = contractHoursPerWeekday(undefined)
+
+    for (let weekday = 0; weekday < 7; weekday++) {
+      expect(hours(weekday)).toBe(DEFAULT_HOURS_PER_DAY)
+    }
+    expect(DEFAULT_HOURS_PER_DAY).toBe(8)
+  })
+
+  it('falls back to 8h for a missing or non-finite contract value', () => {
+    // A malformed record (e.g. NaN from a bad cast) must not poison the expected hours.
+    const hours = contractHoursPerWeekday({ ...CONTRACT, hours_2: Number.NaN })
+
+    expect(hours(2)).toBe(DEFAULT_HOURS_PER_DAY)
+    // Unaffected weekdays keep their contract value.
+    expect(hours(1)).toBe(8)
+  })
+})

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -1,26 +1,28 @@
-// Expected working hours per weekday. Like the previous stats UI this is a
-// client-side setting (per browser) until a backend settings API exists;
-// the storage shape is a map of JS weekday (1 = Monday … 5 = Friday) → hours.
-const STORAGE_KEY = 'timetracker-hours-per-weekday'
-const DEFAULT_HOURS_PER_DAY = 8
+import type { ContractHoursRecord } from '../api/queries'
 
-export function hoursPerWeekday(weekday: number): number {
-  // window.localStorage explicitly: Node >= 22 exposes a global localStorage
-  // that shadows the DOM one under test runners.
-  const stored = window.localStorage.getItem(STORAGE_KEY)
-  if (stored !== null) {
-    try {
-      const parsed: unknown = JSON.parse(stored)
-      if (typeof parsed === 'object' && parsed !== null) {
-        const hours = (parsed as Record<string, unknown>)[String(weekday)]
-        if (typeof hours === 'number' && Number.isFinite(hours)) {
-          return hours
-        }
-      }
-    } catch {
-      // Malformed storage falls back to the default below.
+// Expected working hours per weekday come from the current user's contract
+// (GET /getContractHours), keyed hours_0 (Sunday) … hours_6 (Saturday) to match
+// JS Date.getDay(). The previous client-side localStorage stopgap was never
+// wired to a settings UI, so it is gone: the contract is the single source of
+// truth, with a uniform 8h fallback when no contract value applies.
+export const DEFAULT_HOURS_PER_DAY = 8
+
+/**
+ * Build a `hoursPerWeekday(weekday)` lookup from a contract-hours record.
+ *
+ * `weekday` is the JS `Date.getDay()` value (0 = Sunday … 6 = Saturday), which
+ * maps 1:1 onto the contract's `hours_<weekday>` field. A missing record (the
+ * query hasn't resolved yet) or a non-finite value falls back to 8h, matching
+ * the backend's all-8 default for users without a contract.
+ */
+export function contractHoursPerWeekday(record: ContractHoursRecord | undefined): (weekday: number) => number {
+  return (weekday: number): number => {
+    if (record === undefined) {
+      return DEFAULT_HOURS_PER_DAY
     }
-  }
 
-  return DEFAULT_HOURS_PER_DAY
+    const hours: unknown = record[`hours_${weekday}` as keyof ContractHoursRecord]
+
+    return typeof hours === 'number' && Number.isFinite(hours) ? hours : DEFAULT_HOURS_PER_DAY
+  }
 }

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -17,7 +17,9 @@ export const DEFAULT_HOURS_PER_DAY = 8
  */
 export function contractHoursPerWeekday(record: ContractHoursRecord | undefined): (weekday: number) => number {
   return (weekday: number): number => {
-    if (record === undefined) {
+    // == null guards both undefined (query unresolved) and a null the API could
+    // hand back, either of which means "no contract value applies".
+    if (record == null) {
       return DEFAULT_HOURS_PER_DAY
     }
 

--- a/frontend/src/pages/Month.tsx
+++ b/frontend/src/pages/Month.tsx
@@ -2,11 +2,11 @@ import { A, useSearchParams } from '@solidjs/router'
 import { useQueries, useQuery } from '@tanstack/solid-query'
 import { createMemo, For, Index, Match, Show, Switch } from 'solid-js'
 
-import { holidaysQuery, type HolidayRecord, monthTimesQuery, type WorktimeRecord } from '../api/queries'
+import { contractHoursQuery, type ContractHoursRecord, holidaysQuery, type HolidayRecord, monthTimesQuery, type WorktimeRecord } from '../api/queries'
 import { appConfig } from '../config'
 import { formatDay, formatMinutes, formatMonthTitle, isoDate } from '../lib/format'
 import { computeMonth, type DayRow, isoWeek, type MonthSummary, summarize } from '../lib/month'
-import { hoursPerWeekday } from '../lib/settings'
+import { contractHoursPerWeekday } from '../lib/settings'
 import { m } from '../paraglide/messages.js'
 
 interface MonthTarget {
@@ -261,6 +261,7 @@ export default function Month() {
 
   const times = useQuery(() => monthTimesQuery(target().year, target().month, config.userId))
   const holidays = useQuery(() => holidaysQuery(target().year, target().month))
+  const contractHours = useQuery(() => contractHoursQuery(target().year, target().month))
 
   const holidayMap = (records: HolidayRecord[]) => new Map(records.map((record) => [record.holiday.date, record.holiday.name]))
   const weekendLabels = () => ({ saturday: m.month_saturday(), sunday: m.month_sunday() })
@@ -268,7 +269,8 @@ export default function Month() {
   const report = createMemo(() => {
     const timesData = times.data
     const holidaysData = holidays.data
-    if (timesData === undefined || holidaysData === undefined) {
+    const contractData = contractHours.data
+    if (timesData === undefined || holidaysData === undefined || contractData === undefined) {
       return null
     }
 
@@ -277,7 +279,7 @@ export default function Month() {
       month: target().month,
       entries: timesData,
       holidays: holidayMap(holidaysData),
-      hoursPerWeekday,
+      hoursPerWeekday: contractHoursPerWeekday(contractData),
       today: new Date(),
       weekendLabels: weekendLabels(),
     })
@@ -296,6 +298,12 @@ export default function Month() {
 
     return { queries: Array.from({ length: 12 }, (_, i) => ({ ...holidaysQuery(year, i + 1), enabled })) }
   })
+  const yearContractHours = useQueries(() => {
+    const enabled = yearMode()
+    const year = target().year
+
+    return { queries: Array.from({ length: 12 }, (_, i) => ({ ...contractHoursQuery(year, i + 1), enabled })) }
+  })
   const yearDays = createMemo<DayRow[] | null>(() => {
     if (!yearMode()) {
       return null
@@ -304,7 +312,8 @@ export default function Month() {
     for (let i = 0; i < 12; i++) {
       const t = yearTimes[i]?.data as WorktimeRecord[] | undefined
       const h = yearHolidays[i]?.data as HolidayRecord[] | undefined
-      if (t === undefined || h === undefined) {
+      const c = yearContractHours[i]?.data as ContractHoursRecord | undefined
+      if (t === undefined || h === undefined || c === undefined) {
         return null
       }
       days.push(...computeMonth({
@@ -312,7 +321,7 @@ export default function Month() {
         month: i + 1,
         entries: t,
         holidays: holidayMap(h),
-        hoursPerWeekday,
+        hoursPerWeekday: contractHoursPerWeekday(c),
         today: new Date(),
         weekendLabels: weekendLabels(),
       }).days)
@@ -380,8 +389,8 @@ export default function Month() {
 
   const isLoading = createMemo(() => (scope() === 'year' ? yearDays() === null || report() === null : report() === null))
   const isError = createMemo(() =>
-    times.isError || holidays.isError
-    || (scope() === 'year' && (yearTimes.some((q) => q.isError) || yearHolidays.some((q) => q.isError))),
+    times.isError || holidays.isError || contractHours.isError
+    || (scope() === 'year' && (yearTimes.some((q) => q.isError) || yearHolidays.some((q) => q.isError) || yearContractHours.some((q) => q.isError))),
   )
 
   return (
@@ -458,6 +467,7 @@ export default function Month() {
             onClick={() => {
               times.refetch()
               holidays.refetch()
+              contractHours.refetch()
             }}
           >
             {m.app_retry()}

--- a/src/Controller/Default/GetContractHoursAction.php
+++ b/src/Controller/Default/GetContractHoursAction.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Default;
+
+use App\Controller\BaseController;
+use App\Entity\Contract;
+use App\Entity\User;
+use App\Model\JsonResponse;
+use App\Repository\ContractRepository;
+use DateTime;
+use Exception;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function assert;
+use function sprintf;
+
+/**
+ * Per-weekday working hours from the current user's own contract, for a month.
+ *
+ * Drives the /ui/month "expected" column: each weekday's expected time comes
+ * from the contract valid in the queried month (hours_0 = Sunday … hours_6 =
+ * Saturday, matching JS Date.getDay()), with an all-8 default when the user has
+ * no contract for that month.
+ */
+final class GetContractHoursAction extends BaseController
+{
+    /** Default daily hours when the user has no contract covering the month. */
+    private const float DEFAULT_HOURS = 8.0;
+
+    /**
+     * @throws BadRequestException When query parameters are malformed
+     * @throws Exception           When date construction fails
+     */
+    #[Route(path: '/getContractHours', name: '_getContractHours_attr', methods: ['GET'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(Request $request, #[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse
+    {
+        if (!$user instanceof User) {
+            return $this->redirectToRoute('_login');
+        }
+
+        $year = $request->query->get('year');
+        $month = $request->query->get('month');
+
+        $filterYear = null !== $year ? (int) $year : (int) date('Y');
+        $filterMonth = null !== $month ? (int) $month : (int) date('n');
+        if ($filterMonth < 1 || $filterMonth > 12) {
+            $filterMonth = (int) date('n');
+        }
+
+        $repository = $this->managerRegistry->getRepository(Contract::class);
+        assert($repository instanceof ContractRepository);
+
+        // Look up the contract valid on the first of the month. A contract change
+        // mid-month is not modelled — the whole month uses the first-of-month
+        // contract (acceptable v1 simplification).
+        $firstOfMonth = new DateTime(sprintf('%04d-%02d-01', $filterYear, $filterMonth));
+        $contract = $repository->findValidContract($user, $firstOfMonth);
+
+        return new JsonResponse($this->buildHours($contract));
+    }
+
+    /**
+     * @return array{hours_0: float, hours_1: float, hours_2: float, hours_3: float, hours_4: float, hours_5: float, hours_6: float}
+     */
+    private function buildHours(?Contract $contract): array
+    {
+        if (!$contract instanceof Contract) {
+            return [
+                'hours_0' => self::DEFAULT_HOURS,
+                'hours_1' => self::DEFAULT_HOURS,
+                'hours_2' => self::DEFAULT_HOURS,
+                'hours_3' => self::DEFAULT_HOURS,
+                'hours_4' => self::DEFAULT_HOURS,
+                'hours_5' => self::DEFAULT_HOURS,
+                'hours_6' => self::DEFAULT_HOURS,
+            ];
+        }
+
+        return [
+            'hours_0' => (float) $contract->getHours0(),
+            'hours_1' => (float) $contract->getHours1(),
+            'hours_2' => (float) $contract->getHours2(),
+            'hours_3' => (float) $contract->getHours3(),
+            'hours_4' => (float) $contract->getHours4(),
+            'hours_5' => (float) $contract->getHours5(),
+            'hours_6' => (float) $contract->getHours6(),
+        ];
+    }
+}

--- a/src/Controller/Default/GetContractHoursAction.php
+++ b/src/Controller/Default/GetContractHoursAction.php
@@ -16,7 +16,6 @@ use App\Model\JsonResponse;
 use App\Repository\ContractRepository;
 use DateTime;
 use Exception;
-use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -40,8 +39,7 @@ final class GetContractHoursAction extends BaseController
     private const float DEFAULT_HOURS = 8.0;
 
     /**
-     * @throws BadRequestException When query parameters are malformed
-     * @throws Exception           When date construction fails
+     * @throws Exception When date construction fails
      */
     #[Route(path: '/getContractHours', name: '_getContractHours_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
@@ -54,7 +52,13 @@ final class GetContractHoursAction extends BaseController
         $year = $request->query->get('year');
         $month = $request->query->get('month');
 
+        // Non-numeric params cast to 0, and a negative or out-of-range year/month
+        // would make the sprintf() below build a string new DateTime() rejects.
+        // Clamp both to a sane range, falling back to the current year/month.
         $filterYear = null !== $year ? (int) $year : (int) date('Y');
+        if ($filterYear < 1000 || $filterYear > 9999) {
+            $filterYear = (int) date('Y');
+        }
         $filterMonth = null !== $month ? (int) $month : (int) date('n');
         if ($filterMonth < 1 || $filterMonth > 12) {
             $filterMonth = (int) date('n');

--- a/src/Repository/ContractRepository.php
+++ b/src/Repository/ContractRepository.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Contract;
+use App\Entity\User;
+use DateTimeInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -66,5 +68,31 @@ class ContractRepository extends ServiceEntityRepository
         }
 
         return $data;
+    }
+
+    /**
+     * Find the user's contract that is valid on the given date.
+     *
+     * A contract is valid on a date when it has started on or before that date
+     * and either has no end date or ends on or after it
+     * (start <= date AND (end IS NULL OR end >= date)). When several contracts
+     * overlap the date (which the admin save flow tries to prevent), the
+     * latest-starting one wins.
+     */
+    public function findValidContract(User $user, DateTimeInterface $date): ?Contract
+    {
+        /** @var Contract|null $contract */
+        $contract = $this->createQueryBuilder('contract')
+            ->andWhere('contract.user = :user')
+            ->andWhere('contract.start <= :date')
+            ->andWhere('contract.end IS NULL OR contract.end >= :date')
+            ->setParameter('user', $user)
+            ->setParameter('date', $date)
+            ->orderBy('contract.start', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $contract;
     }
 }

--- a/tests/Controller/GetContractHoursActionTest.php
+++ b/tests/Controller/GetContractHoursActionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\AbstractWebTestCase;
+
+/**
+ * Functional coverage for GET /getContractHours, which feeds the /ui/month
+ * "expected" column from the current user's contract.
+ *
+ * Fixture contracts for user 1 (unittest):
+ *   - contract 1: 2020-01-01 … 2020-01-31, hours 0,1,2,3,4,5,0
+ *   - contract 2: 2020-02-01 … open,       hours 0,1.1,2.2,3.3,4.4,5.5,0.5
+ * User 5 (noContract) has none.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class GetContractHoursActionTest extends AbstractWebTestCase
+{
+    public function testReturnsContractHoursForTheValidMonth(): void
+    {
+        $this->logInSession('unittest');
+        $this->client->request(
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+            '/getContractHours',
+            ['year' => 2020, 'month' => 1],
+        );
+
+        $response = $this->client->getResponse();
+        self::assertTrue($response->isSuccessful());
+        $json = $this->getJsonResponse($response);
+
+        // hours_0 = Sunday … hours_6 = Saturday (matches JS Date.getDay()).
+        // JSON has no float/int distinction, so whole numbers decode as int;
+        // assert loosely on value (the frontend reads them as numbers regardless).
+        self::assertEquals(0, $json['hours_0']);
+        self::assertEquals(1, $json['hours_1']);
+        self::assertEquals(2, $json['hours_2']);
+        self::assertEquals(3, $json['hours_3']);
+        self::assertEquals(4, $json['hours_4']);
+        self::assertEquals(5, $json['hours_5']);
+        self::assertEquals(0, $json['hours_6']);
+    }
+
+    public function testPicksTheOpenEndedContractForALaterMonth(): void
+    {
+        $this->logInSession('unittest');
+        $this->client->request(
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+            '/getContractHours',
+            ['year' => 2021, 'month' => 6],
+        );
+
+        $response = $this->client->getResponse();
+        self::assertTrue($response->isSuccessful());
+        $json = $this->getJsonResponse($response);
+
+        // The open-ended contract 2 covers any month from 2020-02 onward.
+        self::assertEqualsWithDelta(1.1, $json['hours_1'], 0.0001);
+        self::assertEqualsWithDelta(5.5, $json['hours_5'], 0.0001);
+        self::assertEqualsWithDelta(0.5, $json['hours_6'], 0.0001);
+    }
+
+    public function testFallsBackToEightHoursWhenUserHasNoContract(): void
+    {
+        $this->logInSession('noContract');
+        $this->client->request(
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+            '/getContractHours',
+            ['year' => 2026, 'month' => 6],
+        );
+
+        $response = $this->client->getResponse();
+        self::assertTrue($response->isSuccessful());
+        $json = $this->getJsonResponse($response);
+
+        foreach (['hours_0', 'hours_1', 'hours_2', 'hours_3', 'hours_4', 'hours_5', 'hours_6'] as $key) {
+            self::assertEquals(8, $json[$key], $key . ' should default to 8');
+        }
+    }
+
+    public function testFallsBackToEightHoursForAMonthBeforeAnyContract(): void
+    {
+        $this->logInSession('unittest');
+        // Before contract 1 starts (2020-01-01): no contract is valid on 2019-12-01.
+        $this->client->request(
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+            '/getContractHours',
+            ['year' => 2019, 'month' => 12],
+        );
+
+        $response = $this->client->getResponse();
+        self::assertTrue($response->isSuccessful());
+        $json = $this->getJsonResponse($response);
+
+        self::assertEquals(8, $json['hours_1']);
+        self::assertEquals(8, $json['hours_6']);
+    }
+}

--- a/tests/Controller/GetContractHoursActionTest.php
+++ b/tests/Controller/GetContractHoursActionTest.php
@@ -92,6 +92,10 @@ final class GetContractHoursActionTest extends AbstractWebTestCase
     {
         $this->logInSession('unittest');
         // Before contract 1 starts (2020-01-01): no contract is valid on 2019-12-01.
+        // This also pins the query's parenthesization: were the
+        // `end IS NULL OR end >= :date` clause not grouped, the dangling OR would
+        // match contract 1 (ends 2020-01-31 >= 2019-12-01) and return its hours
+        // instead of the 8h fallback asserted below.
         $this->client->request(
             \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             '/getContractHours',
@@ -104,5 +108,27 @@ final class GetContractHoursActionTest extends AbstractWebTestCase
 
         self::assertEquals(8, $json['hours_1']);
         self::assertEquals(8, $json['hours_6']);
+    }
+
+    public function testClampsAMalformedYearInsteadOfErroring(): void
+    {
+        $this->logInSession('unittest');
+        // A non-numeric (or negative / out-of-range) year casts to an int that
+        // would make sprintf() build a date string new DateTime() rejects. The
+        // guard clamps it to the current year, so the request succeeds with a
+        // complete, numeric payload rather than a 500.
+        $this->client->request(
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+            '/getContractHours',
+            ['year' => 'not-a-year', 'month' => 1],
+        );
+
+        $response = $this->client->getResponse();
+        self::assertTrue($response->isSuccessful());
+        $json = $this->getJsonResponse($response);
+
+        foreach (['hours_0', 'hours_1', 'hours_2', 'hours_3', 'hours_4', 'hours_5', 'hours_6'] as $key) {
+            self::assertIsNumeric($json[$key], $key . ' should be present and numeric');
+        }
     }
 }


### PR DESCRIPTION
The month overview's per-day **"expected"** was effectively **8h hard-coded** — `hoursPerWeekday` read an unused localStorage key (no settings UI ever wrote it), else `DEFAULT_HOURS = 8` — ignoring the user's contract.

**Fix:** compute expected from the contract's per-weekday hours.
- New `GET /getContractHours?year&month` (`IS_AUTHENTICATED_FULLY`, the current user's own contract) → `{hours_0…hours_6}` of the contract valid on the 1st of the month, all-8 when the user has no contract for that month.
- `ContractRepository::findValidContract(user, date)`: `start <= date AND (end IS NULL OR end >= date)`, latest-starting overlap wins.
- Frontend fetches contract hours (per month; 12 queries in year scope) and feeds them into `computeMonth`'s `hoursPerWeekday` (`hours_N` by JS `getDay()`: hours_0=Sun … hours_6=Sat), fallback 8. Weekends stay 0.
- Replaced the unused localStorage `hoursPerWeekday` stopgap with the contract-based source.

**Weekday mapping verified** from 3 sources (admin widget labels, the existing `BulkEntryAction` contract lookup, and `sql/002_contracts.sql`).

**v1 simplification:** a mid-month contract change isn't modelled (the month uses its first-of-month contract); year scope respects per-month changes.

**Validation (local — e2e CI is currently gated by an unrelated legacy-ExtJS Encore build failure):** backend `controller,api-functional,integration` 410 green incl. 4 new `GetContractHoursActionTest` cases; frontend 271 vitest green; typecheck/eslint/phpstan clean.

> ⚠️ CI will show red until the separate Encore build breakage is resolved (the build jobs gate everything). This change is locally validated and ready to merge once that's cleared.