### PR TITLE
perf(admin): composite indexes for the "Last activity" aggregate (~900ms → ~120ms)

### DIFF
--- a/migrations/Version20260625_AddEntriesActivityIndexes.php
+++ b/migrations/Version20260625_AddEntriesActivityIndexes.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Composite indexes for the admin "Last activity" column.
+ *
+ * The column runs `SELECT col, MAX(day) FROM entries GROUP BY col` for
+ * customer_id / project_id. user_id already had a matching (user_id, day) index
+ * (idx_entries_user_day); customer_id and project_id only had single-column FK
+ * indexes, so the aggregate did a full ~466k-row scan (~900ms each on prod). The
+ * matching (col, day) indexes let it scan the index instead (~900ms → ~120ms),
+ * verified on production.
+ */
+final class Version20260625_AddEntriesActivityIndexes extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add (customer_id, day) and (project_id, day) indexes for the admin last-activity aggregate';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_entries_customer_day ON entries (customer_id, day DESC)');
+        $this->addSql('CREATE INDEX idx_entries_project_day ON entries (project_id, day DESC)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_entries_customer_day ON entries');
+        $this->addSql('DROP INDEX idx_entries_project_day ON entries');
+    }
+}

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -225,6 +225,8 @@ CREATE TABLE `entries` (
   KEY (`activity_id`),
   KEY (`customer_id`),
   KEY `idx_entries_user_day` (`user_id`, `day` DESC),
+  KEY `idx_entries_customer_day` (`customer_id`, `day` DESC),
+  KEY `idx_entries_project_day` (`project_id`, `day` DESC),
   KEY `idx_entries_day` (`day`),
   KEY `idx_entries_ticket` (`ticket`),
   KEY `idx_entries_user_project` (`user_id`, `project_id`),
@@ -333,7 +335,8 @@ INSERT INTO `doctrine_migration_versions` (`version`, `executed_at`, `execution_
 ('DoctrineMigrations\\Version20260622_AddMinEntryDuration',   '2026-06-22 00:00:00', 0),
 ('DoctrineMigrations\\Version20260622_AddJiraCloudSupport',   '2026-06-22 00:00:00', 0),
 ('DoctrineMigrations\\Version20260624_RemoveAccountEntity',   '2026-06-24 00:00:00', 0),
-('DoctrineMigrations\\Version20260624_AddUserActive',         '2026-06-24 00:00:01', 0);
+('DoctrineMigrations\\Version20260624_AddUserActive',         '2026-06-24 00:00:01', 0),
+('DoctrineMigrations\\Version20260625_AddEntriesActivityIndexes', '2026-06-25 00:00:00', 0);
 
 
 -- EXPORT-VIEWS ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The new admin **"Last activity"** column (#442) runs, per admin list:
```sql
SELECT col, MAX(day) FROM entries WHERE col IS NOT NULL GROUP BY col
```
for `customer_id` / `project_id` / `user_id`. `user_id` already had a `(user_id, day)` composite index (`idx_entries_user_day`), but `customer_id` and `project_id` only had **single-column FK indexes** — so their aggregate did a **full ~466k-row scan**.

Measured on production (466,346 entries):

| GROUP BY | before |
|---|---|
| `customer_id` | **894 ms** |
| `project_id` | **936 ms** |
| `user_id` (already indexed) | 123 ms |

So the admin **Customers** and **Projects** lists each spent ~0.9s just on this column.

## Fix
Add the matching `(customer_id, day DESC)` and `(project_id, day DESC)` indexes (mirroring the existing `idx_entries_user_day`). The aggregate then scans the index instead of the table.

**Verified on production** by adding the `(customer_id, day)` index, re-timing, and removing it again: **894 ms → 118 ms** (7.5×), in line with `user_id`. Index creation was online (`~1s`, `ALGORITHM=INPLACE`).

## Change
- `Version20260625_AddEntriesActivityIndexes` adds both indexes (online `CREATE INDEX`).
- `sql/full.sql` carries the two indexes + the migration version-seed row for fresh installs.
- Runtime validated locally (migrated 7 → 8, both indexes created).
- No code/query change — `LastActivityTrait` is untouched; correctness suites green (`LastActivityTraitTest`, `AdminControllerTest`). PHPStan clean.

The index add is additive + online; it applies on the next prod deploy via the auto-migrate entrypoint.