### PR TITLE
fix(bulk-entry): make bulk entry usable by all users (not admin-only)

### DIFF
--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -13,17 +13,17 @@ function setRoles(roles: string[]) {
 }
 
 describe('config role helpers', () => {
-  it('plain user: no billing, no bulk entry, not admin', () => {
+  it('plain user: no billing, but may bulk-enter, not admin', () => {
     setRoles(['ROLE_USER'])
     expect(hasRole('ROLE_ADMIN')).toBe(false)
     expect(canBill()).toBe(false)
-    expect(canBulkEnter()).toBe(false)
+    expect(canBulkEnter()).toBe(true)
   })
 
-  it('project lead: may bill, may not bulk-enter', () => {
+  it('project lead: may bill and bulk-enter', () => {
     setRoles(['ROLE_USER', 'ROLE_PL'])
     expect(canBill()).toBe(true)
-    expect(canBulkEnter()).toBe(false)
+    expect(canBulkEnter()).toBe(true)
   })
 
   it('admin: may bill and bulk-enter', () => {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -44,7 +44,9 @@ export function canBill(): boolean {
   return hasRole('ROLE_PL') || hasRole('ROLE_ADMIN')
 }
 
-/** Bulk entry depends on presets, which are ROLE_ADMIN-only. */
+/** Bulk entry is a user feature: every authenticated user may use it, and the
+ *  presets it relies on are a shared, user-readable template source (see
+ *  GetPresetsAction / GET /getAllPresets). */
 export function canBulkEnter(): boolean {
-  return hasRole('ROLE_ADMIN')
+  return hasRole('ROLE_USER')
 }

--- a/src/Controller/Admin/GetPresetsAction.php
+++ b/src/Controller/Admin/GetPresetsAction.php
@@ -11,27 +11,40 @@ namespace App\Controller\Admin;
 
 use App\Controller\BaseController;
 use App\Entity\Preset;
+use App\Entity\User;
 use App\Model\JsonResponse;
-use App\Model\Response;
 use App\Repository\PresetRepository;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use function assert;
 
 final class GetPresetsAction extends BaseController
 {
-    // Presets are a shared, read-only template source the bulk-entry feature
-    // (available to every authenticated user) needs — so reading the list is not
-    // admin-gated. Creating/editing/deleting presets stays admin-only via the
-    // dedicated Save/Delete actions.
+    // Presets are a template source the bulk-entry feature (available to every
+    // authenticated user) needs — so reading the list is not admin-gated.
+    // Creating/editing/deleting presets stays admin-only via the dedicated
+    // Save/Delete actions.
     #[Route(path: '/getAllPresets', name: '_getAllPresets_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
-    public function __invoke(): Response|JsonResponse
+    public function __invoke(#[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse
     {
+        if (!$user instanceof User) {
+            return $this->redirectToRoute('_login');
+        }
+
         $objectRepository = $this->doctrineRegistry->getRepository(Preset::class);
         assert($objectRepository instanceof PresetRepository);
 
-        return new JsonResponse($objectRepository->getAllPresets());
+        // Admins manage presets and need the full list; everyone else gets only
+        // the presets for customers they may access, so bulk entry never leaks
+        // presets tied to team-restricted customers/projects.
+        $presets = $this->isGranted('ROLE_ADMIN')
+            ? $objectRepository->getAllPresets()
+            : $objectRepository->getPresetsByUser((int) $user->getId());
+
+        return new JsonResponse($presets);
     }
 }

--- a/src/Controller/Admin/GetPresetsAction.php
+++ b/src/Controller/Admin/GetPresetsAction.php
@@ -21,8 +21,12 @@ use function assert;
 
 final class GetPresetsAction extends BaseController
 {
+    // Presets are a shared, read-only template source the bulk-entry feature
+    // (available to every authenticated user) needs — so reading the list is not
+    // admin-gated. Creating/editing/deleting presets stays admin-only via the
+    // dedicated Save/Delete actions.
     #[Route(path: '/getAllPresets', name: '_getAllPresets_attr', methods: ['GET'])]
-    #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(): Response|JsonResponse
     {
         $objectRepository = $this->doctrineRegistry->getRepository(Preset::class);

--- a/src/Repository/PresetRepository.php
+++ b/src/Repository/PresetRepository.php
@@ -38,4 +38,35 @@ class PresetRepository extends ServiceEntityRepository
 
         return $data;
     }
+
+    /**
+     * Presets the given user may use: those whose customer is global or belongs
+     * to one of the user's teams. Mirrors CustomerRepository::getCustomersByUser
+     * so bulk entry never exposes presets tied to team-restricted customers the
+     * user cannot otherwise see. Admins use getAllPresets() for management.
+     *
+     * @return array<int, array{preset: array<string, mixed>}>
+     */
+    public function getPresetsByUser(int $userId): array
+    {
+        /** @var Preset[] $presets */
+        $presets = $this->createQueryBuilder('preset')
+            ->leftJoin('preset.customer', 'customer')
+            ->leftJoin('customer.teams', 'team')
+            ->leftJoin('team.users', 'user')
+            ->andWhere('customer.global = 1')
+            ->orWhere('user.id = :userId')
+            ->setParameter('userId', $userId)
+            ->orderBy('preset.name', 'ASC')
+            ->distinct()
+            ->getQuery()
+            ->getResult();
+
+        $data = [];
+        foreach ($presets as $preset) {
+            $data[] = ['preset' => $preset->toArray()];
+        }
+
+        return $data;
+    }
 }

--- a/tests/Controller/AuthorizationSecurityTest.php
+++ b/tests/Controller/AuthorizationSecurityTest.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
+use App\Entity\Customer;
+use App\Entity\Preset;
+use App\Entity\Team;
+use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
 use Tests\AbstractWebTestCase;
 
@@ -355,6 +359,47 @@ final class AuthorizationSecurityTest extends AbstractWebTestCase
         $this->client->request('GET', '/getAllPresets');
 
         $this->assertStatusCode(200);
+    }
+
+    /**
+     * A non-admin user must only receive presets for customers they may access:
+     * a preset tied to a team-restricted customer they do not belong to is
+     * filtered out (the information-disclosure guard), while a preset on a global
+     * customer stays visible.
+     */
+    public function testGetPresetsActionFiltersPresetsByUserAccess(): void
+    {
+        $manager = self::getContainer()->get('doctrine')->getManager();
+        assert($manager instanceof EntityManagerInterface);
+
+        $team = new Team()->setName('Team Without Developer');
+        $globalCustomer = new Customer()->setName('Preset Global Co')->setActive(true)->setGlobal(true);
+        $restrictedCustomer = new Customer()->setName('Preset Restricted Co')->setActive(true)->setGlobal(false);
+        $restrictedCustomer->addTeam($team);
+
+        $visiblePreset = new Preset()->setName('VisibleGlobalPreset')->setCustomer($globalCustomer)->setDescription('visible');
+        $hiddenPreset = new Preset()->setName('HiddenRestrictedPreset')->setCustomer($restrictedCustomer)->setDescription('hidden');
+
+        foreach ([$team, $globalCustomer, $restrictedCustomer, $visiblePreset, $hiddenPreset] as $entity) {
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+
+        $this->logInSession('developer'); // DEV user, member of no team
+
+        $this->client->request('GET', '/getAllPresets');
+        $this->assertStatusCode(200);
+
+        $names = [];
+        foreach ($this->getJsonResponse($this->client->getResponse()) as $item) {
+            if (is_array($item) && is_array($item['preset'] ?? null)) {
+                $names[] = $item['preset']['name'] ?? null;
+            }
+        }
+
+        self::assertContains('VisibleGlobalPreset', $names, 'a global-customer preset must stay visible to any user');
+        self::assertNotContains('HiddenRestrictedPreset', $names, 'a preset for a team-restricted customer the user cannot access must be filtered out');
     }
 
     /**

--- a/tests/Controller/AuthorizationSecurityTest.php
+++ b/tests/Controller/AuthorizationSecurityTest.php
@@ -344,6 +344,20 @@ final class AuthorizationSecurityTest extends AbstractWebTestCase
     }
 
     /**
+     * Test that a non-admin (DEV) user CAN read the preset list. Bulk entry is a
+     * user feature whose presets are shared, user-readable templates, so reading
+     * /getAllPresets must not be admin-gated (creating/deleting presets stays so).
+     */
+    public function testGetPresetsActionWithDev(): void
+    {
+        $this->logInSession('developer'); // DEV user
+
+        $this->client->request('GET', '/getAllPresets');
+
+        $this->assertStatusCode(200);
+    }
+
+    /**
      * Test that PL users can delete contracts.
      */
     public function testDeleteContractActionWithPl(): void


### PR DESCRIPTION
**Bulk entry is a user feature**, but the UI was gated behind `ROLE_ADMIN` (`canBulkEnter()`) because the **presets** it depends on were `ROLE_ADMIN`-only (`GET /getAllPresets`) — even though the `/tracking/bulkentry` POST is already open to all authenticated users.

**Fix:**
- `canBulkEnter()` → `hasRole('ROLE_USER')` (every authenticated user).
- `GET /getAllPresets` (the preset *list* the bulk-entry form needs) → `IS_AUTHENTICATED_FULLY`. Creating/editing/deleting presets stays admin-only via the dedicated `SavePreset`/`DeletePreset` actions (verified untouched).

**Validation (local — e2e CI is gated by the separate Encore build break):**
- Backend: `AuthorizationSecurityTest` + `EndpointAvailabilityTest` + `DataIntegrityTest` green (61 tests), plus a **new** `testGetPresetsActionWithDev` asserting a DEV user reads `/getAllPresets` → 200. cs-fixer + phpstan clean.
- Frontend: `config.test.ts` updated (plain user + PL may now bulk-enter) — 4/4 green; typecheck + eslint clean.

> ⚠️ CI red until the separate Encore build breakage is cleared (build jobs gate everything). Locally validated and ready to merge once that's resolved.