### PR TITLE
feat(ui): move help into the tool line; freetext worklog day range

### DIFF
--- a/e2e/worklog-crud.spec.ts
+++ b/e2e/worklog-crud.spec.ts
@@ -94,7 +94,11 @@ test.describe('Worklog CRUD', () => {
 
   test('changing the days range refetches, and the CSV export anchor matches it', async ({ page }) => {
     const refetched = page.waitForResponse((r) => /\/getData\/days\/35\b/.test(r.url()));
-    await page.locator('.tracking-days select').selectOption('35');
+    // The day range is a freetext combobox now: type a value and commit on blur,
+    // which fires the native change handler (applyDays).
+    const days = page.locator('.tracking-days-input');
+    await days.fill('35');
+    await days.blur();
     await refetched;
 
     await expect(page.getByRole('link', { name: /Export CSV|CSV-Export/i })).toHaveAttribute('href', '/export/35');

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -169,6 +169,7 @@
   "tracking_days_label": "Zeige",
   "tracking_days_option": "Letzte {count} Tage",
   "tracking_days_option_one": "Letzter Tag",
+  "tracking_days_unit": "Tage",
   "tracking_empty": "Keine Einträge in diesem Zeitraum.",
   "tracking_empty_range": "Keine Einträge in den letzten {count} Tagen.",
   "tracking_empty_cta": "Lege deinen ersten Eintrag an.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -169,6 +169,7 @@
   "tracking_days_label": "Show",
   "tracking_days_option": "Last {count} days",
   "tracking_days_option_one": "Last day",
+  "tracking_days_unit": "days",
   "tracking_empty": "No entries in this period.",
   "tracking_empty_range": "No entries in the last {count} days.",
   "tracking_empty_cta": "Add your first entry.",

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -409,6 +409,12 @@ export function AdminCrudShell(props: {
             <button type="button" class="link-button" disabled={bulkBusy()} onClick={() => clearSelection()}>{m.admin_bulk_clear()}</button>
           </div>
         </Show>
+        {/* The entity help shares the bulk bar's slot (right after Add) and steps
+            aside the moment a selection turns the bulk bar on — so it never adds a
+            line that shoves the table down. */}
+        <Show when={selectedCount() === 0 && props.descriptor.description !== undefined}>
+          <p class="admin-intro">{props.descriptor.description?.()}</p>
+        </Show>
         <Show when={notice()}>
           <span role="status" class="form-status is-ok">{notice()}</span>
         </Show>
@@ -461,10 +467,6 @@ export function AdminCrudShell(props: {
           banner — the old inline toolbar text was easy to miss. */}
       <Show when={error()}>
         <p class="admin-error-banner" role="alert">{error()}</p>
-      </Show>
-
-      <Show when={props.descriptor.description !== undefined}>
-        <p class="admin-intro">{props.descriptor.description?.()}</p>
       </Show>
 
       <Show when={!list.isError} fallback={<p role="alert">{m.app_load_error()}</p>}>

--- a/frontend/src/lib/trackingDaysPref.ts
+++ b/frontend/src/lib/trackingDaysPref.ts
@@ -5,12 +5,14 @@
 
 const STORAGE_KEY = 'tt-tracking-days'
 
-export function getTrackingDays(allowed: readonly number[], fallback: number): number {
+export function getTrackingDays(fallback: number): number {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (raw !== null) {
       const value = Number(raw)
-      if (allowed.includes(value)) {
+      // The range is freetext now (any whole number ≥ 1), so validate the shape
+      // rather than membership in a fixed preset list. The caller caps the upper end.
+      if (Number.isInteger(value) && value >= 1) {
         return value
       }
     }

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -170,6 +170,32 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('accepts a freetext (non-preset) day range and refetches it', async () => {
+    mockApi()
+    const { getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
+
+    fireEvent.change(getByRole('combobox'), { target: { value: '14' } })
+
+    await waitFor(() => expect(getJson).toHaveBeenCalledWith('/getData/days/14'))
+
+    unmount()
+  })
+
+  it('clamps an out-of-range day entry to a year and re-syncs the field', async () => {
+    mockApi()
+    const { getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
+
+    const combo = getByRole('combobox') as HTMLInputElement
+    fireEvent.change(combo, { target: { value: '9999' } })
+
+    await waitFor(() => expect(getJson).toHaveBeenCalledWith('/getData/days/366'))
+    expect(combo.value).toBe('366')
+
+    unmount()
+  })
+
   it('has no automatically detectable accessibility violations', async () => {
     mockApi()
     const { container, getByRole, unmount } = renderTracking()

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -26,6 +26,9 @@ void gridNav
 
 const DAYS_OPTIONS = [1, 3, 7, 35] as const
 const DEFAULT_DAYS = 3
+// The freetext day-range accepts any whole number, capped at a year so a stray
+// keystroke (or a stale localStorage value) can't ask the grid for everything.
+const MAX_DAYS = 366
 // Widen target for the range-aware empty state (the largest preset window).
 const WIDEN_DAYS = 35
 
@@ -169,7 +172,7 @@ function RowAction(props: { label: string; danger?: boolean; keyshortcut?: strin
 export default function Tracking() {
   const queryClient = useQueryClient()
   // The day range persists across remounts/logins (client-side, like the theme).
-  const [days, setDays] = createSignal<number>(getTrackingDays(DAYS_OPTIONS, DEFAULT_DAYS))
+  const [days, setDays] = createSignal<number>(Math.min(getTrackingDays(DEFAULT_DAYS), MAX_DAYS))
   const entries = useQuery(() => trackingEntriesQuery(days()))
   const customers = useQuery(trackingCustomersQuery)
   const projects = useQuery(trackingProjectsQuery)
@@ -670,9 +673,15 @@ export default function Tracking() {
   }
 
   // Change the day range and persist the choice (so it survives a remount/login).
+  // Whole numbers only, floored at one day and capped at MAX_DAYS — the freetext
+  // input lets a user type anything, so the clamp lives here, the single setter.
   function applyDays(value: number): void {
-    setDays(value)
-    setTrackingDays(value)
+    const clamped = Math.min(Math.max(1, Math.trunc(value)), MAX_DAYS)
+    if (!Number.isFinite(clamped)) {
+      return
+    }
+    setDays(clamped)
+    setTrackingDays(clamped)
   }
 
   const exportHref = (): string => `/export/${days()}`
@@ -781,22 +790,41 @@ export default function Tracking() {
         {/* Continue / Prolong / Info moved to per-row action icons; Alt+C/P/I
             still act on the keyboard-cursor row via the global shortcut handler. */}
         <a class="action-button is-icon" href={exportHref()} aria-keyshortcuts="Alt+X" aria-label={m.tracking_export()} title={m.tracking_export()}><DownloadIcon /></a>
+        {/* Freetext combobox: the presets are suggestions in the datalist, but the
+            user can type any whole number of days (applyDays clamps + persists).
+            A text input with `list` is a combobox (role) — not a numeric
+            spinbutton — so the datalist dropdown stays a one-tap pick. */}
         <label class="tracking-days">
           <span>{m.tracking_days_label()}</span>
-          <select
+          <input
+            type="text"
+            inputmode="numeric"
+            class="tracking-days-input"
+            list="tracking-days-options"
             value={String(days())}
-            onChange={(event) => applyDays(Number(event.currentTarget.value))}
-          >
+            onChange={(event) => {
+              const typed = Number(event.currentTarget.value.trim())
+              if (Number.isFinite(typed) && typed >= 1) {
+                applyDays(typed)
+              }
+              // Re-sync the field to the effective (clamped) value, reverting any
+              // invalid or out-of-range entry rather than leaving it on screen.
+              event.currentTarget.value = String(days())
+            }}
+          />
+          <datalist id="tracking-days-options">
             <For each={DAYS_OPTIONS}>
-              {(option) => <option value={String(option)}>{option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })}</option>}
+              {(option) => <option value={String(option)} label={option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })} />}
             </For>
-          </select>
+          </datalist>
+          <span class="tracking-days-unit">{m.tracking_days_unit()}</span>
         </label>
-      </div>
 
-      {/* Inline-edit + keyboard discoverability (the only on-screen cue otherwise
-          is a hover text-cursor on editable cells). */}
-      <p class="tracking-hint">{m.tracking_edit_hint()}</p>
+        {/* Inline-edit + keyboard discoverability hint — last in the tool line, so
+            the only otherwise-on-screen cue (a hover text-cursor on editable cells)
+            gets a written explanation without a separate band above the grid. */}
+        <p class="tracking-hint">{m.tracking_edit_hint()}</p>
+      </div>
 
       {/* A session-expiry refetch errors too, but the overlay owns that — keep the
           last-good grid (and the user's drafts) visible+dimmed behind it, not a

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -639,11 +639,14 @@ main {
   color: var(--color-accent, #0a84ff);
 }
 
+/* Entity help, inline in the toolbar (it shares the bulk bar's slot). No vertical
+   margin — the toolbar's gap spaces it; max-width keeps it from crowding out the
+   right-aligned filter on wide rows. */
 .admin-intro {
-  margin: 0 0 0.75rem;
-  max-width: 70ch;
+  margin: 0;
+  max-width: 60ch;
   color: var(--color-text-muted);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
 
 /* Checkbox + its ⓘ help, kept outside the <label> so the help icon neither
@@ -1205,10 +1208,11 @@ kbd {
   gap: 0.5rem;
 }
 
-/* The days-range select must use the theme tokens (like .field select) — an
-   unstyled native select renders a light box in dark mode. color-scheme keeps
-   the option popup legible in both themes. */
-.tracking-days select {
+/* The days-range combobox must use the theme tokens (like .field select) — an
+   unstyled native control renders a light box in dark mode. color-scheme keeps
+   the datalist popup legible in both themes. Narrow: it holds a number, not a
+   sentence. */
+.tracking-days-input {
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -1217,12 +1221,17 @@ kbd {
   font: inherit;
   min-height: 44px; /* match the 44px touch-target the rest of the toolbar commits to */
   padding: 0 0.4rem;
+  width: 4.5rem;
 }
 
-.tracking-days select:focus-visible {
+.tracking-days-input:focus-visible {
   border-color: var(--color-accent);
   outline: 2px solid var(--color-accent);
   outline-offset: -1px;
+}
+
+.tracking-days-unit {
+  color: var(--color-text-muted);
 }
 
 .tracking-empty {
@@ -1245,11 +1254,15 @@ kbd {
   gap: var(--space-3);
 }
 
-/* Inline-edit / keyboard discoverability hint above the grid. */
+/* Inline-edit / keyboard discoverability hint — now the last item in the tool
+   line. No bottom margin (the toolbar's gap spaces it); it grows to fill the row
+   and wraps onto its own line when the toolbar runs out of width. */
 .tracking-hint {
   color: var(--color-text-muted);
+  flex: 1 1 18rem;
   font-size: 0.85rem;
-  margin: 0 0 var(--space-3);
+  margin: 0;
+  min-width: 16rem;
 }
 
 /* In-flight refetch cue (refresh / range change): the previous rows stay visible
@@ -2259,7 +2272,7 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='compact'] .link-button,
 :root[data-density='compact'] .action-button,
 :root[data-density='compact'] .admin-subnav-link,
-:root[data-density='compact'] .tracking-days select {
+:root[data-density='compact'] .tracking-days-input {
   min-height: 30px;
 }
 


### PR DESCRIPTION
## What

Two related tool-line cleanups requested for the admin tables and the worklog.

### Admin tables
The entity help (e.g. *"Projects belong to a customer. Inactive projects aren't offered for booking."*) moves out of its own band above the grid and **into the toolbar**, in the **same slot as the bulk-action bar**. The help shows while nothing is selected and **steps aside the moment a selection turns the bulk bar on** — so selecting rows no longer inserts a line that shoves the table down, and the help no longer permanently costs a row of vertical space.

### Worklog
- The inline-edit / keyboard discoverability hint moves into the tool line as the **last item**, after the day-range control (no separate band above the grid).
- The **"Last X days"** selector becomes a **freetext combobox**: `<input type="text" list>` with the presets (1 / 3 / 7 / 35) as `datalist` suggestions, but the user can **type any whole number of days**.
  - `applyDays` clamps input to **1…366 days** (one year) — a guard so a stray keystroke or a stale `localStorage` value can't ask the grid (and DB) for everything. Invalid / out-of-range entries revert in-field.
  - `getTrackingDays` now validates a positive integer rather than membership in the fixed preset list, so a custom range persists across remount/login.
- Added `tracking_days_unit` ("days" / "Tage").

The control keeps the `combobox` ARIA role (not a numeric spinbutton), so the datalist stays a one-tap pick and assistive tech announces it as a combobox.

## Tests

2 new worklog tests (freetext non-preset range refetches; out-of-range value clamps to a year and re-syncs the field). Full suite + typecheck + lint + build green.

## Note

The 1…366 day cap is a deliberate guard. If a truly unbounded range is wanted, it's a one-line change — say the word.
