### PR TITLE
fix(worklog): localize the time-order error (#441) and refresh header totals on save (#446)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -177,6 +177,7 @@
   "tracking_class_pause": "Pause",
   "tracking_class_overlap": "Zeitüberschneidung",
   "tracking_invalid_time": "Bitte eine gültige Start- und Endzeit eingeben.",
+  "tracking_time_order": "Die Startzeit muss vor der Endzeit liegen.",
   "tracking_actions": "Aktionen",
   "tracking_add": "Eintrag hinzufügen",
   "tracking_continue": "Fortsetzen",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -177,6 +177,7 @@
   "tracking_class_pause": "Break",
   "tracking_class_overlap": "Time overlap",
   "tracking_invalid_time": "Please enter a valid start and end time.",
+  "tracking_time_order": "Start time must be before end time.",
   "tracking_actions": "Actions",
   "tracking_add": "Add entry",
   "tracking_continue": "Continue",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { sessionExpired, setSessionExpired } from '../lib/session'
-import { ApiError, apiErrorMessage, getJson, postForm, postJson, SessionExpiredError } from './client'
+import { ApiError, apiErrorMessage, getJson, postForm, postJson, SessionExpiredError, ValidationError } from './client'
 
 interface FakeResponse {
   ok?: boolean
@@ -136,8 +136,12 @@ describe('api/client', () => {
   })
 
   describe('apiErrorMessage', () => {
-    it('returns the ApiError message, else the fallback', () => {
+    it('returns the ApiError or ValidationError message, else the fallback', () => {
       expect(apiErrorMessage(new ApiError(400, 'nope'), 'fb')).toBe('nope')
+      // A client-side ValidationError carries an already-localized, user-facing
+      // message and is surfaced verbatim (e.g. the start ≥ end check, #441).
+      expect(apiErrorMessage(new ValidationError('start before end'), 'fb')).toBe('start before end')
+      // A plain Error may be technical → fall back rather than leak it.
       expect(apiErrorMessage(new Error('other'), 'fb')).toBe('fb')
       expect(apiErrorMessage('weird', 'fb')).toBe('fb')
     })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,9 +18,20 @@ export class ApiError extends Error {
   }
 }
 
-/** The message from an ApiError, or a fallback for any other failure. */
+/** A client-side validation failure whose message is already a user-facing,
+ *  localized string (e.g. start ≥ end) and should be shown verbatim — unlike a
+ *  raw Error, whose message may be technical (and must fall back instead). */
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+
+/** The message from an ApiError or a client-side ValidationError (both already
+ *  user-facing), or a fallback for any other (possibly technical) failure. */
 export function apiErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof ApiError ? error.message : fallback
+  return error instanceof ApiError || error instanceof ValidationError ? error.message : fallback
 }
 
 // Raise the app-wide session-expired state — the shell shows an in-place re-login

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -50,7 +50,10 @@ function setBadge(loggedIn: boolean, userName: string): void {
   })
 }
 
-async function updateWorktime(): Promise<void> {
+// Exported so the SolidJS worklog can refresh the header's today/week/month
+// totals right after it saves, edits or deletes an entry — otherwise the header
+// sums (loaded once on init) go stale until a full page reload (#446).
+export async function updateWorktime(): Promise<void> {
   try {
     const summary = await getJson<TimeSummary>('/getTimeSummary')
     setText('worktime-day', formatDuration(summary.today.duration))

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -12,6 +12,7 @@ const postForm = vi.fn()
 vi.mock('../api/client', () => ({
   SessionExpiredError: class extends Error {},
   ApiError: class extends Error {},
+  ValidationError: class extends Error {},
   apiErrorMessage: (error: unknown, fallback: string) => (error instanceof Error ? error.message : fallback),
   getJson: (...args: unknown[]) => getJson(...args),
   postJson: (...args: unknown[]) => postJson(...args),
@@ -211,6 +212,49 @@ describe('Tracking (Worklog grid)', () => {
     ;(getByRole('combobox') as HTMLElement).focus()
 
     await waitFor(() => expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({ start: '08:00' })))
+
+    unmount()
+  })
+
+  it('blocks a save with start >= end and shows a localized message, no round-trip (#441)', async () => {
+    mockApi()
+    postJson.mockResolvedValue({})
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    // DEFAULT_ENTRY is 09:00–10:30; set end == start (09:00) and commit.
+    const editor = editCell(container, 'end')
+    fireEvent.input(editor, { target: { value: '09:00' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    // Localized validation message shown — and crucially no /tracking/save round-
+    // trip (the old behaviour surfaced the backend's untranslated 422 instead).
+    await waitFor(() => expect(screen.getByText('Start time must be before end time.')).toBeInTheDocument())
+    expect(postJson).not.toHaveBeenCalledWith('/tracking/save', expect.anything())
+
+    unmount()
+  })
+
+  it('refreshes the header day/week/month totals after a save (#446)', async () => {
+    mockApi()
+    // A complete save response so the post-save upsert succeeds and the flow
+    // reaches the header refresh (an empty {} would throw in savedEntryToRow).
+    postJson.mockResolvedValue({
+      result: {
+        id: 1, date: '2026-06-16', start: '09:00', end: '10:30', user: 1,
+        customer: 1, project: 4, activity: 5, duration: '1:30', durationMinutes: 90, class: 0, ticket: 'XYZ-9',
+      },
+    })
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    const editor = editCell(container, 'ticket')
+    fireEvent.input(editor, { target: { value: 'xyz-9' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.anything()))
+    // The save also re-pulls the server header's totals (otherwise stale until F5).
+    await waitFor(() => expect(getJson).toHaveBeenCalledWith('/getTimeSummary'))
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -180,10 +180,13 @@ export default function Tracking() {
   // Refetch the worklog grid AND refresh the server header's day/week/month
   // totals. The header loads those once on init, so without this they go stale
   // after a save / edit / delete (and the refresh button) until a full page
-  // reload (#446). updateWorktime swallows its own errors, so awaiting is safe.
+  // reload (#446). The two are independent (the mutation already hit the DB),
+  // so run them in parallel. updateWorktime swallows its own errors.
   const refreshWorklog = async (): Promise<void> => {
-    await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
-    await updateWorktime()
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] }),
+      updateWorktime(),
+    ])
   }
 
   // Polite live region: a screen reader gets no other confirmation that a row

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from 'solid-js'
 
-import { apiErrorMessage, postForm, postJson } from '../api/client'
+import { apiErrorMessage, postForm, postJson, ValidationError } from '../api/client'
 import { activitiesQuery, ENTRIES_KEY, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, upsertSavedEntry, type NamedOption, type SavedEntryResult, type SummaryScope, type TrackingEntry } from '../api/queries'
 import { appConfig, canBulkEnter } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
@@ -17,6 +17,7 @@ import { ContinueIcon, DiskIcon, DownloadIcon, InfoIcon, PlusIcon, ProlongIcon, 
 import { BulkEntryForm } from '../components/BulkEntryForm'
 import { PageDialog } from '../components/PageDialog'
 import { sessionExpired } from '../lib/session'
+import { updateWorktime } from '../header'
 import { dmyToIso, parseTime, toIsoDate } from '../lib/timeParse'
 import { m } from '../paraglide/messages.js'
 
@@ -175,6 +176,15 @@ export default function Tracking() {
   const [bulkOpen, setBulkOpen] = createSignal(false)
   // Confirmation dialog for a destructive delete (replaces window.confirm).
   const [pendingDelete, setPendingDelete] = createSignal<TrackingEntry | null>(null)
+
+  // Refetch the worklog grid AND refresh the server header's day/week/month
+  // totals. The header loads those once on init, so without this they go stale
+  // after a save / edit / delete (and the refresh button) until a full page
+  // reload (#446). updateWorktime swallows its own errors, so awaiting is safe.
+  const refreshWorklog = async (): Promise<void> => {
+    await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+    await updateWorktime()
+  }
 
   // Polite live region: a screen reader gets no other confirmation that a row
   // saved, deleted, or its end time changed (the row just mutates or vanishes).
@@ -336,7 +346,14 @@ export default function Tracking() {
       const start = parseTime(str(draft.start))
       const end = parseTime(str(draft.end))
       if (start === null || end === null) {
-        throw new Error(m.tracking_invalid_time())
+        throw new ValidationError(m.tracking_invalid_time())
+      }
+      // start/end are zero-padded "HH:mm", so a string compare orders them. The
+      // backend rejects start >= end too, but its message isn't localized (#441)
+      // and only fires after a round-trip — so catch it here, in the user's
+      // language, before the request.
+      if (start >= end) {
+        throw new ValidationError(m.tracking_time_order())
       }
       const isNew = num(entry.id) <= 0
       const saved = await postJson<SavedEntryResult>('/tracking/save', savePayload({
@@ -360,7 +377,7 @@ export default function Tracking() {
       if (isNew) {
         setNewRows((list) => list.filter((row) => num(row.id) !== num(entry.id)))
       }
-      await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+      await refreshWorklog()
     },
     onCommit: handleCommit,
     // Confirm every successful save (auto, force, or row-leave): announce to AT
@@ -519,7 +536,7 @@ export default function Tracking() {
       await postForm('/tracking/delete', { id: num(entry.id) })
       // Drop any pending inline draft for the now-deleted entry.
       editor.takeDraft(num(entry.id))
-      await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+      await refreshWorklog()
       announce(m.tracking_deleted())
       // The deleted row (and its trash button) left the DOM — restore cell focus
       // to the grid so keyboard users aren't dropped back to document start.
@@ -631,7 +648,7 @@ export default function Tracking() {
       }))
       upsertSavedEntry(queryClient, saved.result) // keep the prolonged row if the refetch fails
       editor.takeDraft(num(base.id)) // the draft is now persisted — clear it
-      await queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+      await refreshWorklog()
       announce(m.tracking_prolonged())
     } catch (caught) {
       setPageError(apiErrorMessage(caught, m.app_load_error()))
@@ -646,11 +663,11 @@ export default function Tracking() {
 
   const exportHref = (): string => `/export/${days()}`
 
-  // Reload the worklog entries (the Alt+R shortcut and the toolbar refresh button
-  // share this). Only the entries query is invalidated — the reference/option
-  // lookups carry a long staleTime and aren't force-refreshed on a routine reload.
+  // Reload the worklog entries and the header totals (the Alt+R shortcut and the
+  // toolbar refresh button share this). The reference/option lookups carry a long
+  // staleTime and aren't force-refreshed on a routine reload.
   function refreshEntries(): void {
-    void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+    void refreshWorklog()
     announce(m.tracking_refreshed())
   }
 
@@ -984,7 +1001,7 @@ export default function Tracking() {
       {/* Bulk-created entries may fall outside the current days range;
           refetch so any that land in view appear. */}
       <PageDialog open={bulkOpen()} onClose={() => setBulkOpen(false)} title={m.extras_title()}>
-        <BulkEntryForm onSaved={() => void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })} />
+        <BulkEntryForm onSaved={() => void refreshWorklog()} />
       </PageDialog>
 
       {/* Accessible delete confirmation (replaces native window.confirm). */}


### PR DESCRIPTION
Two regressions in the new SolidJS `/ui/tracking` (Worklog) tab, reported together by @ngolatka.

## #441 — error messages not in the configured language
Closes #441.

An entry with **identical (or reversed) start/end times** passed the client-side *format* check and went to the backend, which rejects it with a hardcoded English message — and via `#[MapRequestPayload]` the violation is even replaced by a generic 422 (`"The request was well-formed but contains semantic errors."`). So a German user saw an English, non-specific error.

- The grid now validates **start < end before the request** and shows the localized message (`tracking_time_order` → "Die Startzeit muss vor der Endzeit liegen." / "Start time must be before end time."). No backend round-trip for this case.
- Root-cause fix for *all* client-side validation: `apiErrorMessage` only surfaced `ApiError` messages, so a thrown plain `Error` fell back to a generic string — meaning the **existing** `tracking_invalid_time` validation was also effectively invisible. A new **`ValidationError`** type carries already-localized, user-facing messages that `apiErrorMessage` surfaces verbatim, while genuinely technical errors still fall back (no message leak).

## #446 — total time not updating after a save
Closes #446.

The server header’s **day / week / month totals** are loaded once on init (`header.ts:updateWorktime`), so they went stale after a save / edit / delete — and the refresh button didn’t help — until a full page reload (F5).

- `updateWorktime` is now exported, and a `refreshWorklog()` helper re-pulls the header totals alongside the entries-cache invalidation. It is wired into **every** mutation: inline save, delete, prolong, bulk save, and the refresh button.

## Test
- The grid blocks a `start == end` save with the localized message **and no `/tracking/save` round-trip**.
- A successful save re-pulls `/getTimeSummary` (the header totals).
- `apiErrorMessage` surfaces a `ValidationError` message but still falls back for a plain `Error`.
- Full frontend suite green (312); lint + typecheck + build clean. Frontend-only — no backend changes.