### PR TITLE
fix(worklog): book external tickets + show Ext. ticket column (#453)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -177,6 +177,7 @@
   "tracking_col_start": "Start",
   "tracking_col_end": "Ende",
   "tracking_col_ticket": "Ticket",
+  "tracking_col_ext_ticket": "Ext. Ticket",
   "tracking_col_customer": "Kunde",
   "tracking_col_project": "Projekt",
   "tracking_col_activity": "Tätigkeit",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -177,6 +177,7 @@
   "tracking_col_start": "Start",
   "tracking_col_end": "End",
   "tracking_col_ticket": "Ticket",
+  "tracking_col_ext_ticket": "Ext. Ticket",
   "tracking_col_customer": "Customer",
   "tracking_col_project": "Project",
   "tracking_col_activity": "Activity",

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -301,6 +301,43 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('derives the project from a ticket whose prefix is one of several in jiraId (#453)', async () => {
+    // jiraId is a comma-separated prefix list; an external ticket like DHLSUP-…
+    // must still resolve the project (an exact jiraId === prefix match missed it,
+    // so the wrong/no project was sent and the save was rejected as invalid).
+    mockTracking({
+      entries: [{ entry: { ...DEFAULT_ENTRY, customer: 0, project: 0, ticket: '', class: 0 } }],
+      customers: [{ customer: { id: 7, name: 'DHL' } }],
+      projects: [{ project: { id: 9, name: 'DHL Support', customer: 7, jiraId: 'SA, DHLSUP' } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
+    postJson.mockResolvedValue({})
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
+
+    const editor = editCell(container, 'ticket')
+    fireEvent.input(editor, { target: { value: 'dhlsup-1067002' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    ;(getByRole('combobox') as HTMLElement).focus()
+
+    await waitFor(() =>
+      expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({ ticket: 'DHLSUP-1067002', project: 9, customer: 7 })),
+    )
+
+    unmount()
+  })
+
+  it('shows the external ticket the backend mirrored, in its own column (#453)', async () => {
+    mockTracking({
+      entries: [{ entry: { ...DEFAULT_ENTRY, id: 1, ticket: 'OPSDHL-2881', extTicket: 'DHLSUP-1067002', customer: 1, project: 4 } }],
+    })
+    const { getByRole, unmount } = renderTracking()
+
+    await waitFor(() => expect(getByRole('gridcell', { name: 'DHLSUP-1067002' })).toBeInTheDocument())
+
+    unmount()
+  })
+
   it('filters the project dropdown by the row customer (cascade)', async () => {
     mockTracking({
       entries: [{ entry: { ...DEFAULT_ENTRY, customer: 7, project: 9, ticket: '', class: 0 } }],

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -111,6 +111,9 @@ const COLUMNS: { key: string; label: () => string; numeric?: boolean }[] = [
   { key: 'start', label: () => m.tracking_col_start(), numeric: true },
   { key: 'end', label: () => m.tracking_col_end(), numeric: true },
   { key: 'ticket', label: () => m.tracking_col_ticket() },
+  // Read-only: the external key the backend mirrored onto the internal Jira
+  // ticket (set during save, not user-editable) — so it isn't a FIELD.
+  { key: 'extTicket', label: () => m.tracking_col_ext_ticket() },
   { key: 'customer', label: () => m.tracking_col_customer() },
   { key: 'project', label: () => m.tracking_col_project() },
   { key: 'activity', label: () => m.tracking_col_activity() },
@@ -293,11 +296,17 @@ export default function Tracking() {
   // cell shows the fixed value immediately, not on the next refetch.
   function handleCommit(id: number, colKey: string, value: unknown): void {
     if (colKey === 'ticket') {
-      const prefix = str(value).toUpperCase().trim().split(/[-:]/)[0]
+      const prefix = str(value).toUpperCase().trim().split(/[-:]/)[0] ?? ''
       if (prefix === '') {
         return
       }
-      const project = (projects.data ?? []).find((candidate) => candidate.jiraId !== '' && candidate.jiraId.toUpperCase() === prefix)
+      // jiraId is a comma/space-separated list of allowed prefixes (the backend
+      // splits it the same way in validateTicketPrefix), so match membership —
+      // an exact === missed multi-prefix projects, so an external ticket like
+      // DHLSUP-1 derived the wrong/no project and the save was rejected (#453).
+      const project = (projects.data ?? []).find(
+        (candidate) => candidate.jiraId !== '' && candidate.jiraId.toUpperCase().split(/[\s,]+/).includes(prefix),
+      )
       if (project !== undefined) {
         editor.setDraftField(id, 'project', project.id)
         if (project.customer > 0) {
@@ -424,6 +433,8 @@ export default function Tracking() {
         return str(row.end)
       case 'ticket':
         return str(row.ticket)
+      case 'extTicket':
+        return str(row.extTicket)
       case 'customer':
         return labelFrom(customerLabels(), num(row.customer))
       case 'project':


### PR DESCRIPTION
Fixes [#453](https://github.com/netresearch/timetracker/issues/453) — booking an external ticket on the new **Worklog** tab failed with *"Given ticket does not have a valid prefix"*, while the old "Time tracking" tab worked.

## Root cause (the save failure)
Both tabs POST to the same `SaveEntryAction`, whose `validateTicketPrefix()` checks the ticket prefix against the **submitted project's** `jiraId` — a **comma-separated list** of allowed prefixes (`explode(',', jiraId)`).

The Worklog ticket→project derivation ([`Tracking.tsx`](https://github.com/netresearch/timetracker/blob/main/frontend/src/pages/Tracking.tsx)) matched the prefix with an **exact** `candidate.jiraId === prefix`. For a project whose `jiraId` lists several prefixes (e.g. `"SA, DHLSUP"`), entering `DHLSUP-1067002` never derived that project → the wrong/no project was submitted → the backend rejected the prefix. (The old `findProjects()` in `assets/js/main.js` already split `jiraId` into its prefixes; this restores parity.)

**Fix:** match membership across the split prefixes (`jiraId.split(/[\s,]+/).includes(prefix)`), mirroring both the backend and the old tab.

## The "Ext. ticket" column
The old tab showed an **Ext. ticket** column. Once an entry on an internal-Jira-mapped project is saved, the `EntryEventSubscriber` mirrors it onto the internal ticket (`ticket` becomes e.g. `OPSDHL-2881`) and keeps the external key as the original — which the Worklog tab carried on the wire but never displayed. Added it as a **read-only** column (the value is backend-assigned, not user-editable).

## Scope
- **Backend unchanged** — it already remaps (auto-creates/looks up the internal ticket) and validates correctly once the right project is sent.
- The reporter's side note about the project autocomplete offering *too many / obsolete* projects is a separate **data/active-flag** matter (the picker already scopes by customer + active), not part of this fix.

## Test
- `Tracking.test.tsx` — a multi-prefix `jiraId` (`"SA, DHLSUP"`) now derives the project from `DHLSUP-…` and saves with the right `project`/`customer`; the **Ext. ticket** column renders the mirrored external key.
- Full frontend suite green (323); typecheck/lint/build clean.