### PR TITLE
feat(admin): deactivatable users (active flag + login block)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -21,6 +21,8 @@ security:
 
         main:
             provider: app_user_provider
+            # Refuse login for deactivated accounts (users.active = 0).
+            user_checker: App\Security\UserChecker
             lazy: true
             # Set entry point to form_login for multiple authenticators
             entry_point: form_login

--- a/frontend/src/admin/entities.test.ts
+++ b/frontend/src/admin/entities.test.ts
@@ -121,4 +121,24 @@ describe('admin entity descriptors', () => {
       expect(col(byKey(key), 'last_activity').render).toBeUndefined()
     }
   })
+
+  it('users have an active (boolean dot) column and the form toggles it', () => {
+    const active = col(byKey('users'), 'active')
+    expect(active.boolean).toBe(true)
+    expect(active.render?.({ active: true }, noOptions)).toBe('✓')
+    expect(active.render?.({ active: false }, noOptions)).toBe('—')
+    const users = byKey('users')
+    expect(users.fields.find((f) => f.name === 'active')?.type).toBe('checkbox')
+    // New users default to active; the row value round-trips.
+    expect(users.toForm(null)).toMatchObject({ active: true })
+    expect(users.toForm({ id: 9, username: 'ex', active: false })).toMatchObject({ active: false })
+    expect(users.toPayload({ id: 9, username: 'ex', abbr: 'EX', locale: 'de', type: 'DEV', active: false, teams: [1] })).toMatchObject({ active: false })
+  })
+
+  it('project lead selects offer only active users (activeOnly)', () => {
+    const projects = byKey('projects')
+    for (const name of ['project_lead', 'technical_lead']) {
+      expect(projects.fields.find((f) => f.name === name)?.activeOnly).toBe(true)
+    }
+  })
 })

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -117,8 +117,8 @@ export function adminEntities(): EntityDescriptor[] {
         { name: 'additionalInformationFromExternal', label: () => m.admin_f_ext_info(), type: 'checkbox' },
         { name: 'active', label: () => m.admin_f_active(), type: 'checkbox' },
         { name: 'global', label: () => m.admin_f_global(), type: 'checkbox' },
-        { name: 'project_lead', label: () => m.admin_f_project_lead(), type: 'select', source: 'users' },
-        { name: 'technical_lead', label: () => m.admin_f_technical_lead(), type: 'select', source: 'users' },
+        { name: 'project_lead', label: () => m.admin_f_project_lead(), type: 'select', source: 'users', activeOnly: true },
+        { name: 'technical_lead', label: () => m.admin_f_technical_lead(), type: 'select', source: 'users', activeOnly: true },
         { name: 'offer', label: () => m.admin_f_offer(), type: 'text' },
         { name: 'cost_center', label: () => m.admin_f_cost_center(), type: 'text' },
         {
@@ -176,10 +176,12 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'type', label: () => m.admin_f_type() },
         { key: 'locale', label: () => m.admin_f_language(), render: (row) => localeLabel(row.locale) },
         { key: 'teams', label: () => m.admin_f_teams(), render: (row, o) => ((row.teams as number[]) ?? []).map((id) => o('teams').find((t) => t.id === id)?.label ?? id).join(', ') },
+        { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active), align: 'center', boolean: true },
         { key: 'last_activity', label: () => m.admin_f_last_activity() },
       ],
       fields: [
         { name: 'username', label: () => m.admin_f_username(), type: 'text', required: true },
+        { name: 'active', label: () => m.admin_f_active(), type: 'checkbox' },
         { name: 'abbr', label: () => m.admin_f_abbr(), type: 'text', required: true },
         {
           name: 'locale', label: () => m.admin_f_language(), type: 'select', stringValue: true,
@@ -201,11 +203,11 @@ export function adminEntities(): EntityDescriptor[] {
       ],
       rowLabel: (row) => str(row.username),
       toForm: (row) => row === null
-        ? { id: 0, username: '', abbr: '', locale: 'de', type: 'DEV', teams: [] }
-        : { id: num(row.id), username: str(row.username), abbr: str(row.abbr), locale: str(row.locale) || 'de', type: str(row.type) || 'DEV', teams: (row.teams as number[]) ?? [] },
+        ? { id: 0, username: '', abbr: '', locale: 'de', type: 'DEV', active: true, teams: [] }
+        : { id: num(row.id), username: str(row.username), abbr: str(row.abbr), locale: str(row.locale) || 'de', type: str(row.type) || 'DEV', active: bool(row.active), teams: (row.teams as number[]) ?? [] },
       // locale/type are string selects; the shell stores select values as numbers,
       // so re-stringify here before sending.
-      toPayload: (v) => ({ id: v.id, username: v.username, abbr: v.abbr, locale: v.locale, type: v.type, teams: v.teams }),
+      toPayload: (v) => ({ id: v.id, username: v.username, abbr: v.abbr, locale: v.locale, type: v.type, active: v.active, teams: v.teams }),
     },
     {
       key: 'teams',

--- a/frontend/src/admin/types.ts
+++ b/frontend/src/admin/types.ts
@@ -30,6 +30,9 @@ export interface FieldDef {
   lockedOnEdit?: boolean
   /** A select whose option values are strings (e.g. locale, user type). */
   stringValue?: boolean
+  /** A select that offers only active options (hides deactivated users), while
+   *  keeping whatever is already assigned so an edit doesn't silently drop it. */
+  activeOnly?: boolean
 }
 
 export type FormValues = Record<string, string | number | boolean | number[]>

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -93,7 +93,10 @@ type OptionRow = Record<string, { id: number; name?: string; username?: string; 
 // The backend serializes `active` via a PHP (bool) cast → JSON true/false, but be
 // defensive about drivers/serializers that emit 1/0 or "1"/"0": treat only the
 // explicit falsy forms as inactive, everything else (incl. absent) as bookable.
-function coerceActive(raw: unknown): boolean {
+/** True unless the value is an explicit "off" form (false / 0 / '0' / 'false');
+ *  undefined → true ("no active concept"). Coerces the loose flags a PHP/Doctrine
+ *  backend may emit so active-only filters can't be bypassed by a stringified 0. */
+export function coerceActive(raw: unknown): boolean {
   return raw !== false && raw !== 0 && raw !== '0' && raw !== 'false'
 }
 

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -683,7 +683,19 @@ function FieldControl(props: {
   const disabled = () => props.editing && props.field.lockedOnEdit === true
   const text = () => String(value() ?? '')
 
-  const selectOptions = createMemo(() => fieldSelectOptions(props.field, props.options))
+  const selectOptions = createMemo(() => {
+    if (props.field.activeOnly !== true || props.field.source === undefined) {
+      return fieldSelectOptions(props.field, props.options)
+    }
+    // Hide deactivated users from assignment selects, but keep whatever is already
+    // assigned (a now-inactive lead) so editing the record doesn't silently drop it.
+    const current = value()
+
+    return props
+      .options(props.field.source)
+      .filter((option) => option.active !== false || option.id === current)
+      .map((option) => ({ value: option.id, label: option.label }))
+  })
 
   const toggleMulti = (optionValue: number, checked: boolean) => {
     const current = new Set((props.values[props.field.name] as number[] | undefined) ?? [])

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -3,7 +3,7 @@ import { createComputed, createMemo, createSignal, For, Match, onCleanup, Show, 
 import { createStore, reconcile } from 'solid-js/store'
 
 import { apiErrorMessage, getJson, postJson } from '../api/client'
-import { optionSourceKey } from '../api/queries'
+import { coerceActive, optionSourceKey } from '../api/queries'
 import { chipValues, createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_OVERLAY_TYPES, INLINE_TYPES, ReadonlyChips } from '../lib/inlineGridEdit'
 import { ChipSelect } from '../lib/chipSelect'
 import { gridNav } from '../lib/gridNavigation'
@@ -693,7 +693,7 @@ function FieldControl(props: {
 
     return props
       .options(props.field.source)
-      .filter((option) => option.active !== false || option.id === current)
+      .filter((option) => coerceActive(option.active) || option.id === current)
       .map((option) => ({ value: option.id, label: option.label }))
   })
 

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -34,7 +34,7 @@ function mockEndpoints() {
       case '/getAllTeams':
         return Promise.resolve([{ team: { id: 2, name: 'Backend', lead_user_id: 3 } }])
       case '/getAllUsers':
-        return Promise.resolve([{ user: { id: 3, username: 'jdoe', abbr: 'JD', type: 'DEV', teams: [2] } }])
+        return Promise.resolve([{ user: { id: 3, username: 'jdoe', abbr: 'JD', type: 'DEV', active: true, teams: [2] } }])
       case '/getAllProjects':
         return Promise.resolve([{ project: { id: 4, name: 'Site', customer: 1, jiraId: 'ABC', active: true, global: false } }])
       case '/getActivities':

--- a/migrations/Version20260624_AddUserActive.php
+++ b/migrations/Version20260624_AddUserActive.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add the `users.active` flag.
+ *
+ * Lets an account be deactivated (ex-employees): a deactivated user can no longer
+ * log in (see App\Security\UserChecker) and is no longer offered for new project /
+ * technical-lead assignments, while their historical entries stay intact. Existing
+ * users default to active.
+ */
+final class Version20260624_AddUserActive extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the users.active flag (default 1) for account deactivation';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users ADD active TINYINT(1) NOT NULL DEFAULT 1');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users DROP COLUMN active');
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,6 +64,7 @@
             <file>tests/Repository/OptimizedEntryRepositoryCacheTest.php</file>
             <!-- Security unit tests (not RememberMeRedirectTest) -->
             <file>tests/Security/LdapAuthenticatorTest.php</file>
+            <file>tests/Security/UserCheckerTest.php</file>
         </testsuite>
         <!-- Integration tests requiring database -->
         <testsuite name="integration">

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -41,6 +41,7 @@ CREATE TABLE `users` (
   `show_empty_line` tinyint(1) NOT NULL DEFAULT '0',
   `suggest_time` tinyint(1) NOT NULL DEFAULT '1',
   `show_future` tinyint(1) NOT NULL DEFAULT '1',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
   `min_entry_duration` int(11) NOT NULL DEFAULT 5,
   `locale` char(2) NOT NULL DEFAULT 'de',
   PRIMARY KEY (`id`),
@@ -331,7 +332,8 @@ INSERT INTO `doctrine_migration_versions` (`version`, `executed_at`, `execution_
 ('DoctrineMigrations\\Version20260612_FixHolidaysSchema',     '2026-06-12 00:00:00', 0),
 ('DoctrineMigrations\\Version20260622_AddMinEntryDuration',   '2026-06-22 00:00:00', 0),
 ('DoctrineMigrations\\Version20260622_AddJiraCloudSupport',   '2026-06-22 00:00:00', 0),
-('DoctrineMigrations\\Version20260624_RemoveAccountEntity',   '2026-06-24 00:00:00', 0);
+('DoctrineMigrations\\Version20260624_RemoveAccountEntity',   '2026-06-24 00:00:00', 0),
+('DoctrineMigrations\\Version20260624_AddUserActive',         '2026-06-24 00:00:01', 0);
 
 
 -- EXPORT-VIEWS ---------------------------------------------------------------------------

--- a/src/Dto/UserSaveDto.php
+++ b/src/Dto/UserSaveDto.php
@@ -34,6 +34,7 @@ final readonly class UserSaveDto
         public string $abbr = '',
         public string $type = '',
         public string $locale = '',
+        public bool $active = true,
 
         /** @var list<int|string> */
         #[Map(if: false)]
@@ -55,6 +56,7 @@ final readonly class UserSaveDto
             abbr: (string) ($request->request->get('abbr') ?? ''),
             type: (string) ($request->request->get('type') ?? ''),
             locale: (string) ($request->request->get('locale') ?? ''),
+            active: $request->request->getBoolean('active', true),
             teams: array_values($teams),
         );
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -52,6 +52,10 @@ class User implements UserInterface
     #[ORM\Column(name: 'show_future', type: 'boolean', nullable: false, options: ['default' => 1])]
     protected bool $showFuture = true;
 
+    /** Deactivated users cannot log in and aren't offered for new lead assignments. */
+    #[ORM\Column(name: 'active', type: 'boolean', nullable: false, options: ['default' => 1])]
+    protected bool $active = true;
+
     /** Minimum entry duration in minutes — a new entry's end pre-fills to start + this. */
     #[ORM\Column(name: 'min_entry_duration', type: 'integer', nullable: false, options: ['default' => 5])]
     protected int $minEntryDuration = 5;
@@ -226,6 +230,18 @@ class User implements UserInterface
         return $this;
     }
 
+    public function getActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): static
+    {
+        $this->active = $active;
+
+        return $this;
+    }
+
     public function getMinEntryDuration(): int
     {
         return $this->minEntryDuration;
@@ -315,7 +331,7 @@ class User implements UserInterface
      * Returns user settings for API responses.
      * Note: Boolean settings are returned as integers (0/1) for frontend compatibility.
      *
-     * @return array{show_empty_line: int, suggest_time: int, show_future: int, min_entry_duration: int, user_name: string, user_id: int, type: string, locale: string, roles: array<string>}
+     * @return array{show_empty_line: int, suggest_time: int, show_future: int, active: bool, min_entry_duration: int, user_name: string, user_id: int, type: string, locale: string, roles: array<string>}
      */
     public function getSettings(): array
     {
@@ -323,6 +339,7 @@ class User implements UserInterface
             'show_empty_line' => (int) $this->getShowEmptyLine(),
             'suggest_time' => (int) $this->getSuggestTime(),
             'show_future' => (int) $this->getShowFuture(),
+            'active' => $this->getActive(),
             'min_entry_duration' => $this->getMinEntryDuration(),
             'user_name' => $this->getUsername() ?? '',
             'user_id' => $this->getId() ?? 0,

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -89,7 +89,7 @@ class UserRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return array<int, array{user: array{id:int, username:string, type:string, abbr:string, locale:string, teams: array<int, int>, last_activity: string|null}}>
+     * @return array<int, array{user: array{id:int, username:string, type:string, abbr:string, locale:string, teams: array<int, int>, active: bool, last_activity: string|null}}>
      */
     public function getAllUsers(): array
     {
@@ -119,6 +119,7 @@ class UserRepository extends ServiceEntityRepository
                 'abbr' => (string) $user->getAbbr(),
                 'locale' => $user->getLocale(),
                 'teams' => $teams,
+                'active' => $user->getActive(),
                 'last_activity' => $lastActivity[(int) $user->getId()] ?? null,
             ]];
         }

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Refuses authentication for deactivated accounts. Runs before the credential
+ * check, so a deactivated user is rejected even before the LDAP bind. Wired as the
+ * `main` firewall's user_checker (config/packages/security.yaml).
+ */
+final class UserChecker implements UserCheckerInterface
+{
+    public function checkPreAuth(UserInterface $user): void
+    {
+        if ($user instanceof User && !$user->getActive()) {
+            throw new CustomUserMessageAccountStatusException('This account has been deactivated.');
+        }
+    }
+
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
+    {
+    }
+}

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -245,6 +245,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'NPL',
                     'locale' => 'de',
                     'teams' => [2], // User 2 is in team 2
+                    'active' => true,
                     'last_activity' => '2020-02-08',
                 ],
             ],
@@ -256,6 +257,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'IMY',
                     'locale' => 'de',
                     'teams' => [], // User 3 has no teams in current test data
+                    'active' => true,
                     'last_activity' => '0500-01-31',
                 ],
             ],
@@ -267,6 +269,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'NCO',
                     'locale' => 'de',
                     'teams' => [], // User 5 has no teams
+                    'active' => true,
                     'last_activity' => null,
                 ],
             ],
@@ -278,6 +281,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'NPL',
                     'locale' => 'de',
                     'teams' => [], // User 4 has no teams
+                    'active' => true,
                     'last_activity' => null,
                 ],
             ],
@@ -289,6 +293,7 @@ class AdminControllerTest extends AbstractWebTestCase
                     'abbr' => 'UTE',
                     'locale' => 'de',
                     'teams' => [1], // User 1 is in team 1
+                    'active' => true,
                     'last_activity' => '2023-10-24',
                 ],
             ],

--- a/tests/Security/UserCheckerTest.php
+++ b/tests/Security/UserCheckerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Security;
+
+use App\Entity\User;
+use App\Security\UserChecker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+/**
+ * @internal
+ */
+final class UserCheckerTest extends TestCase
+{
+    public function testActiveUserPassesPreAuth(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        new UserChecker()->checkPreAuth(new User()->setActive(true));
+    }
+
+    public function testDeactivatedUserIsRejected(): void
+    {
+        $this->expectException(CustomUserMessageAccountStatusException::class);
+
+        new UserChecker()->checkPreAuth(new User()->setActive(false));
+    }
+
+    public function testNonAppUserIsIgnored(): void
+    {
+        // The check only applies to our User entity; any other UserInterface passes.
+        $this->expectNotToPerformAssertions();
+
+        new UserChecker()->checkPreAuth(new InMemoryUser('x', null));
+    }
+}


### PR DESCRIPTION
## Why

Users couldn't be deactivated — an ex-employee kept full login access and stayed
in every picker. This adds a proper **active** flag (per the chosen "block login +
hide from assignment selects" behaviour).

## What

`users.active` (default 1; migration `Version20260624_AddUserActive`):

- **Login block** — a custom `App\Security\UserChecker` throws in `checkPreAuth`
  for deactivated users (before the LDAP bind), wired as the `main` firewall's
  `user_checker`.
- **Admin management** — the Users list gets an **Active** column + a form
  checkbox. The shell's pre-existing "show inactive" toggle keeps deactivated
  users hidden by default but reachable for reactivation.
- **Assignment selects** — project- / technical-lead selects offer only active
  users (`activeOnly` field flag), but **keep whatever is already assigned** so
  editing a project never silently drops a now-inactive lead.
- **Preserved** — historical entries stay intact, and the Auswertung / Abrechnung
  user filters still list deactivated users so an ex-employee's past bookings
  remain analyzable.

## Test

- **PHP:** full suite **1979 / 0 failures**. New `UserCheckerTest` (active passes,
  deactivated rejected, non-App user ignored). `AdminControllerTest` getAllUsers
  expectations updated with `active`.
- **Static analysis:** PHPStan clean (incl. the `UserCheckerInterface` 7.3
  signature + the `User::toArray` / repository `@return` shapes), php-cs-fixer
  clean.
- **Frontend:** lint + typecheck clean, **301 tests** (active column/form + the
  `activeOnly` lead-select assertions; mock updated for the active row filter).
- **Migration** validated up/down against the pre-`active` schema via the real
  doctrine runner (active 0 → 1).

No prod deploy in this PR.
