### PR TITLE
fix(ui): worklog polish — IST/SOLL popover clip, save toast, dense controls

### DIFF
--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -818,7 +818,7 @@ export default function Tracking() {
           Purely visual: aria-hidden so AT users aren't told twice — the polite
           live region above already announces the save. */}
       <Show when={savedNotice() !== ''}>
-        <p class="form-status is-ok" aria-hidden="true">{savedNotice()}</p>
+        <p class="save-toast" aria-hidden="true">{savedNotice()}</p>
       </Show>
 
       <div class="tracking-toolbar">

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -796,6 +796,7 @@ main {
    into the page's top-left corner. */
 .save-toast {
   position: fixed;
+  margin: 0; /* reset the default <p> margin so it can't skew the fixed offset */
   bottom: 1rem;
   left: 50%;
   transform: translateX(-50%);
@@ -2518,6 +2519,7 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='compact'] .action-button.is-icon,
 :root[data-density='compact'] .primary-button.is-icon {
   min-width: 30px;
+  padding: 0; /* keep the icon-only button square (beats the .primary-button padding above) */
 }
 
 /* ── Ultra-compact — even tighter than Compact, plus a compacted header and no
@@ -2564,6 +2566,7 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='ultra-compact'] .action-button.is-icon,
 :root[data-density='ultra-compact'] .primary-button.is-icon {
   min-width: 26px;
+  padding: 0; /* keep the icon-only button square (beats the .primary-button padding above) */
 }
 
 /* Header compaction — overrides the static header.css defaults (loaded first).

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -780,8 +780,43 @@ main {
   opacity: 0.6;
 }
 
+/* Icon-only primary action (e.g. the worklog Add "+"): a square target, not a
+   text-padded pill, so it matches the other toolbar icon buttons. */
+.primary-button.is-icon {
+  min-width: 44px;
+  padding: 0;
+}
+
 .form-status.is-ok {
   color: var(--color-success-text);
+}
+
+/* Auto-dismissing save confirmation for the worklog (the polite live region
+   handles AT). A fixed toast — NOT an inline .form-status, which dumped the text
+   into the page's top-left corner. */
+.save-toast {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
+  border: 1px solid var(--color-success-text);
+  border-radius: 8px;
+  padding: 0.5rem 0.9rem;
+  font-weight: 600;
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.16);
+  animation: save-toast-in 0.15s ease;
+}
+
+@keyframes save-toast-in {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .save-toast { animation: none; }
 }
 
 .form-status.is-error {
@@ -2469,12 +2504,19 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='compact'] .link-button,
 :root[data-density='compact'] .action-button,
 :root[data-density='compact'] .admin-subnav-link,
+:root[data-density='compact'] .primary-button,
+:root[data-density='compact'] .days-combo-toggle,
 :root[data-density='compact'] .tracking-days-input {
   min-height: 30px;
 }
 
+:root[data-density='compact'] .primary-button {
+  padding: 0 0.7rem;
+}
+
 :root[data-density='compact'] .link-button.is-icon,
-:root[data-density='compact'] .action-button.is-icon {
+:root[data-density='compact'] .action-button.is-icon,
+:root[data-density='compact'] .primary-button.is-icon {
   min-width: 30px;
 }
 
@@ -2508,12 +2550,19 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='ultra-compact'] .link-button,
 :root[data-density='ultra-compact'] .action-button,
 :root[data-density='ultra-compact'] .admin-subnav-link,
+:root[data-density='ultra-compact'] .primary-button,
+:root[data-density='ultra-compact'] .days-combo-toggle,
 :root[data-density='ultra-compact'] .tracking-days-input {
   min-height: 26px;
 }
 
+:root[data-density='ultra-compact'] .primary-button {
+  padding: 0 0.6rem;
+}
+
 :root[data-density='ultra-compact'] .link-button.is-icon,
-:root[data-density='ultra-compact'] .action-button.is-icon {
+:root[data-density='ultra-compact'] .action-button.is-icon,
+:root[data-density='ultra-compact'] .primary-button.is-icon {
   min-width: 26px;
 }
 
@@ -2800,9 +2849,10 @@ th[aria-sort='descending'] .th-sort-glyph {
     display: block;
     position: fixed;
     z-index: 60;
-    /* em so it scales with the user's text-size preference (--font-scale), keeping
-       the IST/SOLL rows from wrapping when text is enlarged. */
-    width: 14em;
+    /* Size to content so the signed-Δ column can't clip (a fixed em width was too
+       narrow at the sidebar's ~13px base font). Content is text (ch/em), so it
+       still scales with the --font-scale text-size preference; capped to viewport. */
+    width: max-content;
     max-width: calc(100vw - 24px);
     padding: 8px 10px;
     background: var(--color-surface);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -801,6 +801,10 @@ main {
   left: 50%;
   transform: translateX(-50%);
   z-index: 200;
+  /* Transient, informational: never intercept clicks on the content beneath it,
+     and cap width so a long localized string can't overflow the viewport. */
+  pointer-events: none;
+  max-width: calc(100vw - 2rem);
   background: var(--color-success-bg);
   color: var(--color-success-text);
   border: 1px solid var(--color-success-text);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2526,6 +2526,11 @@ th[aria-sort='descending'] .th-sort-glyph {
   padding: 0; /* keep the icon-only button square (beats the .primary-button padding above) */
 }
 
+/* Match the day-range toggle's width to its shrunk height so it stays square. */
+:root[data-density='compact'] .days-combo-toggle {
+  width: 30px;
+}
+
 /* ── Ultra-compact — even tighter than Compact, plus a compacted header and no
    ambient helper UI. Shares Compact's full-width + structural rules above; this
    block only goes further. Interactive targets clamp at 26px (≥24px AA). */
@@ -2571,6 +2576,10 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='ultra-compact'] .primary-button.is-icon {
   min-width: 26px;
   padding: 0; /* keep the icon-only button square (beats the .primary-button padding above) */
+}
+
+:root[data-density='ultra-compact'] .days-combo-toggle {
+  width: 26px;
 }
 
 /* Header compaction — overrides the static header.css defaults (loaded first).

--- a/tests/Controller/GetTimeSummaryActionTest.php
+++ b/tests/Controller/GetTimeSummaryActionTest.php
@@ -36,7 +36,6 @@ final class GetTimeSummaryActionTest extends AbstractWebTestCase
         $json = $this->getJsonResponse($response);
         self::assertIsArray($json);
 
-        $targets = [];
         foreach (['today', 'week', 'month'] as $period) {
             self::assertArrayHasKey($period, $json);
             $data = $json[$period];
@@ -46,11 +45,10 @@ final class GetTimeSummaryActionTest extends AbstractWebTestCase
             self::assertIsNumeric($data['duration']);
             self::assertIsNumeric($data['target']);
             self::assertGreaterThanOrEqual(0, $data['target'], $period . ' target is never negative');
-            $targets[$period] = $data['target'];
         }
 
-        // SOLL accumulates over longer periods: month-to-date ≥ week-to-date ≥ today.
-        self::assertGreaterThanOrEqual($targets['week'], $targets['month']);
-        self::assertGreaterThanOrEqual($targets['today'], $targets['week']);
+        // NB: no month ≥ week ≥ today ordering — week-to-date (Mon→today) can exceed
+        // month-to-date early in a month, when the week reaches into the prior month
+        // (e.g. the 1st on a Wednesday: month = today only, week = Mon–Wed).
     }
 }


### PR DESCRIPTION
## Summary

Polish follow-ups to #482 (sidebar footer + IST/SOLL), all found while reviewing the live `:profiling` deploy:

1. **IST/SOLL popover clipped the Δ column** — the `14em` width (from a review suggestion assuming a 15px base) was too narrow at the sidebar's ~13px base font. Now `width: max-content` (capped to viewport): it sizes to its content so the signed delta never clips, and since the content is text it still scales with the text-size preference.
2. **"Entry saved" appeared as stray text in the content's top-left** — it was rendered as an inline `.form-status` paragraph, not a toast. Now a fixed bottom-centre `.save-toast` (the polite live region still handles AT; reduced-motion respected).
3. **Add "+" and the day-range toggle stayed 44px in dense modes** while the other toolbar controls shrink — density now also targets `.primary-button` / `.primary-button.is-icon` / `.days-combo-toggle` (→ 30px compact, 26px ultra), and an icon-only primary button is square rather than a text-padded pill.
4. **Removed a false test invariant** — `GetTimeSummaryActionTest` asserted `month ≥ week ≥ today`, but week-to-date legitimately exceeds month-to-date early in a month (the 1st on a Wednesday: month = today only, week = Mon–Wed). This is exactly what prod showed on 2026-07-01 (Month 0:00/1:00 vs Week 0:00/3:00) — correct behaviour, wrong assertion. Kept the per-period checks.

## Test plan
- `frontend`: `bun run test` (335), `typecheck`, `lint` — green.
- Verified the popover renders the full `−1:00 / −3:00 / −1:00` deltas (no clip) against the built CSS with the prod values.
- PHPStan / php-cs-fixer clean on the changed test.

Note: the Month<Week display (#4) is correct at month boundaries and not a bug — only the test assertion was wrong.

https://claude.ai/code/session_01PG6BQp6gyXhm1UdQnT5cMn
