### PR TITLE
test(e2e): stabilize the worklog save→refetch reconcile (shard-9 flake)

### DIFF
--- a/e2e/helpers/worklog.ts
+++ b/e2e/helpers/worklog.ts
@@ -129,6 +129,11 @@ export async function createWorklogEntry(page: Page): Promise<string> {
   await saved;
   await refetched;
 
-  await expect(rowByStamp(page, stamp)).toBeVisible();
+  // The grid rebuilds this <tr> from the post-save refetch, then SolidJS may
+  // re-reconcile it once more as the authoritative list settles. Under CI
+  // 2-worker contention that save→refetch→render path can outlast Playwright's
+  // default 5s expect timeout — the historic shard-9 worklog-crud flake — so
+  // give the row the same 15s the page's other readiness waits use.
+  await expect(rowByStamp(page, stamp)).toBeVisible({ timeout: 15000 });
   return stamp;
 }


### PR DESCRIPTION
The `worklog-crud` "create → edit → delete" test (helpers/worklog.ts:132) asserts the freshly-saved row is visible after waiting for the save 200 + the reconciling `getData/days` refetch. Under CI 2-worker contention the refetch → SolidJS reconcile → render can exceed Playwright's default **5s** expect timeout — the recurring **shard-9** flake that has re-run-gated nearly every PR this round (#427 hit it 3×).

Fix: give that one visibility assertion a **15s** window (the same the page's other readiness waits use). No production code changes.