### PR TITLE
feat(profiler): admin-gated production profiler via a prod-like :profiling image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,3 +85,18 @@ jobs:
           set: |
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max,ignore-error=true
+
+      # Prod-like image with the Symfony profiler (admin-gated). Published for
+      # operators to switch to on demand — never the default deployment.
+      - name: Build and push profiling image
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
+        env:
+          GIT_SHA: ${{ github.sha }}
+        with:
+          source: .
+          targets: app-profiling
+          files: docker-bake.hcl
+          push: ${{ github.event_name != 'pull_request' }}
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max,ignore-error=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -273,3 +273,48 @@ EXPOSE 9000
 
 ENTRYPOINT ["/usr/local/bin/app-entrypoint"]
 CMD ["php-fpm"]
+
+# =============================================================================
+# PROFILING - Prod-like image WITH the Symfony profiler (admin-gated).
+# Never the default deployment: an operator switches the server to :profiling
+# on demand to capture production profiling data, then switches back. Built on
+# `deps` (no Xdebug — Xdebug would skew the very timings we measure).
+# =============================================================================
+FROM deps AS profiling
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+ENV CAPTAINHOOK_DISABLE=true
+ENV APP_ENV=profiling
+ENV APP_DEBUG=0
+
+# Add dev dependencies (web-profiler-bundle, debug-bundle, stopwatch) on top of
+# the prod vendor tree, keep an optimized authoritative autoloader, and warm the
+# profiling cache (APCu is built into the base image).
+RUN composer install --ignore-platform-req=php --no-scripts \
+    && composer dump-autoload --optimize --classmap-authoritative \
+    && php bin/console cache:clear --no-debug \
+    && php bin/console cache:warmup --no-debug \
+    && chown -R app:app var/
+
+COPY --chmod=755 docker/php/healthcheck.sh /usr/local/bin/healthcheck
+COPY --chmod=755 docker/php/docker-entrypoint.sh /usr/local/bin/app-entrypoint
+
+RUN update-ca-certificates 2>/dev/null || true
+
+ARG APP_BUILD_REVISION=""
+ARG APP_BUILD_REF=""
+ARG APP_BUILD_DATE=""
+ENV APP_BUILD_REVISION=${APP_BUILD_REVISION}
+ENV APP_BUILD_REF=${APP_BUILD_REF}
+ENV APP_BUILD_DATE=${APP_BUILD_DATE}
+
+USER app
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD /usr/local/bin/healthcheck
+
+EXPOSE 9000
+
+ENTRYPOINT ["/usr/local/bin/app-entrypoint"]
+CMD ["php-fpm"]

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -18,6 +18,6 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['dev' => true, 'test' => true],
     Pentatrion\ViteBundle\PentatrionViteBundle::class => ['all' => true],
-    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true, 'profiling' => true],
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true, 'profiling' => true],
 ];

--- a/config/packages/profiling/doctrine.yaml
+++ b/config/packages/profiling/doctrine.yaml
@@ -1,0 +1,11 @@
+# Reuse the production ORM/cache setup so timings stay representative, then
+# turn on DBAL query profiling so the profiler's Database panel (queries,
+# timings, EXPLAIN) populates — kernel.debug is false in this env, so the base
+# `profiling: '%kernel.debug%'` would otherwise leave it empty.
+imports:
+    - { resource: ../prod/doctrine.yaml }
+
+doctrine:
+    dbal:
+        profiling: true
+        profiling_collect_backtrace: false

--- a/config/packages/profiling/security.yaml
+++ b/config/packages/profiling/security.yaml
@@ -1,0 +1,7 @@
+# The shared `dev` firewall is `security: false` and matches ^/_(profiler|wdt).
+# Narrow it to assets in this env so the profiler paths fall through to the
+# `main` (authenticated) firewall, where the access_control rule applies.
+security:
+    firewalls:
+        dev:
+            pattern: ^/(css|images|js)/

--- a/config/packages/profiling/web_profiler.yaml
+++ b/config/packages/profiling/web_profiler.yaml
@@ -1,0 +1,10 @@
+framework:
+    profiler:
+        enabled: true
+        # Dormant: nothing is collected unless ProfilerAdminGateSubscriber
+        # calls Profiler::enable() for an admin request.
+        collect: false
+
+web_profiler:
+    toolbar: true
+    intercept_redirects: false

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -69,6 +69,10 @@ security:
         - { path: ^/status/check, roles: PUBLIC_ACCESS }
         - { path: ^/status/page, roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: ROLE_ADMIN }
+        # Profiler/web-debug-toolbar routes exist only in the `profiling` env,
+        # where the `dev` firewall is narrowed so these fall through to `main`;
+        # lock them to admins. Inert in dev/test/prod (no such routes/firewall match).
+        - { path: ^/_(profiler|wdt), roles: ROLE_ADMIN }
         - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
 
         # Uncomment to restrict access to paths starting with /_internal to only localhost

--- a/config/routes/profiling/web_profiler.yaml
+++ b/config/routes/profiling/web_profiler.yaml
@@ -1,0 +1,9 @@
+# Web Debug Toolbar routes
+web_profiler_wdt:
+    resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
+    prefix: '/_wdt'
+
+# Profiler routes
+web_profiler_profiler:
+    resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
+    prefix: '/_profiler'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -43,6 +43,9 @@ services:
         exclude:
             - '../src/Entity/'
             - '../src/Kernel.php'
+            # Registered only in the profiling env (config/services_profiling.yaml),
+            # where the `profiler` service it depends on exists.
+            - '../src/EventSubscriber/ProfilerAdminGateSubscriber.php'
             - '../src/Service/Integration/Jira/JiraHttpClientService.php'
             - '../src/Service/Integration/Jira/JiraWorkLogService.php'
             - '../src/Service/Integration/Jira/JiraTicketService.php'

--- a/config/services_profiling.yaml
+++ b/config/services_profiling.yaml
@@ -1,0 +1,7 @@
+# Loaded only when APP_ENV=profiling (Symfony imports config/services_<env>.yaml).
+# The profiler service exists here (WebProfilerBundle is enabled for this env),
+# so the gate subscriber can autowire it.
+services:
+    App\EventSubscriber\ProfilerAdminGateSubscriber:
+        autowire: true
+        autoconfigure: true

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -145,6 +145,17 @@ target "app-e2e" {
   ])
 }
 
+# Profiling image (prod-like + Symfony profiler, admin-gated). Built by CI,
+# never the default deployment — operators switch to :profiling on demand.
+target "app-profiling" {
+  inherits = ["_common"]
+  target   = "profiling"
+  tags = compact([
+    "${REGISTRY}/${IMAGE_NAME}:profiling",
+    GIT_SHA != "" ? "${REGISTRY}/${IMAGE_NAME}:profiling-${GIT_SHA}" : "",
+  ])
+}
+
 # =============================================================================
 # BUILD GROUPS
 # =============================================================================
@@ -156,7 +167,7 @@ group "default" {
 
 # All application images (for local development)
 group "all" {
-  targets = ["app", "app-dev", "app-tools", "app-e2e"]
+  targets = ["app", "app-dev", "app-tools", "app-e2e", "app-profiling"]
 }
 
 # CI images (production + e2e for all CI jobs)

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -2084,6 +2084,37 @@ For ongoing support:
 
 ---
 
+## Production Profiling (admin-gated profiler image)
+
+The pipeline builds a second image, `ghcr.io/netresearch/timetracker:profiling`,
+alongside `:production`. It is **prod-like** (`APP_ENV=profiling`, debug off,
+optimized) but ships the Symfony web profiler, exposed **only to admins**. It is
+**never the default deployment** — switch to it on demand to capture real
+production profiling data for an issue report, then switch back.
+
+**To profile a production request:**
+
+1. Pull the profiling image: `docker pull ghcr.io/netresearch/timetracker:profiling`.
+2. Switch the running container to the `:profiling` tag (compose image override /
+   hot-deploy), same DB and env as production. The image self-migrates like
+   `:production`, so a switch over an already-migrated DB is a no-op.
+3. Reproduce the slow action **while logged in as an admin**. On full-page loads
+   the web-debug-toolbar appears; each SPA/XHR call (e.g. `/getAllCustomers`)
+   carries an `X-Debug-Token` — open `/_profiler/{token}?panel=db` for its
+   queries, timings, and `EXPLAIN`.
+4. Capture what you need (screenshots / the `/_profiler` token) for the report.
+5. **Switch the tag back to `:production`.**
+
+**Security notes:**
+- Non-admins see nothing on this image: the profiler never collects for them and
+  `/_profiler` / `/_wdt` return 403 (locked to `ROLE_ADMIN`).
+- The dump and config profiler panels are removed to limit secret exposure; the
+  login route is never profiled.
+- Collected profiles live in the container's cache dir and vanish when it is
+  swapped back. Keep the profiling image deployed only as long as needed.
+
+---
+
 **Last Updated**: 2025-01-20  
 **Deployment Version**: v4.1  
 **Support**: Create a GitHub issue or contact DevOps team

--- a/docs/superpowers/plans/2026-06-26-admin-gated-production-profiler.md
+++ b/docs/superpowers/plans/2026-06-26-admin-gated-production-profiler.md
@@ -1,0 +1,674 @@
+# Admin-gated Production Profiler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a second, prod-like `:profiling` container image (alongside the unchanged `:production` image) in which the full Symfony web profiler is available but exposed only to admins, so real production profiling data can be captured for issue reports.
+
+**Architecture:** The default production image stays profiler-free. A new `APP_ENV=profiling` image (debug off, optimized, but with the dev bundles installed) enables the profiler with `collect: false`; a `kernel.request` subscriber turns collection on only for `ROLE_ADMIN` requests, the `/_profiler` + `/_wdt` routes are `ROLE_ADMIN`-locked, the sensitive data collectors are stripped, and Doctrine query profiling is on so the DB panel works. CI builds and pushes `:profiling`; an operator switches the server to it on demand, then back.
+
+**Tech Stack:** PHP 8.5, Symfony 7.3 (MicroKernelTrait), Doctrine, web-profiler-bundle/debug-bundle (already `require-dev`), Docker buildx Bake, GitHub Actions.
+
+## Global Constraints
+
+- Every PHP file starts with the license header block (`Copyright (c) 2025-2026 Netresearch DTT GmbH` / `SPDX-License-Identifier: AGPL-3.0-only`) then `declare(strict_types=1);` — copy verbatim from any file in `src/`.
+- New classes are `final readonly` where they hold only injected dependencies (matches `src/EventSubscriber/AccessDeniedSubscriber.php`).
+- Unit tests live under `tests/EventSubscriber/` (or matching `tests/` subdir) so they belong to the `unit` PHPUnit testsuite; namespace `Tests\…`; `final class`, extends `PHPUnit\Framework\TestCase`, annotate with `#[CoversClass(...)]`.
+- Run unit tests: `composer test:unit`. Static analysis: `composer analyze` (PHPStan, runs at `-d memory_limit=1G`). Style: `composer cs-fix` before every commit, then `composer cs-check` must pass.
+- Commits: Conventional Commit subject, **signed off** (`git commit -s`), **no** AI/bot attribution or Co-Authored-By lines.
+- The default `production` image and `prod` env must remain functionally unchanged — every new bundle/config/service is scoped to the `profiling` env only.
+
+---
+
+### Task 1: Admin-gate subscriber (enable the profiler only for admins)
+
+A `kernel.request` subscriber that calls `Profiler::enable()` only when the authenticated user has `ROLE_ADMIN`. With the profiling env's `collect: false` default, this is the sole switch that turns collection (and therefore the toolbar) on — and only for admins. Pure logic, unit-tested with no kernel/DB.
+
+**Files:**
+- Create: `src/EventSubscriber/ProfilerAdminGateSubscriber.php`
+- Test: `tests/EventSubscriber/ProfilerAdminGateSubscriberTest.php`
+
+**Interfaces:**
+- Produces: `App\EventSubscriber\ProfilerAdminGateSubscriber` with constructor `__construct(Security $security, #[Autowire(service: 'profiler')] Profiler $profiler)` and method `onKernelRequest(RequestEvent $event): void`. Subscribes to `KernelEvents::REQUEST` at priority `4` (after the firewall at 8, before the controller). It is registered as a service **only** in the `profiling` env (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\ProfilerAdminGateSubscriber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProfilerAdminGateSubscriber::class)]
+final class ProfilerAdminGateSubscriberTest extends TestCase
+{
+    private function event(): RequestEvent
+    {
+        $kernel = $this->createMock(HttpKernelInterface::class);
+
+        return new RequestEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
+    }
+
+    private function profiler(): Profiler
+    {
+        // Start disabled, mirroring the profiling env's `collect: false` default.
+        return new Profiler($this->createMock(ProfilerStorageInterface::class), null, false);
+    }
+
+    public function testEnablesProfilerForAdmin(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security->method('isGranted')->with('ROLE_ADMIN')->willReturn(true);
+        $profiler = $this->profiler();
+
+        (new ProfilerAdminGateSubscriber($security, $profiler))->onKernelRequest($this->event());
+
+        self::assertTrue($profiler->isEnabled());
+    }
+
+    public function testLeavesProfilerDisabledForNonAdmin(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security->method('isGranted')->with('ROLE_ADMIN')->willReturn(false);
+        $profiler = $this->profiler();
+
+        (new ProfilerAdminGateSubscriber($security, $profiler))->onKernelRequest($this->event());
+
+        self::assertFalse($profiler->isEnabled());
+    }
+
+    public function testSubscribesToKernelRequest(): void
+    {
+        self::assertArrayHasKey('kernel.request', ProfilerAdminGateSubscriber::getSubscribedEvents());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `composer test:unit -- --filter ProfilerAdminGateSubscriberTest`
+Expected: FAIL — `Class "App\EventSubscriber\ProfilerAdminGateSubscriber" not found`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```php
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+/**
+ * Turns the profiler on only for admin requests. Registered solely in the
+ * `profiling` env (config/services_profiling.yaml), where the profiler is
+ * configured with `collect: false`; this is the only switch that enables
+ * collection — and therefore the web-debug-toolbar — and only for ROLE_ADMIN.
+ * Runs after the firewall (priority 8) so the security token is resolved.
+ */
+final readonly class ProfilerAdminGateSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private Security $security,
+        #[Autowire(service: 'profiler')]
+        private Profiler $profiler,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 4],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        // isGranted() resolves the lazy firewall token; false for anonymous
+        // requests (e.g. the login page), so credentials are never profiled.
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            $this->profiler->enable();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `composer test:unit -- --filter ProfilerAdminGateSubscriberTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Static analysis + style**
+
+Run: `composer cs-fix && composer analyze`
+Expected: cs-fix reports the file formatted; PHPStan reports no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/EventSubscriber/ProfilerAdminGateSubscriber.php tests/EventSubscriber/ProfilerAdminGateSubscriberTest.php
+git commit -s -m "feat(profiler): gate profiler collection to admin requests"
+```
+
+---
+
+### Task 2: Strip sensitive data collectors in the profiling env
+
+A compiler pass that removes the `dump` and `config` data collectors so those panels (which can surface env/secret data) never exist in the profiling image. Registered from `Kernel::build()` only when the env is `profiling`.
+
+**Files:**
+- Create: `src/DependencyInjection/Compiler/RemoveSensitiveCollectorsPass.php`
+- Create: `tests/DependencyInjection/Compiler/RemoveSensitiveCollectorsPassTest.php`
+- Modify: `src/Kernel.php`
+- Modify: `phpunit.xml.dist` (add `tests/DependencyInjection` to the `unit` testsuite)
+
+**Interfaces:**
+- Produces: `App\DependencyInjection\Compiler\RemoveSensitiveCollectorsPass implements CompilerPassInterface` with `process(ContainerBuilder $container): void`, removing service ids `data_collector.dump` and `data_collector.config` when present.
+
+- [ ] **Step 1: Add the test directory to the unit suite**
+
+In `phpunit.xml.dist`, inside `<testsuite name="unit">`, add a line after `<directory>tests/DTO/Jira</directory>`:
+
+```xml
+            <directory>tests/DependencyInjection</directory>
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```php
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\DependencyInjection\Compiler;
+
+use App\DependencyInjection\Compiler\RemoveSensitiveCollectorsPass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+#[CoversClass(RemoveSensitiveCollectorsPass::class)]
+final class RemoveSensitiveCollectorsPassTest extends TestCase
+{
+    public function testRemovesDumpAndConfigCollectorsButKeepsOthers(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('data_collector.dump', stdClass::class);
+        $container->register('data_collector.config', stdClass::class);
+        $container->register('data_collector.request', stdClass::class);
+
+        (new RemoveSensitiveCollectorsPass())->process($container);
+
+        self::assertFalse($container->hasDefinition('data_collector.dump'));
+        self::assertFalse($container->hasDefinition('data_collector.config'));
+        self::assertTrue($container->hasDefinition('data_collector.request'));
+    }
+
+    public function testIsANoOpWhenCollectorsAbsent(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new RemoveSensitiveCollectorsPass())->process($container);
+
+        self::assertFalse($container->hasDefinition('data_collector.dump'));
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `composer test:unit -- --filter RemoveSensitiveCollectorsPassTest`
+Expected: FAIL — class not found.
+
+- [ ] **Step 4: Write the compiler pass**
+
+```php
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Removes the profiler data collectors that can surface env/secret data
+ * (dump, config). Registered from Kernel::build() in the `profiling` env only,
+ * so the kept panels are DB/Time/Memory/Request/Routing/Events/Logs/Cache.
+ */
+final class RemoveSensitiveCollectorsPass implements CompilerPassInterface
+{
+    private const array SENSITIVE_COLLECTORS = [
+        'data_collector.dump',
+        'data_collector.config',
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (self::SENSITIVE_COLLECTORS as $id) {
+            if ($container->hasDefinition($id)) {
+                $container->removeDefinition($id);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `composer test:unit -- --filter RemoveSensitiveCollectorsPassTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Register the pass in the kernel (profiling env only)**
+
+In `src/Kernel.php`, add the imports near the existing `use` block:
+
+```php
+use App\DependencyInjection\Compiler\RemoveSensitiveCollectorsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+```
+
+Add this method to the `Kernel` class (after `getProjectDir()`):
+
+```php
+    #[Override]
+    protected function build(ContainerBuilder $container): void
+    {
+        if ($this->environment === 'profiling') {
+            $container->addCompilerPass(new RemoveSensitiveCollectorsPass());
+        }
+    }
+```
+
+- [ ] **Step 7: Static analysis + style**
+
+Run: `composer cs-fix && composer analyze`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/DependencyInjection/Compiler/RemoveSensitiveCollectorsPass.php tests/DependencyInjection/Compiler/RemoveSensitiveCollectorsPassTest.php src/Kernel.php phpunit.xml.dist
+git commit -s -m "feat(profiler): strip dump/config collectors in the profiling env"
+```
+
+---
+
+### Task 3: Wire the `profiling` Symfony environment
+
+Enable the bundles, profiler, routes, Doctrine query profiling, the route lock, and the admin-gate service — all scoped to `profiling`. Verified by compiling the container and inspecting routes/config in that env. No production/prod-env file changes except one always-inert `access_control` line.
+
+**Files:**
+- Modify: `config/bundles.php`
+- Modify: `config/services.yaml`
+- Create: `config/services_profiling.yaml`
+- Create: `config/packages/profiling/web_profiler.yaml`
+- Create: `config/packages/profiling/doctrine.yaml`
+- Create: `config/packages/profiling/security.yaml`
+- Create: `config/routes/profiling/web_profiler.yaml`
+- Modify: `config/packages/security.yaml`
+
+**Interfaces:**
+- Consumes: `App\EventSubscriber\ProfilerAdminGateSubscriber` (Task 1), the `profiler` service (from WebProfilerBundle).
+
+- [ ] **Step 1: Enable the bundles for `profiling`**
+
+In `config/bundles.php`, change the last two entries to:
+
+```php
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true, 'profiling' => true],
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true, 'profiling' => true],
+```
+
+- [ ] **Step 2: Exclude the subscriber from the global autoload**
+
+In `config/services.yaml`, inside the `App\` resource `exclude:` list, add:
+
+```yaml
+            - '../src/EventSubscriber/ProfilerAdminGateSubscriber.php'
+```
+
+- [ ] **Step 3: Register the subscriber only in the profiling env**
+
+Create `config/services_profiling.yaml`:
+
+```yaml
+# Loaded only when APP_ENV=profiling (Symfony imports config/services_<env>.yaml).
+# The profiler service exists here (WebProfilerBundle is enabled for this env),
+# so the gate subscriber can autowire it.
+services:
+    App\EventSubscriber\ProfilerAdminGateSubscriber:
+        autowire: true
+        autoconfigure: true
+```
+
+- [ ] **Step 4: Enable the profiler, dormant by default**
+
+Create `config/packages/profiling/web_profiler.yaml`:
+
+```yaml
+framework:
+    profiler:
+        enabled: true
+        # Dormant: nothing is collected unless ProfilerAdminGateSubscriber
+        # calls Profiler::enable() for an admin request.
+        collect: false
+
+web_profiler:
+    toolbar: true
+    intercept_redirects: false
+```
+
+- [ ] **Step 5: Turn on Doctrine query profiling (prod-like cache otherwise)**
+
+Create `config/packages/profiling/doctrine.yaml`:
+
+```yaml
+# Reuse the production ORM/cache setup so timings stay representative, then
+# turn on DBAL query profiling so the profiler's Database panel (queries,
+# timings, EXPLAIN) populates — kernel.debug is false in this env, so the base
+# `profiling: '%kernel.debug%'` would otherwise leave it empty.
+imports:
+    - { resource: ../prod/doctrine.yaml }
+
+doctrine:
+    dbal:
+        profiling: true
+        profiling_collect_backtrace: false
+```
+
+- [ ] **Step 6: Send `/_profiler` through the authenticated firewall**
+
+Create `config/packages/profiling/security.yaml`:
+
+```yaml
+# The shared `dev` firewall is `security: false` and matches ^/_(profiler|wdt).
+# Narrow it to assets in this env so the profiler paths fall through to the
+# `main` (authenticated) firewall, where the access_control rule below applies.
+security:
+    firewalls:
+        dev:
+            pattern: ^/(css|images|js)/
+```
+
+- [ ] **Step 7: Load the profiler routes in this env**
+
+Create `config/routes/profiling/web_profiler.yaml` with the same content as `config/routes/dev/web_profiler.yaml` (copy it verbatim — it defines `web_profiler_wdt` at prefix `/_wdt` and `web_profiler_profiler` at prefix `/_profiler`).
+
+```bash
+cp config/routes/dev/web_profiler.yaml config/routes/profiling/web_profiler.yaml
+```
+
+- [ ] **Step 8: Lock the profiler routes to admins**
+
+In `config/packages/security.yaml`, add this line to `access_control` immediately **above** the final `- { path: ^/, roles: IS_AUTHENTICATED_FULLY }`:
+
+```yaml
+        - { path: ^/_(profiler|wdt), roles: ROLE_ADMIN }
+```
+
+(Inert in `dev`/`test` — the `dev` firewall short-circuits those paths there — and in `prod` the routes do not exist.)
+
+- [ ] **Step 9: Verify the profiling container compiles and is wired correctly**
+
+```bash
+APP_ENV=profiling APP_DEBUG=0 php bin/console cache:clear --no-debug
+APP_ENV=profiling APP_DEBUG=0 php bin/console debug:container ProfilerAdminGateSubscriber
+APP_ENV=profiling APP_DEBUG=0 php bin/console debug:router | grep _profiler
+APP_ENV=profiling APP_DEBUG=0 php bin/console debug:config security | grep -A2 'dev'
+```
+Expected: cache clears with no error; the subscriber service is listed; `/_profiler` + `/_wdt` routes are present; the `dev` firewall pattern is `^/(css|images|js)/`.
+
+- [ ] **Step 10: Verify prod is untouched**
+
+```bash
+APP_ENV=prod APP_DEBUG=0 php bin/console cache:clear --no-debug
+APP_ENV=prod APP_DEBUG=0 php bin/console debug:router | grep _profiler || echo "no profiler routes in prod (correct)"
+```
+Expected: prod cache clears cleanly; no `_profiler` routes in prod.
+
+- [ ] **Step 11: Run the unit suite + style/analysis**
+
+Run: `composer test:unit && composer cs-check && composer analyze`
+Expected: all green.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add config/bundles.php config/services.yaml config/services_profiling.yaml config/packages/profiling/ config/routes/profiling/ config/packages/security.yaml
+git commit -s -m "feat(profiler): wire the profiling Symfony environment"
+```
+
+---
+
+### Task 4: Build the prod-like `profiling` Docker stage
+
+A new Dockerfile stage that takes the built `deps` stage (full source + frontend, no Xdebug), installs the dev dependencies (which include `web-profiler-bundle`/`debug-bundle`), sets `APP_ENV=profiling` with debug off, warms the profiling cache with an optimized autoloader, and runs as the `app` user with the production entrypoint.
+
+**Files:**
+- Modify: `Dockerfile` (append a `profiling` stage)
+
+**Interfaces:**
+- Consumes: the `deps` and `base`/`production` stages and `docker/php/docker-entrypoint.sh`, `docker/php/healthcheck.sh`.
+
+- [ ] **Step 1: Add the `profiling` stage**
+
+Append to `Dockerfile` (after the `production` stage):
+
+```dockerfile
+# =============================================================================
+# PROFILING - Prod-like image WITH the Symfony profiler (admin-gated).
+# Never the default deployment: an operator switches the server to :profiling
+# on demand to capture production profiling data, then switches back.
+# =============================================================================
+FROM deps AS profiling
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# Add dev dependencies (web-profiler-bundle, debug-bundle, stopwatch) on top of
+# the prod vendor tree, keeping an optimized, authoritative autoloader.
+ENV CAPTAINHOOK_DISABLE=true
+ENV APP_ENV=profiling
+ENV APP_DEBUG=0
+RUN composer install --ignore-platform-req=php \
+    && composer dump-autoload --optimize --classmap-authoritative \
+    && APP_ENV=profiling APP_DEBUG=0 php bin/console cache:clear --no-debug \
+    && APP_ENV=profiling APP_DEBUG=0 php bin/console cache:warmup --no-debug \
+    && chown -R app:app var/
+
+COPY --chmod=755 docker/php/healthcheck.sh /usr/local/bin/healthcheck
+COPY --chmod=755 docker/php/docker-entrypoint.sh /usr/local/bin/app-entrypoint
+
+ARG APP_BUILD_REVISION=""
+ARG APP_BUILD_REF=""
+ARG APP_BUILD_DATE=""
+ENV APP_BUILD_REVISION=${APP_BUILD_REVISION}
+ENV APP_BUILD_REF=${APP_BUILD_REF}
+ENV APP_BUILD_DATE=${APP_BUILD_DATE}
+
+USER app
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD /usr/local/bin/healthcheck
+```
+
+- [ ] **Step 2: Build the stage**
+
+Run: `docker build --target profiling -t timetracker:profiling-local .`
+Expected: the build completes. (If Docker is not running in this environment, start it first — `sudo service docker start` — Docker does not auto-start here.)
+
+- [ ] **Step 3: Verify the image runs prod-like with the profiler present**
+
+```bash
+docker run --rm --entrypoint php timetracker:profiling-local bin/console about | grep -E "Environment|Debug"
+docker run --rm --entrypoint php timetracker:profiling-local bin/console debug:router | grep _profiler
+```
+Expected: `Environment  profiling`, `Debug  false`; `/_profiler` + `/_wdt` routes present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Dockerfile
+git commit -s -m "build(profiler): add prod-like APP_ENV=profiling image stage"
+```
+
+---
+
+### Task 5: Publish the `:profiling` image from the pipeline
+
+Add a Bake target for the new stage and a CI step that builds + pushes `:profiling` on the default branch (never auto-deployed).
+
+**Files:**
+- Modify: `docker-bake.hcl`
+- Modify: `.github/workflows/docker-publish.yml`
+
+**Interfaces:**
+- Consumes: the `profiling` Dockerfile stage (Task 4).
+
+- [ ] **Step 1: Add the bake target**
+
+In `docker-bake.hcl`, after the `app-e2e` target, add:
+
+```hcl
+# Profiling image (prod-like + Symfony profiler, admin-gated). Built by CI,
+# never the default deployment — operators switch to :profiling on demand.
+target "app-profiling" {
+  inherits = ["_common"]
+  target   = "profiling"
+  tags = compact([
+    "${REGISTRY}/${IMAGE_NAME}:profiling",
+    GIT_SHA != "" ? "${REGISTRY}/${IMAGE_NAME}:profiling-${GIT_SHA}" : "",
+  ])
+}
+```
+
+In the same file, add `app-profiling` to the `all` group:
+
+```hcl
+group "all" {
+  targets = ["app", "app-dev", "app-tools", "app-e2e", "app-profiling"]
+}
+```
+
+- [ ] **Step 2: Verify the bake config resolves**
+
+Run: `docker buildx bake --print app-profiling`
+Expected: JSON showing `target = "profiling"` and the `:profiling` tag(s); no error.
+
+- [ ] **Step 3: Add the CI publish step**
+
+In `.github/workflows/docker-publish.yml`, after the "Build and push E2E image" step, add:
+
+```yaml
+      - name: Build and push profiling image
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
+        env:
+          GIT_SHA: ${{ github.sha }}
+        with:
+          source: .
+          targets: app-profiling
+          files: docker-bake.hcl
+          push: ${{ github.event_name != 'pull_request' }}
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max,ignore-error=true
+```
+
+- [ ] **Step 4: Verify the workflow is valid YAML**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/docker-publish.yml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-bake.hcl .github/workflows/docker-publish.yml
+git commit -s -m "ci(profiler): build and push the :profiling image"
+```
+
+---
+
+### Task 6: Document the switch in the deploy runbook
+
+Record how to switch the server to `:profiling` and back, and that it is never the default.
+
+**Files:**
+- Modify: the deploy/ops doc (find it: `ls docs/ AGENTS.md README.md docker/README.md 2>/dev/null` and pick the existing deployment/runbook doc; if none exists, add a short `docs/profiling.md`).
+
+- [ ] **Step 1: Add the runbook section**
+
+Document, in prose: pull `:profiling`, switch the running container's image tag to it (compose image override / hot-deploy), reproduce the issue **as an admin**, open the web-debug-toolbar / `/_profiler/{token}?panel=db` for the slow request (e.g. `/getAllCustomers`), then **switch the tag back to `:production`**. Note: non-admins see nothing on this image; `:profiling` is never the default deployment; collected profiles vanish when the container is replaced.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add -A
+git commit -s -m "docs(profiler): document switching to the profiling image"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two images / pipeline → Tasks 4, 5. ✓
+- Prod-like profiling env → Task 3 (config) + Task 4 (`APP_DEBUG=0`, optimized autoloader, prod doctrine cache import). ✓
+- Profiler dormant, admin-only activation → Task 3 (`collect: false`) + Task 1 (gate subscriber). ✓
+- `/_profiler` ROLE_ADMIN-locked, incl. the `dev`-firewall pitfall → Task 3 Steps 6 & 8. ✓
+- DB panel works (Doctrine profiling) → Task 3 Step 5. ✓
+- Sensitive collectors removed → Task 2. ✓
+- Production/prod env untouched → Task 3 Step 10 verifies; bundles stay `require-dev` (only the profiling image installs them). ✓
+- Ops/runbook → Task 6. ✓
+- Time-panel/`stopwatch` caveat (spec §7): `composer install` (dev) in Task 4 pulls `symfony/stopwatch` transitively via web-profiler-bundle; if the Time panel is empty in Task 4 Step 3, add `symfony/stopwatch` explicitly to `require-dev` — noted here rather than as a separate task since it is a verify-and-maybe-add.
+
+**Placeholder scan:** none — every code/config step shows full content; verification steps give exact commands + expected output.
+
+**Type consistency:** `ProfilerAdminGateSubscriber(Security, Profiler)` and `RemoveSensitiveCollectorsPass::process(ContainerBuilder)` are used identically in their tests, the kernel wiring, and `config/services_profiling.yaml`. Service id `profiler` and route prefixes `/_profiler` `/_wdt` are consistent across Tasks 1, 3.

--- a/docs/superpowers/specs/2026-06-26-admin-gated-production-profiler-design.md
+++ b/docs/superpowers/specs/2026-06-26-admin-gated-production-profiler-design.md
@@ -1,0 +1,115 @@
+# Admin-gated production profiler — design
+
+- **Date:** 2026-06-26
+- **Status:** Approved (design); implementation plan pending
+- **Author:** Sebastian Mendel
+
+## Goal
+
+Let an **admin enable the full Symfony web profiler (web-debug-toolbar + `/_profiler`) for their own session in production**, on demand and time-boxed, so real-world production profiling data can be captured and attached to issue reports.
+
+Motivation: profiling problems often need real production data. Developers may be able to run profiling on prod, but other admins cannot, and so cannot provide detailed data when reporting an issue (e.g. the recently-observed slow first load of `/ui/admin` Customers/Projects). This feature gives any admin a self-service way to collect that data.
+
+## Non-goals (YAGNI)
+
+- No password re-authentication or IP-pinning to enable profiling (can be added later).
+- No web UI to run `bin/console` commands.
+- No purpose-built custom diagnostics panel — we expose the real Symfony profiler, not a re-implementation.
+- No profiling for non-admins.
+
+## Approach
+
+**Dormant by default, opt-in per admin, time-boxed.** The profiler is shipped to prod but collects nothing until a specific admin turns it on for their own session. This keeps the default production behaviour, overhead, and attack surface unchanged.
+
+## Architecture & flow
+
+1. **Ship the bundles to prod, dormant.**
+   - Move `symfony/web-profiler-bundle` and `symfony/debug-bundle` from `require-dev` to `require` in `composer.json` (so `composer install --no-dev` in the prod image still installs them).
+   - Enable `WebProfilerBundle` (and `DebugBundle`) for `prod` in `config/bundles.php` (currently `['dev' => true, 'test' => true]`).
+   - Add `config/packages/prod/web_profiler.yaml`:
+     - `framework.profiler: { enabled: true, collect: false }` — the profiler service exists but collects on **no** request unless explicitly enabled per-request.
+     - `web_profiler: { toolbar: true, intercept_redirects: false }` — the toolbar only injects when a profile was actually collected, so `collect: false` means no toolbar for normal traffic.
+
+2. **Per-admin, time-boxed opt-in (session-based).**
+   - `POST /profiling/enable` (ROLE_ADMIN) → sets session key `profiler_until = now + TTL` (TTL = **30 minutes**).
+   - `POST /profiling/disable` (ROLE_ADMIN) → clears the key and purges that session's collected profiles.
+   - `GET /profiling/status` (ROLE_ADMIN) → `{ active: bool, remainingSeconds: int }`.
+   - Session-based = per-browser, exactly "enable for myself". Auto-expires; manual off supported.
+
+3. **Gate listener (`kernel.request`, high priority, after firewall).**
+   - If the authenticated token's user has `ROLE_ADMIN` **and** `profiler_until` is set and in the future → call `Profiler::enable()` for this request.
+   - Otherwise: do nothing (profiler stays dormant).
+   - Reads the real authenticated user from the security token — never a client-supplied header.
+   - Never enables on the login route (`_login`) so credentials are never collected.
+
+4. **Make the data useful (Doctrine query panel).**
+   - `config/packages/doctrine.yaml` sets `dbal.profiling: '%kernel.debug%'` → `false` in prod, which leaves the profiler's DB panel empty.
+   - In `config/packages/prod/doctrine.yaml` (or the prod profiler config) enable `dbal.profiling: true` so the query list, timings, and `EXPLAIN` appear. Small per-request overhead; acceptable and only matters for the (rare) profiled requests in practice. Keep `profiling_collect_backtrace: false` to bound memory.
+   - Caveat to verify during implementation: some collectors (e.g. the **Time** panel via `symfony/stopwatch`) are normally wired only under `kernel.debug`. Confirm which panels populate in an `APP_ENV=prod` build with the profiler enabled, and pull `symfony/stopwatch` into `require` if the timeline panel is wanted in prod.
+
+5. **Lock down the profiler routes.**
+   - Load the profiler routes in prod: add `config/routes/prod/web_profiler.yaml` (mirroring the existing `config/routes/dev/web_profiler.yaml`) exposing `/_wdt` and `/_profiler`.
+   - In `config/packages/security.yaml`, add **above** the `^/ → IS_AUTHENTICATED_FULLY` catch-all:
+     - `{ path: ^/_(profiler|wdt), roles: ROLE_ADMIN }`
+   - The prod `dev` firewall pattern (`^/(_(profiler|wdt)|...)`) is dev-only; in prod these paths fall under the `main` firewall, so they are authenticated + now ROLE_ADMIN-gated.
+
+6. **Reduce panel exposure.**
+   - A small `CompilerPass` removes the most sensitive data collectors in prod so their panels are absent: the **dump** collector (`VarDumper`) and the **config** collector (`Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector`), plus scrub server/env params from the request collector where feasible.
+   - Remaining panels: Database (Doctrine), Time, Memory, Request/Response, Routing, Events, Logs, Cache — the perf-relevant ones.
+   - Exact collector service IDs to be confirmed during implementation.
+
+7. **Frontend toggle (admin-only).**
+   - A ROLE_ADMIN-only control on the **Settings** page: "Production profiling" with on/off, remaining time, and a link to `/_profiler`.
+   - Visible only when `hasRole('ROLE_ADMIN')` (helper already exists in `frontend/src/config.ts`).
+   - Calls `/profiling/enable|disable|status`; reflects state and counts down remaining time.
+
+## Components (units)
+
+| Unit | Responsibility | Interface | Depends on |
+|------|----------------|-----------|------------|
+| `ProfilingSession` service | Enable/disable/inspect the time-boxed opt-in | `enable(): void`, `disable(): void`, `isActive(): bool`, `remainingSeconds(): int` | Session, clock |
+| `ProfilingController` | `enable`/`disable`/`status` actions | 3 routes, JSON, ROLE_ADMIN | `ProfilingSession` |
+| `EnableProfilerListener` | Per-request gate that flips the profiler on | `kernel.request` subscriber | `Profiler`, security token, `ProfilingSession` |
+| `RemoveSensitiveCollectorsPass` | Drop dump/config collectors in prod | compiler pass | container |
+| Config + infra | composer move, bundles.php, prod `web_profiler.yaml` + `doctrine.yaml`, prod routes, security access_control | — | — |
+| Frontend `ProfilingToggle` | Admin-only on/off + status + `/_profiler` link | Solid component + API hook | `config.ts` `hasRole`, api client |
+| Profile hygiene | Purge on disable + bounded max-age storage | (storage DSN / disable hook) | profiler storage |
+
+## Lifecycle / hygiene
+
+- **Time-box:** 30-minute TTL, auto-expires; the listener treats an expired flag as off.
+- **Purge:** on `disable`, delete profiles collected for that session; storage uses a bounded max-age (e.g. `file:%kernel.cache_dir%/profiler` with a periodic/maxage purge) so nothing accumulates indefinitely.
+- **Login never profiled** (credential safety).
+
+## Security model (explicitly accepted)
+
+- Only `ROLE_ADMIN` can enable; collection is the enabling admin's own authenticated requests only; time-boxed; `/_profiler` + `/_wdt` are `ROLE_ADMIN`-locked under the `main` firewall.
+- **Accepted residual risks:**
+  1. Profiler panels can reveal server/env data and request bodies to anyone who can open `/_profiler` (any `ROLE_ADMIN`). Mitigated by removing the dump/config collectors and never profiling the login route; the remainder is accepted within the ROLE_ADMIN trust boundary.
+  2. One admin can view another admin's collected profile (listed by token). Accepted within ROLE_ADMIN trust.
+  3. Stored profiles hold sensitive request data → isolated dir + purge-on-disable + bounded max-age.
+  4. Larger attack surface; an admin session hijack also reaches the profiler. Mitigated by dormant-by-default + 30-min time-box.
+
+## Testing strategy
+
+**Backend**
+- `EnableProfilerListener`: enables the profiler **only** when user is ROLE_ADMIN **and** flag active; not for non-admins, not when expired, not on `_login`.
+- `ProfilingController`: `enable`/`disable`/`status` require ROLE_ADMIN (403 otherwise); `enable` sets a future expiry; `disable` clears it; `status` reports remaining time.
+- `ProfilingSession`: TTL math, expiry boundary.
+- Security: a functional test that `/_profiler` is 403 for a non-admin and reachable for an admin (route loaded in the test/prod-like env).
+
+**Frontend**
+- `ProfilingToggle` renders only for `ROLE_ADMIN`; reflects active/inactive + remaining time; posts to enable/disable; hidden for non-admins.
+
+## Rollout / deployment notes
+
+- The prod container self-migrates on start; this feature needs **no DB migration** (session-based flag).
+- After deploy, `composer install --no-dev` must now include the two bundles (they moved to `require`) — verify the prod image builds and the profiler stays dormant (`collect: false`) until enabled.
+- CI builds but does not run the prod entrypoint — validate the prod profiler config (dormant by default, routes gated) locally against an `APP_ENV=prod` build before shipping.
+
+## Resolved decisions
+
+- Viewing surface: **full web-debug-toolbar + `/_profiler`** (not a custom export).
+- Time-box: **30 minutes**, auto-expire + manual off.
+- Toggle location: **Settings page**, admin-only section.
+- Residual risks (above) **accepted**, including removing the secrets/config/dump collectors.

--- a/docs/superpowers/specs/2026-06-26-admin-gated-production-profiler-design.md
+++ b/docs/superpowers/specs/2026-06-26-admin-gated-production-profiler-design.md
@@ -1,4 +1,4 @@
-# Admin-gated production profiler — design
+# Admin-gated production profiler (two-image pipeline) — design
 
 - **Date:** 2026-06-26
 - **Status:** Approved (design); implementation plan pending
@@ -6,110 +6,90 @@
 
 ## Goal
 
-Let an **admin enable the full Symfony web profiler (web-debug-toolbar + `/_profiler`) for their own session in production**, on demand and time-boxed, so real-world production profiling data can be captured and attached to issue reports.
+Let an **admin use the full Symfony web profiler (web-debug-toolbar + `/_profiler`) against the production server** to capture real-world profiling data for issue reports — without the default production image ever carrying profiler code.
 
-Motivation: profiling problems often need real production data. Developers may be able to run profiling on prod, but other admins cannot, and so cannot provide detailed data when reporting an issue (e.g. the recently-observed slow first load of `/ui/admin` Customers/Projects). This feature gives any admin a self-service way to collect that data.
+Achieved by building a **second, dedicated "profiling" image** alongside the normal production image. The production server runs `:production` by default; when profiling is needed, an operator **switches the running image to `:profiling`**, captures data, then switches back. Inside the profiling image the profiler is **only ever exposed to admins**.
+
+Motivation: profiling problems needs real production data; non-developer admins currently cannot capture it and so cannot provide detailed issue reports (e.g. the slow first load of `/ui/admin` Customers/Projects). The image swap is a deliberate, auditable infrastructure action — not a runtime flag a bug could flip.
 
 ## Non-goals (YAGNI)
 
-- No password re-authentication or IP-pinning to enable profiling (can be added later).
+- No in-app enable/disable toggle, no per-session time-box, no profiling endpoints, no frontend control. The image swap is the activation; ROLE_ADMIN is the in-image gate.
+- No profiler code in the default production image.
 - No web UI to run `bin/console` commands.
-- No purpose-built custom diagnostics panel — we expose the real Symfony profiler, not a re-implementation.
-- No profiling for non-admins.
+- No password re-auth or IP-pinning.
+- No profiling for non-admins (never collected, toolbar never injected, `/_profiler` 403).
 
 ## Approach
 
-**Dormant by default, opt-in per admin, time-boxed.** The profiler is shipped to prod but collects nothing until a specific admin turns it on for their own session. This keeps the default production behaviour, overhead, and attack surface unchanged.
+**Two images from one pipeline.**
 
-## Architecture & flow
+- **`:production`** — unchanged. `APP_ENV=prod`, `composer install --no-dev`. No profiler bundles. This stays the default deployed image.
+- **`:profiling`** — new. **Prod-like** (`APP_ENV=profiling`, debug OFF, optimized autoloader, prod cache warmup) so measured timings are representative — *plus* the profiler bundles installed and the Symfony profiler enabled, gated to admins. Built and pushed by CI but **never deployed by default**; an operator switches to it on demand.
 
-1. **Ship the bundles to prod, dormant.**
-   - Move `symfony/web-profiler-bundle` and `symfony/debug-bundle` from `require-dev` to `require` in `composer.json` (so `composer install --no-dev` in the prod image still installs them).
-   - Enable `WebProfilerBundle` (and `DebugBundle`) for `prod` in `config/bundles.php` (currently `['dev' => true, 'test' => true]`).
-   - Add `config/packages/prod/web_profiler.yaml`:
-     - `framework.profiler: { enabled: true, collect: false }` — the profiler service exists but collects on **no** request unless explicitly enabled per-request.
-     - `web_profiler: { toolbar: true, intercept_redirects: false }` — the toolbar only injects when a profile was actually collected, so `collect: false` means no toolbar for normal traffic.
+## Pipeline changes
 
-2. **Per-admin, time-boxed opt-in (session-based).**
-   - `POST /profiling/enable` (ROLE_ADMIN) → sets session key `profiler_until = now + TTL` (TTL = **30 minutes**).
-   - `POST /profiling/disable` (ROLE_ADMIN) → clears the key and purges that session's collected profiles.
-   - `GET /profiling/status` (ROLE_ADMIN) → `{ active: bool, remainingSeconds: int }`.
-   - Session-based = per-browser, exactly "enable for myself". Auto-expires; manual off supported.
+Current build (`docker-bake.hcl` + `.github/workflows/docker-publish.yml`): target `app` → Dockerfile stage `production` (tags `:production`/`:latest`/semver/sha); `app-e2e` → stage `e2e`.
 
-3. **Gate listener (`kernel.request`, high priority, after firewall).**
-   - If the authenticated token's user has `ROLE_ADMIN` **and** `profiler_until` is set and in the future → call `Profiler::enable()` for this request.
-   - Otherwise: do nothing (profiler stays dormant).
-   - Reads the real authenticated user from the security token — never a client-supplied header.
-   - Never enables on the login route (`_login`) so credentials are never collected.
+1. **New Dockerfile stage `profiling`.** Prod-like, like `production` (optimized autoloader, `APP_DEBUG=0`, prod cache warmup) but:
+   - Installs the profiler bundles (does **not** pass `--no-dev`, or installs `web-profiler-bundle` + `debug-bundle` + `stopwatch` explicitly), keeping an optimized autoloader.
+   - Sets `ENV APP_ENV=profiling`.
+   - (Exact stage structuring — `FROM base` mirroring `production` vs `FROM production` + add deps + re-warm cache — decided in the implementation plan; the autoloader-optimization and prod cache-warmup must be preserved.)
+2. **New bake target `app-profiling`** in `docker-bake.hcl` → stage `profiling`, tag `${REGISTRY}/${IMAGE_NAME}:profiling` (and optionally `:profiling-${GIT_SHA}` for an immutable pin), added to the `all` / a `ci` group.
+3. **CI push step** in `docker-publish.yml`: a `docker/bake-action` step with `targets: app-profiling`, pushed on the default branch only (mirrors the production/e2e steps). The image goes to GHCR like the others.
 
-4. **Make the data useful (Doctrine query panel).**
-   - `config/packages/doctrine.yaml` sets `dbal.profiling: '%kernel.debug%'` → `false` in prod, which leaves the profiler's DB panel empty.
-   - In `config/packages/prod/doctrine.yaml` (or the prod profiler config) enable `dbal.profiling: true` so the query list, timings, and `EXPLAIN` appear. Small per-request overhead; acceptable and only matters for the (rare) profiled requests in practice. Keep `profiling_collect_backtrace: false` to bound memory.
-   - Caveat to verify during implementation: some collectors (e.g. the **Time** panel via `symfony/stopwatch`) are normally wired only under `kernel.debug`. Confirm which panels populate in an `APP_ENV=prod` build with the profiler enabled, and pull `symfony/stopwatch` into `require` if the timeline panel is wanted in prod.
+## Application changes (small)
 
-5. **Lock down the profiler routes.**
-   - Load the profiler routes in prod: add `config/routes/prod/web_profiler.yaml` (mirroring the existing `config/routes/dev/web_profiler.yaml`) exposing `/_wdt` and `/_profiler`.
-   - In `config/packages/security.yaml`, add **above** the `^/ → IS_AUTHENTICATED_FULLY` catch-all:
-     - `{ path: ^/_(profiler|wdt), roles: ROLE_ADMIN }`
-   - The prod `dev` firewall pattern (`^/(_(profiler|wdt)|...)`) is dev-only; in prod these paths fall under the `main` firewall, so they are authenticated + now ROLE_ADMIN-gated.
+All scoped to the `profiling` env; the `prod` env is untouched.
 
-6. **Reduce panel exposure.**
-   - A small `CompilerPass` removes the most sensitive data collectors in prod so their panels are absent: the **dump** collector (`VarDumper`) and the **config** collector (`Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector`), plus scrub server/env params from the request collector where feasible.
-   - Remaining panels: Database (Doctrine), Time, Memory, Request/Response, Routing, Events, Logs, Cache — the perf-relevant ones.
-   - Exact collector service IDs to be confirmed during implementation.
-
-7. **Frontend toggle (admin-only).**
-   - A ROLE_ADMIN-only control on the **Settings** page: "Production profiling" with on/off, remaining time, and a link to `/_profiler`.
-   - Visible only when `hasRole('ROLE_ADMIN')` (helper already exists in `frontend/src/config.ts`).
-   - Calls `/profiling/enable|disable|status`; reflects state and counts down remaining time.
+1. **Bundles per env.** `config/bundles.php`: enable `WebProfilerBundle` and `DebugBundle` for `profiling` (currently `['dev' => true, 'test' => true]`). Composer keeps the bundles in `require-dev`; only the profiling image installs dev deps.
+2. **Profiler config** `config/packages/profiling/web_profiler.yaml`:
+   - `framework.profiler: { enabled: true, collect: true }`.
+   - `web_profiler: { toolbar: true, intercept_redirects: false }`.
+3. **Collect only for admins** — `CollectForAdminsOnlyListener` (`kernel.request`, after the firewall sets the token): if the authenticated user is **not** `ROLE_ADMIN`, call `Profiler::disable()` for the request. So non-admins are never collected and never get the toolbar; the (unauthenticated) login route is naturally skipped (no admin token yet). Admins get full collection + toolbar on HTML pages, and every SPA XHR gets an `X-Debug-Token` viewable in `/_profiler/{token}?panel=db`.
+4. **Route lock.** Load the profiler routes in the profiling env (`config/routes/profiling/web_profiler.yaml`, mirroring the dev one for `/_wdt` + `/_profiler`). In `config/packages/security.yaml`, add **above** the `^/ → IS_AUTHENTICATED_FULLY` catch-all: `{ path: ^/_(profiler|wdt), roles: ROLE_ADMIN }`. (Harmless in `prod`/`dev` — those paths don't exist in `prod`, and `dev` has its own firewall.)
+5. **Make the DB panel work.** `doctrine.yaml` sets `dbal.profiling: '%kernel.debug%'` (false when debug is off). In `config/packages/profiling/doctrine.yaml` set `dbal.profiling: true` (with `profiling_collect_backtrace: false` to bound memory) so the query list, timings, and `EXPLAIN` populate — the whole point for perf work.
+6. **Trim sensitive panels.** A `CompilerPass` (registered only in the profiling env) removes the **dump** (`VarDumper`) and **config** (`ConfigDataCollector`) data collectors so their panels are absent. Keep DB/Time/Memory/Request/Routing/Events/Logs/Cache. Exact collector service IDs confirmed during implementation.
+7. **Time panel caveat.** The Time panel needs `symfony/stopwatch`, normally wired under `kernel.debug`. Verify it populates in the `profiling` env (debug off); pull `symfony/stopwatch` into the installed set if the timeline is wanted.
+8. **(Optional) status hint.** Surface "running profiling image" on the existing `/ui/admin` status surface (which already shows git ref / build date), so admins can tell at a glance they're on the profiling build. Low effort, reuses an existing panel.
 
 ## Components (units)
 
 | Unit | Responsibility | Interface | Depends on |
 |------|----------------|-----------|------------|
-| `ProfilingSession` service | Enable/disable/inspect the time-boxed opt-in | `enable(): void`, `disable(): void`, `isActive(): bool`, `remainingSeconds(): int` | Session, clock |
-| `ProfilingController` | `enable`/`disable`/`status` actions | 3 routes, JSON, ROLE_ADMIN | `ProfilingSession` |
-| `EnableProfilerListener` | Per-request gate that flips the profiler on | `kernel.request` subscriber | `Profiler`, security token, `ProfilingSession` |
-| `RemoveSensitiveCollectorsPass` | Drop dump/config collectors in prod | compiler pass | container |
-| Config + infra | composer move, bundles.php, prod `web_profiler.yaml` + `doctrine.yaml`, prod routes, security access_control | — | — |
-| Frontend `ProfilingToggle` | Admin-only on/off + status + `/_profiler` link | Solid component + API hook | `config.ts` `hasRole`, api client |
-| Profile hygiene | Purge on disable + bounded max-age storage | (storage DSN / disable hook) | profiler storage |
-
-## Lifecycle / hygiene
-
-- **Time-box:** 30-minute TTL, auto-expires; the listener treats an expired flag as off.
-- **Purge:** on `disable`, delete profiles collected for that session; storage uses a bounded max-age (e.g. `file:%kernel.cache_dir%/profiler` with a periodic/maxage purge) so nothing accumulates indefinitely.
-- **Login never profiled** (credential safety).
+| Dockerfile `profiling` stage | Prod-like image + profiler bundles, `APP_ENV=profiling` | build stage | `base`/`production` |
+| `app-profiling` bake target | Build/tag `:profiling` | bake target | Dockerfile stage |
+| CI push step | Build+push `:profiling` on default branch | workflow step | bake target |
+| `config/packages/profiling/*` | Enable profiler, toolbar, doctrine profiling | config | bundles |
+| `config/bundles.php` | Enable WebProfiler/Debug bundles for `profiling` | config | — |
+| `config/routes/profiling/web_profiler.yaml` | Load `/_wdt` + `/_profiler` | routes | bundle |
+| `security.yaml` access_control | ROLE_ADMIN-lock `/_(profiler|wdt)` | config | — |
+| `CollectForAdminsOnlyListener` | Disable profiler for non-admins | `kernel.request` subscriber | `Profiler`, security token |
+| `RemoveSensitiveCollectorsPass` | Drop dump/config collectors in profiling env | compiler pass | container |
 
 ## Security model (explicitly accepted)
 
-- Only `ROLE_ADMIN` can enable; collection is the enabling admin's own authenticated requests only; time-boxed; `/_profiler` + `/_wdt` are `ROLE_ADMIN`-locked under the `main` firewall.
-- **Accepted residual risks:**
-  1. Profiler panels can reveal server/env data and request bodies to anyone who can open `/_profiler` (any `ROLE_ADMIN`). Mitigated by removing the dump/config collectors and never profiling the login route; the remainder is accepted within the ROLE_ADMIN trust boundary.
+- The default production image contains **no profiler code** — zero added surface in normal operation.
+- The profiling image is a **deliberate, temporary, operator-initiated** switch. While running it:
+  - Non-admins: never collected, no toolbar, `/_profiler` → 403.
+  - Admins: full toolbar + `/_profiler`.
+- **Accepted residual risks (only while the profiling image is deployed):**
+  1. Profiler panels can reveal server/env data and request bodies to any `ROLE_ADMIN`. Mitigated by removing the dump/config collectors; the rest is accepted within the ROLE_ADMIN trust boundary.
   2. One admin can view another admin's collected profile (listed by token). Accepted within ROLE_ADMIN trust.
-  3. Stored profiles hold sensitive request data → isolated dir + purge-on-disable + bounded max-age.
-  4. Larger attack surface; an admin session hijack also reaches the profiler. Mitigated by dormant-by-default + 30-min time-box.
+  3. Stored profiles hold sensitive request data → bounded by the image being temporary; profiles live in the container's cache dir and vanish when it's swapped back.
+  4. Larger attack surface; an admin session hijack also reaches the profiler. Bounded by the temporary, deliberate switch.
 
-## Testing strategy
+## Operations / rollout
 
-**Backend**
-- `EnableProfilerListener`: enables the profiler **only** when user is ROLE_ADMIN **and** flag active; not for non-admins, not when expired, not on `_login`.
-- `ProfilingController`: `enable`/`disable`/`status` require ROLE_ADMIN (403 otherwise); `enable` sets a future expiry; `disable` clears it; `status` reports remaining time.
-- `ProfilingSession`: TTL math, expiry boundary.
-- Security: a functional test that `/_profiler` is 403 for a non-admin and reachable for an admin (route loaded in the test/prod-like env).
-
-**Frontend**
-- `ProfilingToggle` renders only for `ROLE_ADMIN`; reflects active/inactive + remaining time; posts to enable/disable; hidden for non-admins.
-
-## Rollout / deployment notes
-
-- The prod container self-migrates on start; this feature needs **no DB migration** (session-based flag).
-- After deploy, `composer install --no-dev` must now include the two bundles (they moved to `require`) — verify the prod image builds and the profiler stays dormant (`collect: false`) until enabled.
-- CI builds but does not run the prod entrypoint — validate the prod profiler config (dormant by default, routes gated) locally against an `APP_ENV=prod` build before shipping.
+- **Default unchanged:** prod runs `:production`. CI also publishes `:profiling`, which is **never auto-deployed**.
+- **To profile:** switch the running container's image tag to `:profiling` (compose image override / hot-deploy), reproduce the issue as an admin, read the toolbar / `/_profiler`, then **switch back to `:production`**.
+- Document the switch + switch-back in the deploy runbook; treat `:profiling` as never-the-default.
+- No DB migration. CI builds but does not run the prod entrypoint — validate the `profiling` image locally (admin sees toolbar, non-admin gets 403, perf is prod-representative) before relying on it.
 
 ## Resolved decisions
 
-- Viewing surface: **full web-debug-toolbar + `/_profiler`** (not a custom export).
-- Time-box: **30 minutes**, auto-expire + manual off.
-- Toggle location: **Settings page**, admin-only section.
-- Residual risks (above) **accepted**, including removing the secrets/config/dump collectors.
+- Delivery: **two images** (`:production` unchanged, new `:profiling`), switch on the server. Composer bundles stay `require-dev`; only the profiling image installs them.
+- Profiling env: **prod-like `APP_ENV=profiling`** (debug off, prod caches) for representative timings.
+- In-image activation: **always-on for admins** — no toggle/time-box; ROLE_ADMIN is the in-image gate, the image swap is the activation.
+- Viewing surface: **full web-debug-toolbar + `/_profiler`**.
+- Sensitive collectors (dump/config) **removed**; residual risks **accepted**.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,7 @@
         <testsuite name="unit">
             <directory>tests/Dto</directory>
             <directory>tests/DTO/Jira</directory>
+            <directory>tests/DependencyInjection</directory>
             <directory>tests/Event</directory>
             <directory>tests/EventSubscriber</directory>
             <directory>tests/Extension</directory>

--- a/src/DependencyInjection/Compiler/RemoveSensitiveCollectorsPass.php
+++ b/src/DependencyInjection/Compiler/RemoveSensitiveCollectorsPass.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Removes the profiler data collectors that can surface env/secret data
+ * (dump, config). Registered from Kernel::build() in the `profiling` env only,
+ * so the kept panels are DB/Time/Memory/Request/Routing/Events/Logs/Cache.
+ */
+final class RemoveSensitiveCollectorsPass implements CompilerPassInterface
+{
+    private const array SENSITIVE_COLLECTORS = [
+        'data_collector.dump',
+        'data_collector.config',
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (self::SENSITIVE_COLLECTORS as $id) {
+            if ($container->hasDefinition($id)) {
+                $container->removeDefinition($id);
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/RemoveSensitiveCollectorsPass.php
+++ b/src/DependencyInjection/Compiler/RemoveSensitiveCollectorsPass.php
@@ -13,9 +13,12 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Removes the profiler data collectors that can surface env/secret data
- * (dump, config). Registered from Kernel::build() in the `profiling` env only,
- * so the kept panels are DB/Time/Memory/Request/Routing/Events/Logs/Cache.
+ * Strips the profiler data collectors that can surface env/secret data (dump,
+ * config) by removing their `data_collector` tag — they vanish from the profiler
+ * and stop collecting, while their service definitions stay intact so anything
+ * referencing them (e.g. the VarDumper listener) still resolves. Registered from
+ * Kernel::build() in the `profiling` env, BEFORE Symfony's ProfilerPass reads the
+ * tags. Kept panels: DB/Time/Memory/Request/Routing/Events/Logs/Cache.
  */
 final class RemoveSensitiveCollectorsPass implements CompilerPassInterface
 {
@@ -28,7 +31,7 @@ final class RemoveSensitiveCollectorsPass implements CompilerPassInterface
     {
         foreach (self::SENSITIVE_COLLECTORS as $id) {
             if ($container->hasDefinition($id)) {
-                $container->removeDefinition($id);
+                $container->getDefinition($id)->clearTag('data_collector');
             }
         }
     }

--- a/src/EventSubscriber/ProfilerAdminGateSubscriber.php
+++ b/src/EventSubscriber/ProfilerAdminGateSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+/**
+ * Turns the profiler on only for admin requests. Registered solely in the
+ * `profiling` env (config/services_profiling.yaml), where the profiler is
+ * configured with `collect: false`; this is the only switch that enables
+ * collection — and therefore the web-debug-toolbar — and only for ROLE_ADMIN.
+ * Runs after the firewall (priority 8) so the security token is resolved.
+ */
+final readonly class ProfilerAdminGateSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private Security $security,
+        #[Autowire(service: 'profiler')]
+        private Profiler $profiler,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 4],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        // isGranted() resolves the lazy firewall token; false for anonymous
+        // requests (e.g. the login page), so credentials are never profiled.
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            $this->profiler->enable();
+        }
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -12,6 +12,7 @@ namespace App;
 use App\DependencyInjection\Compiler\RemoveSensitiveCollectorsPass;
 use Override;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
@@ -58,9 +59,15 @@ class Kernel extends BaseKernel
     protected function build(ContainerBuilder $container): void
     {
         // The profiling image enables the web profiler; strip the data
-        // collectors that could surface env/secret data (dump, config).
+        // collectors that could surface env/secret data (dump, config). Priority
+        // 1000 runs this before Symfony's ProfilerPass (priority 0) reads the
+        // `data_collector` tags, so the untagged collectors are never registered.
         if ('profiling' === $this->environment) {
-            $container->addCompilerPass(new RemoveSensitiveCollectorsPass());
+            $container->addCompilerPass(
+                new RemoveSensitiveCollectorsPass(),
+                PassConfig::TYPE_BEFORE_OPTIMIZATION,
+                1000,
+            );
         }
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\DependencyInjection\Compiler\RemoveSensitiveCollectorsPass;
 use Override;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
@@ -50,5 +52,15 @@ class Kernel extends BaseKernel
     public function getProjectDir(): string
     {
         return dirname(__DIR__);
+    }
+
+    #[Override]
+    protected function build(ContainerBuilder $container): void
+    {
+        // The profiling image enables the web profiler; strip the data
+        // collectors that could surface env/secret data (dump, config).
+        if ('profiling' === $this->environment) {
+            $container->addCompilerPass(new RemoveSensitiveCollectorsPass());
+        }
     }
 }

--- a/tests/DependencyInjection/Compiler/RemoveSensitiveCollectorsPassTest.php
+++ b/tests/DependencyInjection/Compiler/RemoveSensitiveCollectorsPassTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\DependencyInjection\Compiler;
+
+use App\DependencyInjection\Compiler\RemoveSensitiveCollectorsPass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+#[CoversClass(RemoveSensitiveCollectorsPass::class)]
+final class RemoveSensitiveCollectorsPassTest extends TestCase
+{
+    public function testRemovesDumpAndConfigCollectorsButKeepsOthers(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('data_collector.dump', stdClass::class);
+        $container->register('data_collector.config', stdClass::class);
+        $container->register('data_collector.request', stdClass::class);
+
+        new RemoveSensitiveCollectorsPass()->process($container);
+
+        self::assertFalse($container->hasDefinition('data_collector.dump'));
+        self::assertFalse($container->hasDefinition('data_collector.config'));
+        self::assertTrue($container->hasDefinition('data_collector.request'));
+    }
+
+    public function testIsANoOpWhenCollectorsAbsent(): void
+    {
+        $container = new ContainerBuilder();
+
+        new RemoveSensitiveCollectorsPass()->process($container);
+
+        self::assertFalse($container->hasDefinition('data_collector.dump'));
+    }
+}

--- a/tests/DependencyInjection/Compiler/RemoveSensitiveCollectorsPassTest.php
+++ b/tests/DependencyInjection/Compiler/RemoveSensitiveCollectorsPassTest.php
@@ -21,18 +21,21 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 #[CoversClass(RemoveSensitiveCollectorsPass::class)]
 final class RemoveSensitiveCollectorsPassTest extends TestCase
 {
-    public function testRemovesDumpAndConfigCollectorsButKeepsOthers(): void
+    public function testUntagsDumpAndConfigCollectorsButKeepsOthers(): void
     {
         $container = new ContainerBuilder();
-        $container->register('data_collector.dump', stdClass::class);
-        $container->register('data_collector.config', stdClass::class);
-        $container->register('data_collector.request', stdClass::class);
+        $container->register('data_collector.dump', stdClass::class)->addTag('data_collector');
+        $container->register('data_collector.config', stdClass::class)->addTag('data_collector');
+        $container->register('data_collector.request', stdClass::class)->addTag('data_collector');
 
         new RemoveSensitiveCollectorsPass()->process($container);
 
-        self::assertFalse($container->hasDefinition('data_collector.dump'));
-        self::assertFalse($container->hasDefinition('data_collector.config'));
-        self::assertTrue($container->hasDefinition('data_collector.request'));
+        // Tag removed → dropped from the profiler, no panel, no collection.
+        self::assertFalse($container->getDefinition('data_collector.dump')->hasTag('data_collector'));
+        self::assertFalse($container->getDefinition('data_collector.config')->hasTag('data_collector'));
+        self::assertTrue($container->getDefinition('data_collector.request')->hasTag('data_collector'));
+        // Definitions are kept so services that reference them still resolve.
+        self::assertTrue($container->hasDefinition('data_collector.dump'));
     }
 
     public function testIsANoOpWhenCollectorsAbsent(): void

--- a/tests/EventSubscriber/ProfilerAdminGateSubscriberTest.php
+++ b/tests/EventSubscriber/ProfilerAdminGateSubscriberTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\ProfilerAdminGateSubscriber;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProfilerAdminGateSubscriber::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class ProfilerAdminGateSubscriberTest extends TestCase
+{
+    private function event(): RequestEvent
+    {
+        $kernel = $this->createMock(HttpKernelInterface::class);
+
+        return new RequestEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
+    }
+
+    public function testEnablesProfilerForAdmin(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security->method('isGranted')->willReturn(true);
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects(self::once())->method('enable');
+
+        new ProfilerAdminGateSubscriber($security, $profiler)->onKernelRequest($this->event());
+    }
+
+    public function testLeavesProfilerDisabledForNonAdmin(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security->method('isGranted')->willReturn(false);
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects(self::never())->method('enable');
+
+        new ProfilerAdminGateSubscriber($security, $profiler)->onKernelRequest($this->event());
+    }
+
+    public function testSubscribesToKernelRequest(): void
+    {
+        self::assertArrayHasKey('kernel.request', ProfilerAdminGateSubscriber::getSubscribedEvents());
+    }
+}


### PR DESCRIPTION
## What

Adds an **admin-gated production profiler** via a second, prod-like image. The default `:production` image stays profiler-free; CI also builds `:profiling` (`APP_ENV=profiling`, debug off, optimized) which ships the Symfony web profiler exposed **only to admins**. An operator switches the server to `:profiling` on demand to capture real production profiling data for an issue report, then switches back.

Design: [`docs/superpowers/specs/2026-06-26-admin-gated-production-profiler-design.md`](docs/superpowers/specs/2026-06-26-admin-gated-production-profiler-design.md) · Plan: [`docs/superpowers/plans/2026-06-26-admin-gated-production-profiler.md`](docs/superpowers/plans/2026-06-26-admin-gated-production-profiler.md)

## How it works

- **Dormant by default.** The profiling env sets `framework.profiler.collect: false`. A `kernel.request` subscriber (`ProfilerAdminGateSubscriber`) calls `Profiler::enable()` only for `ROLE_ADMIN` requests — so non-admins are never collected and never see the toolbar; the login route is never profiled.
- **`/_profiler` + `/_wdt` are `ROLE_ADMIN`-locked.** The shared `dev` firewall (`security: false`) is narrowed to assets in the profiling env so those paths fall through to the authenticated `main` firewall, where the new `access_control` rule applies.
- **DB panel works:** Doctrine `dbal.profiling` is turned on in the profiling env (off in prod), so queries/timings/`EXPLAIN` populate — the point for perf work.
- **Reduced exposure:** a compiler pass strips the `dump` and `config` data collectors in the profiling env.
- **Two-image pipeline:** new Dockerfile `profiling` stage + `app-profiling` bake target + a CI publish step. The bundles stay `require-dev` — only the profiling image installs them; `:production` and the `prod` env are unchanged.

## Verification

- Unit tests (TDD) for the gate subscriber and the collector compiler pass; full unit suite green (1590), PHPStan + cs-fixer clean.
- Profiling container compiles (`lint:container`); `/_wdt` + `/_profiler` routes present; subscriber registered; `dev` firewall narrowed; **prod has no profiler routes**.
- Built the `:profiling` image via Bake and confirmed in-image: `Environment=profiling`, `Debug=false`, Xdebug absent, 14 profiler routes, DB/time/memory/request collectors present, **dump/config collectors removed**.

## Ops

Runbook in [`docs/DEPLOYMENT_GUIDE.md`](docs/DEPLOYMENT_GUIDE.md): pull `:profiling`, switch the running container to it, reproduce as an admin, read the toolbar / `/_profiler/{token}?panel=db`, then switch back to `:production`. Never the default deployment.
