### PR TITLE
fix(admin): grandfather unchanged names in unique-name validators (project deactivate)

### DIFF
--- a/src/Validator/Constraints/UniqueActivityNameValidator.php
+++ b/src/Validator/Constraints/UniqueActivityNameValidator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\Validator\Constraints;
 
 use App\Dto\ActivitySaveDto;
+use App\Entity\Activity;
 use App\Repository\ActivityRepository;
 use Exception;
 use Symfony\Component\Validator\Constraint;
@@ -46,12 +47,21 @@ class UniqueActivityNameValidator extends ConstraintValidator
             return; // Let other validators handle non-string values
         }
 
+        $object = $this->context->getObject();
+
+        // Grandfather an unchanged name: re-saving an existing activity (e.g. just
+        // toggling a flag) must not fail because a legacy duplicate shares the
+        // name. Only a new or changed name is checked.
+        if ($object instanceof ActivitySaveDto && $object->id > 0) {
+            $current = $this->activityRepository->find($object->id);
+            if ($current instanceof Activity && $current->getName() === $value) {
+                return;
+            }
+        }
+
         $existingActivity = $this->activityRepository->findOneBy(['name' => $value]);
 
         if (null !== $existingActivity) {
-            // Check if we're updating an existing activity
-            $object = $this->context->getObject();
-
             // Type-safe check for ActivitySaveDto
             if ($object instanceof ActivitySaveDto && $object->id > 0 && $existingActivity->getId() === $object->id) {
                 return;

--- a/src/Validator/Constraints/UniqueCustomerNameValidator.php
+++ b/src/Validator/Constraints/UniqueCustomerNameValidator.php
@@ -48,6 +48,17 @@ class UniqueCustomerNameValidator extends ConstraintValidator
         }
 
         $entityRepository = $this->entityManager->getRepository(Customer::class);
+
+        // Grandfather an unchanged name: re-saving an existing customer (e.g. just
+        // toggling "active") must not fail because a legacy duplicate shares the
+        // name. Only a new or changed name is checked.
+        if ($customerId > 0) {
+            $current = $entityRepository->find($customerId);
+            if ($current instanceof Customer && $current->getName() === $value) {
+                return;
+            }
+        }
+
         $queryBuilder = $entityRepository->createQueryBuilder('c')
             ->where('c.name = :name')
             ->setParameter('name', $value);

--- a/src/Validator/Constraints/UniqueProjectNameForCustomerValidator.php
+++ b/src/Validator/Constraints/UniqueProjectNameForCustomerValidator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\Validator\Constraints;
 
 use App\Dto\ProjectSaveDto;
+use App\Entity\Project;
 use App\Repository\ProjectRepository;
 use Exception;
 use Symfony\Component\Validator\Constraint;
@@ -45,6 +46,17 @@ class UniqueProjectNameForCustomerValidator extends ConstraintValidator
 
         if ('' === $name || '0' === $name || null === $customerId) {
             return; // Other validators will handle these
+        }
+
+        // Grandfather an unchanged name+customer: re-saving an existing project
+        // (e.g. just toggling "active") must not fail because a legacy duplicate
+        // shares the name for this customer. Only a new or changed name/customer
+        // is checked, so existing duplicates coexist while no new one is created.
+        if ($projectId > 0) {
+            $current = $this->projectRepository->find($projectId);
+            if ($current instanceof Project && $current->getName() === $name && $current->getCustomer()?->getId() === $customerId) {
+                return;
+            }
         }
 
         // Check if a project with this name already exists for this customer

--- a/src/Validator/Constraints/UniqueTeamNameValidator.php
+++ b/src/Validator/Constraints/UniqueTeamNameValidator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\Validator\Constraints;
 
 use App\Dto\TeamSaveDto;
+use App\Entity\Team;
 use App\Repository\TeamRepository;
 use Exception;
 use Symfony\Component\Validator\Constraint;
@@ -45,12 +46,21 @@ class UniqueTeamNameValidator extends ConstraintValidator
             return; // Let other validators handle non-string values
         }
 
+        $object = $this->context->getObject();
+
+        // Grandfather an unchanged name: re-saving an existing team (e.g. just
+        // toggling a flag) must not fail because a legacy duplicate shares the
+        // name. Only a new or changed name is checked.
+        if ($object instanceof TeamSaveDto && $object->id > 0) {
+            $current = $this->teamRepository->find($object->id);
+            if ($current instanceof Team && $current->getName() === $value) {
+                return;
+            }
+        }
+
         $existingTeam = $this->teamRepository->findOneBy(['name' => $value]);
 
         if (null !== $existingTeam) {
-            // Check if we're updating an existing team
-            $object = $this->context->getObject();
-
             // Type-safe check for TeamSaveDto
             if ($object instanceof TeamSaveDto && $object->id > 0 && $existingTeam->getId() === $object->id) {
                 return;

--- a/src/Validator/Constraints/UniqueTicketSystemNameValidator.php
+++ b/src/Validator/Constraints/UniqueTicketSystemNameValidator.php
@@ -47,12 +47,14 @@ class UniqueTicketSystemNameValidator extends ConstraintValidator
         }
 
         $object = $this->context->getObject();
+        // TicketSystemSaveDto::$id is nullable, so narrow it explicitly before comparing.
+        $id = $object instanceof TicketSystemSaveDto ? $object->id : null;
 
         // Grandfather an unchanged name: re-saving an existing ticket system (e.g.
         // just toggling a flag) must not fail because a legacy duplicate shares the
         // name. Only a new or changed name is checked.
-        if ($object instanceof TicketSystemSaveDto && $object->id > 0) {
-            $current = $this->ticketSystemRepository->find($object->id);
+        if (null !== $id && $id > 0) {
+            $current = $this->ticketSystemRepository->find($id);
             if ($current instanceof TicketSystem && $current->getName() === $value) {
                 return;
             }
@@ -61,8 +63,7 @@ class UniqueTicketSystemNameValidator extends ConstraintValidator
         $existingSystem = $this->ticketSystemRepository->findOneBy(['name' => $value]);
 
         if (null !== $existingSystem) {
-            // Type-safe check for TicketSystemSaveDto
-            if ($object instanceof TicketSystemSaveDto && $object->id > 0 && $existingSystem->getId() === $object->id) {
+            if (null !== $id && $id > 0 && $existingSystem->getId() === $id) {
                 return;
                 // Same ticket system being updated
             }

--- a/src/Validator/Constraints/UniqueTicketSystemNameValidator.php
+++ b/src/Validator/Constraints/UniqueTicketSystemNameValidator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\Validator\Constraints;
 
 use App\Dto\TicketSystemSaveDto;
+use App\Entity\TicketSystem;
 use App\Repository\TicketSystemRepository;
 use Exception;
 use Symfony\Component\Validator\Constraint;
@@ -45,12 +46,21 @@ class UniqueTicketSystemNameValidator extends ConstraintValidator
             return; // Let other validators handle non-string values
         }
 
+        $object = $this->context->getObject();
+
+        // Grandfather an unchanged name: re-saving an existing ticket system (e.g.
+        // just toggling a flag) must not fail because a legacy duplicate shares the
+        // name. Only a new or changed name is checked.
+        if ($object instanceof TicketSystemSaveDto && $object->id > 0) {
+            $current = $this->ticketSystemRepository->find($object->id);
+            if ($current instanceof TicketSystem && $current->getName() === $value) {
+                return;
+            }
+        }
+
         $existingSystem = $this->ticketSystemRepository->findOneBy(['name' => $value]);
 
         if (null !== $existingSystem) {
-            // Check if we're updating an existing ticket system
-            $object = $this->context->getObject();
-
             // Type-safe check for TicketSystemSaveDto
             if ($object instanceof TicketSystemSaveDto && $object->id > 0 && $existingSystem->getId() === $object->id) {
                 return;

--- a/tests/Validator/UniqueProjectNameForCustomerValidatorTest.php
+++ b/tests/Validator/UniqueProjectNameForCustomerValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Validator;
 
 use App\Dto\ProjectSaveDto;
+use App\Entity\Customer;
 use App\Entity\Project;
 use App\Repository\ProjectRepository;
 use App\Validator\Constraints\UniqueProjectNameForCustomer;
@@ -119,6 +120,49 @@ final class UniqueProjectNameForCustomerValidatorTest extends TestCase
 
         $dto = new ProjectSaveDto(id: 10, name: 'Conflicting Name', customer: 1);
         $this->validator->validateInContext($dto, new UniqueProjectNameForCustomer(), $this->context);
+    }
+
+    public function testValidateGrandfathersAnUnchangedNameDespiteALegacyDuplicate(): void
+    {
+        // Re-saving project 5 with its UNCHANGED name+customer (e.g. just toggling
+        // active) must pass even if a different project shares the name — the
+        // uniqueness lookup is skipped entirely.
+        $this->repository->expects(self::once())->method('find')->with(5)
+            ->willReturn($this->stubProject(5, 'Existing Project', 1));
+        $this->repository->expects(self::never())->method('findOneBy');
+        $this->context->expects(self::never())->method('buildViolation');
+
+        $dto = new ProjectSaveDto(id: 5, name: 'Existing Project', customer: 1);
+        $this->validator->validateInContext($dto, new UniqueProjectNameForCustomer(), $this->context);
+    }
+
+    public function testValidateStillRejectsChangingToACollidingName(): void
+    {
+        // Changing project 5's name to one another project (id 8) already holds is
+        // still rejected — the grandfather only covers an unchanged name.
+        $this->repository->expects(self::once())->method('find')->with(5)
+            ->willReturn($this->stubProject(5, 'Old Name', 1));
+        $other = self::createStub(Project::class);
+        $other->method('getId')->willReturn(8);
+        $this->repository->expects(self::once())->method('findOneBy')
+            ->with(['name' => 'Taken Name', 'customer' => 1])
+            ->willReturn($other);
+        $this->expectSingleViolation();
+
+        $dto = new ProjectSaveDto(id: 5, name: 'Taken Name', customer: 1);
+        $this->validator->validateInContext($dto, new UniqueProjectNameForCustomer(), $this->context);
+    }
+
+    private function stubProject(int $id, string $name, int $customerId): Project
+    {
+        $customer = self::createStub(Customer::class);
+        $customer->method('getId')->willReturn($customerId);
+        $project = self::createStub(Project::class);
+        $project->method('getId')->willReturn($id);
+        $project->method('getName')->willReturn($name);
+        $project->method('getCustomer')->willReturn($customer);
+
+        return $project;
     }
 
     /**


### PR DESCRIPTION
Deactivating a project on `/ui/admin/projects` failed with *"A project with the name \"DHL Online Retoure Support\" already exists for this customer."* — exactly the [#454](https://github.com/netresearch/timetracker/pull/454) abbr pattern, now for names.

## Why
The save re-sends the whole project, and [`UniqueProjectNameForCustomerValidator`](https://github.com/netresearch/timetracker/blob/main/src/Validator/Constraints/UniqueProjectNameForCustomerValidator.php) excluded the current id **only if `findOneBy` returned that very row**. With a **legacy duplicate** (two projects sharing the name for the customer), `findOneBy` returns the *other* row → id mismatch → false "already exists". So toggling `active` is blocked even though nothing about the name changed.

The uniqueness check should only fire on **creation or a name change** — exactly what the reporter expected.

## Fix
Apply the same **grandfather** as the user-abbr validator (#454) across **all five** name-uniqueness validators (project, customer, team, activity, ticket system): when editing an existing entity whose persisted name (and customer, for projects) is **unchanged**, skip the uniqueness lookup. Existing duplicates coexist; a new or changed name is still checked, so no new collision can be introduced. Done for the whole family so the same footgun can't surface deactivating a team/activity/customer/ticket-system.

## Test
- `UniqueProjectNameForCustomerValidatorTest`: re-saving with an unchanged name passes despite a legacy duplicate (the lookup is skipped); changing to a name another project holds is still rejected (422).
- Full validator + admin-save + project-CRUD suites green (119); PHPStan + cs-fixer + Rector clean.