### PR TITLE
fix(deps): resolve Dependabot alerts for uuid and http-proxy-middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "timetracker",
+  "name": "fix-dependabot-npm-uuid-hpm",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -4886,9 +4886,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7787,14 +7787,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/varint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "fix-dependabot-npm-uuid-hpm",
+  "name": "timetracker",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "timetracker",
       "license": "UNLICENSED",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "timetracker",
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@babel/core": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "node": "^22.13.0 || >=24.0.0"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "uuid": "11.1.1",
+    "http-proxy-middleware": "2.0.10"
   },
   "license": "UNLICENSED",
   "private": true,


### PR DESCRIPTION
## Description

Resolves the two open [Dependabot alerts](https://github.com/netresearch/timetracker/security/dependabot) (both medium/moderate, transitive npm build dependencies) by pinning the patched versions via npm `overrides`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — security dependency fix

## Related Issue

Dependabot alerts [#102](https://github.com/netresearch/timetracker/security/dependabot/102) and [#119](https://github.com/netresearch/timetracker/security/dependabot/119).

## Changes Made

- **`uuid` 8.3.2 → 11.1.1** (alert #102 — missing buffer bounds check in v3/v5/v6 when `buf` is provided). Forced via `overrides`. The only in-tree consumers — `sockjs` and `node-notifier` — use just the named `{ v4 }` export, which is unchanged across uuid 8→11. Pinned to the minimal patched release (`11.1.1`, the `legacy-11` line).
- **`http-proxy-middleware` 2.0.9 → 2.0.10** (alert #119 — Host-header-driven backend routing bypass). Forced via `overrides`; `2.0.10` satisfies `webpack-dev-server`'s `^2.0.9` requirement.

Both packages are dev-only build tooling (webpack-dev-server / webpack-notifier); neither ships in the production bundle. The lockfile diff is scoped to exactly these two `version` bumps — no other dependencies drift.

## Testing

- [x] Smoke test: under the new resolutions, `require('uuid').v4` works (returns a valid 36-char UUID) and both `sockjs` and `node-notifier` load without error; `http-proxy-middleware` resolves to `2.0.10`.
- [x] `npm install` regenerates a clean lockfile with `found 0 vulnerabilities`.

> [!NOTE]
> The production webpack build (`npm run build`) currently fails on `main` independently of this PR with `Encore.isRuntimeEnvironmentConfigured is not a function` — the lockfile pins `@symfony/webpack-encore@7.1.0` while `package.json` declares `^5.2.0`, and `webpack.config.js` calls an API removed in encore 7. Verified identical failure on a clean `origin/main` checkout (this PR's diff does not touch encore). Out of scope here, but worth a separate fix.

## Code Quality

- [x] Self-review completed
- [x] No breaking changes
