### PR TITLE
feat(auswertung): make team, activity, ticket & description real filters

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -242,7 +242,7 @@
   "range_last_7_days": "Letzte 7 Tage",
   "range_last_30_days": "Letzte 30 Tage",
   "range_last_12_months": "Letzte 12 Monate",
-  "auswertung_pick_filter": "Mindestens Kunde, Projekt, Mitarbeiter oder Fall auswählen.",
+  "auswertung_pick_filter": "Mindestens Kunde, Projekt, Team, Mitarbeiter, Tätigkeit, Ticket oder Beschreibung auswählen.",
   "auswertung_by_customer": "Aufwand nach Kunden",
   "auswertung_by_project": "Aufwand nach Projekt",
   "auswertung_by_ticket": "Aufwand nach Fall",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -242,7 +242,7 @@
   "range_last_7_days": "Last 7 days",
   "range_last_30_days": "Last 30 days",
   "range_last_12_months": "Last 12 months",
-  "auswertung_pick_filter": "Choose at least a customer, project, user or ticket.",
+  "auswertung_pick_filter": "Choose at least a customer, project, team, user, activity, ticket or description.",
   "auswertung_by_customer": "Effort by customer",
   "auswertung_by_project": "Effort by project",
   "auswertung_by_ticket": "Effort by ticket",

--- a/frontend/src/api/queries.test.ts
+++ b/frontend/src/api/queries.test.ts
@@ -39,8 +39,14 @@ describe('hasInterpretationCriteria', () => {
     expect(hasInterpretationCriteria({ ...base, ticket: ' ABC-1 ' })).toBe(true)
   })
 
-  it('does not count team/activity/dates alone', () => {
-    expect(hasInterpretationCriteria({ ...base, team: 2, activity: 5, datestart: '2026-01-01' })).toBe(false)
+  it('counts team, activity and description as standalone criteria', () => {
+    expect(hasInterpretationCriteria({ ...base, team: 2 })).toBe(true)
+    expect(hasInterpretationCriteria({ ...base, activity: 5 })).toBe(true)
+    expect(hasInterpretationCriteria({ ...base, description: 'meeting' })).toBe(true)
+  })
+
+  it('does not count dates alone', () => {
+    expect(hasInterpretationCriteria({ ...base, datestart: '2026-01-01', dateend: '2026-01-31' })).toBe(false)
   })
 })
 

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -353,11 +353,19 @@ export interface GroupRow {
 
 export type InterpretationGroup = 'customer' | 'project' | 'ticket' | 'activity' | 'user'
 
-// The backend only accepts a query when at least one of customer/project/
-// user/ticket (or year+month) is set; otherwise it answers 406. Mirror that
-// so we don't fire requests that can only fail.
+// The backend only accepts a query when at least one real filter dimension is
+// set (customer/project/team/user/activity/ticket/description); otherwise it
+// answers 406. Mirror that so we don't fire requests that can only fail.
 export function hasInterpretationCriteria(filters: InterpretationFilters): boolean {
-  return filters.customer > 0 || filters.project > 0 || filters.user > 0 || filters.ticket.trim() !== ''
+  return (
+    filters.customer > 0 ||
+    filters.project > 0 ||
+    filters.team > 0 ||
+    filters.user > 0 ||
+    filters.activity > 0 ||
+    filters.ticket.trim() !== '' ||
+    filters.description.trim() !== ''
+  )
 }
 
 function filterParams(filters: InterpretationFilters): Record<string, string | number> {

--- a/src/Controller/Interpretation/BaseInterpretationController.php
+++ b/src/Controller/Interpretation/BaseInterpretationController.php
@@ -100,8 +100,13 @@ abstract class BaseInterpretationController extends BaseController
             $arParams['dateend'] = $dateend->format('Y-m-d');
         }
 
-        if (null === $arParams['customer'] && null === $arParams['project'] && null === $arParams['user'] && null === $arParams['ticket']) {
-            throw new MissingSearchCriteriaException($this->translate('You need to specify at least customer, project, ticket, user or month and year.'));
+        $isSet = static fn (mixed $value): bool => null !== $value && '' !== $value && 0 !== $value && '0' !== $value;
+        if (
+            !$isSet($arParams['customer']) && !$isSet($arParams['project']) && !$isSet($arParams['user'])
+            && !$isSet($arParams['activity']) && !$isSet($arParams['team'])
+            && !$isSet($arParams['ticket']) && !$isSet($arParams['description'])
+        ) {
+            throw new MissingSearchCriteriaException($this->translate('You need to specify at least a customer, project, team, user, activity, ticket or description.'));
         }
 
         $objectRepository = $this->managerRegistry->getRepository(Entry::class);

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -728,14 +728,19 @@ class EntryRepository extends ServiceEntityRepository
     {
         foreach (['ticket', 'description'] as $field) {
             $value = $arFilter[$field] ?? null;
-            if (!is_string($value) || '' === $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+            if ('' === $value) {
                 continue;
             }
 
             // Escape LIKE wildcards so a literal % / _ in the search text matches
-            // itself instead of acting as a wildcard.
-            $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
-            $queryBuilder->andWhere(sprintf('e.%s LIKE :%s', $field, $field))
+            // itself instead of acting as a wildcard. Use a '|' escape char and
+            // spell out ESCAPE explicitly — SQLite (used by the test suite) has no
+            // default LIKE escape character, unlike MySQL/MariaDB.
+            $escaped = str_replace(['|', '%', '_'], ['||', '|%', '|_'], $value);
+            $queryBuilder->andWhere(sprintf("e.%s LIKE :%s ESCAPE '|'", $field, $field))
                 ->setParameter($field, '%' . $escaped . '%');
         }
 

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -717,6 +717,36 @@ class EntryRepository extends ServiceEntityRepository
     }
 
     /**
+     * Interpretation filters the relation/date filters don't cover: a
+     * contains-search on the entry's own ticket/description columns, and a team
+     * filter scoping to entries booked by a member of that team (the entry's
+     * user is left-joined as `u` upstream).
+     *
+     * @param array<string, mixed> $arFilter
+     */
+    private function applyInterpretationExtraFilters(QueryBuilder $queryBuilder, array $arFilter): void
+    {
+        foreach (['ticket', 'description'] as $field) {
+            $value = $arFilter[$field] ?? null;
+            if (!is_string($value) || '' === $value) {
+                continue;
+            }
+
+            // Escape LIKE wildcards so a literal % / _ in the search text matches
+            // itself instead of acting as a wildcard.
+            $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
+            $queryBuilder->andWhere(sprintf('e.%s LIKE :%s', $field, $field))
+                ->setParameter($field, '%' . $escaped . '%');
+        }
+
+        $team = $arFilter['team'] ?? null;
+        if (is_numeric($team) && (int) $team > 0) {
+            $queryBuilder->andWhere(':team MEMBER OF u.teams')
+                ->setParameter('team', (int) $team);
+        }
+    }
+
+    /**
      * Applies pagination with safe casting.
      * Prefers 'start' (ExtJS offset) over calculating the offset from 'page'.
      *
@@ -1388,6 +1418,7 @@ class EntryRepository extends ServiceEntityRepository
         // Apply filters similar to queryByFilterArray but return results directly
         $this->applyRelationFilters($queryBuilder, $arFilter);
         $this->applyDateWindowFilters($queryBuilder, $arFilter);
+        $this->applyInterpretationExtraFilters($queryBuilder, $arFilter);
 
         // Apply limit if specified with safe casting
         if (isset($arFilter['maxResults']) && is_numeric($arFilter['maxResults'])) {

--- a/tests/Controller/InterpretationControllerTest.php
+++ b/tests/Controller/InterpretationControllerTest.php
@@ -72,7 +72,7 @@ final class InterpretationControllerTest extends AbstractWebTestCase
         // the guard but was never applied to the query). A unique ticket returns
         // exactly its one entry; a non-matching ticket returns none.
         self::assertNotNull($this->connection);
-        $ticket = 'FILT-' . substr(uniqid(), 0, 6);
+        $ticket = 'FILT-' . bin2hex(random_bytes(4));
         $this->connection->executeStatement(
             "INSERT INTO entries (day, start, end, customer_id, project_id, activity_id, description, ticket, duration, user_id, class, synced_to_ticketsystem, internal_jira_ticket_original_key)
              VALUES (CURDATE(), '08:00:00', '08:50:00', 1, 1, 1, 'x', :ticket, 50, 1, 1, 0, '')",

--- a/tests/Controller/InterpretationControllerTest.php
+++ b/tests/Controller/InterpretationControllerTest.php
@@ -66,6 +66,55 @@ final class InterpretationControllerTest extends AbstractWebTestCase
         self::assertSame($testTicket, $ticketValue, 'Entry should have the requested ticket');
     }
 
+    public function testTicketFilterExcludesNonMatchingEntries(): void
+    {
+        // The ticket filter must actually narrow the result (it previously passed
+        // the guard but was never applied to the query). A unique ticket returns
+        // exactly its one entry; a non-matching ticket returns none.
+        self::assertNotNull($this->connection);
+        $ticket = 'FILT-' . substr(uniqid(), 0, 6);
+        $this->connection->executeStatement(
+            "INSERT INTO entries (day, start, end, customer_id, project_id, activity_id, description, ticket, duration, user_id, class, synced_to_ticketsystem, internal_jira_ticket_original_key)
+             VALUES (CURDATE(), '08:00:00', '08:50:00', 1, 1, 1, 'x', :ticket, 50, 1, 1, 0, '')",
+            ['ticket' => $ticket],
+        );
+
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/entries', ['ticket' => $ticket]);
+        $this->assertStatusCode(200);
+        $matching = $this->getJsonResponse($this->client->getResponse());
+        self::assertIsArray($matching);
+        self::assertCount(1, $matching);
+
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/entries', ['ticket' => $ticket . 'ZZZ']);
+        $this->assertStatusCode(200);
+        $none = $this->getJsonResponse($this->client->getResponse());
+        self::assertIsArray($none);
+        self::assertCount(0, $none);
+    }
+
+    public function testTeamFilterScopesGroupByUserToTeamMembers(): void
+    {
+        // Team 1 holds user 1 (unittest), team 2 holds user 2 (developer). Grouping
+        // by user filtered to team 2 must include developer and exclude unittest.
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/user', ['team' => 2]);
+        $this->assertStatusCode(200);
+        $json = $this->getJsonResponse($this->client->getResponse());
+        self::assertIsArray($json);
+        $names = array_column($json, 'name');
+        self::assertContains('developer', $names);
+        self::assertNotContains('unittest', $names);
+    }
+
+    public function testActivityTeamDescriptionAreAcceptedAsStandaloneFilters(): void
+    {
+        // Each used to trip the "specify at least …" guard; now each is a valid
+        // standalone criterion (200, not 406).
+        foreach ([['activity' => '1'], ['team' => '1'], ['description' => 'Test']] as $params) {
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/interpretation/entries', $params);
+            $this->assertStatusCode(200);
+        }
+    }
+
     public function testGroupByWorktimeAction(): void
     {
         $parameter = [

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -28,6 +28,7 @@
 "Please provide a valid preset name with at least 3 letters.": "Bitte gib einen Namen (mindestens 3 Zeichen) ein!"
 "Jira login failed!": "Jira-Login ist fehlgeschlagen!"
 "You need to specify at least customer, project, ticket, user or month and year.": "Bitte gib mindestens Kunde, Projekt, Ticket, Benutzer oder Monat und Jahr an."
+"You need to specify at least a customer, project, team, user, activity, ticket or description.": "Bitte gib mindestens Kunde, Projekt, Team, Benutzer, Tätigkeit, Ticket oder Beschreibung an."
 "This project is inactive and cannot be used for booking.": "Dieses Projekt ist inaktiv und darf nicht bebucht werden."
 "This customer is inactive and cannot be used for booking.": "Dieser Kunde ist inaktiv und darf nicht bebucht werden."
 "Please enter a token (min 3 chars)!": "Bitte gib ein Kürzel (mindestens 3 Zeichen) ein!"


### PR DESCRIPTION
Follow-up to the "selecting only a Team errors" question — the Auswertung filters were inconsistent end-to-end.

## The problem
The filter UI offers **Team, Activity, Ticket, Description** controls, but across the pipeline:

| Dimension | query filtered it? | guard accepted it alone? |
|---|:---:|:---:|
| customer / project / user | ✅ | ✅ |
| **activity** | ✅ | ❌ |
| **ticket** | ❌ | ✅ |
| **description** | ❌ | ❌ |
| **team** | ❌ | ❌ |

So **"Team only" errored** with *"Choose at least a customer, project, user or ticket"*, and — worse — **ticket *passed* the guard but never filtered**: `findByFilterArray` only applied customer/project/activity/user + dates, so a ticket filter returned **every** entry (just ordered). A silent no-op.

## The fix
Make all four real, standalone-valid filters:
- [`EntryRepository::findByFilterArray`](https://github.com/netresearch/timetracker/blob/main/src/Repository/EntryRepository.php#L1384) now also applies **ticket + description** as a contains-search (`LIKE`, with the user's `%`/`_` escaped) and **team** as `:team MEMBER OF u.teams` (entries booked by a **member of that team** — matching the old "Effort by team" intent).
- The interpretation guard ([`BaseInterpretationController`](https://github.com/netresearch/timetracker/blob/main/src/Controller/Interpretation/BaseInterpretationController.php#L103)) and the frontend `hasInterpretationCriteria` mirror now accept **customer / project / team / user / activity / ticket / description**; the "pick a filter" messages list them accurately (de + en + the backend translation).

Activity already filtered in the query — it just needed to count as a criterion. Dates remain non-standalone (the frontend always sends a range), so that behaviour is unchanged.

## Test
- `InterpretationControllerTest`: the ticket filter actually **narrows** (1 match, 0 for a non-match — proving it's applied, not reordered); `team=2` scopes `GroupByUser` to the team member (developer) and excludes a non-member (unittest); activity/team/description are each accepted standalone (200, not 406).
- `queries.test.ts`: the frontend guard now counts team/activity/description (and still not dates alone).
- Full frontend suite green (324); backend interpretation suite green (23); PHPStan + cs-fixer clean.