### PR TITLE
fix(ui): refresh header login badge after in-place re-login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import { SessionExpiredOverlay } from './components/SessionExpiredOverlay'
 import { ShortcutsDialog } from './components/ShortcutsDialog'
 import { appConfig, canBill, hasRole } from './config'
 import { sessionExpired, setSessionExpired, startSessionMonitor } from './lib/session'
-import { initHeaderDynamics } from './header'
+import { initHeaderDynamics, refreshLoginStatus } from './header'
 import { syncNav } from './nav'
 import { m } from './paraglide/messages.js'
 import Admin from './pages/Admin'
@@ -199,7 +199,7 @@ function Layout(props: ParentProps) {
       {/* Lost backend session → dim+lock the page and re-login in place; on success
           refetch (the stale 302'd data) and resume — drafts survive (no unmount). */}
       <Show when={sessionExpired()}>
-        <SessionExpiredOverlay onSuccess={() => { setSessionExpired(false); void queryClient.invalidateQueries() }} />
+        <SessionExpiredOverlay onSuccess={() => { setSessionExpired(false); void queryClient.invalidateQueries(); void refreshLoginStatus(appConfig()) }} />
       </Show>
       <CommandPalette />
       <ShortcutsDialog />

--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { formatDays, formatDuration, handleHelpClick, handleShortcut, hideAccessHints, showAccessHints } from './header'
+import { getJson } from './api/client'
+import type { AppConfig } from './config'
+import { formatDays, formatDuration, handleHelpClick, handleShortcut, hideAccessHints, refreshLoginStatus, showAccessHints } from './header'
 import { setShortcutsHelpOpen, shortcutsHelpOpen } from './lib/shortcutsHelp'
+
+vi.mock('./api/client', () => ({ getJson: vi.fn() }))
 
 describe('formatDuration', () => {
   it('formats minutes as H:MM like the ExtJS header', () => {
@@ -363,5 +367,54 @@ describe('handleShortcut', () => {
     } finally {
       document.removeEventListener('keydown', handleShortcut)
     }
+  })
+})
+
+describe('refreshLoginStatus', () => {
+  const config = { userName: 'Ada Lovelace' } as AppConfig
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  /** Render a badge in the logged-out (red) state, as the poll leaves it after a
+   *  silent logout. */
+  function redBadge(): HTMLElement {
+    document.body.innerHTML = `
+      <span class="js-user-badge status_inactive"><span class="js-user-name"></span></span>`
+
+    return document.querySelector<HTMLElement>('.js-user-badge')!
+  }
+
+  it('repaints the badge green with the user name when the session is restored', async () => {
+    const badge = redBadge()
+    vi.mocked(getJson).mockResolvedValue({ loginStatus: true })
+
+    await refreshLoginStatus(config)
+
+    expect(badge.classList.contains('status_active')).toBe(true)
+    expect(badge.classList.contains('status_inactive')).toBe(false)
+    expect(badge.querySelector('.js-user-name')?.textContent).toBe('Ada Lovelace')
+  })
+
+  it('leaves the badge red when the check still reports logged out', async () => {
+    const badge = redBadge()
+    vi.mocked(getJson).mockResolvedValue({ loginStatus: false })
+
+    await refreshLoginStatus(config)
+
+    expect(badge.classList.contains('status_inactive')).toBe(true)
+    expect(badge.classList.contains('status_active')).toBe(false)
+  })
+
+  it('leaves the badge red when the check fails', async () => {
+    const badge = redBadge()
+    vi.mocked(getJson).mockRejectedValue(new Error('network'))
+
+    await refreshLoginStatus(config)
+
+    expect(badge.classList.contains('status_inactive')).toBe(true)
+    expect(badge.classList.contains('status_active')).toBe(false)
   })
 })

--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -5,7 +5,12 @@ import type { AppConfig } from './config'
 import { formatDays, formatDuration, handleHelpClick, handleShortcut, hideAccessHints, refreshLoginStatus, showAccessHints } from './header'
 import { setShortcutsHelpOpen, shortcutsHelpOpen } from './lib/shortcutsHelp'
 
-vi.mock('./api/client', () => ({ getJson: vi.fn() }))
+// Preserve the module's other exports (SessionExpiredError, postJson, …) and stub
+// only getJson, so anything else loaded during the run keeps working.
+vi.mock('./api/client', async () => ({
+  ...await vi.importActual<typeof import('./api/client')>('./api/client'),
+  getJson: vi.fn(),
+}))
 
 describe('formatDuration', () => {
   it('formats minutes as H:MM like the ExtJS header', () => {

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -424,19 +424,31 @@ function initShortcuts(): void {
   window.addEventListener('blur', hideAccessHints)
 }
 
+/** One-shot `/status/check` → repaint the header badge. Shared by the poll loop
+ *  and the re-login refresh below; never reschedules a timer itself. */
+async function fetchLoginStatus(config: AppConfig): Promise<void> {
+  try {
+    const status = await getJson<{ loginStatus: boolean }>('/status/check')
+    setBadge(status.loginStatus, status.loginStatus ? config.userName : '')
+  } catch {
+    setBadge(false, '')
+  }
+}
+
+// Exported so the in-place re-login overlay can repaint the badge the instant the
+// session is restored — otherwise it stays red until the next poll tick (up to
+// STATUS_POLL_INTERVAL_MS later), since the overlay's success path only clears
+// the session-expired signal and refetches data (#446 follow-up).
+export function refreshLoginStatus(config: AppConfig): Promise<void> {
+  return fetchLoginStatus(config)
+}
+
 function pollLoginStatus(config: AppConfig): void {
-  void getJson<{ loginStatus: boolean }>('/status/check')
-    .then((status) => {
-      setBadge(status.loginStatus, status.loginStatus ? config.userName : '')
-    })
-    .catch(() => {
-      setBadge(false, '')
-    })
-    .finally(() => {
-      setTimeout(() => {
-        pollLoginStatus(config)
-      }, STATUS_POLL_INTERVAL_MS)
-    })
+  void fetchLoginStatus(config).finally(() => {
+    setTimeout(() => {
+      pollLoginStatus(config)
+    }, STATUS_POLL_INTERVAL_MS)
+  })
 }
 
 export function initHeaderDynamics(config: AppConfig): void {


### PR DESCRIPTION
## Problem

After a background/silent logout and re-login through the in-place session-expired modal, the header login-status badge stays **red** even though the user is logged back in.

## Cause

The header badge is repainted **only** by `header.ts`'s 90-second `pollLoginStatus` (`/status/check`). The `SessionExpiredOverlay`'s `onSuccess` cleared the `sessionExpired` signal and refetched data, but never refreshed the badge — so it stayed red until the next poll tick (up to 90s later). The full-page login path was unaffected because a reload re-runs `initHeaderDynamics`.

## Fix

- Export a one-shot `refreshLoginStatus(config)` from `header.ts` that runs a single `/status/check` and repaints the badge — reusing the existing logic, **without** spawning a duplicate poll timer.
- Call it from the overlay's `onSuccess` alongside the existing signal-clear + refetch.

## Tests

Added 3 unit tests (badge goes green on restored session, stays red on still-logged-out, stays red on a failed check). Full suite + typecheck + lint + build green.
