### PR TITLE
feat(ui): honour the configured date format in modal form date fields

### DIFF
--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -744,7 +744,7 @@ function FieldControl(props: {
         <label class="field">
           <span>{props.field.label()}</span>
           <DateField
-            value={String(text() ?? '')}
+            value={text()}
             onChange={(iso) => props.setField(props.field.name, iso)}
             required={props.field.required}
             disabled={disabled()}

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -8,6 +8,7 @@ import { chipValues, createInlineGridEdit, fieldSelectOptions, InlineEditor, INL
 import { ChipSelect } from '../lib/chipSelect'
 import { gridNav } from '../lib/gridNavigation'
 import { DiskIcon, DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
+import { DateField } from './DateField'
 import { PageDialog } from './PageDialog'
 import { m } from '../paraglide/messages.js'
 import type { ColumnDef, EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
@@ -739,11 +740,22 @@ function FieldControl(props: {
           <textarea disabled={disabled()} value={text()} onInput={(e) => props.setField(props.field.name, e.currentTarget.value)} />
         </label>
       </Match>
+      <Match when={props.field.type === 'date'}>
+        <label class="field">
+          <span>{props.field.label()}</span>
+          <DateField
+            value={String(text() ?? '')}
+            onChange={(iso) => props.setField(props.field.name, iso)}
+            required={props.field.required}
+            disabled={disabled()}
+          />
+        </label>
+      </Match>
       <Match when={true}>
         <label class="field">
           <span>{props.field.label()}</span>
           <input
-            type={props.field.type === 'number' ? 'number' : props.field.type === 'date' ? 'date' : 'text'}
+            type={props.field.type === 'number' ? 'number' : 'text'}
             required={props.field.required}
             disabled={disabled()}
             value={text()}

--- a/frontend/src/components/BulkEntryForm.tsx
+++ b/frontend/src/components/BulkEntryForm.tsx
@@ -3,6 +3,7 @@ import { createSignal, For, Show } from 'solid-js'
 
 import { apiErrorMessage, postForm } from '../api/client'
 import { presetsQuery } from '../api/queries'
+import { DateField } from './DateField'
 import { m } from '../paraglide/messages.js'
 
 type Status =
@@ -103,11 +104,11 @@ export function BulkEntryForm(props: { onSaved?: () => void }) {
         <div class="field-row">
           <label class="field">
             <span>{m.extras_start_date()}</span>
-            <input type="date" value={startDate()} onInput={(e) => setStartDate(e.currentTarget.value)} />
+            <DateField value={startDate()} onChange={setStartDate} />
           </label>
           <label class="field">
             <span>{m.extras_end_date()}</span>
-            <input type="date" value={endDate()} onInput={(e) => setEndDate(e.currentTarget.value)} />
+            <DateField value={endDate()} onChange={setEndDate} />
           </label>
         </div>
 

--- a/frontend/src/components/DateField.test.tsx
+++ b/frontend/src/components/DateField.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render } from '@solidjs/testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AppConfig } from '../config'
+import { setDateFormat } from '../lib/dateFormat'
+import { DateField } from './DateField'
+
+const appConfigStub: AppConfig = {
+  locale: 'de', userId: 1, userName: 'x', appTitle: '', roles: [],
+  showEmptyLine: false, suggestTime: false, showFuture: false, minEntryDuration: 5, logoutUrl: '', legacyUrl: '',
+  csrfToken: '', loginPath: '/login',
+}
+
+beforeEach(() => {
+  window.APP_CONFIG = { ...appConfigStub }
+  setDateFormat({ mode: 'custom', pattern: 'DD.MM.YYYY' })
+})
+afterEach(() => {
+  cleanup()
+})
+
+function renderField(value: string, onChange = vi.fn()): { input: HTMLInputElement; onChange: ReturnType<typeof vi.fn> } {
+  const { container } = render(() => <DateField value={value} onChange={onChange} />)
+  return { input: container.querySelector('input.date-field') as HTMLInputElement, onChange }
+}
+
+describe('DateField', () => {
+  it('displays the ISO value in the configured format, with a matching placeholder', () => {
+    const { input } = renderField('2026-06-19')
+    expect(input.value).toBe('19.06.2026')
+    expect(input.placeholder).toBe('DD.MM.YYYY')
+  })
+
+  it('parses a value typed in the configured format back to ISO', () => {
+    const { input, onChange } = renderField('2026-06-19')
+    fireEvent.input(input, { target: { value: '25.12.2026' } })
+    fireEvent.change(input)
+    expect(onChange).toHaveBeenCalledWith('2026-12-25')
+  })
+
+  it('accepts ISO directly as a fallback', () => {
+    const { input, onChange } = renderField('')
+    fireEvent.input(input, { target: { value: '2026-12-25' } })
+    fireEvent.change(input)
+    expect(onChange).toHaveBeenCalledWith('2026-12-25')
+  })
+
+  it('clears to empty when blanked', () => {
+    const { input, onChange } = renderField('2026-06-19')
+    fireEvent.input(input, { target: { value: '' } })
+    fireEvent.change(input)
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('flags an unparseable value (aria-invalid) without committing', () => {
+    const { input, onChange } = renderField('')
+    fireEvent.input(input, { target: { value: 'not a date' } })
+    fireEvent.change(input)
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+  })
+})

--- a/frontend/src/components/DateField.tsx
+++ b/frontend/src/components/DateField.tsx
@@ -1,0 +1,77 @@
+import { createEffect, createMemo, createSignal } from 'solid-js'
+
+import { dateFormatPlaceholder, formatUserDate, parseUserDate } from '../lib/dateFormat'
+
+interface DateFieldProps {
+  /** ISO yyyy-mm-dd, or '' for no date. */
+  value: string
+  /** Called with a validated ISO yyyy-mm-dd (or '' when cleared). */
+  onChange: (iso: string) => void
+  id?: string
+  required?: boolean
+  disabled?: boolean
+}
+
+/**
+ * A date input that displays AND accepts the user's configured date format
+ * ({@link dateFormat}), with ISO yyyy-mm-dd always accepted as a fallback, and
+ * commits a validated ISO value via onChange. It is a plain text input — not a
+ * native `<input type="date">`, whose display the browser owns and cannot render
+ * in the configured format — mirroring the inline-grid date editor so forms and
+ * grid stay consistent.
+ */
+export function DateField(props: DateFieldProps) {
+  let inputRef: HTMLInputElement | undefined
+  const formatIso = (iso: string): string => (iso === '' ? '' : formatUserDate(iso))
+  // Tracks props.value AND the date-format pref (via formatUserDate), so the
+  // resting display reformats live when either changes.
+  const formatted = createMemo(() => (props.value === '' ? '' : formatUserDate(props.value)))
+  // eslint-disable-next-line solid/reactivity -- one-time initial seed; the effect below keeps text in sync
+  const [text, setText] = createSignal(formatted())
+  const [invalid, setInvalid] = createSignal(false)
+
+  // Re-sync the shown text when the resting value/format changes from outside —
+  // but never while the user is typing in this field.
+  createEffect(() => {
+    const next = formatted()
+    if (document.activeElement !== inputRef) {
+      setText(next)
+      setInvalid(false)
+    }
+  })
+
+  const commit = (): void => {
+    const iso = parseUserDate(text())
+    if (iso === null) {
+      setInvalid(true)
+      return
+    }
+    setInvalid(false)
+    props.onChange(iso)
+    setText(formatIso(iso))
+  }
+
+  return (
+    <input
+      ref={(el) => {
+        inputRef = el
+      }}
+      id={props.id}
+      type="text"
+      class="date-field"
+      inputmode="numeric"
+      autocomplete="off"
+      required={props.required}
+      disabled={props.disabled}
+      aria-invalid={invalid() ? 'true' : undefined}
+      placeholder={dateFormatPlaceholder()}
+      value={text()}
+      onInput={(e) => {
+        setText(e.currentTarget.value)
+        setInvalid(false)
+      }}
+      onChange={commit}
+      onBlur={commit}
+    />
+  )
+}

--- a/frontend/src/components/DateField.tsx
+++ b/frontend/src/components/DateField.tsx
@@ -47,7 +47,9 @@ export function DateField(props: DateFieldProps) {
       return
     }
     setInvalid(false)
-    props.onChange(iso)
+    if (iso !== props.value) {
+      props.onChange(iso)
+    }
     setText(formatIso(iso))
   }
 
@@ -59,7 +61,6 @@ export function DateField(props: DateFieldProps) {
       id={props.id}
       type="text"
       class="date-field"
-      inputmode="numeric"
       autocomplete="off"
       required={props.required}
       disabled={props.disabled}
@@ -71,7 +72,6 @@ export function DateField(props: DateFieldProps) {
         setInvalid(false)
       }}
       onChange={commit}
-      onBlur={commit}
     />
   )
 }

--- a/frontend/src/lib/dateFormat.test.ts
+++ b/frontend/src/lib/dateFormat.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { AppConfig } from '../config'
-import { formatUserDate, formatWith, setDateFormat, validatePattern } from './dateFormat'
+import { dateFormatPlaceholder, formatUserDate, formatWith, parseUserDate, setDateFormat, validatePattern } from './dateFormat'
 
 const ISO = '2026-06-19'
 
@@ -72,6 +72,50 @@ describe('dateFormat', () => {
       expect(formatUserDate(ISO)).toBe('19.06.2026')
       setDateFormat({ mode: 'iso', pattern: 'DD.MM.YYYY' })
       expect(formatUserDate(ISO)).toBe(ISO)
+    })
+  })
+
+  describe('parseUserDate (form save path)', () => {
+    beforeEach(() => {
+      window.APP_CONFIG = { ...appConfigStub }
+    })
+
+    const custom = { mode: 'custom', pattern: 'DD.MM.YYYY' } as const
+
+    it('parses the configured custom format back to ISO', () => {
+      expect(parseUserDate('19.06.2026', custom)).toBe(ISO)
+    })
+    it('pads single-digit day/month', () => {
+      expect(parseUserDate('5.6.2026', custom)).toBe('2026-06-05')
+    })
+    it('expands a 2-digit year to 20YY', () => {
+      expect(parseUserDate('19.06.26', { mode: 'custom', pattern: 'DD.MM.YY' })).toBe(ISO)
+    })
+    it('ALWAYS accepts ISO as a fallback, whatever the format', () => {
+      expect(parseUserDate('2026-06-19', custom)).toBe(ISO)
+      expect(parseUserDate('2026-06-19', { mode: 'iso', pattern: '' })).toBe(ISO)
+    })
+    it('auto mode parses the locale order (de → d.m.y)', () => {
+      expect(parseUserDate('19.06.2026', { mode: 'auto', pattern: '' })).toBe(ISO)
+    })
+    it('blank input parses to empty (clears an optional date)', () => {
+      expect(parseUserDate('   ', custom)).toBe('')
+    })
+    it('rejects an impossible date (Feb 30)', () => {
+      expect(parseUserDate('30.02.2026', custom)).toBeNull()
+    })
+    it('rejects garbage and a non-ISO string in iso mode', () => {
+      expect(parseUserDate('not a date', custom)).toBeNull()
+      expect(parseUserDate('19.06.2026', { mode: 'iso', pattern: '' })).toBeNull()
+    })
+  })
+
+  describe('dateFormatPlaceholder', () => {
+    it('shows the pattern for custom, YYYY-MM-DD for iso, a sample for auto', () => {
+      window.APP_CONFIG = { ...appConfigStub }
+      expect(dateFormatPlaceholder({ mode: 'custom', pattern: 'DD.MM.YYYY' })).toBe('DD.MM.YYYY')
+      expect(dateFormatPlaceholder({ mode: 'iso', pattern: '' })).toBe('YYYY-MM-DD')
+      expect(dateFormatPlaceholder({ mode: 'auto', pattern: '' })).toMatch(/\d/)
     })
   })
 })

--- a/frontend/src/lib/dateFormat.ts
+++ b/frontend/src/lib/dateFormat.ts
@@ -6,9 +6,11 @@ import { appConfig } from '../config'
  * User preference for how dates render in the UI. Client-side only (localStorage),
  * like the grid Enter-behavior and theme — it carries no data semantics, so it
  * never touches the server settings. The WIRE format, the sort key, and the inline
- * date EDITOR all stay ISO yyyy-mm-dd; this preference applies only at the
- * read-only display leaves (the worklog/eval date cells), so no display→ISO parser
- * is ever introduced on the save path. Signal-backed so open grids reformat live.
+ * date EDITOR stays ISO yyyy-mm-dd. Display formatting applies at the read-only
+ * grid leaves; modal FORM date fields additionally round-trip through
+ * parseUserDate() below, which accepts the active display format OR ISO and
+ * always validates back to ISO for the save path. Signal-backed so open grids
+ * reformat live.
  */
 export type DateFormatMode = 'iso' | 'auto' | 'custom'
 
@@ -169,4 +171,102 @@ export function setDateFormat(pref: DateFormatPref): void {
 /** Format an ISO yyyy-mm-dd date with the current preference (reactive). */
 export function formatUserDate(iso: string): string {
   return formatWith(iso, dateFormat())
+}
+
+const isFieldToken = (token: Token): token is Extract<Token, { field: 'y' | 'm' | 'd' }> => 'field' in token
+
+/** The order the y/m/d fields appear in the active display format (first
+ *  occurrence of each), or null when the format is plain ISO (only ISO input is
+ *  then accepted) or doesn't carry all three fields. */
+function fieldOrder(pref: DateFormatPref): ('y' | 'm' | 'd')[] | null {
+  if (pref.mode === 'iso') {
+    return null
+  }
+  if (pref.mode === 'custom') {
+    const seen: ('y' | 'm' | 'd')[] = []
+    for (const token of tokenize(pref.pattern)) {
+      if (isFieldToken(token) && !seen.includes(token.field)) {
+        seen.push(token.field)
+      }
+    }
+
+    return seen.length === 3 ? seen : null
+  }
+
+  // 'auto' — read the field order the locale renders (de → d,m,y; en → m,d,y).
+  try {
+    const parts = new Intl.DateTimeFormat(appConfig().locale, { year: 'numeric', month: '2-digit', day: '2-digit' })
+      .formatToParts(new Date(Date.UTC(2001, 11, 25)))
+    const order = parts
+      .filter((part) => part.type === 'year' || part.type === 'month' || part.type === 'day')
+      .map((part) => (part.type === 'year' ? 'y' : part.type === 'month' ? 'm' : 'd') as 'y' | 'm' | 'd')
+
+    return order.length === 3 ? order : ['y', 'm', 'd']
+  } catch {
+    return ['y', 'm', 'd']
+  }
+}
+
+/** True when iso (a yyyy-mm-dd string) names a real calendar date (rejects 2026-02-30). */
+function isRealIsoDate(iso: string): boolean {
+  const [year, month, day] = iso.split('-').map(Number)
+  const date = new Date(Date.UTC(year!, month! - 1, day!))
+
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month! - 1 && date.getUTCDate() === day
+}
+
+/**
+ * Parse a user-typed date (in the active display format, or ISO) back to ISO
+ * yyyy-mm-dd for the save path. Returns '' for blank input, or null when the
+ * value can't be understood as a date. ISO yyyy-mm-dd is ALWAYS accepted as a
+ * fallback regardless of the active preference, so the canonical form (or a
+ * paste) always works.
+ */
+export function parseUserDate(input: string, pref: DateFormatPref = dateFormat()): string | null {
+  const raw = input.trim()
+  if (raw === '') {
+    return ''
+  }
+  if (ISO_SHAPE.test(raw)) {
+    return isRealIsoDate(raw) ? raw : null
+  }
+
+  const order = fieldOrder(pref)
+  if (order === null) {
+    return null // ISO-only format and the input wasn't ISO
+  }
+
+  // Numeric groups left-to-right. `\d+` is linear (no backtracking → no ReDoS).
+  const groups = raw.match(/\d+/g)
+  if (groups === null || groups.length < 3) {
+    return null
+  }
+  const part: Record<'y' | 'm' | 'd', string> = { y: '', m: '', d: '' }
+  order.forEach((field, index) => {
+    part[field] = groups[index]!
+  })
+
+  let year = part.y
+  if (year.length === 2) {
+    year = String(2000 + Number(year)) // 2-digit year → 20YY
+  }
+  if (!/^\d{4}$/.test(year)) {
+    return null
+  }
+  const iso = `${year}-${part.m.padStart(2, '0')}-${part.d.padStart(2, '0')}`
+
+  return ISO_SHAPE.test(iso) && isRealIsoDate(iso) ? iso : null
+}
+
+/** A placeholder hint for a date input in the active format (e.g. "DD.MM.YYYY",
+ *  a locale sample, or "YYYY-MM-DD"). */
+export function dateFormatPlaceholder(pref: DateFormatPref = dateFormat()): string {
+  if (pref.mode === 'custom' && validatePattern(pref.pattern).ok) {
+    return pref.pattern
+  }
+  if (pref.mode === 'auto') {
+    return formatAuto('2026-12-31') // a sample so the order/separators are obvious
+  }
+
+  return 'YYYY-MM-DD'
 }

--- a/frontend/src/pages/tabs.test.tsx
+++ b/frontend/src/pages/tabs.test.tsx
@@ -103,9 +103,13 @@ describe('Bulk entry form', () => {
     const select = container.querySelector('select') as HTMLSelectElement
     select.value = '3'
     fireEvent.input(select)
-    const dates = container.querySelectorAll<HTMLInputElement>('input[type=date]')
+    // The date fields are now format-aware text inputs (DateField); ISO is always
+    // accepted, and the parsed value commits on change/blur, not on every keystroke.
+    const dates = container.querySelectorAll<HTMLInputElement>('input.date-field')
     fireEvent.input(dates[0]!, { target: { value: '2026-06-01' } })
+    fireEvent.change(dates[0]!)
     fireEvent.input(dates[1]!, { target: { value: '2026-06-05' } })
+    fireEvent.change(dates[1]!)
 
     fireEvent.submit(getByRole('button', { name: /Create entries/i }).closest('form') as HTMLFormElement)
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -620,6 +620,13 @@ main {
   outline-offset: -1px;
 }
 
+/* Date field whose typed value couldn't be parsed (in the user's date format or ISO). */
+.field input.date-field[aria-invalid='true'] {
+  border-color: var(--color-danger, #c0392b);
+  outline: 2px solid var(--color-danger, #c0392b);
+  outline-offset: -1px;
+}
+
 .field-row {
   display: grid;
   gap: 1.1rem;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -620,8 +620,11 @@ main {
   outline-offset: -1px;
 }
 
-/* Date field whose typed value couldn't be parsed (in the user's date format or ISO). */
-.field input.date-field[aria-invalid='true'] {
+/* Date field whose typed value couldn't be parsed (in the user's date format or
+   ISO). The :focus-visible variant keeps the danger outline while the field is
+   focused — it out-specifies the generic input:focus-visible accent rule. */
+.field input.date-field[aria-invalid='true'],
+.field input.date-field[aria-invalid='true']:focus-visible {
   border-color: var(--color-danger, #c0392b);
   outline: 2px solid var(--color-danger, #c0392b);
   outline-offset: -1px;


### PR DESCRIPTION
Modal forms used a native `<input type="date">` (browser locale + ISO value), so they ignored the user's configured date format that the worklog/eval grid already honours — the inconsistency reported.

- **`dateFormat.ts`**: new `parseUserDate()` (accepts the active display format **or** ISO as a fallback, validates back to ISO for the save path; field order derived from the pattern/locale, parsing via a linear `\d+` scan — no ReDoS) + `dateFormatPlaceholder()`.
- **`DateField.tsx`** (new): a format-aware text input (display via `formatUserDate`, commit via `parseUserDate`, `aria-invalid` on unparseable input) — mirrors the inline-grid date editor, so forms and grid are consistent.
- Wired into the admin entity forms (Contract start/end, Holiday date) and `BulkEntryForm` (start/end).

Tested: `parseUserDate`/`dateFormatPlaceholder` (custom/auto/iso, 2-digit year, ISO fallback, impossible dates, garbage) + a `DateField` component test + the updated bulk-entry tab test. 285 frontend tests green.