### PR TITLE
fix(ui): worktime overview layout + app-wide dense control sizing

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2857,7 +2857,8 @@ th[aria-sort='descending'] .th-sort-glyph {
      by header.ts from IST vs SOLL. Neutral (no target, e.g. weekend) stays plain. */
   :root[data-nav-layout='side'] .worktime-item dd a {
     display: inline-block;
-    font-size: 0.95rem;
+    /* em (not rem) so it scales with the --font-scale text-size preference (ADR-014). */
+    font-size: 1.05em;
     font-weight: 700;
     border-bottom: 2px solid transparent;
     padding-bottom: 1px;
@@ -2893,8 +2894,9 @@ th[aria-sort='descending'] .th-sort-glyph {
     width: max-content;
     max-width: calc(100vw - 24px);
     /* It's a transient hover/focus overlay, not sidebar chrome — render it
-       comfortably legible rather than shrunk to the 13px sidebar font. */
-    font-size: 0.92rem;
+       comfortably legible rather than shrunk to the 13px sidebar font. em (not
+       rem) so it still tracks the --font-scale text-size preference (ADR-014). */
+    font-size: 1.15em;
     padding: 12px 15px;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
@@ -3176,7 +3178,7 @@ th[aria-sort='descending'] .th-sort-glyph {
   }
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item[data-period='today'] dd a {
-    font-size: 0.82rem;
+    font-size: 0.94em;
   }
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item + .worktime-item::before {
@@ -3194,7 +3196,7 @@ th[aria-sort='descending'] .th-sort-glyph {
   }
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item[data-period='week'] dd a {
-    font-size: 0.7rem;
+    font-size: 0.8em;
     font-weight: 600;
   }
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2892,11 +2892,14 @@ th[aria-sort='descending'] .th-sort-glyph {
        still scales with the --font-scale text-size preference; capped to viewport. */
     width: max-content;
     max-width: calc(100vw - 24px);
-    padding: 8px 10px;
+    /* It's a transient hover/focus overlay, not sidebar chrome — render it
+       comfortably legible rather than shrunk to the 13px sidebar font. */
+    font-size: 0.92rem;
+    padding: 12px 15px;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 10px;
-    box-shadow: 0 6px 22px rgba(0, 0, 0, 0.16);
+    border-radius: 12px;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.22);
     opacity: 0;
     visibility: hidden;
     transform: translateY(4px);
@@ -2912,10 +2915,10 @@ th[aria-sort='descending'] .th-sort-glyph {
   }
 
   :root[data-nav-layout='side'] .worktime-detail-title {
-    margin: 0 0 5px;
-    font-size: 0.62em;
+    margin: 0 0 8px;
+    font-size: 0.66em;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.07em;
     font-weight: 700;
     color: var(--color-text-muted);
   }
@@ -2923,10 +2926,10 @@ th[aria-sort='descending'] .th-sort-glyph {
   :root[data-nav-layout='side'] .worktime-detail-row {
     display: grid;
     grid-template-columns: auto auto auto 1fr;
-    gap: 2px 7px;
+    gap: 3px 16px;
     align-items: baseline;
-    padding: 3px 0;
-    font-size: 0.78em;
+    padding: 6px 0;
+    font-size: 0.95em;
   }
 
   :root[data-nav-layout='side'] .worktime-detail-row + .worktime-detail-row {
@@ -2946,6 +2949,7 @@ th[aria-sort='descending'] .th-sort-glyph {
   :root[data-nav-layout='side'] .wd-delta {
     text-align: right;
     font-weight: 700;
+    font-size: 1.02em;
   }
 
   :root[data-nav-layout='side'] .worktime-detail-row.is-ok .wd-delta {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2511,7 +2511,18 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='compact'] .admin-subnav-link,
 :root[data-density='compact'] .primary-button,
 :root[data-density='compact'] .days-combo-toggle,
-:root[data-density='compact'] .tracking-days-input {
+:root[data-density='compact'] .tracking-days-input,
+/* All interactive controls commit to the same tighter target in dense mode, not
+   just the worklog toolbar: form inputs/selects (Auswertung date range + filters,
+   modals), the range presets, the admin filter, and the Month year/month/today
+   nav. Textarea keeps its multi-line height. */
+:root[data-density='compact'] .field input:not([type='checkbox']):not([type='radio']),
+:root[data-density='compact'] .field select,
+:root[data-density='compact'] .range-preset,
+:root[data-density='compact'] .admin-filter,
+:root[data-density='compact'] .today-button,
+:root[data-density='compact'] .year-arrow,
+:root[data-density='compact'] .month-chip {
   min-height: 30px;
 }
 
@@ -2563,7 +2574,14 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='ultra-compact'] .admin-subnav-link,
 :root[data-density='ultra-compact'] .primary-button,
 :root[data-density='ultra-compact'] .days-combo-toggle,
-:root[data-density='ultra-compact'] .tracking-days-input {
+:root[data-density='ultra-compact'] .tracking-days-input,
+:root[data-density='ultra-compact'] .field input:not([type='checkbox']):not([type='radio']),
+:root[data-density='ultra-compact'] .field select,
+:root[data-density='ultra-compact'] .range-preset,
+:root[data-density='ultra-compact'] .admin-filter,
+:root[data-density='ultra-compact'] .today-button,
+:root[data-density='ultra-compact'] .year-arrow,
+:root[data-density='ultra-compact'] .month-chip {
   min-height: 26px;
 }
 
@@ -2782,14 +2800,14 @@ th[aria-sort='descending'] .th-sort-glyph {
 
   /* The worktime block opens the bottom footer cluster — a hairline divider makes
      the flexible gap above the nav read as intentional, not a load failure. */
+  /* Reset the top-bar's display:flex (header.css): as a flex ROW it shrank the
+     worktime-list to content and left-packed it (uncentered, tiny). As a block
+     the list fills the column, so the 3 columns spread evenly (expanded) and the
+     stacked values centre (rail). */
   :root[data-nav-layout='side'] .header-worktime {
+    display: block;
     border-top: 1px solid var(--color-border);
     padding-top: 0.5rem;
-  }
-
-  /* Anchor for the IST/SOLL detail popover. */
-  :root[data-nav-layout='side'] .header-worktime {
-    position: relative;
   }
 
   /* Totals as one aligned ledger: three equal columns (label over value) split
@@ -2839,6 +2857,8 @@ th[aria-sort='descending'] .th-sort-glyph {
      by header.ts from IST vs SOLL. Neutral (no target, e.g. weekend) stays plain. */
   :root[data-nav-layout='side'] .worktime-item dd a {
     display: inline-block;
+    font-size: 0.95rem;
+    font-weight: 700;
     border-bottom: 2px solid transparent;
     padding-bottom: 1px;
   }
@@ -2864,7 +2884,9 @@ th[aria-sort='descending'] .th-sort-glyph {
   :root[data-nav-layout='side'] .worktime-detail {
     display: block;
     position: fixed;
-    z-index: 60;
+    /* Above the sidebar column and the content's border/edge (below modals at 1200)
+       so the sidebar divider can't show through the popover. */
+    z-index: 1000;
     /* Size to content so the signed-Δ column can't clip (a fixed em width was too
        narrow at the sidebar's ~13px base font). Content is text (ch/em), so it
        still scales with the --font-scale text-size preference; capped to viewport. */
@@ -3149,9 +3171,8 @@ th[aria-sort='descending'] .th-sort-glyph {
     line-height: 1.1;
   }
 
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item[data-period='today'] dd {
-    font-size: 0.74em;
-    font-weight: 700;
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item[data-period='today'] dd a {
+    font-size: 0.82rem;
   }
 
   :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item + .worktime-item::before {
@@ -3168,8 +3189,9 @@ th[aria-sort='descending'] .th-sort-glyph {
     padding-bottom: 0;
   }
 
-  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item[data-period='week'] dd {
-    font-size: 0.64em;
+  :root[data-nav-layout='side'][data-sidebar-collapsed='true'] .worktime-item[data-period='week'] dd a {
+    font-size: 0.7rem;
+    font-weight: 600;
   }
 
   /* Labels are visually hidden (not display:none) in the rail so the icon-only


### PR DESCRIPTION
## Summary

Fixes the worktime-overview regression + extends dense sizing app-wide (both surfaced reviewing the live deploy).

### Worktime overview (the "doesn't look right / deranged rail" report)
Root cause: `.header-worktime` kept the top-bar's `display:flex` (row) in the sidebar, so its `.worktime-list` shrank to content and left-packed — **uncentered and tiny in the rail, and too small / off-centre expanded**. Reset it to `display:block` so the list fills the column:
- Expanded: the three columns spread evenly across the gutter; values are **0.95rem/700** to match the approved Option A.
- Collapsed rail: the stacked Today/Week values **centre** (aligned with the icons) at a readable 0.82 / 0.7rem (was 9.6px).
- IST/SOLL popover `z-index` 60 → 1000 so the sidebar divider no longer shows through it.

### Dense sizing — now app-wide, not just the worklog toolbar
The previous PR only shrank the worklog toolbar. Density now tightens **every** 44px touch-target control to 30px (compact) / 26px (ultra):
- `.field` inputs & selects — Auswertung **date-range** + all filters, modal forms, Settings
- `.range-preset` — Auswertung presets
- `.admin-filter` — the `/ui/admin` filter box
- `.today-button`, `.year-arrow`, `.month-chip` — the `/ui/month` year / month / today nav

## Test plan
- `frontend`: `bun run test` (335), `typecheck`, `lint` — green.
- Verified expanded + collapsed-rail footer + popover against the built CSS (centered, correct size, no border-through).

Follow-up (next): the **right-side menu** — add a "Right sidebar" Navigation Layout option and mirror the rail. Tracked separately as it's a new feature, not a regression.

https://claude.ai/code/session_01PG6BQp6gyXhm1UdQnT5cMn
