### PR TITLE
fix(profiler): register _profiler_vite route so the profiling toolbar renders

### DIFF
--- a/config/packages/profiling/monolog.yaml
+++ b/config/packages/profiling/monolog.yaml
@@ -1,0 +1,16 @@
+# The base monolog config only defines the `tracking` channel handler, so in the
+# profiling env application errors were logged nowhere — a toolbar/profiler 500
+# left no trace in `docker logs`. Route errors to the container's stderr so the
+# profiling image is debuggable (mirrors the prod handler, but to stderr).
+monolog:
+    handlers:
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+            buffer_size: 50
+        nested:
+            type: stream
+            path: "php://stderr"
+            level: debug

--- a/config/routes/profiling/vite_profiler.yaml
+++ b/config/routes/profiling/vite_profiler.yaml
@@ -1,0 +1,11 @@
+# The pentatrion/vite-bundle data collector is active in every env, but its
+# web-debug-toolbar block links to the `_profiler_vite` route, which the bundle
+# only registers under `when@dev`. In the profiling env the toolbar therefore
+# 500s ("route _profiler_vite does not exist") even though the profiler pages
+# render fine. Register the route here so the full toolbar works (mirrors how
+# the bundle wires it in dev). Covered by the ^/_(profiler|wdt) ROLE_ADMIN
+# access_control rule.
+_profiler_vite:
+    path: /_profiler/vite
+    defaults:
+        _controller: Pentatrion\ViteBundle\Controller\ProfilerController::info


### PR DESCRIPTION
## Problem

On the `:profiling` image, opening any page as an admin showed **"An error occurred while loading the web debug toolbar."** The toolbar AJAX (`/_wdt/{token}`) returned **500**, while the full profiler (`/_profiler/{token}`) returned **200** and worked.

## Root cause

`pentatrion/vite-bundle` registers a profiler **data collector** in *every* environment, but its web-debug-toolbar block links to the **`_profiler_vite`** route — which the bundle only registers under `when@dev`. In the `profiling` env that route doesn't exist, so:

- the profiler **page** renders the collector's *panel* block (no route call) → 200;
- the **toolbar** renders the collector's *toolbar* block, which calls `path('_profiler_vite')` → `RouteNotFoundException` → 500.

Diagnosed by building the profiling image and rendering the real toolbar controller in-process (the exception named the exact route + template `@PentatrionVite/Collector/vite_collector.html.twig:12`).

A second gap surfaced: the profiling env's monolog config only defined the `tracking` channel, so application errors were logged **nowhere** — the 500 left no trace in `docker logs`.

## Fix

- `config/routes/profiling/vite_profiler.yaml` — register `_profiler_vite` (mirrors the bundle's dev wiring). It falls under the existing `^/_(profiler|wdt)` ROLE_ADMIN `access_control` rule, so it stays admin-gated. Keeps the **full** toolbar working (vite panel included).
- `config/packages/profiling/monolog.yaml` — route errors to stderr so the profiling image is debuggable in `docker logs`.

Both scoped to the `profiling` env; `prod`/`:production` untouched.

## Verification

Built the `:profiling` image from this branch and rendered the real toolbar controller end-to-end: **`/_wdt/{token}` now returns 200** (was 500); `debug:router` shows `_profiler_vite` present in the profiling env.
