### PR TITLE
feat(ui): responsive worklog table — thin out by priority instead of scrolling

### DIFF
--- a/e2e/date-format.spec.ts
+++ b/e2e/date-format.spec.ts
@@ -20,10 +20,10 @@ test.describe('Date-format preference', () => {
 
   test('a custom pattern reformats the worklog date cells, but editing stays ISO', async ({ page }) => {
     const stamp = await createWorklogEntry(page);
-    // (the date cell also carries a visually-hidden row-class label, hence the
-    // optional suffix in the matchers)
-    await expect(rowByStamp(page, stamp).locator('td[data-col-key="date"]'))
-      .toHaveText(/^\d{4}-\d{2}-\d{2}( \(.+\))?$/); // ISO by default
+    // The date cell renders three responsive widths (full / MM-DD / DD) plus a
+    // visually-hidden row-class label; assert on the full-date span only.
+    await expect(rowByStamp(page, stamp).locator('td[data-col-key="date"] .dt-full'))
+      .toHaveText(/^\d{4}-\d{2}-\d{2}$/); // ISO by default
 
     // Switch to a custom DD.MM.YYYY pattern.
     await page.goto('/ui/settings');
@@ -36,7 +36,7 @@ test.describe('Date-format preference', () => {
     await page.goto('/ui/tracking');
     await page.waitForSelector('table.tracking-table');
     const dateCell = rowByStamp(page, stamp).locator('td[data-col-key="date"]');
-    await expect(dateCell).toHaveText(/^\d{2}\.\d{2}\.\d{4}( \(.+\))?$/);
+    await expect(dateCell.locator('.dt-full')).toHaveText(/^\d{2}\.\d{2}\.\d{4}$/);
 
     // ... but opening its editor shows the ISO value (edit/wire format unchanged).
     await dateCell.focus();

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -524,7 +524,9 @@ describe('Tracking (Worklog grid)', () => {
     await waitFor(() => expect(getByRole('gridcell', { name: 'Newest' })).toBeInTheDocument())
 
     // Dates render in ISO (yyyy-mm-dd), one consistent format everywhere.
-    const dates = Array.from(container.querySelectorAll('tbody tr td[data-col-key="date"]')).map((td) => td.textContent)
+    // The date cell renders three responsive widths (full / MM-DD / DD); read the
+    // full-date span rather than the whole cell's concatenated text.
+    const dates = Array.from(container.querySelectorAll('tbody tr td[data-col-key="date"] .dt-full')).map((el) => el.textContent)
     expect(dates).toEqual(['2026-06-16', '2026-06-15', '2026-06-14'])
 
     unmount()

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -144,6 +144,16 @@ function displayDate(value: string): string {
   return formatUserDate(dmyToIso(value) ?? value)
 }
 
+// Three widths of the same date so the responsive table can shrink the Date
+// column purely in CSS: full (the user's preferred format), then MM-DD, then DD.
+function dateParts(value: string): { full: string; mid: string; short: string } {
+  const full = displayDate(value)
+  const iso = dmyToIso(value) ?? value
+  const parts = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
+
+  return parts ? { full, mid: `${parts[2]}-${parts[3]}`, short: parts[3]! } : { full, mid: full, short: full }
+}
+
 // One icon button in the row-actions cell — same shape for Continue/Prolong/Info/
 // Delete (label drives both the accessible name and the hover tooltip).
 function RowAction(props: { label: string; danger?: boolean; keyshortcut?: string; onClick: () => void; children: JSX.Element }): JSX.Element {
@@ -250,6 +260,9 @@ export default function Tracking() {
   // The grid's move handle — used to restore cell focus after a row is deleted.
   let gridHandle: GridMoveHandle | null = null
   const rows = createMemo<TrackingEntry[]>(() => [...newRows(), ...(entries.data ?? [])])
+  // The External-ticket column is read-only and often empty; when no visible row
+  // has one it becomes a hide candidate for the responsive (narrow) table.
+  const hasExtTicket = createMemo<boolean>(() => rows().some((row) => str(row.extTicket) !== ''))
   const allProjectOptions = createMemo<NamedOption[]>(() => (projects.data ?? []).map((project) => ({ id: project.id, label: project.name })))
 
   // id→label maps, rebuilt only when the option list changes, so resolving a
@@ -498,9 +511,14 @@ export default function Tracking() {
         : <a class="ticket-link" href={ticketUrlFor(ticket, num(row.project))} target="_blank" rel="noopener noreferrer">{ticket}</a>
     }
     if (colKey === 'date') {
+      const parts = dateParts(str(editor.overlayRow(entry).date))
+
       return (
         <>
-          {displayCell(entry, 'date')}
+          {/* Three widths; the responsive table CSS shows exactly one per column width. */}
+          <span class="dt dt-full">{parts.full}</span>
+          <span class="dt dt-mid">{parts.mid}</span>
+          <span class="dt dt-short">{parts.short}</span>
           <Show when={classLabel(entry.class) !== ''}>
             <span class="visually-hidden"> ({classLabel(entry.class)})</span>
           </Show>
@@ -903,7 +921,7 @@ export default function Tracking() {
         <div class="table-scroll">
           <table
             class="data-table tracking-table"
-            classList={{ 'is-fetching': entries.isFetching }}
+            classList={{ 'is-fetching': entries.isFetching, 'no-extticket': !hasExtTicket() }}
             // A refetch (refresh / range change) keeps the previous rows visible
             // (keepPreviousData) — aria-busy + a subtle dim are the only in-flight
             // cue a sighted user gets, since the first-load spinner won't fire.
@@ -924,8 +942,8 @@ export default function Tracking() {
           >
             <thead>
               <tr>
-                <For each={COLUMNS}>{(col) => <th scope="col" classList={{ numeric: col.numeric }}>{col.label()}</th>}</For>
-                <th scope="col">{m.tracking_actions()}</th>
+                <For each={COLUMNS}>{(col) => <th scope="col" data-col-key={col.key} classList={{ numeric: col.numeric }}>{col.label()}</th>}</For>
+                <th scope="col" data-col-key="actions">{m.tracking_actions()}</th>
               </tr>
             </thead>
             <tbody>
@@ -999,7 +1017,7 @@ export default function Tracking() {
                       </For>
                       {/* data-row-id (no data-col-key → not inline-editable) keeps focus
                           "inside the row" so clicking Delete isn't read as a row-leave. */}
-                      <td class="tracking-row-actions" data-row-id={String(id)}>
+                      <td class="tracking-row-actions" data-col-key="actions" data-row-id={String(id)}>
                         <div class="row-actions">
                           {/* Per-row Continue / Prolong / Info — only for saved entries. */}
                           <Show when={id > 0}>

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -150,8 +150,13 @@ function dateParts(value: string): { full: string; mid: string; short: string } 
   const full = displayDate(value)
   const iso = dmyToIso(value) ?? value
   const parts = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
+  const month = parts?.[2]
+  const day = parts?.[3]
+  if (month !== undefined && day !== undefined) {
+    return { full, mid: `${month}-${day}`, short: day }
+  }
 
-  return parts ? { full, mid: `${parts[2]}-${parts[3]}`, short: parts[3]! } : { full, mid: full, short: full }
+  return { full, mid: full, short: full }
 }
 
 // One icon button in the row-actions cell — same shape for Continue/Prolong/Info/
@@ -865,7 +870,8 @@ export default function Tracking() {
                   if (daysMenuOpen()) { setDaysActiveIdx((i) => Math.max(0, i - 1)) }
                 } else if (event.key === 'Enter' && daysMenuOpen() && daysActiveIdx() >= 0) {
                   event.preventDefault()
-                  chooseDays(DAYS_OPTIONS[daysActiveIdx()]!)
+                  const option = DAYS_OPTIONS[daysActiveIdx()]
+                  if (option !== undefined) { chooseDays(option) }
                 } else if (event.key === 'Escape' && daysMenuOpen()) {
                   event.preventDefault()
                   closeDaysMenu()

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1140,6 +1140,53 @@ kbd {
 /* Lets wide tables scroll sideways on narrow screens instead of overflowing. */
 .table-scroll {
   overflow-x: auto;
+  /* A query container so the worklog table can adapt to the available width
+     (window AND sidebar width) — see the responsive rules below. Horizontal
+     scroll remains the safety net once everything has been thinned. */
+  container-type: inline-size;
+}
+
+/* ── Responsive worklog table ─────────────────────────────────────────────────
+   As the available width shrinks, thin the table out (instead of scrolling) in
+   this priority order: Date YYYY-MM-DD → MM-DD → DD; hide an empty Ext. Ticket
+   column; hide Actions; hide Duration; then shrink Project + Description. All
+   rules are scoped to .tracking-table so the shared admin/summary tables (same
+   .table-scroll container, same data-col-key attributes) are untouched. */
+.tracking-table .dt-mid,
+.tracking-table .dt-short {
+  display: none;
+}
+
+@container (max-width: 1040px) {
+  .tracking-table .dt-full { display: none; }
+  .tracking-table .dt-mid { display: inline; }
+}
+
+@container (max-width: 920px) {
+  .tracking-table .dt-mid { display: none; }
+  .tracking-table .dt-short { display: inline; }
+}
+
+@container (max-width: 860px) {
+  .tracking-table.no-extticket [data-col-key='extTicket'] { display: none; }
+}
+
+@container (max-width: 780px) {
+  .tracking-table [data-col-key='actions'] { display: none; }
+}
+
+@container (max-width: 680px) {
+  .tracking-table [data-col-key='duration'] { display: none; }
+}
+
+@container (max-width: 580px) {
+  .tracking-table [data-col-key='project'],
+  .tracking-table [data-col-key='description'] {
+    max-width: 8rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 /* A long detail list scrolls inside its own box instead of stretching the page;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1180,12 +1180,14 @@ kbd {
 }
 
 @container (max-width: 580px) {
+  /* Auto-layout tables don't honour ellipsis on a <td>, so cap the width and let
+     the text wrap (em scales with the text-size preference) — this shrinks the
+     two widest free-text columns rather than truncating unreliably. */
   .tracking-table [data-col-key='project'],
   .tracking-table [data-col-key='description'] {
-    max-width: 8rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    max-width: 10em;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 }
 


### PR DESCRIPTION
When the available width can't hold the full worklog table, it degrades in priority order (CSS **container queries** on `.table-scroll` — responds to the window **and** the resizable sidebar) instead of horizontal-scrolling:

1. **Date**: YYYY-MM-DD → MM-DD → DD (cell renders three widths; CSS shows one; full width still honours the date-format preference).
2. Hide **Ext. Ticket** when no visible row has one (data-driven `.no-extticket`).
3. Hide **Actions**.
4. Hide **Duration**.
5. Shrink **Project + Description** (ellipsis).

Horizontal scroll stays as the safety net. All rules scoped to `.tracking-table` so the shared admin/summary tables (same container + `data-col-key`) are untouched; the sticky header still works.

Verified at container widths 1152→556: date full/mid/short at 1040/920, column hides at 860/780/680, shrink at 580; sticky thead intact. typecheck/lint/**329 tests**/build green.