### PR TITLE
feat(ui): admin entity sub-menu in sidebar (per-entity add); fix collapsed overlap

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { SessionExpiredError } from './api/client'
 import { CommandPalette } from './components/CommandPalette'
 import { SessionExpiredOverlay } from './components/SessionExpiredOverlay'
 import { ShortcutsDialog } from './components/ShortcutsDialog'
+import { SidebarAdminMenu } from './components/SidebarAdminMenu'
 import { appConfig, canBill, hasRole } from './config'
 import { sessionExpired, setSessionExpired, startSessionMonitor } from './lib/session'
 import { initHeaderDynamics, refreshLoginStatus } from './header'
@@ -195,6 +196,7 @@ function Layout(props: ParentProps) {
       </Show>
       <CommandPalette />
       <ShortcutsDialog />
+      <SidebarAdminMenu />
     </QueryClientProvider>
   )
 }

--- a/frontend/src/admin/pendingAdd.ts
+++ b/frontend/src/admin/pendingAdd.ts
@@ -1,22 +1,21 @@
 import { createSignal } from 'solid-js'
 
-// A one-shot hand-off so the left-sidebar admin menu's per-entity "+" can open the
+// A reactive hand-off so the left-sidebar admin menu's per-entity "+" can open the
 // add form on a page it doesn't own. The "+" records the target entity and
-// navigates to /ui/admin/<key>; AdminCrudShell (which remounts per entity) reads
-// and clears this on mount and opens its create form. Null = no pending request.
-const [pending, setPending] = createSignal<string | null>(null)
+// navigates to /ui/admin/<key>; AdminCrudShell observes this reactively (not just
+// on mount) and opens its create form when the value matches its entity — so it
+// also works when you are already on that entity's page and the shell does not
+// remount. Null = no pending request.
+const [pendingAdd, setPendingAdd] = createSignal<string | null>(null)
 
-/** Request that the given entity's add form open once its shell mounts. */
+export { pendingAdd }
+
+/** Request that the given entity's add form open. */
 export function requestAdd(entityKey: string): void {
-  setPending(entityKey)
+  setPendingAdd(entityKey)
 }
 
-/** Read and clear the pending entity (returns null if none / mismatch caller). */
-export function takePendingAdd(): string | null {
-  const value = pending()
-  if (value !== null) {
-    setPending(null)
-  }
-
-  return value
+/** Clear the pending request (called by the shell once it has handled it). */
+export function clearPendingAdd(): void {
+  setPendingAdd(null)
 }

--- a/frontend/src/admin/pendingAdd.ts
+++ b/frontend/src/admin/pendingAdd.ts
@@ -1,0 +1,22 @@
+import { createSignal } from 'solid-js'
+
+// A one-shot hand-off so the left-sidebar admin menu's per-entity "+" can open the
+// add form on a page it doesn't own. The "+" records the target entity and
+// navigates to /ui/admin/<key>; AdminCrudShell (which remounts per entity) reads
+// and clears this on mount and opens its create form. Null = no pending request.
+const [pending, setPending] = createSignal<string | null>(null)
+
+/** Request that the given entity's add form open once its shell mounts. */
+export function requestAdd(entityKey: string): void {
+  setPending(entityKey)
+}
+
+/** Read and clear the pending entity (returns null if none / mismatch caller). */
+export function takePendingAdd(): string | null {
+  const value = pending()
+  if (value !== null) {
+    setPending(null)
+  }
+
+  return value
+}

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient, useQuery } from '@tanstack/solid-query'
-import { createComputed, createMemo, createSignal, For, Match, onCleanup, onMount, Show, Switch } from 'solid-js'
+import { createComputed, createMemo, createSignal, For, Match, onCleanup, Show, Switch } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
 
 import { apiErrorMessage, getJson, postJson } from '../api/client'
@@ -11,7 +11,7 @@ import { DiskIcon, DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
 import { DateField } from './DateField'
 import { PageDialog } from './PageDialog'
 import { m } from '../paraglide/messages.js'
-import { takePendingAdd } from '../admin/pendingAdd'
+import { clearPendingAdd, pendingAdd } from '../admin/pendingAdd'
 import type { ColumnDef, EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
 
 type Row = Record<string, unknown>
@@ -347,10 +347,14 @@ export function AdminCrudShell(props: {
 
   // The sidebar admin menu's "+" navigates here and asks (once) for the add form.
   // The shell remounts per entity (keyed), so this fires for the right entity.
-  onMount(() => {
-    if (takePendingAdd() === props.descriptor.key) {
-      // Defer one frame: toggling the dialog open synchronously during the
-      // shell's own mount tick races the dialog machine's init and no-ops.
+  // The sidebar admin menu's "+" hands its entity here. Observe it reactively so
+  // it fires both when the shell mounts (cross-entity navigation) AND when the
+  // value changes while already mounted (clicking "+" for the current entity,
+  // which does not remount the shell). Defer one frame: toggling the dialog open
+  // synchronously during the shell's own mount tick races the dialog machine.
+  createComputed(() => {
+    if (pendingAdd() === props.descriptor.key) {
+      clearPendingAdd()
       requestAnimationFrame(() => openForm(null))
     }
   })

--- a/frontend/src/components/AdminCrudShell.tsx
+++ b/frontend/src/components/AdminCrudShell.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient, useQuery } from '@tanstack/solid-query'
-import { createComputed, createMemo, createSignal, For, Match, onCleanup, Show, Switch } from 'solid-js'
+import { createComputed, createMemo, createSignal, For, Match, onCleanup, onMount, Show, Switch } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
 
 import { apiErrorMessage, getJson, postJson } from '../api/client'
@@ -11,6 +11,7 @@ import { DiskIcon, DownloadIcon, EditIcon, TrashIcon } from '../lib/icons'
 import { DateField } from './DateField'
 import { PageDialog } from './PageDialog'
 import { m } from '../paraglide/messages.js'
+import { takePendingAdd } from '../admin/pendingAdd'
 import type { ColumnDef, EntityDescriptor, FieldDef, FormValues, OptionLookup } from '../admin/types'
 
 type Row = Record<string, unknown>
@@ -343,6 +344,16 @@ export function AdminCrudShell(props: {
     setValues(reconcile(form))
     setEditing(form)
   }
+
+  // The sidebar admin menu's "+" navigates here and asks (once) for the add form.
+  // The shell remounts per entity (keyed), so this fires for the right entity.
+  onMount(() => {
+    if (takePendingAdd() === props.descriptor.key) {
+      // Defer one frame: toggling the dialog open synchronously during the
+      // shell's own mount tick races the dialog machine's init and no-ops.
+      requestAnimationFrame(() => openForm(null))
+    }
+  })
 
   function setField(name: string, value: FormValues[string]) {
     setValues(name, value)

--- a/frontend/src/components/SidebarAdminMenu.tsx
+++ b/frontend/src/components/SidebarAdminMenu.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate } from '@solidjs/router'
-import { For, Show } from 'solid-js'
+import { createSignal, For, onMount, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
 import { adminEntities } from '../admin/entities'
@@ -21,18 +21,18 @@ import { m } from '../paraglide/messages.js'
  * switcher lives in exactly one place per layout.
  */
 export function SidebarAdminMenu() {
-  // Admin-only, and only when the shared header actually exposed the slot. Both
-  // are fixed for the session, so a render-once guard is fine — expressed as a
-  // <Show> to satisfy solid/components-return-once.
-  const slot = document.getElementById('sidebar-admin-slot')
+  // Resolve the Twig-rendered slot after mount (not during setup) so we never race
+  // the server-rendered header element. Admin-only; both are fixed for the session.
+  const [slot, setSlot] = createSignal<HTMLElement | null>(null)
+  onMount(() => setSlot(document.getElementById('sidebar-admin-slot')))
   const entities = adminEntities()
   const navigate = useNavigate()
   const location = useLocation()
   const activeKey = (): string | undefined => location.pathname.match(/\/admin\/([^/?]+)/)?.[1]
 
   return (
-    <Show when={slot !== null && hasRole('ROLE_ADMIN')}>
-      <Portal mount={slot!}>
+    <Show when={slot() !== null && hasRole('ROLE_ADMIN')}>
+      <Portal mount={slot()!}>
         <ul class="sidebar-admin-menu">
         <For each={entities}>
           {(entity) => (

--- a/frontend/src/components/SidebarAdminMenu.tsx
+++ b/frontend/src/components/SidebarAdminMenu.tsx
@@ -1,0 +1,75 @@
+import { useLocation, useNavigate } from '@solidjs/router'
+import { For, Show } from 'solid-js'
+import { Portal } from 'solid-js/web'
+
+import { adminEntities } from '../admin/entities'
+import { requestAdd } from '../admin/pendingAdd'
+import { hasRole } from '../config'
+import { PlusIcon } from '../lib/icons'
+import { m } from '../paraglide/messages.js'
+
+/**
+ * The admin entity switcher, rendered as nested items in the left sidebar (the
+ * layout the user opted into via Settings). It portals into a slot the shared
+ * Twig header exposes under the "Administration" link, so the entity list stays
+ * single-sourced in SolidJS (adminEntities) rather than duplicated in Twig.
+ *
+ * Each entity row links to its admin route and carries a "+" that opens that
+ * entity's add form — even from another page — via the pendingAdd hand-off
+ * (AdminCrudShell consumes it on mount). The slot is CSS-hidden in the top-bar
+ * layout, and the in-page tab bar is hidden in the sidebar layout, so the
+ * switcher lives in exactly one place per layout.
+ */
+export function SidebarAdminMenu() {
+  // Admin-only, and only when the shared header actually exposed the slot. Both
+  // are fixed for the session, so a render-once guard is fine — expressed as a
+  // <Show> to satisfy solid/components-return-once.
+  const slot = document.getElementById('sidebar-admin-slot')
+  const entities = adminEntities()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const activeKey = (): string | undefined => location.pathname.match(/\/admin\/([^/?]+)/)?.[1]
+
+  return (
+    <Show when={slot !== null && hasRole('ROLE_ADMIN')}>
+      <Portal mount={slot!}>
+        <ul class="sidebar-admin-menu">
+        <For each={entities}>
+          {(entity) => (
+            <li class="sidebar-admin-item" classList={{ 'is-active': entity.key === activeKey() }}>
+              <a
+                class="sidebar-admin-link"
+                href={`/ui/admin/${entity.key}`}
+                aria-current={entity.key === activeKey() ? 'page' : undefined}
+                onClick={(event) => { event.preventDefault(); navigate(`/admin/${entity.key}`) }}
+              >
+                {entity.title()}
+              </a>
+              <button
+                type="button"
+                class="sidebar-admin-add"
+                aria-label={`${m.admin_add()}: ${entity.title()}`}
+                title={`${m.admin_add()}: ${entity.title()}`}
+                onClick={() => { requestAdd(entity.key); navigate(`/admin/${entity.key}`) }}
+              >
+                <PlusIcon />
+              </button>
+            </li>
+          )}
+        </For>
+        {/* Read-only diagnostics sub-page — no add action. */}
+        <li class="sidebar-admin-item" classList={{ 'is-active': activeKey() === 'status' }}>
+          <a
+            class="sidebar-admin-link"
+            href="/ui/admin/status"
+            aria-current={activeKey() === 'status' ? 'page' : undefined}
+            onClick={(event) => { event.preventDefault(); navigate('/admin/status') }}
+          >
+            {m.admin_status()}
+          </a>
+        </li>
+      </ul>
+      </Portal>
+    </Show>
+  )
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2431,6 +2431,11 @@ th[aria-sort='descending'] .th-sort-glyph {
   display: contents;
 }
 
+/* The admin entity sub-menu only exists in the left-sidebar layout. */
+#sidebar-admin-slot {
+  display: none;
+}
+
 .sidebar-reopen {
   position: fixed;
   top: 8px;
@@ -2656,6 +2661,87 @@ th[aria-sort='descending'] .th-sort-glyph {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+  }
+
+  /* Collapsed: reserve a left rail so the floating reopen button never overlaps
+     the page content (e.g. the Worklog "Add" button or the admin tabs). */
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #app {
+    margin-left: 3.25rem;
+  }
+
+  /* ── Admin entity sub-menu (portaled under the Administration nav link) ────── */
+  :root[data-nav-layout='side'] #sidebar-admin-slot {
+    display: block;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-menu {
+    list-style: none;
+    margin: 2px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-item {
+    display: flex;
+    align-items: stretch;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-link {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    /* indented under "Administration" (gutter + room for the active edge bar) */
+    padding: 5px 6px 5px calc(var(--sidebar-gutter) + 14px);
+    border-left: 4px solid transparent;
+    color: var(--color-text-muted);
+    font-size: 0.86em;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-link:hover {
+    background: var(--color-accent-soft);
+    color: var(--color-accent);
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-item.is-active .sidebar-admin-link {
+    color: var(--color-accent);
+    border-left-color: var(--color-accent);
+    font-weight: 600;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-add {
+    flex: 0 0 auto;
+    width: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-add:hover,
+  :root[data-nav-layout='side'] .sidebar-admin-add:focus-visible {
+    color: var(--color-accent);
+    background: var(--color-accent-soft);
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-add svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  /* The entity switcher now lives in the sidebar — drop the in-page tab bar so
+     the main area is the table only. */
+  :root[data-nav-layout='side'] .admin-subnav {
+    display: none;
   }
 }
 

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -56,6 +56,10 @@
                 <a class="main-nav-link{% if active == 'admin' %} is-active{% endif %}"
                    {% if active == 'admin' %}aria-current="page"{% endif %}
                    data-nav="admin" href="{{ path('ui_spa', {'path': 'admin'}) }}">{{ 'Administration'|trans }}</a>
+                {# The SolidJS SidebarAdminMenu portals the admin entity sub-items
+                   (each with a "+") into this slot; CSS shows it only in the
+                   left-sidebar layout. Empty in the top bar. #}
+                <div id="sidebar-admin-slot"></div>
             {% endif %}
 
             {# Overflow disclosure — empty until the priority-overflow script


### PR DESCRIPTION
## What

Follow-ups on the left-sidebar layout, from hands-on review of the collapsed and admin states.

### Admin entity sub-menu (the requested design)
`Administration` now expands into its entities as nested sidebar sub-items, each with a **`+`**:

```
Administration
  Customers   +
  Projects    +
  Users       +
  …
  Status
```

- The entity list is **single-sourced from SolidJS** (`adminEntities`) and portaled into a slot the shared Twig header exposes under the Administration link — no duplication in Twig.
- Each row links to `/ui/admin/<entity>`; the **`+`** opens that entity's add form, even from another page, via a one-shot `pendingAdd` hand-off that `AdminCrudShell` consumes on mount (deferred one frame so the dialog machine is ready).
- In the sidebar layout the now-redundant **in-page tab bar is hidden**, so the main area is the table only.
- All CSS-gated to the sidebar layout; the top bar is unchanged.

### Fix: collapsed overlap
In the collapsed sidebar the floating reopen button overlapped the page content (the Worklog **Add** button / admin tabs — ~16px gap, crowding). Collapsed now reserves a left rail so the button never overlaps (now ~42px clearance).

## Notes
- I could not reproduce the "narrow menu clips content" report even at the 150px floor with the largest text-size (`--font-scale 1.3`) — nav labels, worktime and the footer all stayed visible. If you can share the width/zoom where it clips, I'll target it precisely.

## Validation
Frontend **typecheck ✓ / lint ✓ / 329 tests ✓ / build ✓**; Twig lint ✓. Browser-verified on the e2e stack: the sub-menu renders (10 items, 9 `+`), in-page tabs hidden in side mode, **`+` opens the entity add form** (dialog confirmed), collapsed clearance 42px (no overlap), and the top-bar layout is unchanged.
