### PR TITLE
fix(ui): pin sidebar footer (nav never vanishes), stack collapsed account, admin sub-nav icons

### DIFF
--- a/frontend/src/components/SidebarAdminMenu.tsx
+++ b/frontend/src/components/SidebarAdminMenu.tsx
@@ -8,22 +8,25 @@ import { hasRole } from '../config'
 import { PlusIcon } from '../lib/icons'
 import { m } from '../paraglide/messages.js'
 
-// Inner SVG markup per admin entity, so each sub-item carries a recognisable icon
-// (consistent with the main nav). Keyed by entity key; a generic dot is the fallback.
-const ADMIN_ICON: Record<string, string> = {
-  customers: '<path d="M4 21V6l8-3 8 3v15"/><path d="M4 21h16M9 9h.01M9 13h.01M15 9h.01M15 13h.01"/>',
-  projects: '<path d="M4 7a2 2 0 0 1 2-2h3l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"/>',
-  users: '<circle cx="12" cy="8" r="3.2"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/>',
-  teams: '<circle cx="9" cy="9" r="2.8"/><path d="M3.5 19a5.5 5.5 0 0 1 11 0"/><path d="M16 6.5a3 3 0 0 1 0 5.4M20.5 19a5.5 5.5 0 0 0-3.5-5.1"/>',
-  holidays: '<circle cx="12" cy="12" r="3.6"/><path d="M12 2.5v2M12 19.5v2M4 12H2M22 12h-2M5.6 5.6 4.2 4.2M19.8 19.8l-1.4-1.4M18.4 5.6l1.4-1.4M4.2 19.8l1.4-1.4"/>',
-  presets: '<path d="M6.5 3.5h11v17l-5.5-3.6-5.5 3.6z"/>',
-  ticketsystems: '<path d="M3.5 10.5 10.5 3.5l10 10-7 7z"/><circle cx="8" cy="8" r="1.3"/>',
-  activities: '<path d="M3 12h4l2.5 6 4-13 2.5 7H21"/>',
-  contracts: '<path d="M7 3h7l5 5v13H7z"/><path d="M14 3v5h5M10 13h6M10 17h5"/>',
-  status: '<circle cx="12" cy="12" r="9"/><path d="M12 8v4.5M12 16h.01"/>',
+// A recognisable icon per admin entity (consistent with the main nav). Each entry
+// returns the inner SVG as JSX — no innerHTML. Keyed by entity key; generic dot
+// is the fallback.
+const ADMIN_ICON: Record<string, () => JSX.Element> = {
+  customers: () => <><path d="M4 21V6l8-3 8 3v15" /><path d="M4 21h16M9 9h.01M9 13h.01M15 9h.01M15 13h.01" /></>,
+  projects: () => <path d="M4 7a2 2 0 0 1 2-2h3l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z" />,
+  users: () => <><circle cx="12" cy="8" r="3.2" /><path d="M5.5 20a6.5 6.5 0 0 1 13 0" /></>,
+  teams: () => <><circle cx="9" cy="9" r="2.8" /><path d="M3.5 19a5.5 5.5 0 0 1 11 0" /><path d="M16 6.5a3 3 0 0 1 0 5.4M20.5 19a5.5 5.5 0 0 0-3.5-5.1" /></>,
+  holidays: () => <><circle cx="12" cy="12" r="3.6" /><path d="M12 2.5v2M12 19.5v2M4 12H2M22 12h-2M5.6 5.6 4.2 4.2M19.8 19.8l-1.4-1.4M18.4 5.6l1.4-1.4M4.2 19.8l1.4-1.4" /></>,
+  presets: () => <path d="M6.5 3.5h11v17l-5.5-3.6-5.5 3.6z" />,
+  ticketsystems: () => <><path d="M3.5 10.5 10.5 3.5l10 10-7 7z" /><circle cx="8" cy="8" r="1.3" /></>,
+  activities: () => <path d="M3 12h4l2.5 6 4-13 2.5 7H21" />,
+  contracts: () => <><path d="M7 3h7l5 5v13H7z" /><path d="M14 3v5h5M10 13h6M10 17h5" /></>,
+  status: () => <><circle cx="12" cy="12" r="9" /><path d="M12 8v4.5M12 16h.01" /></>,
 }
 
 function adminIco(key: string): JSX.Element {
+  const inner = ADMIN_ICON[key] ?? (() => <circle cx="12" cy="12" r="3" />)
+
   return (
     <svg
       class="sidebar-admin-ico"
@@ -34,9 +37,9 @@ function adminIco(key: string): JSX.Element {
       stroke-linecap="round"
       stroke-linejoin="round"
       aria-hidden="true"
-      // eslint-disable-next-line solid/no-innerhtml
-      innerHTML={ADMIN_ICON[key] ?? '<circle cx="12" cy="12" r="3"/>'}
-    />
+    >
+      {inner()}
+    </svg>
   )
 }
 

--- a/frontend/src/components/SidebarAdminMenu.tsx
+++ b/frontend/src/components/SidebarAdminMenu.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate } from '@solidjs/router'
-import { createSignal, For, onMount, Show } from 'solid-js'
+import { createSignal, For, type JSX, onMount, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
 import { adminEntities } from '../admin/entities'
@@ -7,6 +7,38 @@ import { requestAdd } from '../admin/pendingAdd'
 import { hasRole } from '../config'
 import { PlusIcon } from '../lib/icons'
 import { m } from '../paraglide/messages.js'
+
+// Inner SVG markup per admin entity, so each sub-item carries a recognisable icon
+// (consistent with the main nav). Keyed by entity key; a generic dot is the fallback.
+const ADMIN_ICON: Record<string, string> = {
+  customers: '<path d="M4 21V6l8-3 8 3v15"/><path d="M4 21h16M9 9h.01M9 13h.01M15 9h.01M15 13h.01"/>',
+  projects: '<path d="M4 7a2 2 0 0 1 2-2h3l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"/>',
+  users: '<circle cx="12" cy="8" r="3.2"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/>',
+  teams: '<circle cx="9" cy="9" r="2.8"/><path d="M3.5 19a5.5 5.5 0 0 1 11 0"/><path d="M16 6.5a3 3 0 0 1 0 5.4M20.5 19a5.5 5.5 0 0 0-3.5-5.1"/>',
+  holidays: '<circle cx="12" cy="12" r="3.6"/><path d="M12 2.5v2M12 19.5v2M4 12H2M22 12h-2M5.6 5.6 4.2 4.2M19.8 19.8l-1.4-1.4M18.4 5.6l1.4-1.4M4.2 19.8l1.4-1.4"/>',
+  presets: '<path d="M6.5 3.5h11v17l-5.5-3.6-5.5 3.6z"/>',
+  ticketsystems: '<path d="M3.5 10.5 10.5 3.5l10 10-7 7z"/><circle cx="8" cy="8" r="1.3"/>',
+  activities: '<path d="M3 12h4l2.5 6 4-13 2.5 7H21"/>',
+  contracts: '<path d="M7 3h7l5 5v13H7z"/><path d="M14 3v5h5M10 13h6M10 17h5"/>',
+  status: '<circle cx="12" cy="12" r="9"/><path d="M12 8v4.5M12 16h.01"/>',
+}
+
+function adminIco(key: string): JSX.Element {
+  return (
+    <svg
+      class="sidebar-admin-ico"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      // eslint-disable-next-line solid/no-innerhtml
+      innerHTML={ADMIN_ICON[key] ?? '<circle cx="12" cy="12" r="3"/>'}
+    />
+  )
+}
 
 /**
  * The admin entity switcher, rendered as nested items in the left sidebar (the
@@ -47,7 +79,7 @@ export function SidebarAdminMenu() {
                 aria-current={entity.key === activeKey() ? 'page' : undefined}
                 onClick={(event) => { event.preventDefault(); navigate(`/admin/${entity.key}`) }}
               >
-                {entity.title()}
+                {adminIco(entity.key)}<span class="sidebar-admin-label">{entity.title()}</span>
               </a>
               <button
                 type="button"
@@ -69,7 +101,7 @@ export function SidebarAdminMenu() {
             aria-current={activeKey() === 'status' ? 'page' : undefined}
             onClick={(event) => { event.preventDefault(); navigate('/admin/status') }}
           >
-            {m.admin_status()}
+            {adminIco('status')}<span class="sidebar-admin-label">{m.admin_status()}</span>
           </a>
         </li>
       </ul>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2483,10 +2483,10 @@ th[aria-sort='descending'] .th-sort-glyph {
     height: 100vh;
     position: sticky;
     top: 0;
-    overflow-y: auto;
-    /* A fixed-width column: keep an over-long username or translation from
-       promoting overflow-x to a horizontal scrollbar (it's clipped instead). */
-    overflow-x: hidden;
+    /* The column itself never scrolls — only the nav region inside does (below),
+       so the logo and the footer (worktime/controls/account) stay pinned and the
+       main nav can never be scrolled out of view. */
+    overflow: hidden;
   }
 
   :root[data-nav-layout='side'] #app {
@@ -2494,25 +2494,46 @@ th[aria-sort='descending'] .th-sort-glyph {
     min-width: 0;
   }
 
-  /* The flex spacer (flex:1) now grows vertically, pushing the worktime badges,
-     the icon controls and the account block to the bottom of the column. */
+  /* Three zones: fixed logo (top), scrollable nav (middle, flex:1), pinned
+     footer (worktime/controls/account, bottom). Only the nav scrolls, so the
+     footer and the top of the nav are always visible regardless of window
+     height — the spacer is no longer needed. */
   :root[data-nav-layout='side'] .app-header {
     --sidebar-gutter: 12px;
     flex-direction: column;
     align-items: stretch;
-    min-height: 100vh;
+    height: 100vh;
+    min-height: 0;
+    overflow: hidden;
     gap: 0.35rem;
   }
 
   :root[data-nav-layout='side'] .header-logo {
+    flex: 0 0 auto;
     justify-content: center;
     padding: 0.25rem 0;
   }
 
+  :root[data-nav-layout='side'] .header-spacer {
+    display: none;
+  }
+
+  /* Nav region: takes the free space and scrolls within itself if its own
+     content (e.g. the admin sub-menu) is taller than the column. */
   :root[data-nav-layout='side'] .main-nav {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
     flex-direction: column;
     align-items: stretch;
     gap: 2px;
+  }
+
+  :root[data-nav-layout='side'] .header-worktime,
+  :root[data-nav-layout='side'] .header-controls,
+  :root[data-nav-layout='side'] .header-account {
+    flex: 0 0 auto;
   }
 
   /* Active indicator moves from the bottom underline to a left edge bar. */
@@ -2686,10 +2707,24 @@ th[aria-sort='descending'] .th-sort-glyph {
     display: none;
   }
 
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-logo,
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-account {
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-logo {
     justify-content: center;
     padding-inline: 0;
+  }
+
+  /* In the rail, stack the status dot above the logout icon (centred) and drop
+     the badge pill so it reads as a tidy footer rather than two crammed items. */
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-account {
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding-inline: 0;
+  }
+
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .user-badge {
+    padding: 0;
+    background: none;
+    min-width: 0;
   }
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .main-nav-link {
@@ -2732,15 +2767,26 @@ th[aria-sort='descending'] .th-sort-glyph {
     min-width: 0;
     display: flex;
     align-items: center;
+    gap: 8px;
     /* indented under "Administration" (gutter + room for the active edge bar) */
-    padding: 5px 6px 5px calc(var(--sidebar-gutter) + 14px);
+    padding: 5px 6px 5px calc(var(--sidebar-gutter) + 10px);
     border-left: 4px solid transparent;
     color: var(--color-text-muted);
     font-size: 0.86em;
     text-decoration: none;
-    white-space: nowrap;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-ico {
+    flex: 0 0 auto;
+    width: 16px;
+    height: 16px;
+  }
+
+  :root[data-nav-layout='side'] .sidebar-admin-label {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   :root[data-nav-layout='side'] .sidebar-admin-link:hover {


### PR DESCRIPTION
## What

Three left-sidebar follow-ups from hands-on testing.

### Nav + worktime no longer vanish (the recurring bug)
Reproduced it: on a short window the **whole sidebar column scrolled**, so scrolling down to reach the footer pushed the main nav off the top — it looked like the nav "vanished." Restructured the column into three zones:
- **fixed logo** (top),
- a **flex:1 nav region that scrolls within itself** (so the admin sub-menu can scroll when tall),
- a **pinned footer** (worktime / controls / account).

Now the logo, the top of the nav, and the footer stay visible at **any** window height — verified at 460px and 400px tall (nav + worktime + account all on-screen). Only the nav list scrolls, and only when its own content exceeds the column.

### Collapsed-rail account
Stack the status dot above the logout icon (centred) and drop the badge pill, instead of cramming them side by side.

### Admin sub-nav icons
Each entity row (Customers/Projects/Users/…/Status) now carries a recognisable icon, consistent with the new main-nav icons.

## Validation
typecheck / lint / build green. Browser-verified on the e2e stack: short-window footer pinning (400px tall), 10 admin sub-nav icons, collapsed account stacked.
