### PR TITLE
fix(ui): show admin sub-menu icons in the collapsed sidebar rail

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2815,9 +2815,7 @@ th[aria-sort='descending'] .th-sort-glyph {
     width: 3.5rem;
   }
 
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .nav-label,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-worktime,
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-label,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-add,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .user-name,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #logo,
@@ -2826,12 +2824,30 @@ th[aria-sort='descending'] .th-sort-glyph {
     display: none;
   }
 
+  /* Labels are visually hidden (not display:none) in the rail so the icon-only
+     nav/admin links keep their accessible name for screen readers. */
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .nav-label,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
   /* Collapsed rail keeps the admin entity sub-menu as icon-only rows (labels and
-     the "+" hidden above); centre each icon like the main nav. */
+     the "+" hidden above); centre each icon and drop the edge bar so it isn't
+     offset — the active row is shown with a soft fill instead. */
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-link {
     justify-content: center;
     padding-left: 0;
     padding-right: 0;
+    border-left: 0;
+  }
+
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-item.is-active .sidebar-admin-link {
+    background: var(--color-accent-soft);
   }
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-logo {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2817,12 +2817,21 @@ th[aria-sort='descending'] .th-sort-glyph {
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .nav-label,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-worktime,
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #sidebar-admin-slot,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-label,
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-add,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .user-name,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] #logo,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-resize,
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-reopen {
     display: none;
+  }
+
+  /* Collapsed rail keeps the admin entity sub-menu as icon-only rows (labels and
+     the "+" hidden above); centre each icon like the main nav. */
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .sidebar-admin-link {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .header-logo {


### PR DESCRIPTION
The collapsed rail hid the whole admin sub-menu; on `/admin` it now keeps the entity rows as **icon-only** (labels + the `+` hidden, icon centred), consistent with the main-nav icons. Verified: collapsed `/admin` rail shows all 10 entity icons (active highlighted), labels/adds hidden. typecheck/lint/build green.