### PR TITLE
feat(deploy): auto-apply DB migrations on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -244,6 +244,10 @@ COPY --from=deps --chown=app:app /var/www/html/var /var/www/html/var
 # Copy healthcheck script
 COPY --chmod=755 docker/php/healthcheck.sh /usr/local/bin/healthcheck
 
+# Copy the production entrypoint — applies pending DB migrations on start so a
+# new image deployed over an existing database self-migrates (AUTO_MIGRATE=0 opts out)
+COPY --chmod=755 docker/php/docker-entrypoint.sh /usr/local/bin/app-entrypoint
+
 # Update CA certificates during build (requires root, done before USER switch)
 RUN update-ca-certificates 2>/dev/null || true
 
@@ -258,5 +262,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 
 EXPOSE 9000
 
-ENTRYPOINT ["docker-php-entrypoint"]
+ENTRYPOINT ["/usr/local/bin/app-entrypoint"]
 CMD ["php-fpm"]

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+# Production entrypoint: bring the database schema up to date before starting
+# PHP-FPM, so deploying a new image over an existing database applies any pending
+# Doctrine migrations automatically instead of leaving the live schema behind the
+# code that reads it.
+#
+# Set AUTO_MIGRATE=0 to skip this (e.g. when migrations are applied out-of-band,
+# or for read-only/replica containers).
+#
+set -eu
+
+PROJECT_DIR=/var/www/html
+
+console() { php "${PROJECT_DIR}/bin/console" "$@"; }
+
+# Run a single-value SQL query and echo just the number, robust against the
+# console's table formatting. Empty/absent result is treated as 0 by callers.
+scalar() { console dbal:run-sql "$1" 2>/dev/null | grep -oE '[0-9]+' | head -n1; }
+
+# Mark a migration as applied WITHOUT running it, when its schema change is
+# already present. This baselines a database that was created from sql/full.sql
+# before migration tracking existed (its tables exist but no versions are
+# recorded), so migrate() below only runs the migrations that are genuinely
+# missing instead of re-attempting already-applied DDL.
+baseline_if_present() {
+    fqcn="$1"
+    present="$(scalar "$2")"
+    if [ "${present:-0}" != "0" ]; then
+        echo "[entrypoint]   already applied, recording: ${fqcn}"
+        console doctrine:migrations:version "${fqcn}" --add --no-interaction >/dev/null
+    fi
+}
+
+auto_migrate() {
+    echo "[entrypoint] AUTO_MIGRATE on — reconciling database schema"
+
+    # Wait for the database to accept connections (up to ~60s).
+    n=0
+    until console dbal:run-sql 'SELECT 1' >/dev/null 2>&1; do
+        n=$((n + 1))
+        if [ "${n}" -ge 30 ]; then
+            echo "[entrypoint] ERROR: database not reachable after 60s" >&2
+            exit 1
+        fi
+        sleep 2
+    done
+
+    console doctrine:migrations:sync-metadata-storage --no-interaction >/dev/null
+
+    # If nothing is recorded yet but the application schema already exists, this is
+    # a pre-tracking database — baseline it from the live schema before migrating.
+    versions="$(scalar 'SELECT COUNT(*) FROM doctrine_migration_versions')"
+    appschema="$(scalar "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'entries'")"
+    if [ "${versions:-0}" = "0" ] && [ "${appschema:-0}" != "0" ]; then
+        echo "[entrypoint] un-versioned existing database — baselining from live schema"
+        baseline_if_present 'DoctrineMigrations\Version20250901_AddPerformanceIndexes' \
+            "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'entries' AND index_name = 'idx_entries_user_day'"
+        baseline_if_present 'DoctrineMigrations\Version20250901_EncryptTokenFields' \
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'users_ticket_systems' AND column_name = 'accesstoken' AND data_type = 'text'"
+        baseline_if_present 'DoctrineMigrations\Version20260612_FixHolidaysSchema' \
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'holidays' AND column_name = 'name'"
+        baseline_if_present 'DoctrineMigrations\Version20260622_AddMinEntryDuration' \
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'users' AND column_name = 'min_entry_duration'"
+        baseline_if_present 'DoctrineMigrations\Version20260622_AddJiraCloudSupport' \
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ticket_systems' AND column_name = 'cloud_id'"
+    fi
+
+    # Apply the remaining pending migrations. Fails loudly (set -e) so a bad
+    # migration aborts the deploy instead of serving a half-migrated schema.
+    console doctrine:migrations:migrate --no-interaction --allow-no-migration
+    echo "[entrypoint] database schema up to date"
+}
+
+if [ "${1:-}" = "php-fpm" ] && [ "${AUTO_MIGRATE:-1}" = "1" ]; then
+    auto_migrate
+fi
+
+exec docker-php-entrypoint "$@"

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1003,6 +1003,21 @@ stderr_logfile=/var/log/supervisor/timetracker-scheduler-error.log
 
 ## Database Setup & Migration
 
+> **Migrations run automatically on container start.** The production image's
+> entrypoint applies any pending Doctrine migrations before PHP-FPM starts, so
+> deploying a new image over an existing database self-migrates — no manual
+> `doctrine:migrations:migrate` step is needed. It is idempotent (a no-op once the
+> schema is current) and fails the container start loudly if a migration fails,
+> so a bad migration aborts the deploy instead of serving a half-migrated schema.
+>
+> - Disable with `AUTO_MIGRATE=0` (e.g. read-only replicas, or when you apply
+>   migrations out-of-band).
+> - `sql/full.sql` ships the migration-version records, so a **fresh** install is
+>   recognised as already up to date and never re-creates its own schema.
+> - A database created **before** migration tracking (tables present but no
+>   `doctrine_migration_versions` rows) is baselined automatically from the live
+>   schema on first start, then only the genuinely-missing migrations run.
+
 ### Database Initialization
 
 ```bash

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -322,6 +322,29 @@ CREATE TABLE `contracts` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Arbeitsvertrag: Stunden pro Woche/Tag';
 
 
+--
+-- Tabellenstruktur für Tabelle `doctrine_migration_versions`
+--
+CREATE TABLE `doctrine_migration_versions` (
+  `version` varchar(191) NOT NULL,
+  `executed_at` datetime DEFAULT NULL,
+  `execution_time` int(11) DEFAULT NULL,
+  PRIMARY KEY (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Record every migration shipped with this dump as already applied, so a fresh
+-- install never re-creates the schema above and an upgrade runs only migrations
+-- added after this release.
+--
+INSERT INTO `doctrine_migration_versions` (`version`, `executed_at`, `execution_time`) VALUES
+('DoctrineMigrations\\Version20250901_AddPerformanceIndexes', '2025-09-01 00:00:00', 0),
+('DoctrineMigrations\\Version20250901_EncryptTokenFields',    '2025-09-01 00:00:00', 0),
+('DoctrineMigrations\\Version20260612_FixHolidaysSchema',     '2026-06-12 00:00:00', 0),
+('DoctrineMigrations\\Version20260622_AddMinEntryDuration',   '2026-06-22 00:00:00', 0),
+('DoctrineMigrations\\Version20260622_AddJiraCloudSupport',   '2026-06-22 00:00:00', 0);
+
+
 -- EXPORT-VIEWS ---------------------------------------------------------------------------
 
 CREATE VIEW `v_Datenexport` AS


### PR DESCRIPTION
## Problem

There are 3 schema migrations since v5.0.2, each properly written — but **nothing applied them**. The production entrypoint was just `php-fpm`, no CD workflow runs `doctrine:migrations:migrate`, and `sql/full.sql` carried the schema but **no `doctrine_migration_versions` rows**. So deploying a new image over an existing DB left the new columns unmigrated (→ runtime errors), and a fresh install + later `migrate` would collide.

## Fix

- **`docker/php/docker-entrypoint.sh`** (new) — production entrypoint: wait for the DB, run pending migrations, then `exec` the normal `php-fpm` start. Idempotent; fails the container start loudly if a migration fails (a bad migration aborts the deploy rather than serving a half-migrated schema). Opt out with `AUTO_MIGRATE=0`.
- **Baseline for legacy DBs** — a database created from `full.sql` before migration tracking (tables present, no version rows) is reconciled from the **live schema**: each migration whose change is already present is recorded as applied (per-migration SQL probe), so only the genuinely-missing migrations run. No re-running already-applied DDL.
- **`sql/full.sql`** — seed `doctrine_migration_versions` with all 5 shipped migrations → fresh installs are recognised as up to date; future upgrades run only newer migrations.
- **`Dockerfile`** — wire the entrypoint into the `production` stage (only; dev/e2e/CI keep their own).
- **`docs/DEPLOYMENT_GUIDE.md`** — document it.

## Verified locally (CI doesn't exercise the prod entrypoint)

- Fresh install (full.sql): `migrations:up-to-date` → **Up-to-date, no-op**.
- Partial un-versioned DB (real db-e2e): baselined the 4 present migrations, **ran the 1 missing** (`EncryptTokenFields`) → success.
- Idempotent re-run: **Already at the latest version**, no-op.
- Version records stored in Doctrine's exact format (single-backslash FQCN, length-checked).