### PR TITLE
feat(admin): surface missing columns in user/project/contract lists

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -305,6 +305,7 @@
   "admin_f_offer": "Angebot",
   "admin_f_cost_center": "Kostenstelle",
   "admin_f_billing": "Abrechnung",
+  "admin_f_hours": "Stunden (Mo–So)",
   "admin_f_estimation": "Geschätzte Dauer",
   "admin_f_internal_jira_key": "Interner JIRA-Projektschlüssel",
   "admin_f_internal_jira_system": "Internes JIRA-Ticket-System",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -305,6 +305,7 @@
   "admin_f_offer": "Offer",
   "admin_f_cost_center": "Cost center",
   "admin_f_billing": "Billing",
+  "admin_f_hours": "Hours (Mon–Sun)",
   "admin_f_estimation": "Estimated duration",
   "admin_f_internal_jira_key": "Internal JIRA project key",
   "admin_f_internal_jira_system": "Internal JIRA ticket system",

--- a/frontend/src/admin/entities.test.ts
+++ b/frontend/src/admin/entities.test.ts
@@ -99,6 +99,7 @@ describe('admin entity descriptors', () => {
     const lead = col(byKey('projects'), 'project_lead')
     const users: OptionLookup = (source) => (source === 'users' ? [{ id: 5, label: 'Alice' }] : [])
     expect(lead.render?.({ project_lead: 5 }, users)).toBe('Alice')
+    expect(lead.render?.({ projectLead: 5 }, users)).toBe('Alice') // camelCase key also resolves (Base::toArray emits both)
     expect(lead.render?.({ project_lead: 0 }, users)).toBe('')
   })
 

--- a/frontend/src/admin/entities.test.ts
+++ b/frontend/src/admin/entities.test.ts
@@ -73,6 +73,35 @@ describe('admin entity descriptors', () => {
     expect(customerCol.render?.({ customer: 0 }, lookup)).toBe('')
   })
 
+  it('user locale column shows the language endonym (unknown code passes through)', () => {
+    const locale = col(byKey('users'), 'locale')
+    expect(locale.render?.({ locale: 'de' }, noOptions)).toBe('Deutsch')
+    expect(locale.render?.({ locale: 'en' }, noOptions)).toBe('English')
+    expect(locale.render?.({ locale: 'xx' }, noOptions)).toBe('xx')
+  })
+
+  it('contract hours column summarises working hours Mon→Sun', () => {
+    const hours = col(byKey('contracts'), 'hours_summary')
+    // entity keys are JS getDay()-indexed (hours_0 = Sunday); shown Mon→Sun.
+    expect(hours.render?.({ hours_1: 8, hours_2: 8, hours_3: 8, hours_4: 8, hours_5: 8, hours_6: 0, hours_0: 0 }, noOptions))
+      .toBe('8 / 8 / 8 / 8 / 8 / 0 / 0')
+    expect(hours.render?.({ hours_1: 8.5 }, noOptions)).toBe('8.5 / 0 / 0 / 0 / 0 / 0 / 0')
+  })
+
+  it('project billing column maps the method code to a label (out-of-range blanks)', () => {
+    const billing = col(byKey('projects'), 'billing')
+    expect(billing.render?.({ billing: 0 }, noOptions)).toBeTruthy()
+    expect(billing.render?.({ billing: 1 }, noOptions)).not.toBe(billing.render?.({ billing: 0 }, noOptions))
+    expect(billing.render?.({ billing: 99 }, noOptions)).toBe('')
+  })
+
+  it('project lead column resolves the user id→label, blanks on 0', () => {
+    const lead = col(byKey('projects'), 'project_lead')
+    const users: OptionLookup = (source) => (source === 'users' ? [{ id: 5, label: 'Alice' }] : [])
+    expect(lead.render?.({ project_lead: 5 }, users)).toBe('Alice')
+    expect(lead.render?.({ project_lead: 0 }, users)).toBe('')
+  })
+
   it('holidays are immutable (not editable) and delete by day, not id', () => {
     const holidays = byKey('holidays')
     expect(holidays.editable).toBe(false)

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -30,6 +30,25 @@ function pick(row: Row, ...keys: string[]): unknown {
 
 const bool: (v: unknown) => boolean = Boolean
 
+/** Language endonyms for the user `locale` column (mirrors the form's options). */
+const LOCALE_NAMES: Record<string, string> = { de: 'Deutsch', en: 'English', es: 'Español', fr: 'Français', ru: 'Русский' }
+function localeLabel(value: unknown): string {
+  const code = str(value)
+
+  return LOCALE_NAMES[code] ?? code
+}
+
+/** Per-day working hours in week order (Mon→Sun), compact, for the contract list.
+ *  Contract keys are JS getDay()-indexed, so hours_0 is Sunday. */
+function hoursSummary(row: Row): string {
+  return [1, 2, 3, 4, 5, 6, 0].map((day) => String(Number(row[`hours_${day}`] ?? 0))).join(' / ')
+}
+
+/** Billing method (0/1/2) → its label, for the project list. */
+function billingLabel(value: unknown): string {
+  return [m.admin_billing_none(), m.admin_billing_tm(), m.admin_billing_fp()][Number(value ?? 0)] ?? ''
+}
+
 export function adminEntities(): EntityDescriptor[] {
   return [
     {
@@ -70,6 +89,10 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'jiraId', label: () => m.admin_f_jira_id() },
         { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active), align: 'center', boolean: true },
         { key: 'global', label: () => m.admin_f_global(), render: (row) => mark(row.global), align: 'center', boolean: true },
+        { key: 'project_lead', label: () => m.admin_f_project_lead(), render: (row, o) => rel('users')(row, 'project_lead', o) },
+        { key: 'technical_lead', label: () => m.admin_f_technical_lead(), render: (row, o) => rel('users')(row, 'technical_lead', o) },
+        { key: 'ticket_system', label: () => m.admin_f_ticket_system(), render: (row, o) => rel('ticketSystems')(row, 'ticket_system', o) },
+        { key: 'billing', label: () => m.admin_f_billing(), render: (row) => billingLabel(row.billing) },
         // View-only: auto-synced from the ticket system (no matching field → read-only).
         { key: 'subtickets', label: () => m.admin_f_subtickets() },
       ],
@@ -139,6 +162,7 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'username', label: () => m.admin_f_username() },
         { key: 'abbr', label: () => m.admin_f_abbr() },
         { key: 'type', label: () => m.admin_f_type() },
+        { key: 'locale', label: () => m.admin_f_language(), render: (row) => localeLabel(row.locale) },
         { key: 'teams', label: () => m.admin_f_teams(), render: (row, o) => ((row.teams as number[]) ?? []).map((id) => o('teams').find((t) => t.id === id)?.label ?? id).join(', ') },
       ],
       fields: [
@@ -348,6 +372,7 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'user_id', label: () => m.admin_f_username(), render: (row, o) => rel('users')(row, 'user_id', o) },
         { key: 'start', label: () => m.admin_f_start() },
         { key: 'end', label: () => m.admin_f_end() },
+        { key: 'hours_summary', label: () => m.admin_f_hours(), render: (row) => hoursSummary(row) },
       ],
       fields: [
         { name: 'user_id', label: () => m.admin_f_username(), type: 'select', source: 'users', required: true },

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -28,6 +28,16 @@ function pick(row: Row, ...keys: string[]): unknown {
   return undefined
 }
 
+/** Like rel(), but resolves the id via pick() so both snake_case and camelCase
+ *  payload keys (Base::toArray emits both) work for relation grid columns. */
+function relPick(source: OptionSource, ...keys: string[]) {
+  return (row: Row, options: OptionLookup): string => {
+    const id = Number(pick(row, ...keys) ?? 0)
+
+    return id > 0 ? (options(source).find((option) => option.id === id)?.label ?? String(id)) : ''
+  }
+}
+
 const bool: (v: unknown) => boolean = Boolean
 
 /** Language endonyms for the user `locale` column (mirrors the form's options). */
@@ -89,9 +99,9 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'jiraId', label: () => m.admin_f_jira_id() },
         { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active), align: 'center', boolean: true },
         { key: 'global', label: () => m.admin_f_global(), render: (row) => mark(row.global), align: 'center', boolean: true },
-        { key: 'project_lead', label: () => m.admin_f_project_lead(), render: (row, o) => rel('users')(row, 'project_lead', o) },
-        { key: 'technical_lead', label: () => m.admin_f_technical_lead(), render: (row, o) => rel('users')(row, 'technical_lead', o) },
-        { key: 'ticket_system', label: () => m.admin_f_ticket_system(), render: (row, o) => rel('ticketSystems')(row, 'ticket_system', o) },
+        { key: 'project_lead', label: () => m.admin_f_project_lead(), render: (row, o) => relPick('users', 'project_lead', 'projectLead')(row, o) },
+        { key: 'technical_lead', label: () => m.admin_f_technical_lead(), render: (row, o) => relPick('users', 'technical_lead', 'technicalLead')(row, o) },
+        { key: 'ticket_system', label: () => m.admin_f_ticket_system(), render: (row, o) => relPick('ticketSystems', 'ticket_system', 'ticketSystem')(row, o) },
         { key: 'billing', label: () => m.admin_f_billing(), render: (row) => billingLabel(row.billing) },
         // View-only: auto-synced from the ticket system (no matching field → read-only).
         { key: 'subtickets', label: () => m.admin_f_subtickets() },


### PR DESCRIPTION
The admin list/table views omitted fields that already exist on the entities and in the list API payloads:

- **Users**: + **Language** column (locale endonym — Deutsch/English/…).
- **Contracts**: + a compact **Hours (Mon–Sun)** per-day summary (the entity keys are JS `getDay()`-indexed, shown in week order).
- **Projects**: + **Project lead**, **Technical lead**, **Ticket system**, **Billing** columns. The `.table-scroll` wrapper already scrolls horizontally, so the wider list stays legible.

No backend change — every field is already in the list payloads. Covered by entity-descriptor render tests (locale endonym, hours summary, billing mapping, lead id→label). 275 frontend tests green.