### PR TITLE
feat(admin): "last activity" column for customers, projects, users

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -310,6 +310,7 @@
   "admin_f_abbr": "Kürzel",
   "admin_f_type": "Typ",
   "admin_f_language": "Sprache",
+  "admin_f_last_activity": "Letzte Aktivität",
   "admin_f_team_lead": "Teamleiter",
   "admin_f_jira_id": "Ticket-Präfix",
   "admin_f_jira_ticket": "Ticketnummer",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -310,6 +310,7 @@
   "admin_f_abbr": "Abbr",
   "admin_f_type": "Type",
   "admin_f_language": "Language",
+  "admin_f_last_activity": "Last activity",
   "admin_f_team_lead": "Team lead",
   "admin_f_jira_id": "Ticket prefix",
   "admin_f_jira_ticket": "Ticket number",

--- a/frontend/src/admin/entities.test.ts
+++ b/frontend/src/admin/entities.test.ts
@@ -112,4 +112,13 @@ describe('admin entity descriptors', () => {
     expect(holidays.toForm(null)).toMatchObject({ day: '', name: '' })
     expect(holidays.toPayload({ id: 0, day: '2026-01-01', name: 'New Year' })).toEqual({ day: '2026-01-01', name: 'New Year' })
   })
+
+  it('customers, projects and users expose a last_activity column (raw ISO date, no custom render)', () => {
+    for (const key of ['customers', 'projects', 'users']) {
+      // col() throws if the column is missing. No render → the shell's cellText falls
+      // back to the raw row value (ISO date, which sorts chronologically) and blanks
+      // when the entity was never booked.
+      expect(col(byKey(key), 'last_activity').render).toBeUndefined()
+    }
+  })
 })

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -73,6 +73,7 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'teams', label: () => m.admin_f_teams(), render: (row, o) => ((row.teams as number[]) ?? []).map((id) => o('teams').find((t) => t.id === id)?.label ?? id).join(', ') },
         { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active), align: 'center', boolean: true },
         { key: 'global', label: () => m.admin_f_global(), render: (row) => mark(row.global), align: 'center', boolean: true },
+        { key: 'last_activity', label: () => m.admin_f_last_activity() },
       ],
       fields: [
         { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true },
@@ -105,6 +106,7 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'billing', label: () => m.admin_f_billing(), render: (row) => billingLabel(row.billing) },
         // View-only: auto-synced from the ticket system (no matching field → read-only).
         { key: 'subtickets', label: () => m.admin_f_subtickets() },
+        { key: 'last_activity', label: () => m.admin_f_last_activity() },
       ],
       fields: [
         { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true },
@@ -174,6 +176,7 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'type', label: () => m.admin_f_type() },
         { key: 'locale', label: () => m.admin_f_language(), render: (row) => localeLabel(row.locale) },
         { key: 'teams', label: () => m.admin_f_teams(), render: (row, o) => ((row.teams as number[]) ?? []).map((id) => o('teams').find((t) => t.id === id)?.label ?? id).join(', ') },
+        { key: 'last_activity', label: () => m.admin_f_last_activity() },
       ],
       fields: [
         { name: 'username', label: () => m.admin_f_username(), type: 'text', required: true },

--- a/src/Controller/Default/GetAllProjectsAction.php
+++ b/src/Controller/Default/GetAllProjectsAction.php
@@ -47,10 +47,17 @@ final class GetAllProjectsAction extends BaseController
         /** @var array<int, Project> $result */
         $result = $customerId > 0 ? $objectRepository->findByCustomer($customerId) : $objectRepository->findAll();
 
+        // "Last activity" (date of the most recent booking) is for the admin overview,
+        // which lists every project unfiltered; skip the aggregate on the customer-filtered
+        // entry-form path, which doesn't show the column.
+        $lastActivity = $customerId > 0 ? [] : $objectRepository->lastActivityBy('project_id');
+
         $data = [];
         foreach ($result as $project) {
             if ($project instanceof Project) {
-                $data[] = ['project' => $project->toArray()];
+                $row = $project->toArray();
+                $row['last_activity'] = $lastActivity[(int) $project->getId()] ?? null;
+                $data[] = ['project' => $row];
             }
         }
 

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -68,10 +68,10 @@ class CustomerRepository extends ServiceEntityRepository
     /**
      * Returns an array of all available customers.
      *
-     * @return array<int, array{customer: array{id:int, name:string, active:bool, global:bool, teams: array<int, int>}}>
+     * @return array<int, array{customer: array{id:int, name:string, active:bool, global:bool, teams: array<int, int>, last_activity: string|null}}>
      */
     /**
-     * @return array<int, array{customer: array{id:int, name:string, active:bool, global:bool, teams: array<int, int>}}>
+     * @return array<int, array{customer: array{id:int, name:string, active:bool, global:bool, teams: array<int, int>, last_activity: string|null}}>
      */
     public function getAllCustomers(): array
     {

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -18,6 +18,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class CustomerRepository extends ServiceEntityRepository
 {
+    use LastActivityTrait;
+
     public function __construct(ManagerRegistry $managerRegistry)
     {
         parent::__construct($managerRegistry, Customer::class);
@@ -79,6 +81,8 @@ class CustomerRepository extends ServiceEntityRepository
             ['name' => 'ASC'],
         );
 
+        $lastActivity = $this->lastActivityBy('customer_id');
+
         $data = [];
         foreach ($customers as $customer) {
             $teams = [];
@@ -92,6 +96,7 @@ class CustomerRepository extends ServiceEntityRepository
                 'active' => (bool) $customer->getActive(),
                 'global' => (bool) $customer->getGlobal(),
                 'teams' => $teams,
+                'last_activity' => $lastActivity[(int) $customer->getId()] ?? null,
             ]];
         }
 

--- a/src/Repository/LastActivityTrait.php
+++ b/src/Repository/LastActivityTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use InvalidArgumentException;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * Shared "date of last time booking" aggregate for the admin list repositories
+ * (customers / projects / users): one grouped MAX(day) over the entries table.
+ */
+trait LastActivityTrait
+{
+    /**
+     * Map of the given entry FK value => the date (Y-m-d) of the most recent
+     * entry that references it. Entities with no entries are absent from the map.
+     *
+     * @return array<int, string>
+     */
+    public function lastActivityBy(string $column): array
+    {
+        // Whitelist — these are the only entry FKs we aggregate on; never user input.
+        if (!in_array($column, ['customer_id', 'project_id', 'user_id'], true)) {
+            throw new InvalidArgumentException(sprintf('Unsupported activity column: %s', $column));
+        }
+
+        /** @var array<int, string> $result */
+        $result = $this->getEntityManager()->getConnection()->fetchAllKeyValue(
+            sprintf('SELECT %1$s, MAX(day) FROM entries WHERE %1$s IS NOT NULL GROUP BY %1$s', $column),
+        );
+
+        return $result;
+    }
+}

--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -23,6 +23,8 @@ use function is_array;
  */
 class ProjectRepository extends ServiceEntityRepository
 {
+    use LastActivityTrait;
+
     public function __construct(ManagerRegistry $managerRegistry)
     {
         parent::__construct($managerRegistry, Project::class);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -89,7 +89,7 @@ class UserRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return array<int, array{user: array{id:int, username:string, type:string, abbr:string, locale:string, teams: array<int, int>}}>
+     * @return array<int, array{user: array{id:int, username:string, type:string, abbr:string, locale:string, teams: array<int, int>, last_activity: string|null}}>
      */
     public function getAllUsers(): array
     {

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -20,6 +20,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class UserRepository extends ServiceEntityRepository
 {
+    use LastActivityTrait;
+
     public function __construct(ManagerRegistry $managerRegistry)
     {
         parent::__construct($managerRegistry, User::class);
@@ -97,6 +99,8 @@ class UserRepository extends ServiceEntityRepository
             ['username' => 'ASC'],
         );
 
+        $lastActivity = $this->lastActivityBy('user_id');
+
         $data = [];
         foreach ($users as $user) {
             if (!$user instanceof User) {
@@ -115,6 +119,7 @@ class UserRepository extends ServiceEntityRepository
                 'abbr' => (string) $user->getAbbr(),
                 'locale' => $user->getLocale(),
                 'teams' => $teams,
+                'last_activity' => $lastActivity[(int) $user->getId()] ?? null,
             ]];
         }
 

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -81,6 +81,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'active' => true,
                     'global' => false,
                     'teams' => [1], // Customer 1 is associated with team 1
+                    'last_activity' => '2023-10-24',
                 ],
             ],
             [
@@ -90,6 +91,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'active' => true,
                     'global' => true,
                     'teams' => [], // Global customer has no specific teams
+                    'last_activity' => null,
                 ],
             ],
             [
@@ -99,6 +101,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'active' => false,
                     'global' => false,
                     'teams' => [2], // Customer 2 is associated with team 2
+                    'last_activity' => null,
                 ],
             ],
         ];
@@ -242,6 +245,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'NPL',
                     'locale' => 'de',
                     'teams' => [2], // User 2 is in team 2
+                    'last_activity' => '2020-02-08',
                 ],
             ],
             1 => [
@@ -252,6 +256,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'IMY',
                     'locale' => 'de',
                     'teams' => [], // User 3 has no teams in current test data
+                    'last_activity' => '0500-01-31',
                 ],
             ],
             2 => [
@@ -262,6 +267,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'NCO',
                     'locale' => 'de',
                     'teams' => [], // User 5 has no teams
+                    'last_activity' => null,
                 ],
             ],
             3 => [
@@ -272,6 +278,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'NPL',
                     'locale' => 'de',
                     'teams' => [], // User 4 has no teams
+                    'last_activity' => null,
                 ],
             ],
             4 => [
@@ -282,6 +289,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'UTE',
                     'locale' => 'de',
                     'teams' => [1], // User 1 is in team 1
+                    'last_activity' => '2023-10-24',
                 ],
             ],
         ];

--- a/tests/Repository/LastActivityDouble.php
+++ b/tests/Repository/LastActivityDouble.php
@@ -15,8 +15,6 @@ use Doctrine\ORM\EntityManagerInterface;
 /**
  * Concrete user of LastActivityTrait so its public method can be unit-tested (and
  * statically typed) without standing up a full Doctrine repository.
- *
- * @internal
  */
 final class LastActivityDouble
 {

--- a/tests/Repository/LastActivityDouble.php
+++ b/tests/Repository/LastActivityDouble.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Repository\LastActivityTrait;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Concrete user of LastActivityTrait so its public method can be unit-tested (and
+ * statically typed) without standing up a full Doctrine repository.
+ *
+ * @internal
+ */
+final class LastActivityDouble
+{
+    use LastActivityTrait;
+
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function getEntityManager(): EntityManagerInterface
+    {
+        return $this->entityManager;
+    }
+}

--- a/tests/Repository/LastActivityTraitTest.php
+++ b/tests/Repository/LastActivityTraitTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class LastActivityTraitTest extends TestCase
+{
+    public function testRejectsNonWhitelistedColumn(): void
+    {
+        $repository = new LastActivityDouble(self::createStub(EntityManagerInterface::class));
+
+        $this->expectException(InvalidArgumentException::class);
+        // Anything outside the FK whitelist (here the removed account_id) is refused
+        // before it reaches the query — no interpolation of untrusted input.
+        $repository->lastActivityBy('account_id');
+    }
+
+    public function testValidColumnAggregatesEntriesByMaxDay(): void
+    {
+        $connection = self::createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('fetchAllKeyValue')
+            ->with(self::stringContains('GROUP BY customer_id'))
+            ->willReturn([1 => '2026-06-24', 2 => '2025-01-01']);
+
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        self::assertSame(
+            [1 => '2026-06-24', 2 => '2025-01-01'],
+            new LastActivityDouble($entityManager)->lastActivityBy('customer_id'),
+        );
+    }
+}


### PR DESCRIPTION
## Why

The admin overview lists customers, projects and users but gives no sense of which
are still in use. This adds a **"Last activity"** column = the date of the most
recent time booking against each.

## What

- **`LastActivityTrait`** — one shared, whitelisted `SELECT <fk>, MAX(day) … GROUP BY <fk>`
  aggregate over `entries` (the FKs are indexed; the whitelist keeps the dynamic
  column name off the injection / Sonar-hotspot path). Used by the Customer, User and
  Project repositories.
- Customers/Users get `last_activity` added to their list rows; **`GetAllProjectsAction`**
  attaches it too — but only on the unfiltered admin path, not the customer-filtered
  entry-form path (which doesn't render the column), so the hot path stays a single query.
- Frontend: a `last_activity` column on the three admin entities, rendered as the raw
  **ISO date** — consistent with the existing holidays `day` column and chronologically
  sortable (the grid sorts on cell text), blank when the entity was never booked.

Why ISO and not the user's date format: the admin grid sorts on the rendered cell text,
so a localized `DD.MM.YYYY` would sort lexically (wrong). ISO sorts correctly and matches
the existing admin date convention. (A formatted-but-correctly-sorted variant would need
a separate sort-key on the grid — out of scope here.)

## Test

- **PHP:** full suite **1976 / 0 failures**. New `LastActivityTraitTest` (whitelist guard
  + aggregate SQL via a typed test double). The exact-match `AdminControllerTest` customer
  & user assertions updated with the real seeded `last_activity` values.
- **Static analysis:** PHPStan clean, php-cs-fixer clean, rector clean.
- **Frontend:** lint + typecheck clean, **299 tests** (new descriptor-column test).

No schema change (computed at query time); no prod deploy in this PR.
