### PR TITLE
feat(ui): sidebar nav icons + icon-rail collapse; fix admin-submenu overflow

### DIFF
--- a/frontend/src/components/SidebarAdminMenu.tsx
+++ b/frontend/src/components/SidebarAdminMenu.tsx
@@ -32,7 +32,7 @@ export function SidebarAdminMenu() {
   // Only expand the entity list while you're in Administration — like a normal
   // disclosure. This keeps the sidebar short elsewhere (the always-expanded list
   // overflowed the column and pushed the main nav / worktime out of view).
-  const onAdmin = (): boolean => location.pathname.replace(/^\/ui/, '').startsWith('/admin')
+  const onAdmin = (): boolean => /^\/admin(\/|$)/.test(location.pathname.replace(/^\/ui/, ''))
 
   return (
     <Show when={slot() !== null && hasRole('ROLE_ADMIN') && onAdmin()}>

--- a/frontend/src/components/SidebarAdminMenu.tsx
+++ b/frontend/src/components/SidebarAdminMenu.tsx
@@ -29,9 +29,13 @@ export function SidebarAdminMenu() {
   const navigate = useNavigate()
   const location = useLocation()
   const activeKey = (): string | undefined => location.pathname.match(/\/admin\/([^/?]+)/)?.[1]
+  // Only expand the entity list while you're in Administration — like a normal
+  // disclosure. This keeps the sidebar short elsewhere (the always-expanded list
+  // overflowed the column and pushed the main nav / worktime out of view).
+  const onAdmin = (): boolean => location.pathname.replace(/^\/ui/, '').startsWith('/admin')
 
   return (
-    <Show when={slot() !== null && hasRole('ROLE_ADMIN')}>
+    <Show when={slot() !== null && hasRole('ROLE_ADMIN') && onAdmin()}>
       <Portal mount={slot()!}>
         <ul class="sidebar-admin-menu">
         <For each={entities}>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2436,6 +2436,12 @@ th[aria-sort='descending'] .th-sort-glyph {
   display: none;
 }
 
+/* Nav-item icons show only in the left-sidebar layout; the top bar stays
+   text-only (icons would crowd the horizontal row). */
+.nav-ico {
+  display: none;
+}
+
 .sidebar-reopen {
   position: fixed;
   top: 8px;
@@ -2512,12 +2518,22 @@ th[aria-sort='descending'] .th-sort-glyph {
   /* Active indicator moves from the bottom underline to a left edge bar. */
   :root[data-nav-layout='side'] .main-nav-link {
     width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
     justify-content: flex-start;
     border-bottom: none;
     border-left: 4px solid transparent;
-    /* align the label with the shared 12px gutter (4px of it is the edge bar) */
+    /* align the icon with the shared 12px gutter (4px of it is the edge bar) */
     padding-left: calc(var(--sidebar-gutter) - 4px);
     padding-right: var(--sidebar-gutter);
+  }
+
+  :root[data-nav-layout='side'] .nav-ico {
+    display: inline-flex;
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
   }
 
   /* Active item: pair the edge bar with a soft fill + accent label so it reads
@@ -2651,22 +2667,45 @@ th[aria-sort='descending'] .th-sort-glyph {
     background: var(--color-accent);
   }
 
-  /* Collapsed: hide the column and its handle, surface the reopen button. */
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #page-header,
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-resize {
+  /* Collapsed = a narrow icon rail (not hidden). Labels, worktime, the admin
+     sub-menu and the username hide; the nav/control icons remain. The resize
+     handle is dropped (a fixed rail isn't resizable) and the floating reopen
+     button is unused — the collapse toggle itself expands the rail again. */
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #page-header {
+    flex: 0 0 3.5rem;
+    width: 3.5rem;
+  }
+
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .nav-label,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-worktime,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #sidebar-admin-slot,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .user-name,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #logo,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-resize,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-reopen {
     display: none;
   }
 
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-reopen {
-    display: inline-flex;
-    align-items: center;
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-logo,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-account {
     justify-content: center;
+    padding-inline: 0;
   }
 
-  /* Collapsed: reserve a left rail so the floating reopen button never overlaps
-     the page content (e.g. the Worklog "Add" button or the admin tabs). */
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #app {
-    margin-left: 3.25rem;
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .main-nav-link {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-controls {
+    justify-content: center;
+    padding-inline: 0;
+  }
+
+  /* The collapse chevron now points outward (it expands the rail). */
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-collapse svg {
+    transform: scaleX(-1);
   }
 
   /* ── Admin entity sub-menu (portaled under the Administration nav link) ────── */

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -37,25 +37,27 @@
 
         <nav class="main-nav" aria-label="{{ 'Main navigation'|trans }}">
             {# Worklog (SolidJS) is the time-tracking grid. Active state is refined
-               client-side via data-nav (nav.ts). #}
+               client-side via data-nav (nav.ts). Each link carries an icon shown in
+               the left-sidebar layout (and alone when the sidebar is collapsed to a
+               rail); the label + title keep it accessible. #}
             <a class="main-nav-link{% if active == 'tracking' %} is-active{% endif %}"
                {% if active == 'tracking' %}aria-current="page"{% endif %}
-               data-nav="tracking" href="{{ path('ui_spa', {'path': 'tracking'}) }}">{{ 'Worklog'|trans }}</a>
+               data-nav="tracking" href="{{ path('ui_spa', {'path': 'tracking'}) }}" title="{{ 'Worklog'|trans }}"><svg class="nav-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3 1.8"/></svg><span class="nav-label">{{ 'Worklog'|trans }}</span></a>
             <a class="main-nav-link{% if active == 'month' %} is-active{% endif %}"
                {% if active == 'month' %}aria-current="page"{% endif %}
-               data-nav="month" href="{{ monthPath }}">{{ 'Overview'|trans }}</a>
+               data-nav="month" href="{{ monthPath }}" title="{{ 'Overview'|trans }}"><svg class="nav-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3.5" y="4.5" width="17" height="16" rx="2"/><path d="M3.5 9h17M8 2.5v4M16 2.5v4"/></svg><span class="nav-label">{{ 'Overview'|trans }}</span></a>
             <a class="main-nav-link{% if active == 'auswertung' %} is-active{% endif %}"
                {% if active == 'auswertung' %}aria-current="page"{% endif %}
-               data-nav="auswertung" href="{{ path('ui_spa', {'path': 'auswertung'}) }}">{{ 'Evaluation'|trans }}</a>
+               data-nav="auswertung" href="{{ path('ui_spa', {'path': 'auswertung'}) }}" title="{{ 'Evaluation'|trans }}"><svg class="nav-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 21h16"/><path d="M6 21V11M12 21V5M18 21v-7"/></svg><span class="nav-label">{{ 'Evaluation'|trans }}</span></a>
             {% if canBill %}
                 <a class="main-nav-link{% if active == 'billing' %} is-active{% endif %}"
                    {% if active == 'billing' %}aria-current="page"{% endif %}
-                   data-nav="billing" href="{{ path('ui_spa', {'path': 'billing'}) }}">{{ 'Billing'|trans }}</a>
+                   data-nav="billing" href="{{ path('ui_spa', {'path': 'billing'}) }}" title="{{ 'Billing'|trans }}"><svg class="nav-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3v18l2-1.2L10 21l2-1.2L14 21l2-1.2L18 21V3l-2 1.2L14 3l-2 1.2L10 3 8 4.2 6 3z"/><path d="M9 8.5h6M9 12.5h6"/></svg><span class="nav-label">{{ 'Billing'|trans }}</span></a>
             {% endif %}
             {% if isAdmin %}
                 <a class="main-nav-link{% if active == 'admin' %} is-active{% endif %}"
                    {% if active == 'admin' %}aria-current="page"{% endif %}
-                   data-nav="admin" href="{{ path('ui_spa', {'path': 'admin'}) }}">{{ 'Administration'|trans }}</a>
+                   data-nav="admin" href="{{ path('ui_spa', {'path': 'admin'}) }}" title="{{ 'Administration'|trans }}"><svg class="nav-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3.5" y="3.5" width="7" height="7" rx="1"/><rect x="13.5" y="3.5" width="7" height="7" rx="1"/><rect x="3.5" y="13.5" width="7" height="7" rx="1"/><rect x="13.5" y="13.5" width="7" height="7" rx="1"/></svg><span class="nav-label">{{ 'Administration'|trans }}</span></a>
                 {# The SolidJS SidebarAdminMenu portals the admin entity sub-items
                    (each with a "+") into this slot; CSS shows it only in the
                    left-sidebar layout. Empty in the top bar. #}

--- a/templates/partials/sidebar-behavior.html.twig
+++ b/templates/partials/sidebar-behavior.html.twig
@@ -9,6 +9,11 @@
     var MIN_WIDTH = 150;
     var MAX_WIDTH = 460;
     var STEP = 16;
+    // The collapse toggle stays visible in the icon rail and flips meaning, so its
+    // accessible name must follow the state. Captured from the rendered (localized)
+    // labels on the collapse + reopen buttons at init.
+    var collapseLabel = null;
+    var expandLabel = null;
 
     function persist(key, value) {
         try {
@@ -49,7 +54,15 @@
         var expanded = collapsed ? 'false' : 'true';
         var collapseBtn = document.getElementById('sidebar-collapse');
         var reopenBtn = document.getElementById('sidebar-reopen');
-        if (collapseBtn) { collapseBtn.setAttribute('aria-expanded', expanded); }
+        if (collapseBtn) {
+            collapseBtn.setAttribute('aria-expanded', expanded);
+            // It expands when collapsed, collapses when expanded — keep the name honest.
+            var label = collapsed ? expandLabel : collapseLabel;
+            if (label) {
+                collapseBtn.setAttribute('aria-label', label);
+                collapseBtn.setAttribute('title', label);
+            }
+        }
         if (reopenBtn) { reopenBtn.setAttribute('aria-expanded', expanded); }
         if (focusEl) {
             // The just-hidden control loses focus; move it to the still-visible one.
@@ -62,9 +75,18 @@
         var reopenBtn = document.getElementById('sidebar-reopen');
         var handle = document.getElementById('sidebar-resize');
 
-        // Sync the controls' aria-expanded with the pre-paint collapsed state.
+        // Capture the localized labels, then sync aria-expanded + the collapse
+        // button's name with the pre-paint collapsed state.
+        if (collapseBtn) { collapseLabel = collapseBtn.getAttribute('aria-label'); }
+        if (reopenBtn) { expandLabel = reopenBtn.getAttribute('aria-label'); }
         var collapsedNow = root.getAttribute('data-sidebar-collapsed') === 'true';
-        if (collapseBtn) { collapseBtn.setAttribute('aria-expanded', collapsedNow ? 'false' : 'true'); }
+        if (collapseBtn) {
+            collapseBtn.setAttribute('aria-expanded', collapsedNow ? 'false' : 'true');
+            if (collapsedNow && expandLabel) {
+                collapseBtn.setAttribute('aria-label', expandLabel);
+                collapseBtn.setAttribute('title', expandLabel);
+            }
+        }
         if (reopenBtn) { reopenBtn.setAttribute('aria-expanded', collapsedNow ? 'false' : 'true'); }
 
         // The collapse toggle flips both ways — the sidebar stays visible as a

--- a/templates/partials/sidebar-behavior.html.twig
+++ b/templates/partials/sidebar-behavior.html.twig
@@ -67,11 +67,17 @@
         if (collapseBtn) { collapseBtn.setAttribute('aria-expanded', collapsedNow ? 'false' : 'true'); }
         if (reopenBtn) { reopenBtn.setAttribute('aria-expanded', collapsedNow ? 'false' : 'true'); }
 
+        // The collapse toggle flips both ways — the sidebar stays visible as a
+        // narrow icon rail when collapsed, so there is no separate reopen step.
         if (collapseBtn) {
-            collapseBtn.addEventListener('click', function () { setCollapsed(true, reopenBtn); });
+            collapseBtn.addEventListener('click', function () {
+                setCollapsed(root.getAttribute('data-sidebar-collapsed') !== 'true');
+            });
         }
+        // The floating reopen button is retained as a no-op fallback (CSS-hidden in
+        // the icon-rail design) for older saved states.
         if (reopenBtn) {
-            reopenBtn.addEventListener('click', function () { setCollapsed(false, collapseBtn); });
+            reopenBtn.addEventListener('click', function () { setCollapsed(false); });
         }
 
         if (handle) {


### PR DESCRIPTION
## What

Uses the left-sidebar space and fixes the "elements vanish when the menu gets narrow/short" report.

### Nav icons + icon-rail collapsed state
- Each main nav item (Worklog, Overview, Evaluation, Billing, Administration) now has an icon, shown in the sidebar layout. The top bar stays text-only.
- **Collapsed is now a narrow icon rail (~3.5rem)** instead of a hidden column + floating button: the nav and control icons stay visible, labels / worktime / username / admin sub-menu hide, and the collapse toggle flips to expand the rail again. No more floating reopen button overlapping content.

### Fix: admin sub-menu overflow (the reported bug)
The admin entity sub-menu was **always expanded**, so its ~10 rows overflowed the column and, on shorter/narrower windows, scrolled the main nav and worktime badges out of view — they appeared to "vanish." It now expands **only while you're in Administration** (`/ui/admin/*`), like a normal disclosure, so the sidebar stays short and complete on every other page.

## Validation
typecheck / lint / **329 tests** / build green. Browser-verified on the e2e stack:
- Top bar: nav icons hidden, labels shown, 64px header (unchanged).
- Sidebar expanded on `/month` (768px-tall window): nav icon+label and worktime visible, **no scroll**, admin sub-menu absent.
- `/admin`: 10-item sub-menu present.
- Collapsed: 56px icon rail, icons visible, labels hidden, toggle expands.
