### PR TITLE
feat(ui): Alt access-key hints on the active worklog row icons

### DIFF
--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -697,6 +697,11 @@ export default function Tracking() {
   onMount(() => document.addEventListener('keydown', onGridShortcut))
   onCleanup(() => document.removeEventListener('keydown', onGridShortcut))
 
+  // A row's Alt-shortcut hint is only truthful while no cell is being edited:
+  // onGridShortcut() ignores Alt+C/P/I during editing, so advertising the
+  // shortcut then (aria-keyshortcuts + the Alt overlay badge) would mislead.
+  const rowShortcut = (key: string): string | undefined => (editor.editCell() === null ? key : undefined)
+
   // Surface the worklog actions in the Ctrl/⌘+K command palette while this page
   // is mounted — the discoverable home for every action (no shortcut to memorise).
   const wl = (): string => m.cmd_group_worklog()
@@ -869,14 +874,14 @@ export default function Tracking() {
                         <div class="row-actions">
                           {/* Per-row Continue / Prolong / Info — only for saved entries. */}
                           <Show when={id > 0}>
-                            <RowAction label={m.tracking_continue()} keyshortcut="Alt+C" onClick={() => continueEntry(entry)}><ContinueIcon /></RowAction>
+                            <RowAction label={m.tracking_continue()} keyshortcut={rowShortcut('Alt+C')} onClick={() => continueEntry(entry)}><ContinueIcon /></RowAction>
                             {/* Prolong rewrites the row's end to now — only meaningful on the
                                 LATEST entry; on an older row it would silently overwrite a past
                                 end with the current time, so it's hidden there. */}
                             <Show when={isLatestEntry(entry)}>
-                              <RowAction label={m.tracking_prolong()} keyshortcut="Alt+P" onClick={() => void prolongLast(entry)}><ProlongIcon /></RowAction>
+                              <RowAction label={m.tracking_prolong()} keyshortcut={rowShortcut('Alt+P')} onClick={() => void prolongLast(entry)}><ProlongIcon /></RowAction>
                             </Show>
-                            <RowAction label={m.tracking_info()} keyshortcut="Alt+I" onClick={() => void showInfo(entry)}><InfoIcon /></RowAction>
+                            <RowAction label={m.tracking_info()} keyshortcut={rowShortcut('Alt+I')} onClick={() => void showInfo(entry)}><InfoIcon /></RowAction>
                           </Show>
                           <RowAction label={m.admin_delete()} danger onClick={() => setPendingDelete(entry)}><TrashIcon /></RowAction>
                           {/* Force-save and discard (reset) share the unsaved cue: both show while the

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -139,13 +139,14 @@ function displayDate(value: string): string {
 
 // One icon button in the row-actions cell — same shape for Continue/Prolong/Info/
 // Delete (label drives both the accessible name and the hover tooltip).
-function RowAction(props: { label: string; danger?: boolean; onClick: () => void; children: JSX.Element }): JSX.Element {
+function RowAction(props: { label: string; danger?: boolean; keyshortcut?: string; onClick: () => void; children: JSX.Element }): JSX.Element {
   return (
     <button
       type="button"
       class="link-button is-icon"
       classList={{ 'is-danger': props.danger }}
       aria-label={props.label}
+      aria-keyshortcuts={props.keyshortcut}
       title={props.label}
       onClick={() => props.onClick()}
     >
@@ -868,14 +869,14 @@ export default function Tracking() {
                         <div class="row-actions">
                           {/* Per-row Continue / Prolong / Info — only for saved entries. */}
                           <Show when={id > 0}>
-                            <RowAction label={m.tracking_continue()} onClick={() => continueEntry(entry)}><ContinueIcon /></RowAction>
+                            <RowAction label={m.tracking_continue()} keyshortcut="Alt+C" onClick={() => continueEntry(entry)}><ContinueIcon /></RowAction>
                             {/* Prolong rewrites the row's end to now — only meaningful on the
                                 LATEST entry; on an older row it would silently overwrite a past
                                 end with the current time, so it's hidden there. */}
                             <Show when={isLatestEntry(entry)}>
-                              <RowAction label={m.tracking_prolong()} onClick={() => void prolongLast(entry)}><ProlongIcon /></RowAction>
+                              <RowAction label={m.tracking_prolong()} keyshortcut="Alt+P" onClick={() => void prolongLast(entry)}><ProlongIcon /></RowAction>
                             </Show>
-                            <RowAction label={m.tracking_info()} onClick={() => void showInfo(entry)}><InfoIcon /></RowAction>
+                            <RowAction label={m.tracking_info()} keyshortcut="Alt+I" onClick={() => void showInfo(entry)}><InfoIcon /></RowAction>
                           </Show>
                           <RowAction label={m.admin_delete()} danger onClick={() => setPendingDelete(entry)}><TrashIcon /></RowAction>
                           {/* Force-save and discard (reset) share the unsaved cue: both show while the

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1860,6 +1860,17 @@ th[aria-sort='descending'] .th-sort-glyph {
   z-index: 6;
 }
 
+/* Worklog row-action badges (Alt+C/P/I) appear only on the row holding the
+   keyboard cursor (aria-current) — that's the row Alt+C/P/I act on. The toolbar
+   badges (Alt+A/R/X) are unaffected (not inside .tracking-row-actions). */
+.show-access-keys .tracking-row-actions [data-access-hint]::after {
+  display: none;
+}
+
+.show-access-keys tr[aria-current="true"] .tracking-row-actions [data-access-hint]::after {
+  display: inline-flex;
+}
+
 .modal-backdrop {
   background: rgba(0, 0, 0, 0.45);
   inset: 0;


### PR DESCRIPTION
## Why

Holding Alt shows the access-key badges on the nav (Alt+1–7) and the worklog
toolbar (Alt+A/R/X), but **not** on the row-level icons — even though Alt+C/P/I
(Continue/Prolong/Info) already act on the row holding the keyboard cursor.

## What

- The Continue / Prolong / Info row actions now carry `aria-keyshortcuts`
  (Alt+C/P/I), so the existing Alt-hold overlay badges them.
- The badge CSS is scoped to `tr[aria-current="true"] .tracking-row-actions`, so
  the hints appear **only on the active (cursor) row** — the one Alt+C/P/I target
  — not on every row. Toolbar badges (Alt+A/R/X) are unaffected.

Frontend-only. No behaviour change to the shortcuts themselves (they already
targeted the active/cursor row via `activeOrLatestEntry()`).

## Test

- Lint + typecheck clean, tests + production build clean.
- Browser smoke (logged-in `/ui/tracking`): focusing a row + holding Alt sets
  `body.show-access-keys` and the active row's action icons show `C` / `P` / `I`
  badges (other rows don't).
