### PR TITLE
fix(worklog): keep inline-edit mode when tabbing after a change (#481)

### DIFF
--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -43,6 +43,36 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
     await expect(page.locator('td[data-col-key="end"][data-inline-editing] input.inline-editor')).toBeVisible();
   });
 
+  // Regression for #481: editing an EXISTING, already-complete entry and pressing
+  // Tab used to drop inline-edit mode — the next cell showed briefly but was not
+  // typeable until re-opened. Cause: a valid change kept the row complete, so the
+  // commit auto-saved, and saveRow's refetch remounted the rows and unmounted the
+  // just-opened editor. (The Tab test above types an incomplete '9', so its row
+  // never auto-saved and it never hit this path.) Auto-save is now deferred for Tab.
+  test('Tab keeps inline-edit mode after a valid change to an existing entry (#481)', async ({ page }) => {
+    const stamp = await createWorklogEntry(page);
+    const row = rowByStamp(page, stamp);
+
+    // The reporter's flow: double-click a cell of a complete row and change it.
+    await row.locator('td[data-col-key="start"]').dblclick();
+    const startEditor = page.locator('td[data-col-key="start"][data-inline-editing] input.inline-editor');
+    await expect(startEditor).toBeVisible();
+    await expect(startEditor).toBeFocused();
+
+    // A real, VALID edit (00:05 is still before the 00:15 end) keeps the row
+    // complete — the exact condition that used to trigger the disruptive auto-save.
+    await startEditor.fill('00:05');
+    await page.keyboard.press('Tab');
+
+    // Edit mode must survive: the next editor is open, focused AND typeable (the
+    // bug left a dead cell that needed a second double-click).
+    const endEditor = page.locator('td[data-col-key="end"][data-inline-editing] input.inline-editor');
+    await expect(endEditor).toBeVisible();
+    await expect(endEditor).toBeFocused();
+    await endEditor.fill('00:20');
+    await expect(endEditor).toHaveValue('00:20');
+  });
+
   test('Ctrl+C copies the focused cell; Ctrl+V pastes into another, seeding the editor', async ({ page }) => {
     // Ctrl+C/V on a focused (non-edit) cell drive the async clipboard API, which needs
     // a secure context. CI serves the app over plain HTTP on a container hostname, so

--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -399,7 +399,11 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     // edited back), drop the draft so the row stays clean — and refreshHints
     // then sees no draft and skips the (pointless) auto-save.
     discardIfClean(cell.rowId)
-    refreshHints(cell.rowId)
+    // A Tab move (left/right) stays in the same row and opens the next cell's
+    // editor; auto-saving now would refetch and remount that editor away (#481),
+    // so defer the save to row-leave. Every other commit auto-saves as before.
+    const staysInRowViaTab = direction === 'left' || direction === 'right'
+    refreshHints(cell.rowId, !staysInRowViaTab)
 
     // The post-commit move (all through the grid's setActive — the single
     // roving-tabindex writer). Enter (stay/down) on an incomplete row is guided to
@@ -446,7 +450,12 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
   // After a commit: recompute the row's invalid-field hints and, when the row is
   // complete (no invalid fields), auto-save it quietly. Saving no longer depends
   // on leaving the row. A no-op when the host provides no invalidFields.
-  function refreshHints(id: number): void {
+  //
+  // autoSave is suppressed for a Tab move that keeps editing the SAME row: saveRow
+  // refetches, which remounts the rows and would unmount the editor Tab just opened
+  // on the next cell (#481 — "lose inline-edit mode on Tab"). The row still saves
+  // when focus leaves it (onTableFocusOut / row-leave) or on any non-Tab commit.
+  function refreshHints(id: number, autoSave = true): void {
     if (config.invalidFields === undefined) {
       return
     }
@@ -457,7 +466,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     }
     const invalid = config.invalidFields(draft, row)
     setFieldHints(id, invalid)
-    if (invalid.length === 0) {
+    if (autoSave && invalid.length === 0) {
       void flushRow(id)
     }
   }


### PR DESCRIPTION
## Summary

Fixes #481 — in the Worklog grid, editing an **existing** (already-complete) entry and pressing **Tab** dropped inline-edit mode: focus moved to the next cell but you couldn't type there until you double-clicked it again. Creating a *new* entry tabbed fine.

### Root cause
A valid edit keeps the row complete, so `commitCell` → `refreshHints` **auto-saves** it. `saveRow` invalidates the entries query; the **refetch replaces the row objects**, so the reference-keyed `<For each={rows()}>` remounts every `<tr>` and unmounts the editor Tab had just opened on the next cell. A new row stays *incomplete* while you tab through it, so it never auto-saves mid-traversal — which is why new entries were unaffected.

### Fix
Defer the auto-save for a **horizontal Tab commit** (`left`/`right`). The row still saves when focus leaves it (`onTableFocusOut` / row-leave) or on any non-Tab commit, so nothing is lost — only the disruptive mid-traversal refetch is avoided. Every other commit auto-saves exactly as before.

One-line change in `refreshHints` (`autoSave` flag) + the call site in `commitCell`.

## Test plan
- Added an e2e regression (`worklog-grid-editing.spec.ts`): open an existing complete entry, make a **valid** change (`00:05`), Tab → the next editor stays visible, focused, and **typeable**. (The pre-existing Tab test types an incomplete `'9'`, so its row never auto-saved and it never exercised this path.)
- `frontend`: `bun run test` (335), `typecheck`, `lint`.

https://claude.ai/code/session_01PG6BQp6gyXhm1UdQnT5cMn

