### PR TITLE
feat(auswertung): sortable detail table + vertical scroll for long lists

### DIFF
--- a/frontend/src/pages/Auswertung.test.tsx
+++ b/frontend/src/pages/Auswertung.test.tsx
@@ -92,6 +92,39 @@ describe('Auswertung', () => {
     unmount()
   })
 
+  it('sorts the detail table chronologically by ISO date, not display text', async () => {
+    getJson.mockImplementation((path: string) => {
+      if (path === '/interpretation/time')
+        return Promise.resolve([{ id: null, name: '26-06-24', day: '24.06.', hours: 4, quota: '100.00%' }])
+      if (path === '/interpretation/entries')
+        return Promise.resolve([
+          { entry: { id: 1, date: '01/07/2026', ticket: 'JUL-01', description: 'b', duration: '2:00', quota: '' } },
+          { entry: { id: 2, date: '24/06/2026', ticket: 'JUN-24', description: 'a', duration: '8:00', quota: '' } },
+        ])
+      if (path.startsWith('/interpretation/')) return Promise.resolve([{ id: 1, name: 'ACME', hours: 8, quota: '80.00%' }])
+
+      return Promise.resolve([])
+    })
+    const { getByRole, container, unmount } = renderPage()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'JUL-01' })).toBeInTheDocument())
+
+    const firstTicket = () => container.querySelector('.data-table tbody tr:first-child td:nth-child(2)')?.textContent
+    // Backend order keeps JUL-01 first until we sort.
+    expect(firstTicket()).toBe('JUL-01')
+
+    // Ascending by date → the earlier calendar day (24 Jun) leads, proving the
+    // sort keys on the ISO date, not the localized "01.07." display string (which
+    // a naive string sort would order before "24.06.").
+    fireEvent.click(getByRole('button', { name: 'Date' }))
+    await waitFor(() => expect(firstTicket()).toBe('JUN-24'))
+
+    // A second click flips to descending.
+    fireEvent.click(getByRole('button', { name: 'Date' }))
+    await waitFor(() => expect(firstTicket()).toBe('JUL-01'))
+
+    unmount()
+  })
+
   it('has no automatically detectable accessibility violations', async () => {
     mockEndpoints()
     const { container, getByRole, unmount } = renderPage()

--- a/frontend/src/pages/Auswertung.tsx
+++ b/frontend/src/pages/Auswertung.tsx
@@ -4,6 +4,7 @@ import { createMemo, createSignal, For, Show } from 'solid-js'
 import {
   activitiesQuery,
   customersQuery,
+  type EntryRecord,
   groupQuery,
   type GroupRow,
   hasInterpretationCriteria,
@@ -85,6 +86,23 @@ const GROUPS: { group: InterpretationGroup; title: () => string }[] = [
   { group: 'user', title: () => m.auswertung_by_user() },
 ]
 
+type EntrySortKey = 'date' | 'ticket' | 'description' | 'hours'
+
+// Comparable key per column. Date sorts by ISO (chronological), not the
+// localized display string; hours sorts numerically over the "H:MM" duration.
+function entrySortValue(record: EntryRecord, key: EntrySortKey): string {
+  switch (key) {
+    case 'date':
+      return dmyToIso(record.entry.date ?? '') ?? record.entry.date ?? ''
+    case 'ticket':
+      return record.entry.ticket
+    case 'description':
+      return record.entry.description
+    case 'hours':
+      return record.entry.duration
+  }
+}
+
 function toEffortRows(rows: GroupRow[] | undefined): EffortRow[] {
   return (rows ?? []).map((row) => ({
     label: row.name,
@@ -152,6 +170,36 @@ export default function Auswertung() {
       quota: row.quota,
     })),
   )
+
+  // Sortable detail table: clicking a header cycles none → asc → desc → none.
+  const [entrySort, setEntrySort] = createSignal<{ key: EntrySortKey; dir: 'asc' | 'desc' } | null>(null)
+  const toggleEntrySort = (key: EntrySortKey) =>
+    setEntrySort((current) =>
+      current?.key !== key ? { key, dir: 'asc' } : current.dir === 'asc' ? { key, dir: 'desc' } : null,
+    )
+  const entryAriaSort = (key: EntrySortKey): 'ascending' | 'descending' | 'none' => {
+    const current = entrySort()
+
+    return current?.key === key ? (current.dir === 'asc' ? 'ascending' : 'descending') : 'none'
+  }
+  const entrySortGlyph = (key: EntrySortKey): string => {
+    const current = entrySort()
+
+    return current?.key === key ? (current.dir === 'asc' ? '▲' : '▼') : '⇅'
+  }
+  const sortedEntries = createMemo<EntryRecord[]>(() => {
+    const data = entries.data ?? []
+    const current = entrySort()
+    if (!current) {
+      return data
+    }
+    const factor = current.dir === 'asc' ? 1 : -1
+
+    return [...data].sort(
+      (a, b) =>
+        factor * entrySortValue(a, current.key).localeCompare(entrySortValue(b, current.key), undefined, { numeric: true }),
+    )
+  })
 
   return (
     <section class="auswertung">
@@ -242,23 +290,43 @@ export default function Auswertung() {
         <section class="effort-chart">
           <h2>{m.auswertung_last_entries()}</h2>
           <QueryBoundary query={entries}>
-            <div class="table-scroll">
+            <div class="table-scroll is-scrollable">
               {/* Read-only grid: arrow-navigated internally, entered/left via
                   Tab. No onExit arrow-bridge to the filter bar — its date/select
                   controls own the arrow keys, so an arrow bridge there would be a
                   one-directional trap (the search↔grid arrow chain only fits the
                   Admin page's single search field). */}
-              <table class="data-table" use:gridNav={{ items: () => entries.data ?? [], readonly: true }}>
+              <table class="data-table" use:gridNav={{ items: () => sortedEntries(), readonly: true }}>
                 <thead>
                   <tr>
-                    <th scope="col">{m.auswertung_date()}</th>
-                    <th scope="col">{m.auswertung_ticket()}</th>
-                    <th scope="col">{m.auswertung_description()}</th>
-                    <th scope="col" class="numeric">{m.auswertung_hours()}</th>
+                    <th scope="col" aria-sort={entryAriaSort('date')}>
+                      <button type="button" class="th-sort" onClick={() => toggleEntrySort('date')}>
+                        <span>{m.auswertung_date()}</span>
+                        <span class="th-sort-glyph" aria-hidden="true">{entrySortGlyph('date')}</span>
+                      </button>
+                    </th>
+                    <th scope="col" aria-sort={entryAriaSort('ticket')}>
+                      <button type="button" class="th-sort" onClick={() => toggleEntrySort('ticket')}>
+                        <span>{m.auswertung_ticket()}</span>
+                        <span class="th-sort-glyph" aria-hidden="true">{entrySortGlyph('ticket')}</span>
+                      </button>
+                    </th>
+                    <th scope="col" aria-sort={entryAriaSort('description')}>
+                      <button type="button" class="th-sort" onClick={() => toggleEntrySort('description')}>
+                        <span>{m.auswertung_description()}</span>
+                        <span class="th-sort-glyph" aria-hidden="true">{entrySortGlyph('description')}</span>
+                      </button>
+                    </th>
+                    <th scope="col" class="numeric" aria-sort={entryAriaSort('hours')}>
+                      <button type="button" class="th-sort" onClick={() => toggleEntrySort('hours')}>
+                        <span>{m.auswertung_hours()}</span>
+                        <span class="th-sort-glyph" aria-hidden="true">{entrySortGlyph('hours')}</span>
+                      </button>
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
-                  <For each={entries.data}>
+                  <For each={sortedEntries()}>
                     {(record) => (
                       <tr>
                         <td>{formatUserDate(dmyToIso(record.entry.date ?? '') ?? record.entry.date ?? '')}</td>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1003,6 +1003,18 @@ kbd {
   overflow-x: auto;
 }
 
+/* A long detail list scrolls inside its own box instead of stretching the page;
+   the header stays pinned so the columns remain labelled while scrolling. */
+.table-scroll.is-scrollable {
+  max-height: min(60vh, 40rem);
+  overflow-y: auto;
+}
+.table-scroll.is-scrollable thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
 .data-table {
   border-collapse: collapse;
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## What

The `/ui/auswertung` *last entries* detail table gained two long-requested affordances:

- **Column sorting** — clickable headers (date / ticket / description / hours) cycling none → ascending → descending → none, reusing the `.th-sort` markup + `aria-sort` semantics from the admin grid. The **date** column sorts by ISO date (chronological), *not* the localized display string (so `24.06.` correctly precedes `01.07.`); **hours** sorts numerically over the `H:MM` duration via `localeCompare(..., { numeric: true })`.
- **Vertical overflow scroll** — a long result set now scrolls inside its own box (`.table-scroll.is-scrollable`: `max-height` + a sticky, still-labelled header) instead of stretching the page unbounded. The shared `.table-scroll` (used by the month calendar) is untouched; only the opt-in modifier adds the cap.

The grouped *effort* charts already sort by value and are bounded, so they are left as-is.

## Test

- New unit test proves the date sort keys on ISO, not display text (a naive string sort would mis-order `01.07.` before `24.06.`), and that a second click flips to descending.
- Full frontend suite green (303 tests); lint + typecheck + build clean.

This is part of the `/ui/auswertung` improvements; the *Effort by day* contract-boundary visualization follows as a separate PR.