### PR TITLE
feat(ui): row-action icon legend in the worklog footer

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -200,6 +200,7 @@
   "tracking_date_format_hint": "Datumsformat: JJJJ-MM-TT",
   "tracking_edit_hint": "Zum Bearbeiten eine Zelle doppelklicken — oder fokussieren und Enter drücken. Tab innerhalb einer Zeile erreicht deren Aktionen; Alt+C / Alt+P / Alt+I wirken auf die aktuelle Zeile. Eine vollständige Zeile wird automatisch gespeichert; das Disketten-Symbol erzwingt das Speichern, das Zurücksetzen-Symbol verwirft die Änderungen.",
   "tracking_legend_title": "Legende der Zeilenfarben",
+  "tracking_legend_icons": "Symbole",
   "auswertung_title": "Auswertung",
   "auswertung_no_data": "Keine Daten gefunden.",
   "auswertung_label": "Name",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -200,6 +200,7 @@
   "tracking_date_format_hint": "Date format: YYYY-MM-DD",
   "tracking_edit_hint": "Double-click a cell — or focus it and press Enter — to edit. Tab within a row reaches its actions; Alt+C / Alt+P / Alt+I act on the current row. A completed row saves automatically; the disk icon force-saves an unsaved row and the reset icon discards it.",
   "tracking_legend_title": "Row colour key",
+  "tracking_legend_icons": "Icons",
   "auswertung_title": "Evaluation",
   "auswertung_no_data": "No data found.",
   "auswertung_label": "Name",

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -934,6 +934,17 @@ export default function Tracking() {
             <span class="tracking-legend-item is-pause">{m.tracking_class_pause()}</span>
             <span class="tracking-legend-item is-overlap">{m.tracking_class_overlap()}</span>
           </p>
+          {/* Row-action icon key — the icons in the Actions column are also discoverable
+              by hover/keyboard, but listing them here aids at-a-glance recognition. */}
+          <p class="tracking-legend tracking-legend-icons">
+            <span class="visually-hidden">{m.tracking_legend_icons()}: </span>
+            <span class="tracking-legend-icon"><ContinueIcon /> {m.tracking_continue()}</span>
+            <span class="tracking-legend-icon"><ProlongIcon /> {m.tracking_prolong()}</span>
+            <span class="tracking-legend-icon"><InfoIcon /> {m.tracking_info()}</span>
+            <span class="tracking-legend-icon"><TrashIcon /> {m.admin_delete()}</span>
+            <span class="tracking-legend-icon"><DiskIcon /> {m.app_save()}</span>
+            <span class="tracking-legend-icon"><ResetIcon /> {m.tracking_reset()}</span>
+          </p>
         </Show>
       </Show>
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1193,6 +1193,11 @@ kbd {
 .tracking-legend-item.is-pause::before { background: var(--color-class-pause); }
 .tracking-legend-item.is-overlap::before { background: var(--color-class-overlap); }
 
+/* Tighter gap so the icon legend reads as one block with the colour legend. */
+.tracking-legend-icons {
+  margin-top: 0.4rem;
+}
+
 /* Icon legend items carry an inline icon instead of a colour swatch. */
 .tracking-legend-icon {
   align-items: center;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1193,6 +1193,18 @@ kbd {
 .tracking-legend-item.is-pause::before { background: var(--color-class-pause); }
 .tracking-legend-item.is-overlap::before { background: var(--color-class-overlap); }
 
+/* Icon legend items carry an inline icon instead of a colour swatch. */
+.tracking-legend-icon {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.3rem;
+}
+
+.tracking-legend-icon svg {
+  height: 1rem;
+  width: 1rem;
+}
+
 /* Wrapper carrying list semantics for the selected chips without taking part in
    the flex layout (so chips + the add button keep their single wrapping flow). */
 .tag-list {


### PR DESCRIPTION
## Why

The worklog footer had a colour key for the row borders, but the **Actions-column
icons** (Continue / Prolong / Info / Delete / Save / Reset) had no at-a-glance
legend — only hover tooltips and the `?`-shortcuts overlay.

## What

Per the chosen "compact icon legend" option: a second legend line beneath the
colour key listing each row-action icon with its label, reusing the existing
action message keys. Shown only when there are rows. Frontend-only.

## Test

- Lint + typecheck clean, **302 tests**, production build clean.
- Browser smoke (logged-in `/ui/tracking`): the `.tracking-legend-icons` row
  renders with all six icons + labels (Fortsetzen / Verlängern / Info / Löschen /
  Speichern / Verwerfen).
