### PR TITLE
test(e2e): self-clean SolidJS teardown (throwaway customer + deleteEntry)

### DIFF
--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -1,5 +1,46 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { login } from './helpers/auth';
+
+const ADD = /^(Hinzufügen|Add)$/i;
+const SAVE = /^(Speichern|Save)$/i;
+const EDIT = /^(Bearbeiten|Edit)$/i;
+const DELETE = /^(Löschen|Delete)$/i;
+
+/** A throwaway Customers row to mutate, by name. */
+function adminRow(page: Page, name: string) {
+  return page.locator('table.admin-table tbody tr').filter({ hasText: name });
+}
+
+/**
+ * Create a self-contained, server-valid throwaway customer via the Add modal
+ * (marked Global so it needs no team), mirroring admin/admin-ui.spec.ts, and
+ * return its name. Mutating inline-edit tests operate on THIS row, never the
+ * shared seed rows, so re-runs stay idempotent and leave no residue.
+ */
+async function createThrowawayCustomer(page: Page): Promise<string> {
+  const name = `E2EInline_${Date.now()}`;
+  await page.locator('.admin-crud-toolbar button.primary-button').filter({ hasText: ADD }).click();
+  const form = page.locator('.modal form.stack-form');
+  await expect(form).toBeVisible();
+  await form.locator('.field input[type="text"]').first().fill(name);
+  await form.locator('.field-check').filter({ hasText: /^Global$/ }).locator('input[type="checkbox"]').check();
+  await form.locator('button[type="submit"]').filter({ hasText: SAVE }).click();
+  await expect(page.locator('.modal')).toHaveCount(0);
+  await expect(adminRow(page, name)).toHaveCount(1);
+  return name;
+}
+
+/** Best-effort delete of the throwaway customer (native confirm), for finally blocks. */
+async function deleteThrowawayCustomer(page: Page, name: string): Promise<void> {
+  try {
+    page.once('dialog', (dialog) => dialog.accept());
+    await adminRow(page, name).getByRole('button', { name: DELETE }).click();
+    await expect(adminRow(page, name)).toHaveCount(0);
+  } catch {
+    // Swallow — a mid-test failure may leave the page in a state where delete
+    // can't complete; never mask the original failure with a cleanup error.
+  }
+}
 
 /**
  * Inline (spreadsheet-style) cell editing on the SolidJS Administration tables.
@@ -15,30 +56,37 @@ test.describe('Admin inline cell editing', () => {
   });
 
   test('edits a cell in place and persists it on row-leave', async ({ page }) => {
-    const cell = page.locator('td[data-col-key="name"]').first();
-    const original = ((await cell.textContent()) ?? '').trim();
-    const updated = `${original}-E2E`;
+    // Mutate a throwaway customer we create + delete, not a shared seed row.
+    const name = await createThrowawayCustomer(page);
+    const updated = `${name}-edited`;
+    try {
+      const cell = adminRow(page, name).locator('td[data-col-key="name"]').first();
+      await cell.focus();
+      await page.keyboard.press('Enter');
+      const editor = page.locator('td[data-inline-editing] input.inline-editor').first();
+      await expect(editor).toBeVisible();
+      await editor.fill(updated);
 
-    await cell.focus();
-    await page.keyboard.press('Enter');
-    const editor = page.locator('td[data-inline-editing] input.inline-editor').first();
-    await expect(editor).toBeVisible();
-    await editor.fill(updated);
+      // Enter commits and (by default) stays in the cell; leaving the row — here by
+      // focusing the filter box — saves the whole entity.
+      await page.keyboard.press('Enter');
+      await expect(page.locator('td[data-inline-editing]')).toHaveCount(0); // editor closed, still on the cell
+      const saved = page.waitForResponse((r) => /\/customer\/save$/.test(r.url()) && r.request().method() === 'POST');
+      await page.locator('input.admin-filter').focus();
+      await saved;
 
-    // Enter commits and (by default) stays in the cell; leaving the row — here by
-    // focusing the filter box — saves the whole entity.
-    await page.keyboard.press('Enter');
-    await expect(page.locator('td[data-inline-editing]')).toHaveCount(0); // editor closed, still on the cell
-    const saved = page.waitForResponse((r) => /\/customer\/save$/.test(r.url()) && r.request().method() === 'POST');
-    await page.locator('input.admin-filter').focus();
-    await saved;
-
-    // The edit survives a full reload (it was persisted, not just optimistic).
-    // exact: the row's selection checkbox is labelled "Select <name>", so a
-    // substring match would also hit the selection cell.
-    await page.reload();
-    await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
-    await expect(page.getByRole('gridcell', { name: updated, exact: true })).toBeVisible();
+      // The edit survives a full reload (it was persisted, not just optimistic).
+      // exact: the row's selection checkbox is labelled "Select <name>", so a
+      // substring match would also hit the selection cell.
+      await page.reload();
+      await page.waitForSelector('table.admin-table [role="gridcell"]', { timeout: 15000 });
+      await expect(page.getByRole('gridcell', { name: updated, exact: true })).toBeVisible();
+    } finally {
+      // The row carries `updated` on success, or `name` if the rename never landed
+      // (mid-test failure); whichever is present, delete it best-effort.
+      await deleteThrowawayCustomer(page, updated);
+      await deleteThrowawayCustomer(page, name);
+    }
   });
 
   test('opens an editor by typing and cancels with Escape', async ({ page }) => {
@@ -113,20 +161,34 @@ test.describe('Admin inline cell editing', () => {
   });
 
   test('the Edit button opens the modal seeded with the in-progress inline value', async ({ page }) => {
-    const row = page.locator('table.admin-table tbody tr').first();
-    await row.locator('td[data-col-key="name"]').focus();
-    await page.keyboard.press('Enter');
-    const editor = page.locator('td[data-inline-editing] input.inline-editor').first();
-    await expect(editor).toBeVisible();
-    await editor.fill('Inline-Draft-X');
+    // The complete row auto-saves in the background, so drive a throwaway customer
+    // we create + delete — never a shared seed row.
+    const name = await createThrowawayCustomer(page);
+    const draft = `${name}-draft`;
+    try {
+      const row = adminRow(page, name);
+      await row.locator('td[data-col-key="name"]').focus();
+      await page.keyboard.press('Enter');
+      const editor = page.locator('td[data-inline-editing] input.inline-editor').first();
+      await expect(editor).toBeVisible();
+      await editor.fill(draft);
 
-    // Clicking Edit commits the in-progress value and opens the modal seeded from
-    // it (the complete row also auto-saves in the background), so the modal shows
-    // the edit, not stale list data. Target Edit by name — the cell also has the
-    // Delete and the (reserved) disk force-save button, so .first() could be the
-    // wrong control.
-    await row.getByRole('button', { name: /^(Bearbeiten|Edit)$/i }).click();
-    await expect(page.locator('.modal input[type="text"]').first()).toHaveValue('Inline-Draft-X');
+      // Clicking Edit commits the in-progress value and opens the modal seeded from
+      // it (the complete row also auto-saves in the background), so the modal shows
+      // the edit, not stale list data. Target Edit by name — the cell also has the
+      // Delete and the (reserved) disk force-save button, so .first() could be the
+      // wrong control.
+      await row.getByRole('button', { name: EDIT }).click();
+      await expect(page.locator('.modal input[type="text"]').first()).toHaveValue(draft);
+    } finally {
+      // Close the modal (Escape-dismissible) so the row's Delete icon is clickable,
+      // then delete: the background auto-save may have renamed the row to `draft`,
+      // so cover both names best-effort.
+      await page.keyboard.press('Escape').catch(() => undefined);
+      await expect(page.locator('.modal')).toHaveCount(0).catch(() => undefined);
+      await deleteThrowawayCustomer(page, draft);
+      await deleteThrowawayCustomer(page, name);
+    }
   });
 
   test('opening and closing the editor neither resizes the cell nor moves its border', async ({ page }) => {

--- a/e2e/admin-inline-edit.spec.ts
+++ b/e2e/admin-inline-edit.spec.ts
@@ -18,7 +18,9 @@ function adminRow(page: Page, name: string) {
  * shared seed rows, so re-runs stay idempotent and leave no residue.
  */
 async function createThrowawayCustomer(page: Page): Promise<string> {
-  const name = `E2EInline_${Date.now()}`;
+  // Date.now() alone can collide when parallel workers create a row in the same
+  // millisecond (a unique-name DB violation); a random suffix makes it collision-safe.
+  const name = `E2EInline_${Date.now()}_${Math.floor(Math.random() * 1_000_000)}`;
   await page.locator('.admin-crud-toolbar button.primary-button').filter({ hasText: ADD }).click();
   const form = page.locator('.modal form.stack-form');
   await expect(form).toBeVisible();
@@ -33,9 +35,15 @@ async function createThrowawayCustomer(page: Page): Promise<string> {
 /** Best-effort delete of the throwaway customer (native confirm), for finally blocks. */
 async function deleteThrowawayCustomer(page: Page, name: string): Promise<void> {
   try {
+    const row = adminRow(page, name);
+    // Of the two names passed across a finally block (pre/post rename), only one
+    // row actually exists — skip the missing one instead of letting its delete
+    // button locator wait out the full timeout (a ~30s stall on every run). Bound
+    // the click for the same reason; the row is present, so it resolves at once.
+    if ((await row.count()) === 0) return;
     page.once('dialog', (dialog) => dialog.accept());
-    await adminRow(page, name).getByRole('button', { name: DELETE }).click();
-    await expect(adminRow(page, name)).toHaveCount(0);
+    await row.getByRole('button', { name: DELETE }).click({ timeout: 2000 });
+    await expect(row).toHaveCount(0);
   } catch {
     // Swallow — a mid-test failure may leave the page in a state where delete
     // can't complete; never mask the original failure with a cleanup error.

--- a/e2e/session-expiry.spec.ts
+++ b/e2e/session-expiry.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+import { deleteEntry } from './helpers/api';
 import { login } from './helpers/auth';
 import { goToWorklogPage } from './helpers/navigation';
-import { createWorklogEntry } from './helpers/worklog';
+import { createWorklogEntry, rowByStamp } from './helpers/worklog';
 
 /**
  * Issue #408: a lost backend session must NOT bounce the user to a separate login
@@ -20,6 +21,14 @@ test.describe('Session expiry — in-place re-login overlay', () => {
     await goToWorklogPage(page);
     const stamp = await createWorklogEntry(page);
     await expect(page.getByRole('gridcell', { name: stamp })).toBeVisible();
+
+    // Clean up the entry we just created BEFORE dropping the session — afterwards
+    // the cleared cookies leave no valid session, so a teardown delete would no-op
+    // and the row would leak into the shared db-e2e on every run. Best-effort.
+    const createdId = await rowByStamp(page, stamp).locator('[data-row-id]').first().getAttribute('data-row-id');
+    if (createdId != null) {
+      await deleteEntry(page, Number(createdId)).catch(() => undefined);
+    }
 
     // Drop the session (and remember-me) — a data request now has no session.
     await context.clearCookies();


### PR DESCRIPTION
Two SolidJS e2e specs leaked/mutated the shared db-e2e:
- `admin-inline-edit.spec.ts` permanently renamed the first seed customer (irreversible, non-idempotent). Rewritten to create→edit→delete a **throwaway customer** (mirroring `admin/admin-ui.spec.ts`).
- `session-expiry.spec.ts` leaked an `e2e-` row every run; now captures the created row's `data-row-id` and `deleteEntry`s it before clearing cookies.

The #420 isolation/clock helpers and ExtJS specs are untouched. Validated via the proven create→edit→delete pattern; relies on CI for the live run (the worklog/admin relation comboboxes render empty *locally* — `/getProjects` 403s for the developer isolation slot — but work in CI).