### PR TITLE
fix(auswertung): sortable/scrollable Effort tables + per-user data & Soll scoping

### DIFF
--- a/frontend/src/components/EffortChart.test.tsx
+++ b/frontend/src/components/EffortChart.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@solidjs/testing-library'
+import { fireEvent, render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 
@@ -17,6 +17,26 @@ describe('EffortChart', () => {
     const bars = [...container.querySelectorAll<HTMLElement>('.effort-bar')]
 
     expect(bars.map((bar) => bar.style.width)).toEqual(['100%', '50%', '0%'])
+    unmount()
+  })
+
+  it('sorts rows by a clicked column header (none → asc → desc)', () => {
+    const data: EffortRow[] = [
+      { label: 'Alpha', minutes: 60, quota: '50.00%' },
+      { label: 'Beta', minutes: 30, quota: '25.00%' },
+      { label: 'Gamma', minutes: 90, quota: '75.00%' },
+    ]
+    const { getByRole, container, unmount } = render(() => <EffortChart title="Effort" rows={data} />)
+    const firstLabel = (): string | undefined => container.querySelector('.effort-bar-label')?.textContent ?? undefined
+
+    // Default keeps the server order.
+    expect(firstLabel()).toBe('Alpha')
+    // Ascending by Hours → the smallest (Beta, 30) leads.
+    fireEvent.click(getByRole('button', { name: 'Hours' }))
+    expect(firstLabel()).toBe('Beta')
+    // A second click flips to descending → the largest (Gamma, 90) leads.
+    fireEvent.click(getByRole('button', { name: 'Hours' }))
+    expect(firstLabel()).toBe('Gamma')
     unmount()
   })
 

--- a/frontend/src/components/EffortChart.tsx
+++ b/frontend/src/components/EffortChart.tsx
@@ -1,7 +1,9 @@
-import { createMemo, For, Show } from 'solid-js'
+import { createMemo, createSignal, For, Show } from 'solid-js'
 
 import { formatMinutes } from '../lib/format'
 import { m } from '../paraglide/messages.js'
+
+type SortKey = 'label' | 'hours' | 'share'
 
 export interface EffortRow {
   label: string
@@ -31,6 +33,38 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
   const max = createMemo(() => Math.max(1, ...props.rows.map((row) => Math.max(row.minutes, row.target ?? 0))))
   const pct = (minutes: number): string => `${(minutes / max()) * 100}%`
 
+  // Optional column sort. Default (null) keeps the server order — value-desc for
+  // the grouped charts, chronological for "by day". Clicking a header cycles
+  // none → asc → desc → none. Share is proportional to minutes, so the hours and
+  // share columns order identically.
+  const [sort, setSort] = createSignal<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null)
+  const toggleSort = (key: SortKey): void => {
+    setSort((current) => (current?.key !== key ? { key, dir: 'asc' } : current.dir === 'asc' ? { key, dir: 'desc' } : null))
+  }
+  const ariaSort = (key: SortKey): 'ascending' | 'descending' | 'none' => {
+    const current = sort()
+
+    return current?.key === key ? (current.dir === 'asc' ? 'ascending' : 'descending') : 'none'
+  }
+  const sortGlyph = (key: SortKey): string => {
+    const current = sort()
+
+    return current?.key === key ? (current.dir === 'asc' ? '▲' : '▼') : '⇅'
+  }
+  const sortedRows = createMemo<EffortRow[]>(() => {
+    const current = sort()
+    if (!current) {
+      return props.rows
+    }
+    const factor = current.dir === 'asc' ? 1 : -1
+
+    return [...props.rows].sort((a, b) =>
+      current.key === 'label'
+        ? factor * a.label.localeCompare(b.label, undefined, { numeric: true })
+        : factor * (a.minutes - b.minutes),
+    )
+  })
+
   return (
     <section class="effort-chart">
       <h2>{props.title}</h2>
@@ -38,17 +72,33 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
         when={props.rows.length > 0}
         fallback={<p class="effort-empty">{m.auswertung_no_data()}</p>}
       >
+        <div class="table-scroll is-scrollable">
         <table class="effort-table">
           <caption class="visually-hidden">{props.title}</caption>
           <thead>
             <tr>
-              <th scope="col">{m.auswertung_label()}</th>
-              <th scope="col" class="numeric">{m.auswertung_hours()}</th>
-              <th scope="col" class="numeric">{m.auswertung_share()}</th>
+              <th scope="col" aria-sort={ariaSort('label')}>
+                <button type="button" class="th-sort" onClick={() => toggleSort('label')}>
+                  <span>{m.auswertung_label()}</span>
+                  <span class="th-sort-glyph" aria-hidden="true">{sortGlyph('label')}</span>
+                </button>
+              </th>
+              <th scope="col" class="numeric" aria-sort={ariaSort('hours')}>
+                <button type="button" class="th-sort" onClick={() => toggleSort('hours')}>
+                  <span>{m.auswertung_hours()}</span>
+                  <span class="th-sort-glyph" aria-hidden="true">{sortGlyph('hours')}</span>
+                </button>
+              </th>
+              <th scope="col" class="numeric" aria-sort={ariaSort('share')}>
+                <button type="button" class="th-sort" onClick={() => toggleSort('share')}>
+                  <span>{m.auswertung_share()}</span>
+                  <span class="th-sort-glyph" aria-hidden="true">{sortGlyph('share')}</span>
+                </button>
+              </th>
             </tr>
           </thead>
           <tbody>
-            <For each={props.rows}>
+            <For each={sortedRows()}>
               {(row) => {
                 // A 0 Soll (weekend / public holiday / contract gap) is "no
                 // boundary for this day": skip the over/under colour, the marker
@@ -87,6 +137,7 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
             </For>
           </tbody>
         </table>
+        </div>
       </Show>
     </section>
   )

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -959,6 +959,16 @@ kbd {
   text-transform: uppercase;
 }
 
+/* Sortable headers carry their padding on the inner .th-sort button, so the
+   cell itself drops its padding; a solid background keeps the pinned header
+   opaque (matching the card) while the body scrolls in .is-scrollable. */
+.effort-table thead th:has(.th-sort) {
+  padding: 0;
+}
+.table-scroll.is-scrollable .effort-table thead th {
+  background: var(--color-surface);
+}
+
 .effort-table .numeric {
   font-variant-numeric: tabular-nums;
   text-align: right;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -965,8 +965,13 @@ kbd {
 .effort-table thead th:has(.th-sort) {
   padding: 0;
 }
+/* Right-align the numeric sort headers (Hours / Share) to match the right-
+   aligned numeric body cells, mirroring .data-table. */
+.effort-table th.numeric .th-sort {
+  justify-content: flex-end;
+}
 .table-scroll.is-scrollable .effort-table thead th {
-  background: var(--color-surface);
+  background-color: var(--color-surface);
 }
 
 .effort-table .numeric {

--- a/src/Controller/Interpretation/GroupByUserAction.php
+++ b/src/Controller/Interpretation/GroupByUserAction.php
@@ -37,8 +37,10 @@ final class GroupByUserAction extends BaseInterpretationController
         #[CurrentUser]
         User $currentUser,
     ): ModelResponse|JsonResponse {
-        $request->query->set('user', $currentUser->getId());
-
+        // Group by whatever the filter selects — not a hardcoded "me". getEntries()
+        // still applies the per-user visibility scope (a DEV only ever sees their
+        // own entries), so a privileged user gets the real per-user breakdown
+        // while a DEV still only sees themselves.
         try {
             $entries = $this->getEntries($request, $currentUser);
         } catch (Exception $exception) {

--- a/src/Controller/Interpretation/GroupByWorktimeAction.php
+++ b/src/Controller/Interpretation/GroupByWorktimeAction.php
@@ -146,6 +146,11 @@ final class GroupByWorktimeAction extends BaseInterpretationController
             return null;
         }
 
+        // The viewer filtering by their own id needs no extra lookup.
+        if ($filterUserId === $currentUser->getId()) {
+            return $currentUser;
+        }
+
         $user = $this->managerRegistry->getRepository(User::class)->find($filterUserId);
 
         return $user instanceof User ? $user : null;

--- a/src/Controller/Interpretation/GroupByWorktimeAction.php
+++ b/src/Controller/Interpretation/GroupByWorktimeAction.php
@@ -11,6 +11,7 @@ namespace App\Controller\Interpretation;
 
 use App\Entity\Contract;
 use App\Entity\User;
+use App\Enum\UserType;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
 use App\Repository\ContractRepository;
@@ -62,11 +63,16 @@ final class GroupByWorktimeAction extends BaseInterpretationController
             return $response;
         }
 
-        // Load the user's contracts once; the per-day "expected" (Soll) is then
-        // resolved in PHP (validContract + weekdayHours) without a query per day.
+        // The per-day Soll is a single user's contract. When the data spans
+        // several users (a privileged user grouping everyone), there is no single
+        // contract to compare against, so no Soll is sent. Load the resolved
+        // user's contracts once; the daily Soll is then resolved in PHP.
+        $sollUser = $this->resolveSollUser($request, $currentUser);
         $contractRepository = $this->managerRegistry->getRepository(Contract::class);
         assert($contractRepository instanceof ContractRepository);
-        $contracts = $contractRepository->findBy(['user' => $currentUser], ['start' => 'DESC']);
+        $contracts = $sollUser instanceof User
+            ? $contractRepository->findBy(['user' => $sollUser], ['start' => 'DESC'])
+            : [];
 
         $times = [];
         foreach ($entries as $entry) {
@@ -83,10 +89,11 @@ final class GroupByWorktimeAction extends BaseInterpretationController
             $times[$key]['minutes'] += $entry->getDuration();
         }
 
-        // The per-day "expected" (Soll) is 0 on a public holiday (matching the
-        // /ui/month calendar), otherwise the contract's hours for that weekday
-        // (5×8h default when no contract applies).
-        $holidayDates = $this->loadHolidayDates($times);
+        // For a single user, the per-day Soll is 0 on a public holiday (matching
+        // the /ui/month calendar), otherwise the contract's hours for that weekday
+        // (5×8h default when no contract applies). For a multi-user query it stays
+        // 0 throughout, which the chart renders as a plain bar with no Soll.
+        $holidayDates = $sollUser instanceof User ? $this->loadHolidayDates($times) : [];
 
         $totalMinutes = 0.0;
         foreach ($times as $t) {
@@ -97,12 +104,15 @@ final class GroupByWorktimeAction extends BaseInterpretationController
             $minutes = $time['minutes'];
             $date = $time['date'];
             $time['hours'] = $minutes / 60.0;
-            $time['expected'] = isset($holidayDates[$date->format('Y-m-d')])
-                ? 0.0
-                : $this->contractHoursResolver->weekdayHours(
+            if (!$sollUser instanceof User || isset($holidayDates[$date->format('Y-m-d')])) {
+                $time['expected'] = 0.0;
+            } else {
+                $time['expected'] = $this->contractHoursResolver->weekdayHours(
                     $this->contractHoursResolver->validContract($contracts, $date),
                     (int) $date->format('w'),
                 );
+            }
+
             unset($time['minutes'], $time['date']);
             $time['quota'] = $this->timeCalculationService->formatQuota($minutes, $totalMinutes);
         }
@@ -116,6 +126,29 @@ final class GroupByWorktimeAction extends BaseInterpretationController
         $prepared = array_reverse($prepared);
 
         return new JsonResponse($prepared);
+    }
+
+    /**
+     * The single user whose contract drives the per-day Soll, or null when the
+     * data spans several users (then no Soll is shown). A DEV only ever sees their
+     * own entries (getEntries scopes them via visibility_user), so for a DEV it is
+     * always themselves; a privileged user gets a Soll only when the filter
+     * narrows to exactly one user.
+     */
+    private function resolveSollUser(Request $request, User $currentUser): ?User
+    {
+        if (UserType::DEV === $currentUser->getType()) {
+            return $currentUser;
+        }
+
+        $filterUserId = $request->query->getInt('user');
+        if ($filterUserId <= 0) {
+            return null;
+        }
+
+        $user = $this->managerRegistry->getRepository(User::class)->find($filterUserId);
+
+        return $user instanceof User ? $user : null;
     }
 
     /**

--- a/tests/Controller/InterpretationControllerTest.php
+++ b/tests/Controller/InterpretationControllerTest.php
@@ -150,6 +150,70 @@ final class InterpretationControllerTest extends AbstractWebTestCase
         ], $this->getJsonResponse($this->client->getResponse()));
     }
 
+    public function testGroupByWorktimeSollFollowsTheFilteredUserNotTheViewer(): void
+    {
+        // 2020-01-06 is a Monday. The filtered user 2 (developer) has hours_1 = 2;
+        // the ADMIN viewer (user 1) has hours_1 = 1 — so a Soll of 2 proves the
+        // per-day Soll follows the FILTERED user's contract, not the viewer's.
+        self::assertNotNull($this->connection);
+        $this->connection->executeStatement(
+            "INSERT INTO entries (day, start, end, customer_id, project_id, activity_id, description, ticket, duration, user_id, class, synced_to_ticketsystem, internal_jira_ticket_original_key)
+             VALUES ('2020-01-06', '08:00:00', '10:00:00', 1, 1, 1, 'mon', 'MON-1', 120, 2, 1, 0, '')",
+        );
+
+        $this->logInSession('unittest');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/time', [
+            'user' => 2,
+            'datestart' => '2020-01-06',
+            'dateend' => '2020-01-06',
+        ]);
+        $this->assertStatusCode(200);
+        $this->assertJsonStructure([
+            ['name' => '20-01-06', 'expected' => 2],
+        ], $this->getJsonResponse($this->client->getResponse()));
+    }
+
+    public function testGroupByWorktimeSendsNoSollForAMultiUserQuery(): void
+    {
+        // Two users booked the same Monday (2020-03-16) under customer 1; querying
+        // that customer for that day (no single user) spans several contracts, so
+        // the Soll is 0 — and 0 on a weekday (not a weekend) proves it is the
+        // multi-user case, not a weekend zero.
+        self::assertNotNull($this->connection);
+        foreach ([2, 3] as $uid) {
+            $this->connection->executeStatement(
+                "INSERT INTO entries (day, start, end, customer_id, project_id, activity_id, description, ticket, duration, user_id, class, synced_to_ticketsystem, internal_jira_ticket_original_key)
+                 VALUES ('2020-03-16', '08:00:00', '09:00:00', 1, 1, 1, 'm', '', 60, :uid, 1, 0, '')",
+                ['uid' => $uid],
+            );
+        }
+
+        $this->logInSession('unittest');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/time', [
+            'customer' => 1,
+            'datestart' => '2020-03-16',
+            'dateend' => '2020-03-16',
+        ]);
+        $this->assertStatusCode(200);
+        $this->assertJsonStructure([
+            ['name' => '20-03-16', 'expected' => 0],
+        ], $this->getJsonResponse($this->client->getResponse()));
+    }
+
+    public function testGroupByUserRespectsTheUserFilterNotTheViewer(): void
+    {
+        // An ADMIN filtering user=2 must get developer's breakdown — the action no
+        // longer forces the grouping back to the current user.
+        $this->logInSession('unittest');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/user', [
+            'user' => 2,
+        ]);
+        $this->assertStatusCode(200);
+        $this->assertJsonStructure([
+            ['id' => 2, 'name' => 'developer'],
+        ], $this->getJsonResponse($this->client->getResponse()));
+    }
+
     public function testGroupByActivityAction(): void
     {
         $parameter = [


### PR DESCRIPTION
/ui/auswertung review fixes (reported on the live site).

## 1 — Sortable + scrollable "Effort by …" tables
The grouped effort charts (and the by-day chart) now have **clickable column headers** (label / hours / share, cycling none → asc → desc → none) and a **vertical overflow scroll with a sticky header**, matching the detail table. Share sorts by the underlying minutes (proportional). The server order remains the default.

## 2 — "Effort by user" now follows the filter
`GroupByUserAction` forced `user = currentUser` unconditionally, so the per-user breakdown **always showed just the viewer**, ignoring the filter. Removed the override — it now groups by whatever the filter selects, while `getEntries()` still applies the per-user visibility scope (a **DEV** only ever sees their own entries, so they still only see themselves).

## 3 — "Effort by day" Soll follows the filtered user, not the viewer
The per-day Soll marker/colour was computed from the **viewer’s** contract while the bars showed the **filtered** user’s data. The Soll is now resolved for the **effective single user**:
- a **DEV** → themselves (their data is always self-scoped);
- otherwise → the **filtered user** when the filter narrows to exactly one;
- a **multi-user** query → no single contract applies, so the Soll is omitted (`0` → plain bar, no marker/colour), reusing the existing `target > 0` gate.

## Test
- `EffortChart` — header click sorts none → asc → desc (13 tests).
- `InterpretationControllerTest` — by-user follows `user=2` (developer), not the ADMIN viewer; the by-day Soll uses the **filtered** user’s contract (Soll 2 = developer’s Monday, not the viewer’s 1); a multi-user query yields Soll 0 on a weekday.
- Full frontend suite green (313); backend interpretation/API suites green; PHPStan + cs-fixer + rector clean.

Follow-up (separate PR): the Admin bulk-action issues (abbreviation grandfathering + surfacing duplicates, list refresh after bulk, page-scoped select-all).