### PR TITLE
fix(ui): worklog day-range picker always lists all presets

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -197,6 +197,7 @@
   "tracking_days_label": "Zeige",
   "tracking_days_option": "Letzte {count} Tage",
   "tracking_days_option_one": "Letzter Tag",
+  "tracking_days_presets": "Voreingestellte Zeiträume anzeigen",
   "tracking_days_unit": "Tage",
   "tracking_empty": "Keine Einträge in diesem Zeitraum.",
   "tracking_empty_range": "Keine Einträge in den letzten {count} Tagen.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -197,6 +197,7 @@
   "tracking_days_label": "Show",
   "tracking_days_option": "Last {count} days",
   "tracking_days_option_one": "Last day",
+  "tracking_days_presets": "Show preset ranges",
   "tracking_days_unit": "days",
   "tracking_empty": "No entries in this period.",
   "tracking_empty_range": "No entries in the last {count} days.",

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -173,6 +173,20 @@ export default function Tracking() {
   const queryClient = useQueryClient()
   // The day range persists across remounts/logins (client-side, like the theme).
   const [days, setDays] = createSignal<number>(Math.min(getTrackingDays(DEFAULT_DAYS), MAX_DAYS))
+  // Preset-range combobox: the menu always lists every preset (unlike a native
+  // datalist, which filters by the typed value and forced the user to clear the
+  // field to pick another range). Free typing still applies a custom day count.
+  const [daysMenuOpen, setDaysMenuOpen] = createSignal(false)
+  let daysComboRef: HTMLDivElement | undefined
+  onMount(() => {
+    const onDocPointer = (event: PointerEvent): void => {
+      if (daysComboRef !== undefined && !daysComboRef.contains(event.target as Node)) {
+        setDaysMenuOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onDocPointer)
+    onCleanup(() => document.removeEventListener('pointerdown', onDocPointer))
+  })
   const entries = useQuery(() => trackingEntriesQuery(days()))
   const customers = useQuery(trackingCustomersQuery)
   const projects = useQuery(trackingProjectsQuery)
@@ -790,35 +804,68 @@ export default function Tracking() {
         {/* Continue / Prolong / Info moved to per-row action icons; Alt+C/P/I
             still act on the keyboard-cursor row via the global shortcut handler. */}
         <a class="action-button is-icon" href={exportHref()} aria-keyshortcuts="Alt+X" aria-label={m.tracking_export()} title={m.tracking_export()}><DownloadIcon /></a>
-        {/* Freetext combobox: the presets are suggestions in the datalist, but the
-            user can type any whole number of days (applyDays clamps + persists).
-            A text input with `list` is a combobox (role) — not a numeric
-            spinbutton — so the datalist dropdown stays a one-tap pick. */}
-        <label class="tracking-days">
-          <span>{m.tracking_days_label()}</span>
-          <input
-            type="text"
-            inputmode="numeric"
-            class="tracking-days-input"
-            list="tracking-days-options"
-            value={String(days())}
-            onChange={(event) => {
-              const typed = Number(event.currentTarget.value.trim())
-              if (Number.isFinite(typed) && typed >= 1) {
-                applyDays(typed)
-              }
-              // Re-sync the field to the effective (clamped) value, reverting any
-              // invalid or out-of-range entry rather than leaving it on screen.
-              event.currentTarget.value = String(days())
-            }}
-          />
-          <datalist id="tracking-days-options">
-            <For each={DAYS_OPTIONS}>
-              {(option) => <option value={String(option)} label={option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })} />}
-            </For>
-          </datalist>
+        {/* Freetext + always-full preset menu: type any whole number of days
+            (applyDays clamps + persists), or pick a preset — the menu always lists
+            ALL presets regardless of what's typed, so switching ranges never needs
+            clearing the field first. */}
+        <div class="tracking-days">
+          <span id="tracking-days-lbl">{m.tracking_days_label()}</span>
+          <div class="days-combo" ref={(el) => { daysComboRef = el }}>
+            <input
+              type="text"
+              inputmode="numeric"
+              class="tracking-days-input"
+              role="combobox"
+              aria-labelledby="tracking-days-lbl"
+              aria-expanded={daysMenuOpen()}
+              aria-controls="tracking-days-menu"
+              aria-haspopup="listbox"
+              value={String(days())}
+              onChange={(event) => {
+                const typed = Number(event.currentTarget.value.trim())
+                if (Number.isFinite(typed) && typed >= 1) {
+                  applyDays(typed)
+                }
+                // Re-sync to the effective (clamped) value, reverting invalid input.
+                event.currentTarget.value = String(days())
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'ArrowDown') { event.preventDefault(); setDaysMenuOpen(true) }
+                else if (event.key === 'Escape') { setDaysMenuOpen(false) }
+              }}
+            />
+            <button
+              type="button"
+              class="days-combo-toggle"
+              tabindex="-1"
+              aria-label={m.tracking_days_presets()}
+              aria-expanded={daysMenuOpen()}
+              aria-controls="tracking-days-menu"
+              onClick={() => setDaysMenuOpen((open) => !open)}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
+            </button>
+            <Show when={daysMenuOpen()}>
+              <ul class="days-combo-menu" id="tracking-days-menu" role="listbox" aria-label={m.tracking_days_label()}>
+                <For each={DAYS_OPTIONS}>
+                  {(option) => (
+                    <li role="option" aria-selected={days() === option}>
+                      <button
+                        type="button"
+                        class="days-combo-option"
+                        classList={{ 'is-active': days() === option }}
+                        onClick={() => { applyDays(option); setDaysMenuOpen(false) }}
+                      >
+                        {option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })}
+                      </button>
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </Show>
+          </div>
           <span class="tracking-days-unit">{m.tracking_days_unit()}</span>
-        </label>
+        </div>
 
         {/* Inline-edit + keyboard discoverability hint — last in the tool line, so
             the only otherwise-on-screen cue (a hover text-cursor on editable cells)

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -182,7 +182,7 @@ export default function Tracking() {
   let daysComboRef: HTMLDivElement | undefined
   const openDaysMenu = (): void => {
     const current = DAYS_OPTIONS.indexOf(days() as (typeof DAYS_OPTIONS)[number])
-    setDaysActiveIdx(current >= 0 ? current : 0)
+    setDaysActiveIdx(Math.max(0, current))
     setDaysMenuOpen(true)
   }
   const closeDaysMenu = (): void => { setDaysMenuOpen(false); setDaysActiveIdx(-1) }
@@ -828,8 +828,6 @@ export default function Tracking() {
               aria-labelledby="tracking-days-lbl"
               aria-expanded={daysMenuOpen()}
               aria-controls="tracking-days-menu"
-              aria-haspopup="listbox"
-              aria-activedescendant={daysMenuOpen() && daysActiveIdx() >= 0 ? `days-opt-${DAYS_OPTIONS[daysActiveIdx()]}` : undefined}
               value={String(days())}
               onChange={(event) => {
                 const typed = Number(event.currentTarget.value.trim())
@@ -842,8 +840,8 @@ export default function Tracking() {
               onKeyDown={(event) => {
                 if (event.key === 'ArrowDown') {
                   event.preventDefault()
-                  if (!daysMenuOpen()) { openDaysMenu() }
-                  else { setDaysActiveIdx((i) => Math.min(DAYS_OPTIONS.length - 1, i + 1)) }
+                  if (daysMenuOpen()) { setDaysActiveIdx((i) => Math.min(DAYS_OPTIONS.length - 1, i + 1)) }
+                  else { openDaysMenu() }
                 } else if (event.key === 'ArrowUp') {
                   event.preventDefault()
                   if (daysMenuOpen()) { setDaysActiveIdx((i) => Math.max(0, i - 1)) }
@@ -868,19 +866,21 @@ export default function Tracking() {
               <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
             </button>
             <Show when={daysMenuOpen()}>
-              <ul class="days-combo-menu" id="tracking-days-menu" role="listbox" aria-label={m.tracking_days_label()}>
+              <ul class="days-combo-menu" id="tracking-days-menu" aria-label={m.tracking_days_label()}>
                 <For each={DAYS_OPTIONS}>
                   {(option, index) => (
-                    <li
-                      class="days-combo-option"
-                      id={`days-opt-${option}`}
-                      role="option"
-                      aria-selected={days() === option}
-                      classList={{ 'is-active': index() === daysActiveIdx() }}
-                      onClick={() => chooseDays(option)}
-                      onPointerEnter={() => setDaysActiveIdx(index())}
-                    >
-                      {option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })}
+                    <li>
+                      <button
+                        type="button"
+                        class="days-combo-option"
+                        tabindex="-1"
+                        classList={{ 'is-active': index() === daysActiveIdx() }}
+                        aria-current={days() === option ? 'true' : undefined}
+                        onClick={() => chooseDays(option)}
+                        onPointerEnter={() => setDaysActiveIdx(index())}
+                      >
+                        {option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })}
+                      </button>
                     </li>
                   )}
                 </For>

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -815,11 +815,7 @@ export default function Tracking() {
               type="text"
               inputmode="numeric"
               class="tracking-days-input"
-              role="combobox"
               aria-labelledby="tracking-days-lbl"
-              aria-expanded={daysMenuOpen()}
-              aria-controls="tracking-days-menu"
-              aria-haspopup="listbox"
               value={String(days())}
               onChange={(event) => {
                 const typed = Number(event.currentTarget.value.trim())
@@ -846,14 +842,15 @@ export default function Tracking() {
               <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
             </button>
             <Show when={daysMenuOpen()}>
-              <ul class="days-combo-menu" id="tracking-days-menu" role="listbox" aria-label={m.tracking_days_label()}>
+              <ul class="days-combo-menu" id="tracking-days-menu" aria-label={m.tracking_days_label()}>
                 <For each={DAYS_OPTIONS}>
                   {(option) => (
-                    <li role="option" aria-selected={days() === option}>
+                    <li>
                       <button
                         type="button"
                         class="days-combo-option"
                         classList={{ 'is-active': days() === option }}
+                        aria-current={days() === option ? 'true' : undefined}
                         onClick={() => { applyDays(option); setDaysMenuOpen(false) }}
                       >
                         {option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })}

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -177,11 +177,20 @@ export default function Tracking() {
   // datalist, which filters by the typed value and forced the user to clear the
   // field to pick another range). Free typing still applies a custom day count.
   const [daysMenuOpen, setDaysMenuOpen] = createSignal(false)
+  // Active option for keyboard navigation (aria-activedescendant), -1 = none.
+  const [daysActiveIdx, setDaysActiveIdx] = createSignal(-1)
   let daysComboRef: HTMLDivElement | undefined
+  const openDaysMenu = (): void => {
+    const current = DAYS_OPTIONS.indexOf(days() as (typeof DAYS_OPTIONS)[number])
+    setDaysActiveIdx(current >= 0 ? current : 0)
+    setDaysMenuOpen(true)
+  }
+  const closeDaysMenu = (): void => { setDaysMenuOpen(false); setDaysActiveIdx(-1) }
+  const chooseDays = (value: number): void => { applyDays(value); closeDaysMenu() }
   onMount(() => {
     const onDocPointer = (event: PointerEvent): void => {
       if (daysComboRef !== undefined && !daysComboRef.contains(event.target as Node)) {
-        setDaysMenuOpen(false)
+        closeDaysMenu()
       }
     }
     document.addEventListener('pointerdown', onDocPointer)
@@ -815,7 +824,12 @@ export default function Tracking() {
               type="text"
               inputmode="numeric"
               class="tracking-days-input"
+              role="combobox"
               aria-labelledby="tracking-days-lbl"
+              aria-expanded={daysMenuOpen()}
+              aria-controls="tracking-days-menu"
+              aria-haspopup="listbox"
+              aria-activedescendant={daysMenuOpen() && daysActiveIdx() >= 0 ? `days-opt-${DAYS_OPTIONS[daysActiveIdx()]}` : undefined}
               value={String(days())}
               onChange={(event) => {
                 const typed = Number(event.currentTarget.value.trim())
@@ -826,8 +840,20 @@ export default function Tracking() {
                 event.currentTarget.value = String(days())
               }}
               onKeyDown={(event) => {
-                if (event.key === 'ArrowDown') { event.preventDefault(); setDaysMenuOpen(true) }
-                else if (event.key === 'Escape') { setDaysMenuOpen(false) }
+                if (event.key === 'ArrowDown') {
+                  event.preventDefault()
+                  if (!daysMenuOpen()) { openDaysMenu() }
+                  else { setDaysActiveIdx((i) => Math.min(DAYS_OPTIONS.length - 1, i + 1)) }
+                } else if (event.key === 'ArrowUp') {
+                  event.preventDefault()
+                  if (daysMenuOpen()) { setDaysActiveIdx((i) => Math.max(0, i - 1)) }
+                } else if (event.key === 'Enter' && daysMenuOpen() && daysActiveIdx() >= 0) {
+                  event.preventDefault()
+                  chooseDays(DAYS_OPTIONS[daysActiveIdx()]!)
+                } else if (event.key === 'Escape' && daysMenuOpen()) {
+                  event.preventDefault()
+                  closeDaysMenu()
+                }
               }}
             />
             <button
@@ -837,24 +863,24 @@ export default function Tracking() {
               aria-label={m.tracking_days_presets()}
               aria-expanded={daysMenuOpen()}
               aria-controls="tracking-days-menu"
-              onClick={() => setDaysMenuOpen((open) => !open)}
+              onClick={() => { if (daysMenuOpen()) { closeDaysMenu() } else { openDaysMenu() } }}
             >
               <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
             </button>
             <Show when={daysMenuOpen()}>
-              <ul class="days-combo-menu" id="tracking-days-menu" aria-label={m.tracking_days_label()}>
+              <ul class="days-combo-menu" id="tracking-days-menu" role="listbox" aria-label={m.tracking_days_label()}>
                 <For each={DAYS_OPTIONS}>
-                  {(option) => (
-                    <li>
-                      <button
-                        type="button"
-                        class="days-combo-option"
-                        classList={{ 'is-active': days() === option }}
-                        aria-current={days() === option ? 'true' : undefined}
-                        onClick={() => { applyDays(option); setDaysMenuOpen(false) }}
-                      >
-                        {option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })}
-                      </button>
+                  {(option, index) => (
+                    <li
+                      class="days-combo-option"
+                      id={`days-opt-${option}`}
+                      role="option"
+                      aria-selected={days() === option}
+                      classList={{ 'is-active': index() === daysActiveIdx() }}
+                      onClick={() => chooseDays(option)}
+                      onPointerEnter={() => setDaysActiveIdx(index())}
+                    >
+                      {option === 1 ? m.tracking_days_option_one() : m.tracking_days_option({ count: String(option) })}
                     </li>
                   )}
                 </For>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1294,6 +1294,75 @@ kbd {
   color: var(--color-text-muted);
 }
 
+/* Day-range combobox: freetext input + a toggle that opens a menu of all presets
+   (always the full list, never filtered by what's typed). */
+.days-combo {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.days-combo-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  min-height: 44px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.days-combo-toggle:hover,
+.days-combo-toggle:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.days-combo-menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  z-index: 30;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  min-width: max(100%, 9rem);
+  white-space: nowrap;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgb(0 0 0 / 0.16);
+}
+
+.days-combo-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: var(--color-text);
+  cursor: pointer;
+  font: inherit;
+  padding: 8px 12px;
+  min-height: 36px;
+}
+
+.days-combo-option:hover,
+.days-combo-option:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.days-combo-option.is-active {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
 .tracking-empty {
   align-items: flex-start;
   color: var(--color-text-muted, #666);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1330,7 +1330,7 @@ kbd {
   margin: 0;
   padding: 4px;
   list-style: none;
-  min-width: max(100%, 9rem);
+  min-width: max(100%, 9em);
   white-space: nowrap;
   background: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1359,7 +1359,7 @@ kbd {
 }
 
 /* The currently-applied range. */
-.days-combo-option[aria-selected='true'] {
+.days-combo-option[aria-current] {
   font-weight: 600;
 }
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1353,13 +1353,13 @@ kbd {
 }
 
 .days-combo-option:hover,
-.days-combo-option:focus-visible {
+.days-combo-option.is-active {
   background: var(--color-accent-soft);
   color: var(--color-accent);
 }
 
-.days-combo-option.is-active {
-  color: var(--color-accent);
+/* The currently-applied range. */
+.days-combo-option[aria-selected='true'] {
   font-weight: 600;
 }
 


### PR DESCRIPTION
The "Show N days" control was a native datalist (filters suggestions by typed text, so you had to clear the field to switch presets). Replaced with a combobox: freetext input for a custom day count **plus** a toggle whose menu **always lists all presets** (Last day / 3 / 7 / 35), regardless of the typed value; picking one applies without clearing. Escape/outside-click close, ArrowDown opens, aria-expanded/controls + role=listbox, targets ≥36px.

Verified: with `35` typed the menu still shows all four presets; picking "Last day" sets 1. typecheck/lint/329 tests/build green. en + de.