### PR TITLE
fix(admin): bulk-action bar inline in the toolbar (no table jump)

### DIFF
--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -388,6 +388,27 @@ export function AdminCrudShell(props: {
         <button type="button" class="primary-button" data-keyboard-add aria-keyshortcuts="Alt+A" onClick={() => openForm(null)}>
           {m.admin_add()}
         </button>
+        {/* Bulk-action bar sits inline in the toolbar (between Add and the filter)
+            so selecting rows doesn't insert a new line that shoves the table down. */}
+        <Show when={selectedCount() > 0}>
+          <div class="admin-bulk-bar" role="region" aria-label={m.admin_bulk_actions()} aria-busy={bulkBusy() ? 'true' : undefined}>
+            <div class="admin-bulk-headline">
+              <span class="admin-bulk-count" role="status" aria-live="polite">{m.admin_bulk_selected({ count: String(selectedCount()) })}</span>
+              <Show when={canSelectAllFiltered()}>
+                <button type="button" class="link-button admin-bulk-selectall" onClick={() => selectAllFiltered()}>
+                  {m.admin_bulk_select_all_filtered({ count: String(visibleRows().length) })}
+                </button>
+              </Show>
+            </div>
+            <Show when={hasActiveField()}>
+              <button type="button" class="action-button" disabled={bulkBusy()} onClick={() => bulkSetActive(true)}>{m.admin_bulk_activate()}</button>
+              <button type="button" class="action-button" disabled={bulkBusy()} onClick={() => bulkSetActive(false)}>{m.admin_bulk_deactivate()}</button>
+            </Show>
+            <button type="button" class="action-button is-icon" disabled={bulkBusy()} aria-label={m.admin_bulk_export()} title={m.admin_bulk_export()} onClick={() => exportCsv(selectedRows())}><DownloadIcon /></button>
+            <button type="button" class="link-button is-icon is-danger" disabled={bulkBusy()} aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => bulkDelete()}><TrashIcon /></button>
+            <button type="button" class="link-button" disabled={bulkBusy()} onClick={() => clearSelection()}>{m.admin_bulk_clear()}</button>
+          </div>
+        </Show>
         <Show when={notice()}>
           <span role="status" class="form-status is-ok">{notice()}</span>
         </Show>
@@ -440,26 +461,6 @@ export function AdminCrudShell(props: {
           banner — the old inline toolbar text was easy to miss. */}
       <Show when={error()}>
         <p class="admin-error-banner" role="alert">{error()}</p>
-      </Show>
-
-      <Show when={selectedCount() > 0}>
-        <div class="admin-bulk-bar" role="region" aria-label={m.admin_bulk_actions()} aria-busy={bulkBusy() ? 'true' : undefined}>
-          <div class="admin-bulk-headline">
-            <span class="admin-bulk-count" role="status" aria-live="polite">{m.admin_bulk_selected({ count: String(selectedCount()) })}</span>
-            <Show when={canSelectAllFiltered()}>
-              <button type="button" class="link-button admin-bulk-selectall" onClick={() => selectAllFiltered()}>
-                {m.admin_bulk_select_all_filtered({ count: String(visibleRows().length) })}
-              </button>
-            </Show>
-          </div>
-          <Show when={hasActiveField()}>
-            <button type="button" class="action-button" disabled={bulkBusy()} onClick={() => bulkSetActive(true)}>{m.admin_bulk_activate()}</button>
-            <button type="button" class="action-button" disabled={bulkBusy()} onClick={() => bulkSetActive(false)}>{m.admin_bulk_deactivate()}</button>
-          </Show>
-          <button type="button" class="action-button is-icon" disabled={bulkBusy()} aria-label={m.admin_bulk_export()} title={m.admin_bulk_export()} onClick={() => exportCsv(selectedRows())}><DownloadIcon /></button>
-          <button type="button" class="link-button is-icon is-danger" disabled={bulkBusy()} aria-label={m.admin_delete()} title={m.admin_delete()} onClick={() => bulkDelete()}><TrashIcon /></button>
-          <button type="button" class="link-button" disabled={bulkBusy()} onClick={() => clearSelection()}>{m.admin_bulk_clear()}</button>
-        </div>
       </Show>
 
       <Show when={props.descriptor.description !== undefined}>

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -788,7 +788,7 @@ describe('Admin status page', () => {
       user: { id: i + 1, username: `user${String(i + 1).padStart(2, '0')}`, abbr: '', type: 'DEV', active: true, teams: [] },
     }))
     getJson.mockImplementation((path: string) => (path === '/getAllUsers' ? Promise.resolve(users) : Promise.resolve([])))
-    const { getByRole, getByText, queryByText, unmount } = renderAdmin('/admin/users')
+    const { container, getByRole, getByText, queryByText, unmount } = renderAdmin('/admin/users')
     await waitFor(() => expect(getByText('user01')).toBeInTheDocument())
 
     const selectAll = getByRole('checkbox', { name: 'Select all rows' }) as HTMLInputElement
@@ -796,6 +796,8 @@ describe('Admin status page', () => {
     fireEvent.input(selectAll)
     // Only the 50-row page is selected — not all 51 across pages.
     await waitFor(() => expect(getByText('50 selected')).toBeInTheDocument())
+    // The bulk bar lives INSIDE the toolbar (inline), so it doesn't push the table down.
+    expect(container.querySelector('.admin-crud-toolbar .admin-bulk-bar')).not.toBeNull()
 
     // Opting in selects the whole filtered set; the offer then disappears.
     fireEvent.click(getByText('Select all 51'))

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1800,7 +1800,9 @@ th[aria-sort='descending'] .th-sort-glyph {
   white-space: nowrap;
 }
 
-/* Bulk-action bar shown when one or more rows are selected. */
+/* Bulk-action bar shown when one or more rows are selected. It sits INLINE in
+   the toolbar (between Add and the filter), so selecting rows doesn't add a row
+   that pushes the table down — hence no vertical margin. */
 .admin-bulk-bar {
   align-items: center;
   background: var(--color-accent-soft);
@@ -1809,8 +1811,7 @@ th[aria-sort='descending'] .th-sort-glyph {
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
-  margin-bottom: 0.9rem;
-  padding: 0.5rem 0.9rem;
+  padding: 0.3rem 0.7rem;
 }
 
 .admin-bulk-bar[aria-busy='true'] {
@@ -1823,7 +1824,6 @@ th[aria-sort='descending'] .th-sort-glyph {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem 0.7rem;
-  margin-right: auto;
 }
 
 .admin-bulk-count {


### PR DESCRIPTION
On `/ui/admin/*`, selecting rows inserted a full-width **bulk-action bar below the toolbar**, pushing the whole table down — irritating on every selection change.

Move the bar **inline into the toolbar**, between **Add** and the (right-aligned) **filter**, and drop its vertical margin. The toolbar height stays constant, so the table no longer jumps. Same actions, same behaviour — only the placement changed.

Test: `Admin.test.tsx` asserts the bulk bar renders **inside** `.admin-crud-toolbar` once rows are selected (and all the existing select-all / bulk behaviour still passes). Frontend suite green; typecheck/lint/build clean.