### PR TITLE
fix(ui): don't run top-bar overflow-fold in the left sidebar (nav/worktime vanish)

### DIFF
--- a/templates/partials/header-behavior.html.twig
+++ b/templates/partials/header-behavior.html.twig
@@ -243,6 +243,19 @@
                 return;
             }
             laying = true;
+            // The left-sidebar layout is a vertical column — the horizontal
+            // priority-overflow must NOT run there. Its width check ("does the
+            // content exceed the column width?") is always true for a narrow
+            // column, which would fold the nav links into "More" and collapse the
+            // worktime badges (making the nav appear to vanish). Restore
+            // everything to its natural place and bail.
+            if (document.documentElement.getAttribute('data-nav-layout') === 'side') {
+                restore();
+                moreWrap.hidden = true;
+                laying = false;
+
+                return;
+            }
             // The "More" button may be hidden below; if it currently holds focus,
             // we must hand focus back to the bar so it isn't lost to <body>.
             var moreHadFocus = moreWrap.contains(document.activeElement);


### PR DESCRIPTION
## Root cause (confirmed via the reported DevTools screenshots)
The header's **priority-overflow** `layout()` — which folds nav links into a "More" menu and adds `is-collapsed` to the worktime when the *horizontal* bar is too narrow — kept running in the **vertical sidebar**. There the column is narrow by design, so its `scrollWidth > clientWidth` check trips once the worktime shows real values (e.g. `176:00`) or with longer German labels → the nav links get folded into the hidden `.nav-more` menu and the worktime gets `is-collapsed`. Both appear to "vanish."

This is why it reproduced on prod (real worktime + `de` labels) but not in a clean/empty test env, and why the fold appeared as the sidebar got a few px narrower.

## Fix
`layout()` now restores everything and bails when `data-nav-layout='side'`.

## Verified
At 150px sidebar width with **forced-wide content** ('9999:59' worktime + an over-long label) and a resize event: `.nav-more` stays hidden, worktime is **not** collapsed, all 5 nav links stay in the bar. Twig lint ✓.