### PR TITLE
fix(admin): grandfather the user-abbr length check on edit (deactivate)

### DIFF
--- a/src/Dto/UserSaveDto.php
+++ b/src/Dto/UserSaveDto.php
@@ -12,6 +12,7 @@ namespace App\Dto;
 use App\Entity\User;
 use App\Validator\Constraints\UniqueUserAbbr;
 use App\Validator\Constraints\UniqueUsername;
+use App\Validator\Constraints\ValidUserAbbr;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\ObjectMapper\Attribute\Map;
@@ -28,8 +29,7 @@ final readonly class UserSaveDto
         #[Assert\Length(min: 3, minMessage: 'Please provide a valid user name with at least 3 letters.')]
         #[UniqueUsername]
         public string $username = '',
-        #[Assert\NotBlank(message: 'Please provide a valid user name abbreviation with 1 to 3 characters.')]
-        #[Assert\Length(max: 3, maxMessage: 'Please provide a valid user name abbreviation with 1 to 3 characters.')]
+        #[ValidUserAbbr]
         #[UniqueUserAbbr]
         public string $abbr = '',
         public string $type = '',

--- a/src/Validator/Constraints/ValidUserAbbr.php
+++ b/src/Validator/Constraints/ValidUserAbbr.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * The user abbreviation must be 1 to 3 characters — but only on creation or when
+ * the abbreviation actually changes. Re-saving an existing user with an unchanged
+ * abbreviation (e.g. just toggling "active") is grandfathered, so a legacy account
+ * whose abbr is empty or over-long can still be edited/deactivated.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ValidUserAbbr extends Constraint
+{
+    public string $message = 'Please provide a valid user name abbreviation with 1 to 3 characters.';
+
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+    }
+}

--- a/src/Validator/Constraints/ValidUserAbbrValidator.php
+++ b/src/Validator/Constraints/ValidUserAbbrValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use App\Dto\UserSaveDto;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+use function is_string;
+use function mb_strlen;
+
+class ValidUserAbbrValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidUserAbbr) {
+            throw new UnexpectedTypeException($constraint, ValidUserAbbr::class);
+        }
+
+        $dto = $this->context->getObject();
+        $userId = $dto instanceof UserSaveDto ? $dto->id : 0;
+
+        // Grandfather an unchanged abbreviation: re-saving an existing user (e.g.
+        // just toggling "active") must not be blocked because a legacy account has
+        // an empty or over-long abbr. Only a new or changed abbr is length-checked.
+        // Cast the persisted value so a NULL legacy abbr equals a submitted ''.
+        if ($userId > 0) {
+            $current = $this->entityManager->getRepository(User::class)->find($userId);
+            if ($current instanceof User && (string) $current->getAbbr() === $value) {
+                return;
+            }
+        }
+
+        if (!is_string($value) || '' === $value || mb_strlen($value) > 3) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+}

--- a/tests/Validator/ValidUserAbbrValidatorTest.php
+++ b/tests/Validator/ValidUserAbbrValidatorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Validator;
+
+use App\Dto\UserSaveDto;
+use App\Entity\User;
+use App\Validator\Constraints\ValidUserAbbr;
+use App\Validator\Constraints\ValidUserAbbrValidator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+/**
+ * Unit tests for ValidUserAbbrValidator (1-3 char abbr, grandfathered on edit).
+ *
+ * @internal
+ */
+#[CoversClass(ValidUserAbbrValidator::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class ValidUserAbbrValidatorTest extends TestCase
+{
+    private EntityRepository&MockObject $repository;
+    private ExecutionContextInterface&MockObject $context;
+    private ValidUserAbbrValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(EntityRepository::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($this->repository);
+        $this->context = $this->createMock(ExecutionContextInterface::class);
+        $this->validator = new ValidUserAbbrValidator($entityManager);
+    }
+
+    public function testThrowsOnInvalidConstraintType(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validateInContext('AB', self::createStub(Constraint::class), $this->context);
+    }
+
+    public function testAcceptsAOneToThreeCharAbbrForANewUser(): void
+    {
+        $this->context->method('getObject')->willReturn(new UserSaveDto(id: 0, abbr: 'ABC'));
+        $this->context->expects(self::never())->method('buildViolation');
+
+        $this->validator->validateInContext('ABC', new ValidUserAbbr(), $this->context);
+    }
+
+    public function testRejectsAnEmptyAbbrForANewUser(): void
+    {
+        $this->context->method('getObject')->willReturn(new UserSaveDto(id: 0, abbr: ''));
+        $this->repository->expects(self::never())->method('find');
+        $this->expectSingleViolation();
+
+        $this->validator->validateInContext('', new ValidUserAbbr(), $this->context);
+    }
+
+    public function testRejectsAnOverLongAbbrForANewUser(): void
+    {
+        $this->context->method('getObject')->willReturn(new UserSaveDto(id: 0, abbr: 'ABCD'));
+        $this->expectSingleViolation();
+
+        $this->validator->validateInContext('ABCD', new ValidUserAbbr(), $this->context);
+    }
+
+    public function testGrandfathersAnUnchangedEmptyAbbrOnEdit(): void
+    {
+        // A legacy user whose abbr is NULL/empty, re-saved unchanged (e.g. just
+        // deactivating), must pass — the length lookup is skipped. The persisted
+        // NULL must compare equal to the submitted ''.
+        $this->context->method('getObject')->willReturn(new UserSaveDto(id: 7, abbr: ''));
+        $this->repository->expects(self::once())->method('find')->with(7)
+            ->willReturn($this->stubUser(null));
+        $this->context->expects(self::never())->method('buildViolation');
+
+        $this->validator->validateInContext('', new ValidUserAbbr(), $this->context);
+    }
+
+    public function testStillRejectsChangingToAnOverLongAbbr(): void
+    {
+        // Changing an existing user's abbr to an over-long value is still rejected.
+        $this->context->method('getObject')->willReturn(new UserSaveDto(id: 7, abbr: 'ABCD'));
+        $this->repository->expects(self::once())->method('find')->with(7)
+            ->willReturn($this->stubUser('AB'));
+        $this->expectSingleViolation();
+
+        $this->validator->validateInContext('ABCD', new ValidUserAbbr(), $this->context);
+    }
+
+    private function stubUser(?string $abbr): User
+    {
+        $user = self::createStub(User::class);
+        $user->method('getAbbr')->willReturn($abbr);
+
+        return $user;
+    }
+
+    private function expectSingleViolation(): void
+    {
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $violationBuilder->expects(self::once())->method('addViolation');
+
+        $this->context->method('buildViolation')->willReturn($violationBuilder);
+    }
+}


### PR DESCRIPTION
Deactivating a user on `/ui/admin/users` failed with *"Please provide a valid user name abbreviation with 1 to 3 characters."* when the account had an **empty/NULL (legacy) abbreviation** — same class as the name/abbr grandfather fixes ([#454](https://github.com/netresearch/timetracker/pull/454), [#462](https://github.com/netresearch/timetracker/pull/462)).

## Why
`UserSaveDto::abbr` carried declarative `#[Assert\NotBlank]` + `#[Assert\Length(max: 3)]`. Those fire on **every** save, so re-saving a legacy account to just toggle `active` is rejected because its abbr was never 1-3 chars. The check should only run on **creation or an actual abbr change**.

Declarative constraints can't look at the DB, so they can't tell "unchanged" from "changed".

## Fix
Replace them with a `ValidUserAbbr` validator (mirroring the unique-abbr one): when editing an existing user whose **persisted abbr is unchanged**, skip the length check (a NULL persisted abbr compares equal to a submitted ``); otherwise enforce 1-3 characters. `UniqueUserAbbr` is untouched.

## Test
- `ValidUserAbbrValidatorTest`: a new/changed abbr must be 1-3 chars (empty/over-long rejected, no DB lookup for a new user); an existing user re-saved with an unchanged empty abbr passes (lookup skipped); changing to an over-long abbr is still rejected.
- Existing `SaveUserAbbrLengthTest` (end-to-end length enforcement) still green; PHPStan + cs-fixer + Rector clean.