### PR TITLE
feat(auswertung): contract Soll on the "Effort by day" chart + literal 5×8h fallback

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -206,6 +206,7 @@
   "auswertung_label": "Name",
   "auswertung_hours": "Stunden",
   "auswertung_share": "Anteil",
+  "auswertung_of_target": "/ {target} Soll",
   "auswertung_all": "Alle",
   "auswertung_date_start": "Datum von",
   "auswertung_date_end": "Datum bis",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -206,6 +206,7 @@
   "auswertung_label": "Name",
   "auswertung_hours": "Hours",
   "auswertung_share": "Share",
+  "auswertung_of_target": "/ {target} target",
   "auswertung_all": "All",
   "auswertung_date_start": "From",
   "auswertung_date_end": "To",

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -11,6 +11,8 @@ export interface WorktimeRecord {
   day: string
   hours: number
   quota: string
+  /** Expected (Soll) hours for the day, from the contract or a 5×8h default. */
+  expected: number
 }
 
 // Response shape of GET /getHolidays (GetHolidaysAction) — ExtJS-style

--- a/frontend/src/components/EffortChart.test.tsx
+++ b/frontend/src/components/EffortChart.test.tsx
@@ -52,4 +52,64 @@ describe('EffortChart', () => {
     expect(await axe(container)).toHaveNoViolations()
     unmount()
   })
+
+  describe('contract Soll (target)', () => {
+    // Mon over Soll (8:30 vs 8:00), Tue under (4:00 vs 8:00).
+    const dayRows: EffortRow[] = [
+      { label: 'Mon', minutes: 510, quota: '40.00%', target: 480 },
+      { label: 'Tue', minutes: 240, quota: '20.00%', target: 480 },
+    ]
+
+    it('scales bars to the larger of worked-or-target and marks over/under', () => {
+      const { container, unmount } = render(() => <EffortChart title="Effort by day" rows={dayRows} />)
+      const bars = [...container.querySelectorAll<HTMLElement>('.effort-bar')]
+
+      // max = max(510, 480, 240, 480) = 510 → Mon fills the track, Tue is 240/510.
+      expect(bars[0]?.style.width).toBe('100%')
+      expect(bars[1]?.style.width).toBe(`${(240 / 510) * 100}%`)
+      expect(bars[0]?.classList.contains('is-over')).toBe(true)
+      expect(bars[1]?.classList.contains('is-under')).toBe(true)
+
+      // A Soll marker per row, positioned at target/max.
+      const markers = [...container.querySelectorAll<HTMLElement>('.effort-soll-marker')]
+      expect(markers).toHaveLength(2)
+      expect(markers[0]?.style.left).toBe(`${(480 / 510) * 100}%`)
+      unmount()
+    })
+
+    it('shows a ghost bar only for under-target rows', () => {
+      const { container, unmount } = render(() => <EffortChart title="Effort by day" rows={dayRows} />)
+      const ghosts = [...container.querySelectorAll<HTMLElement>('.effort-bar-ghost')]
+
+      // Only Tue (under) gets a ghost, spanning the full Soll extent.
+      expect(ghosts).toHaveLength(1)
+      expect(ghosts[0]?.style.width).toBe(`${(480 / 510) * 100}%`)
+      unmount()
+    })
+
+    it('prints the Soll next to the worked time as a non-colour cue', () => {
+      const underRow: EffortRow = { label: 'Tue', minutes: 240, quota: '20.00%', target: 480 }
+      const { container, unmount } = render(() => <EffortChart title="Effort by day" rows={[underRow]} />)
+
+      expect(container.querySelector('.effort-target')?.textContent).toContain(formatMinutes(480))
+      unmount()
+    })
+
+    it('omits the Soll overlay entirely for target-less rows', () => {
+      const { container, unmount } = render(() => <EffortChart title="Effort by customer" rows={rows} />)
+
+      expect(container.querySelector('.effort-soll-marker')).toBeNull()
+      expect(container.querySelector('.effort-bar-ghost')).toBeNull()
+      expect(container.querySelector('.effort-bar.is-over')).toBeNull()
+      expect(container.querySelector('.effort-target')).toBeNull()
+      unmount()
+    })
+
+    it('stays axe-clean with the Soll overlay', async () => {
+      const { container, unmount } = render(() => <EffortChart title="Effort by day" rows={dayRows} />)
+
+      expect(await axe(container)).toHaveNoViolations()
+      unmount()
+    })
+  })
 })

--- a/frontend/src/components/EffortChart.test.tsx
+++ b/frontend/src/components/EffortChart.test.tsx
@@ -105,6 +105,30 @@ describe('EffortChart', () => {
       unmount()
     })
 
+    it('treats a zero Soll (worked weekend/holiday) as a neutral bar, not green over', () => {
+      // expected=0 reaches the chart as target:0 (Auswertung always sets target).
+      const zeroRow: EffortRow = { label: 'Sat', minutes: 120, quota: '100.00%', target: 0 }
+      const { container, unmount } = render(() => <EffortChart title="Effort by day" rows={[zeroRow]} />)
+
+      // No contract boundary for the day → no colour, marker, ghost or Soll text.
+      expect(container.querySelector('.effort-bar.is-over')).toBeNull()
+      expect(container.querySelector('.effort-bar.is-under')).toBeNull()
+      expect(container.querySelector('.effort-soll-marker')).toBeNull()
+      expect(container.querySelector('.effort-bar-ghost')).toBeNull()
+      expect(container.querySelector('.effort-target')).toBeNull()
+      unmount()
+    })
+
+    it('classifies worked-exactly-Soll as over (not under) with no ghost', () => {
+      const exactRow: EffortRow = { label: 'Wed', minutes: 480, quota: '100.00%', target: 480 }
+      const { container, unmount } = render(() => <EffortChart title="Effort by day" rows={[exactRow]} />)
+
+      expect(container.querySelector('.effort-bar.is-over')).not.toBeNull()
+      expect(container.querySelector('.effort-bar.is-under')).toBeNull()
+      expect(container.querySelector('.effort-bar-ghost')).toBeNull()
+      unmount()
+    })
+
     it('stays axe-clean with the Soll overlay', async () => {
       const { container, unmount } = render(() => <EffortChart title="Effort by day" rows={dayRows} />)
 

--- a/frontend/src/components/EffortChart.tsx
+++ b/frontend/src/components/EffortChart.tsx
@@ -7,6 +7,10 @@ export interface EffortRow {
   label: string
   minutes: number
   quota: string
+  /** Optional expected (Soll) minutes. When set, the bar gains a contract
+   *  boundary: a Soll marker, an over/under colour, and a ghost bar showing the
+   *  shortfall. Only the "Effort by day" chart provides it. */
+  target?: number
 }
 
 /**
@@ -14,11 +18,18 @@ export interface EffortRow {
  * inside each row. No charting library — the table is the source of truth for
  * screen readers, the bar is decorative (aria-hidden), and colours come from
  * the design tokens so it themes with light/dark automatically.
+ *
+ * When a row carries a `target` (the "Effort by day" chart), the bar also shows
+ * the contract Soll: coloured over/under, a Soll marker tick, a ghost bar for
+ * the shortfall, and the Soll printed next to the worked time (the non-colour,
+ * screen-reader-visible cue — WCAG 1.4.1).
  */
 export function EffortChart(props: { title: string; rows: EffortRow[] }) {
   // Memoize so the O(N) reduction runs once per rows change, not once per row
-  // on every reactive read inside the <For> below.
-  const max = createMemo(() => Math.max(1, ...props.rows.map((row) => row.minutes)))
+  // on every reactive read inside the <For> below. Bars scale to the larger of
+  // worked-or-target so a Soll marker beyond the worked time still fits.
+  const max = createMemo(() => Math.max(1, ...props.rows.map((row) => Math.max(row.minutes, row.target ?? 0))))
+  const pct = (minutes: number): string => `${(minutes / max()) * 100}%`
 
   return (
     <section class="effort-chart">
@@ -38,20 +49,36 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
           </thead>
           <tbody>
             <For each={props.rows}>
-              {(row) => (
-                <tr>
-                  <th scope="row" class="effort-bar-cell">
-                    <span
-                      class="effort-bar"
-                      aria-hidden="true"
-                      style={{ width: `${(row.minutes / max()) * 100}%` }}
-                    />
-                    <span class="effort-bar-label">{row.label}</span>
-                  </th>
-                  <td class="numeric">{formatMinutes(row.minutes)}</td>
-                  <td class="numeric">{row.quota}</td>
-                </tr>
-              )}
+              {(row) => {
+                const under = (): boolean => row.target != null && row.minutes < row.target
+
+                return (
+                  <tr>
+                    <th scope="row" class="effort-bar-cell">
+                      <Show when={under()}>
+                        <span class="effort-bar-ghost" aria-hidden="true" style={{ width: pct(row.target ?? 0) }} />
+                      </Show>
+                      <span
+                        class="effort-bar"
+                        classList={{ 'is-over': row.target != null && row.minutes >= row.target, 'is-under': under() }}
+                        aria-hidden="true"
+                        style={{ width: pct(row.minutes) }}
+                      />
+                      <Show when={row.target != null}>
+                        <span class="effort-soll-marker" aria-hidden="true" style={{ left: pct(row.target ?? 0) }} />
+                      </Show>
+                      <span class="effort-bar-label">{row.label}</span>
+                    </th>
+                    <td class="numeric">
+                      {formatMinutes(row.minutes)}
+                      <Show when={row.target != null}>
+                        <small class="effort-target">{m.auswertung_of_target({ target: formatMinutes(row.target ?? 0) })}</small>
+                      </Show>
+                    </td>
+                    <td class="numeric">{row.quota}</td>
+                  </tr>
+                )
+              }}
             </For>
           </tbody>
         </table>

--- a/frontend/src/components/EffortChart.tsx
+++ b/frontend/src/components/EffortChart.tsx
@@ -50,7 +50,12 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
           <tbody>
             <For each={props.rows}>
               {(row) => {
-                const under = (): boolean => row.target != null && row.minutes < row.target
+                // A 0 Soll (weekend / public holiday / contract gap) is "no
+                // boundary for this day": skip the over/under colour, the marker
+                // and the printed Soll so a worked weekend reads as a neutral
+                // bar, not a misleading green "over target 0:00".
+                const hasTarget = (): boolean => row.target != null && row.target > 0
+                const under = (): boolean => hasTarget() && row.minutes < (row.target ?? 0)
 
                 return (
                   <tr>
@@ -60,18 +65,18 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
                       </Show>
                       <span
                         class="effort-bar"
-                        classList={{ 'is-over': row.target != null && row.minutes >= row.target, 'is-under': under() }}
+                        classList={{ 'is-over': hasTarget() && row.minutes >= (row.target ?? 0), 'is-under': under() }}
                         aria-hidden="true"
                         style={{ width: pct(row.minutes) }}
                       />
-                      <Show when={row.target != null}>
+                      <Show when={hasTarget()}>
                         <span class="effort-soll-marker" aria-hidden="true" style={{ left: pct(row.target ?? 0) }} />
                       </Show>
                       <span class="effort-bar-label">{row.label}</span>
                     </th>
                     <td class="numeric">
                       {formatMinutes(row.minutes)}
-                      <Show when={row.target != null}>
+                      <Show when={hasTarget()}>
                         <small class="effort-target">{m.auswertung_of_target({ target: formatMinutes(row.target ?? 0) })}</small>
                       </Show>
                     </td>

--- a/frontend/src/pages/Auswertung.test.tsx
+++ b/frontend/src/pages/Auswertung.test.tsx
@@ -21,7 +21,7 @@ function mockEndpoints() {
         { id: 2, name: 'Globex', hours: 2, quota: '20.00%' },
       ])
     if (path === '/interpretation/time')
-      return Promise.resolve([{ id: null, name: '26-06-01', day: '01.06.', hours: 4, quota: '100.00%' }])
+      return Promise.resolve([{ id: null, name: '26-06-01', day: '01.06.', hours: 4, quota: '100.00%', expected: 8 }])
     if (path === '/interpretation/entries')
       return Promise.resolve([
         { entry: { id: 5, date: '01/06/2026', ticket: 'ABC-1', description: 'work', duration: '8:00', quota: '100.00%' } },
@@ -95,7 +95,7 @@ describe('Auswertung', () => {
   it('sorts the detail table chronologically by ISO date, not display text', async () => {
     getJson.mockImplementation((path: string) => {
       if (path === '/interpretation/time')
-        return Promise.resolve([{ id: null, name: '26-06-24', day: '24.06.', hours: 4, quota: '100.00%' }])
+        return Promise.resolve([{ id: null, name: '26-06-24', day: '24.06.', hours: 4, quota: '100.00%', expected: 8 }])
       if (path === '/interpretation/entries')
         return Promise.resolve([
           { entry: { id: 1, date: '01/07/2026', ticket: 'JUL-01', description: 'b', duration: '2:00', quota: '' } },

--- a/frontend/src/pages/Auswertung.tsx
+++ b/frontend/src/pages/Auswertung.tsx
@@ -168,6 +168,7 @@ export default function Auswertung() {
       label: row.day,
       minutes: Math.round(row.hours * 60),
       quota: row.quota,
+      target: Math.round(row.expected * 60),
     })),
   )
 

--- a/frontend/src/pages/Month.test.tsx
+++ b/frontend/src/pages/Month.test.tsx
@@ -9,8 +9,8 @@ import Month, { resolveDayTokens } from './Month'
 // One booking in the past, one in the future (Fri 2026-06-19) relative to the
 // frozen "today" — the until-today summary must ignore the future one.
 const times: WorktimeRecord[] = [
-  { id: null, name: '26-06-01', day: '01.06.', hours: 8, quota: '50%' },
-  { id: null, name: '26-06-19', day: '19.06.', hours: 8, quota: '50%' },
+  { id: null, name: '26-06-01', day: '01.06.', hours: 8, quota: '50%', expected: 8 },
+  { id: null, name: '26-06-19', day: '19.06.', hours: 8, quota: '50%', expected: 8 },
 ]
 const holidays: HolidayRecord[] = [
   { holiday: { name: 'Pfingstmontag', date: '2026-06-01' } },

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -988,6 +988,44 @@ kbd {
   z-index: 0;
 }
 
+/* "Effort by day" only: the per-day contract Soll overlaid on each bar. The
+   colour is reinforced by the Soll marker and the printed Soll so the over/
+   under state never depends on colour alone (WCAG 1.4.1). */
+.effort-bar.is-over {
+  background: var(--color-success-bg);
+}
+
+.effort-bar.is-under {
+  background: var(--color-warning-bg);
+}
+
+/* The Soll extent, drawn faintly behind a short (under-target) bar so the
+   shortfall reads as the gap from the bar's end to the marker. */
+.effort-bar-ghost {
+  border: 1px dashed var(--color-border);
+  border-radius: 4px;
+  inset: 3px auto 3px 0;
+  position: absolute;
+  z-index: 0;
+}
+
+/* A crisp vertical tick at the Soll (target) position on the bar track. */
+.effort-soll-marker {
+  background: var(--color-accent);
+  inset: 1px auto 1px 0;
+  margin-left: -1px;
+  position: absolute;
+  width: 2px;
+  z-index: 1;
+}
+
+/* The Soll printed next to the worked time — the non-colour cue. */
+.effort-target {
+  color: var(--color-text-muted);
+  font-weight: 400;
+  margin-left: 0.25rem;
+}
+
 .effort-bar-label {
   overflow: hidden;
   position: relative;

--- a/src/Controller/Default/GetContractHoursAction.php
+++ b/src/Controller/Default/GetContractHoursAction.php
@@ -14,6 +14,7 @@ use App\Entity\Contract;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Repository\ContractRepository;
+use App\Service\Util\ContractHoursResolver;
 use DateTime;
 use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Service\Attribute\Required;
 
 use function assert;
 use function sprintf;
@@ -30,13 +32,18 @@ use function sprintf;
  *
  * Drives the /ui/month "expected" column: each weekday's expected time comes
  * from the contract valid in the queried month (hours_0 = Sunday … hours_6 =
- * Saturday, matching JS Date.getDay()), with an all-8 default when the user has
- * no contract for that month.
+ * Saturday, matching JS Date.getDay()), with a 5×8h default (8h Mon–Fri, 0 at
+ * the weekend) when the user has no contract for that month.
  */
 final class GetContractHoursAction extends BaseController
 {
-    /** Default daily hours when the user has no contract covering the month. */
-    private const float DEFAULT_HOURS = 8.0;
+    private ContractHoursResolver $contractHoursResolver;
+
+    #[Required]
+    public function setContractHoursResolver(ContractHoursResolver $contractHoursResolver): void
+    {
+        $this->contractHoursResolver = $contractHoursResolver;
+    }
 
     /**
      * @throws Exception When date construction fails
@@ -81,26 +88,14 @@ final class GetContractHoursAction extends BaseController
      */
     private function buildHours(?Contract $contract): array
     {
-        if (!$contract instanceof Contract) {
-            return [
-                'hours_0' => self::DEFAULT_HOURS,
-                'hours_1' => self::DEFAULT_HOURS,
-                'hours_2' => self::DEFAULT_HOURS,
-                'hours_3' => self::DEFAULT_HOURS,
-                'hours_4' => self::DEFAULT_HOURS,
-                'hours_5' => self::DEFAULT_HOURS,
-                'hours_6' => self::DEFAULT_HOURS,
-            ];
-        }
-
         return [
-            'hours_0' => (float) $contract->getHours0(),
-            'hours_1' => (float) $contract->getHours1(),
-            'hours_2' => (float) $contract->getHours2(),
-            'hours_3' => (float) $contract->getHours3(),
-            'hours_4' => (float) $contract->getHours4(),
-            'hours_5' => (float) $contract->getHours5(),
-            'hours_6' => (float) $contract->getHours6(),
+            'hours_0' => $this->contractHoursResolver->weekdayHours($contract, 0),
+            'hours_1' => $this->contractHoursResolver->weekdayHours($contract, 1),
+            'hours_2' => $this->contractHoursResolver->weekdayHours($contract, 2),
+            'hours_3' => $this->contractHoursResolver->weekdayHours($contract, 3),
+            'hours_4' => $this->contractHoursResolver->weekdayHours($contract, 4),
+            'hours_5' => $this->contractHoursResolver->weekdayHours($contract, 5),
+            'hours_6' => $this->contractHoursResolver->weekdayHours($contract, 6),
         ];
     }
 }

--- a/src/Controller/Interpretation/GroupByWorktimeAction.php
+++ b/src/Controller/Interpretation/GroupByWorktimeAction.php
@@ -26,6 +26,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Service\Attribute\Required;
 
 use function assert;
+use function is_string;
 
 final class GroupByWorktimeAction extends BaseInterpretationController
 {

--- a/src/Controller/Interpretation/GroupByWorktimeAction.php
+++ b/src/Controller/Interpretation/GroupByWorktimeAction.php
@@ -17,6 +17,7 @@ use App\Repository\ContractRepository;
 use App\Service\Util\ContractHoursResolver;
 use App\Service\Util\TimeCalculationService;
 use DateTimeInterface;
+use Doctrine\DBAL\Connection;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -75,15 +76,16 @@ final class GroupByWorktimeAction extends BaseInterpretationController
 
             $key = $day->format('y-m-d');
             if (!isset($times[$key])) {
-                $expected = $this->contractHoursResolver->weekdayHours(
-                    $this->contractHoursResolver->validContract($contracts, $day),
-                    (int) $day->format('w'),
-                );
-                $times[$key] = ['id' => null, 'name' => $key, 'day' => $day->format('d.m.'), 'hours' => 0.0, 'minutes' => 0.0, 'quota' => 0, 'expected' => $expected];
+                $times[$key] = ['id' => null, 'name' => $key, 'day' => $day->format('d.m.'), 'date' => $day, 'hours' => 0.0, 'minutes' => 0.0, 'quota' => 0, 'expected' => 0.0];
             }
 
             $times[$key]['minutes'] += $entry->getDuration();
         }
+
+        // The per-day "expected" (Soll) is 0 on a public holiday (matching the
+        // /ui/month calendar), otherwise the contract's hours for that weekday
+        // (5×8h default when no contract applies).
+        $holidayDates = $this->loadHolidayDates($times);
 
         $totalMinutes = 0.0;
         foreach ($times as $t) {
@@ -92,10 +94,18 @@ final class GroupByWorktimeAction extends BaseInterpretationController
 
         foreach ($times as &$time) {
             $minutes = $time['minutes'];
+            $date = $time['date'];
             $time['hours'] = $minutes / 60.0;
-            unset($time['minutes']);
+            $time['expected'] = isset($holidayDates[$date->format('Y-m-d')])
+                ? 0.0
+                : $this->contractHoursResolver->weekdayHours(
+                    $this->contractHoursResolver->validContract($contracts, $date),
+                    (int) $date->format('w'),
+                );
+            unset($time['minutes'], $time['date']);
             $time['quota'] = $this->timeCalculationService->formatQuota($minutes, $totalMinutes);
         }
+        unset($time);
 
         usort($times, $this->sortByName(...));
         $prepared = array_map(static fn (array $t): array => [
@@ -105,5 +115,39 @@ final class GroupByWorktimeAction extends BaseInterpretationController
         $prepared = array_reverse($prepared);
 
         return new JsonResponse($prepared);
+    }
+
+    /**
+     * Public-holiday dates ('Y-m-d' => true) spanning the booked days, queried
+     * once so the per-day Soll can drop to 0 on a holiday (matching /ui/month).
+     *
+     * @param array<string, array{date: DateTimeInterface, ...}> $times
+     *
+     * @return array<string, true>
+     */
+    private function loadHolidayDates(array $times): array
+    {
+        if ([] === $times) {
+            return [];
+        }
+
+        $dates = array_map(static fn (array $time): string => $time['date']->format('Y-m-d'), $times);
+
+        /** @var Connection $connection */
+        $connection = $this->managerRegistry->getConnection();
+        $rows = $connection->fetchFirstColumn(
+            'SELECT day FROM holidays WHERE day BETWEEN ? AND ?',
+            [min($dates), max($dates)],
+        );
+
+        $holidays = [];
+        foreach ($rows as $row) {
+            // A DATE column comes back as a 'Y-m-d' string; ignore anything else.
+            if (is_string($row)) {
+                $holidays[substr($row, 0, 10)] = true;
+            }
+        }
+
+        return $holidays;
     }
 }

--- a/src/Controller/Interpretation/GroupByWorktimeAction.php
+++ b/src/Controller/Interpretation/GroupByWorktimeAction.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace App\Controller\Interpretation;
 
+use App\Entity\Contract;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
+use App\Repository\ContractRepository;
+use App\Service\Util\ContractHoursResolver;
 use App\Service\Util\TimeCalculationService;
 use DateTimeInterface;
 use Exception;
@@ -21,14 +24,24 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Service\Attribute\Required;
 
+use function assert;
+
 final class GroupByWorktimeAction extends BaseInterpretationController
 {
     private TimeCalculationService $timeCalculationService;
+
+    private ContractHoursResolver $contractHoursResolver;
 
     #[Required]
     public function setTimeCalculationService(TimeCalculationService $timeCalculationService): void
     {
         $this->timeCalculationService = $timeCalculationService;
+    }
+
+    #[Required]
+    public function setContractHoursResolver(ContractHoursResolver $contractHoursResolver): void
+    {
+        $this->contractHoursResolver = $contractHoursResolver;
     }
 
     #[Route(path: '/interpretation/time', name: 'interpretation_time_attr', methods: ['GET'])]
@@ -47,6 +60,12 @@ final class GroupByWorktimeAction extends BaseInterpretationController
             return $response;
         }
 
+        // Load the user's contracts once; the per-day "expected" (Soll) is then
+        // resolved in PHP (validContract + weekdayHours) without a query per day.
+        $contractRepository = $this->managerRegistry->getRepository(Contract::class);
+        assert($contractRepository instanceof ContractRepository);
+        $contracts = $contractRepository->findBy(['user' => $currentUser], ['start' => 'DESC']);
+
         $times = [];
         foreach ($entries as $entry) {
             $day = $entry->getDay();
@@ -56,7 +75,11 @@ final class GroupByWorktimeAction extends BaseInterpretationController
 
             $key = $day->format('y-m-d');
             if (!isset($times[$key])) {
-                $times[$key] = ['id' => null, 'name' => $key, 'day' => $day->format('d.m.'), 'hours' => 0.0, 'minutes' => 0.0, 'quota' => 0];
+                $expected = $this->contractHoursResolver->weekdayHours(
+                    $this->contractHoursResolver->validContract($contracts, $day),
+                    (int) $day->format('w'),
+                );
+                $times[$key] = ['id' => null, 'name' => $key, 'day' => $day->format('d.m.'), 'hours' => 0.0, 'minutes' => 0.0, 'quota' => 0, 'expected' => $expected];
             }
 
             $times[$key]['minutes'] += $entry->getDuration();
@@ -76,7 +99,7 @@ final class GroupByWorktimeAction extends BaseInterpretationController
 
         usort($times, $this->sortByName(...));
         $prepared = array_map(static fn (array $t): array => [
-            'id' => $t['id'], 'name' => $t['name'], 'day' => $t['day'], 'hours' => $t['hours'], 'quota' => $t['quota'],
+            'id' => $t['id'], 'name' => $t['name'], 'day' => $t['day'], 'hours' => $t['hours'], 'quota' => $t['quota'], 'expected' => $t['expected'],
         ], $times);
 
         $prepared = array_reverse($prepared);

--- a/src/Service/Util/ContractHoursResolver.php
+++ b/src/Service/Util/ContractHoursResolver.php
@@ -58,9 +58,15 @@ final class ContractHoursResolver
      */
     public function validContract(array $contracts, DateTimeInterface $date): ?Contract
     {
+        // Compare on the 'Y-m-d' date only, mirroring the SQL DATE comparison.
+        // A direct DateTimeInterface comparison would include the time, so a
+        // contract ending 2020-01-31 00:00:00 would wrongly exclude an entry
+        // dated 2020-01-31 08:30:00.
+        $dateKey = $date->format('Y-m-d');
         foreach ($contracts as $contract) {
             $end = $contract->getEnd();
-            if ($contract->getStart() <= $date && (!$end instanceof DateTimeInterface || $end >= $date)) {
+            $endKey = $end instanceof DateTimeInterface ? $end->format('Y-m-d') : null;
+            if ($contract->getStart()->format('Y-m-d') <= $dateKey && (null === $endKey || $endKey >= $dateKey)) {
                 return $contract;
             }
         }

--- a/src/Service/Util/ContractHoursResolver.php
+++ b/src/Service/Util/ContractHoursResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Util;
+
+use App\Entity\Contract;
+use DateTimeInterface;
+
+/**
+ * Resolves a user's expected ("Soll") working hours for a given weekday, from
+ * their contract or a 5×8h default (8h Mon–Fri, 0 at the weekend) when no
+ * contract covers the day.
+ *
+ * Shared by /getContractHours (the /ui/month per-weekday Soll) and
+ * /interpretation/time (the per-day Soll markers on the "Effort by day" chart)
+ * so the fallback stays identical in both places.
+ */
+final class ContractHoursResolver
+{
+    /** Default daily hours on a weekday (Mon–Fri) when no contract covers the day. */
+    private const float DEFAULT_WEEKDAY_HOURS = 8.0;
+
+    /**
+     * Expected hours for a weekday index (0 = Sunday … 6 = Saturday, matching
+     * JS Date.getDay() and PHP date('w')). Without a contract the default is a
+     * standard 5×8h week: 8h on Mon–Fri and 0 on the weekend.
+     */
+    public function weekdayHours(?Contract $contract, int $weekday): float
+    {
+        if ($contract instanceof Contract) {
+            return (float) match ($weekday) {
+                0 => $contract->getHours0(),
+                1 => $contract->getHours1(),
+                2 => $contract->getHours2(),
+                3 => $contract->getHours3(),
+                4 => $contract->getHours4(),
+                5 => $contract->getHours5(),
+                default => $contract->getHours6(),
+            };
+        }
+
+        return $weekday >= 1 && $weekday <= 5 ? self::DEFAULT_WEEKDAY_HOURS : 0.0;
+    }
+
+    /**
+     * The contract valid on $date from a pre-loaded, start-descending list, or
+     * null. Mirrors ContractRepository::findValidContract (start <= date, and
+     * end open or >= date, most recent start wins) without a per-day query —
+     * the caller loads the user's contracts once and resolves each day in PHP.
+     *
+     * @param Contract[] $contracts ordered by contract.start DESC
+     */
+    public function validContract(array $contracts, DateTimeInterface $date): ?Contract
+    {
+        foreach ($contracts as $contract) {
+            $end = $contract->getEnd();
+            if ($contract->getStart() <= $date && (!$end instanceof DateTimeInterface || $end >= $date)) {
+                return $contract;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Controller/GetContractHoursActionTest.php
+++ b/tests/Controller/GetContractHoursActionTest.php
@@ -70,7 +70,7 @@ final class GetContractHoursActionTest extends AbstractWebTestCase
         self::assertEqualsWithDelta(0.5, $json['hours_6'], 0.0001);
     }
 
-    public function testFallsBackToEightHoursWhenUserHasNoContract(): void
+    public function testFallsBackToFiveByEightHoursWhenUserHasNoContract(): void
     {
         $this->logInSession('noContract');
         $this->client->request(
@@ -83,19 +83,23 @@ final class GetContractHoursActionTest extends AbstractWebTestCase
         self::assertTrue($response->isSuccessful());
         $json = $this->getJsonResponse($response);
 
-        foreach (['hours_0', 'hours_1', 'hours_2', 'hours_3', 'hours_4', 'hours_5', 'hours_6'] as $key) {
+        // 5×8h default: 8h Mon–Fri, 0 on the weekend (hours_0 = Sunday, hours_6 = Saturday).
+        self::assertEquals(0, $json['hours_0'], 'Sunday should default to 0');
+        foreach (['hours_1', 'hours_2', 'hours_3', 'hours_4', 'hours_5'] as $key) {
             self::assertEquals(8, $json[$key], $key . ' should default to 8');
         }
+
+        self::assertEquals(0, $json['hours_6'], 'Saturday should default to 0');
     }
 
-    public function testFallsBackToEightHoursForAMonthBeforeAnyContract(): void
+    public function testFallsBackToFiveByEightHoursForAMonthBeforeAnyContract(): void
     {
         $this->logInSession('unittest');
         // Before contract 1 starts (2020-01-01): no contract is valid on 2019-12-01.
         // This also pins the query's parenthesization: were the
         // `end IS NULL OR end >= :date` clause not grouped, the dangling OR would
         // match contract 1 (ends 2020-01-31 >= 2019-12-01) and return its hours
-        // instead of the 8h fallback asserted below.
+        // instead of the 5×8h fallback asserted below.
         $this->client->request(
             \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             '/getContractHours',
@@ -106,8 +110,8 @@ final class GetContractHoursActionTest extends AbstractWebTestCase
         self::assertTrue($response->isSuccessful());
         $json = $this->getJsonResponse($response);
 
-        self::assertEquals(8, $json['hours_1']);
-        self::assertEquals(8, $json['hours_6']);
+        self::assertEquals(8, $json['hours_1'], 'Monday should default to 8');
+        self::assertEquals(0, $json['hours_6'], 'Saturday should default to 0');
     }
 
     public function testClampsAMalformedYearInsteadOfErroring(): void

--- a/tests/Controller/InterpretationControllerTest.php
+++ b/tests/Controller/InterpretationControllerTest.php
@@ -99,6 +99,57 @@ final class InterpretationControllerTest extends AbstractWebTestCase
         $this->assertJsonStructure($expectedJson, $this->getJsonResponse($this->client->getResponse()));
     }
 
+    public function testGroupByWorktimeZeroesExpectedOnAHoliday(): void
+    {
+        // 1000-01-29 (Wed) carries user-1 fixture bookings; marking it a public
+        // holiday must drop that day's Soll to 0, matching /ui/month, while
+        // 1000-01-30 (Thu, no holiday, before any contract) keeps the 8h default.
+        self::assertNotNull($this->connection);
+        $this->connection->insert('holidays', ['day' => '1000-01-29', 'name' => 'Test Holiday']);
+
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/time', [
+            'user' => 1,
+            'datestart' => '1000-01-29',
+            'dateend' => '1000-01-30',
+        ]);
+        $this->assertStatusCode(200);
+        $this->assertJsonStructure([
+            ['name' => '00-01-29', 'expected' => 0],
+            ['name' => '00-01-30', 'expected' => 8],
+        ], $this->getJsonResponse($this->client->getResponse()));
+    }
+
+    public function testGroupByWorktimeDerivesExpectedFromTheContract(): void
+    {
+        // A contract covering the year-1000 fixture bookings: Wed (hours_3) = 5,
+        // Thu (hours_4) = 6. The per-day Soll must come from the contract weekday
+        // columns, not the 5x8h default.
+        self::assertNotNull($this->connection);
+        $this->connection->insert('contracts', [
+            'user_id' => 1,
+            'start' => '1000-01-01',
+            'end' => '1000-12-31',
+            'hours_0' => 0,
+            'hours_1' => 0,
+            'hours_2' => 0,
+            'hours_3' => 5,
+            'hours_4' => 6,
+            'hours_5' => 0,
+            'hours_6' => 0,
+        ]);
+
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/time', [
+            'user' => 1,
+            'datestart' => '1000-01-29',
+            'dateend' => '1000-01-30',
+        ]);
+        $this->assertStatusCode(200);
+        $this->assertJsonStructure([
+            ['name' => '00-01-29', 'expected' => 5],
+            ['name' => '00-01-30', 'expected' => 6],
+        ], $this->getJsonResponse($this->client->getResponse()));
+    }
+
     public function testGroupByActivityAction(): void
     {
         $parameter = [

--- a/tests/Controller/InterpretationControllerTest.php
+++ b/tests/Controller/InterpretationControllerTest.php
@@ -74,18 +74,23 @@ final class InterpretationControllerTest extends AbstractWebTestCase
             'dateend' => '1000-01-30',  // opt
         ];
 
+        // 1000-01-29/30 fall before any contract (the fixtures start 2020), so
+        // each day's "expected" Soll comes from the 5×8h default. Both are
+        // weekdays (Wed/Thu) → 8h.
         $expectedJson = [
             [
                 'name' => '00-01-29',
                 'day' => '29.01.',
                 'hours' => 0.23333333333333334,
                 'quota' => '5.98%',
+                'expected' => 8,
             ],
             [
                 'name' => '00-01-30',
                 'day' => '30.01.',
                 'hours' => 3.6666666666666665,
                 'quota' => '94.02%',
+                'expected' => 8,
             ],
         ];
 

--- a/tests/Service/Util/ContractHoursResolverTest.php
+++ b/tests/Service/Util/ContractHoursResolverTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Service\Util;
+
+use App\Entity\Contract;
+use App\Service\Util\ContractHoursResolver;
+use DateTime;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ContractHoursResolver.
+ *
+ * @internal
+ */
+#[CoversClass(ContractHoursResolver::class)]
+final class ContractHoursResolverTest extends TestCase
+{
+    private ContractHoursResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ContractHoursResolver();
+    }
+
+    public function testWeekdayHoursReadsTheContractPerWeekday(): void
+    {
+        $contract = new Contract()
+            ->setHours0(0.0)
+            ->setHours1(8.0)
+            ->setHours2(7.5)
+            ->setHours3(8.0)
+            ->setHours4(8.0)
+            ->setHours5(6.0)
+            ->setHours6(0.0);
+
+        self::assertSame(0.0, $this->resolver->weekdayHours($contract, 0)); // Sunday
+        self::assertSame(8.0, $this->resolver->weekdayHours($contract, 1)); // Monday
+        self::assertSame(7.5, $this->resolver->weekdayHours($contract, 2));
+        self::assertSame(6.0, $this->resolver->weekdayHours($contract, 5)); // Friday
+        self::assertSame(0.0, $this->resolver->weekdayHours($contract, 6)); // Saturday
+    }
+
+    public function testWeekdayHoursFallsBackToFiveByEightWithoutAContract(): void
+    {
+        // 5×8h default: 8h Mon–Fri, 0 on the weekend.
+        self::assertSame(0.0, $this->resolver->weekdayHours(null, 0)); // Sunday
+        self::assertSame(8.0, $this->resolver->weekdayHours(null, 1)); // Monday
+        self::assertSame(8.0, $this->resolver->weekdayHours(null, 5)); // Friday
+        self::assertSame(0.0, $this->resolver->weekdayHours(null, 6)); // Saturday
+    }
+
+    public function testValidContractPicksTheCoveringContractAndIsNullBeforeAny(): void
+    {
+        $old = new Contract()
+            ->setStart(new DateTime('2020-01-01'))
+            ->setEnd(new DateTime('2020-01-31'));
+        $current = new Contract()
+            ->setStart(new DateTime('2020-02-01'))
+            ->setEnd(null);
+        // Caller passes start-DESC order (newest first), as
+        // findBy(..., ['start' => 'DESC']) returns.
+        $contracts = [$current, $old];
+
+        self::assertSame($old, $this->resolver->validContract($contracts, new DateTime('2020-01-15')));
+        self::assertSame($current, $this->resolver->validContract($contracts, new DateTime('2021-06-01')));
+        self::assertNull($this->resolver->validContract($contracts, new DateTime('2019-12-01')));
+    }
+}


### PR DESCRIPTION
## What

The `/ui/auswertung` **Effort by day** chart now visualizes each day’s contract boundary (the "Soll"), three ways combined:

- **Over/under colour** — the bar is green when worked ≥ Soll, amber when under.
- **Soll marker** — a crisp vertical tick at the target position on the bar track.
- **Ghost bar** — a dashed outline spanning the shortfall, shown only when under Soll.

The worked time also prints the Soll (`8:30 / 8:00`) next to it — the **non-colour, screen-reader-visible cue** so the over/under state never depends on colour alone (WCAG 1.4.1). The grouped *effort* charts carry no target and are visually unchanged.

## How

The per-day Soll is computed **in the backend**, where the full date, the user’s contract, and the holiday calendar are available — the frontend only receives `d.m.` labels (no year), so it cannot derive the weekday reliably.

A new `ContractHoursResolver` centralizes two things shared by the month Soll and the new by-day Soll:
- `weekdayHours(contract, weekday)` — the contract’s hours for a weekday, or a **5×8h default** (8h Mon–Fri, 0 at the weekend).
- `validContract(contracts, date)` — an in-memory mirror of `ContractRepository::findValidContract` (compared on the `Y-m-d` date, matching the SQL DATE semantics), so `GroupByWorktimeAction` loads the user’s contracts **once** and resolves each day in PHP (no per-day query).

`GroupByWorktimeAction` adds an `expected` field per day to `/interpretation/time`; `EffortChart` gains an optional per-row `target`.

### Holiday-aware, and honest about zero-Soll days
- **Holidays** — `expected` drops to **0 on a public holiday** (the action loads the holidays spanning the booked days once), matching the `/ui/month` calendar. Without this, a Mon–Fri holiday with a booking rendered red "under 8:00" while the month view showed Soll 0.
- **Zero-Soll days** — a day whose Soll is 0 (weekend / holiday / contract gap) renders as a plain **neutral bar** (no over/under colour, no marker, no `/ 0:00` cue), so a worked weekend is not shown as a misleading green "on target".

### Also fixes the `/ui/month` Soll fallback at the source
`/getContractHours` previously defaulted to **8h on every weekday including the weekend** when the user had no contract. That was harmless for `/ui/month` (which zeroes weekends downstream) but is not the literal "5×8h" and would mis-mark weekends on the new by-day chart. It now returns a true 5×8h via the shared resolver. *(The `/ui/month` Soll display itself already existed and is live on prod — this only corrects the fallback at the data layer.)*

## Test

- `ContractHoursResolverTest` — contract weekday hours, 5×8h fallback (weekend = 0), valid-contract resolution incl. before-any-contract → null.
- `GetContractHoursActionTest` — no-contract default updated to 5×8h (Sun/Sat = 0).
- `InterpretationControllerTest` — `/interpretation/time` asserts the per-day `expected`, a booked **holiday → 0** (vs the 8h weekday fallback), and a **contract-derived** Soll (Wed `hours_3`, Thu `hours_4`).
- `EffortChart.test.tsx` — over/under classes, marker position, ghost only when under, printed Soll, a **zero-Soll day stays neutral**, worked-exactly-Soll = over (no ghost), axe-clean, and target-less charts get no overlay.
- Full frontend suite green (310); backend resolver/contract/interpretation suites green; PHPStan + cs-fixer + rector clean.

## Review
Hardened via an adversarial multi-dimension review (correctness / a11y / edge-cases / coverage) plus gemini: holiday inconsistency, the zero-Soll rendering, and the date-only contract comparison were all caught and fixed here.