### PR TITLE
feat(ui): right-dockable sidebar (Navigation Layout: Right sidebar)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -86,6 +86,7 @@
   "settings_layout_hint": "Wird sofort angewendet. Legt fest, wo das Menü sitzt.",
   "settings_layout_top": "Obere Leiste",
   "settings_layout_side": "Linke Seitenleiste",
+  "settings_layout_side_right": "Rechte Seitenleiste",
   "settings_saved": "Einstellungen gespeichert.",
   "settings_save_error": "Einstellungen konnten nicht gespeichert werden.",
   "extras_title": "Massen-Eintragung",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -86,6 +86,7 @@
   "settings_layout_hint": "Applies immediately. Choose where the menu sits.",
   "settings_layout_top": "Top bar",
   "settings_layout_side": "Left sidebar",
+  "settings_layout_side_right": "Right sidebar",
   "settings_saved": "Settings saved.",
   "settings_save_error": "Settings could not be saved.",
   "extras_title": "Bulk entry",

--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getJson } from './api/client'
 import type { AppConfig } from './config'
-import { formatDays, formatDuration, formatSignedDuration, handleHelpClick, handleShortcut, hideAccessHints, initialsFrom, refreshLoginStatus, showAccessHints, updateWorktime, worktimeStatus } from './header'
+import { formatDays, formatDuration, formatSignedDuration, handleHelpClick, handleShortcut, hideAccessHints, initialsFrom, refreshLoginStatus, showAccessHints, updateWorktime, wireWorktimeDetail, worktimeStatus } from './header'
 import { setShortcutsHelpOpen, shortcutsHelpOpen } from './lib/shortcutsHelp'
 
 // Preserve the module's other exports (SessionExpiredError, postJson, …) and stub
@@ -124,6 +124,48 @@ describe('updateWorktime', () => {
     expect(today.classList.contains('is-ok')).toBe(false)
     expect(today.classList.contains('is-under')).toBe(false)
     expect(document.getElementById('worktime-day')?.textContent).toBe('7:30')
+  })
+})
+
+describe('wireWorktimeDetail', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  function renderWorktimeBlock(): void {
+    document.body.innerHTML = `
+      <section class="header-worktime" tabindex="-1">
+        <dl class="worktime-list"><div class="worktime-item" data-period="today"><dd><a id="worktime-day" href="#">0:00</a></dd></div></dl>
+        <div class="worktime-detail" id="worktime-detail" role="tooltip"></div>
+      </section>`
+  }
+
+  it('portals the popover to <body> and opens on hover', () => {
+    renderWorktimeBlock()
+    wireWorktimeDetail()
+    const block = document.querySelector<HTMLElement>('.header-worktime')!
+    const popover = document.getElementById('worktime-detail')!
+
+    expect(popover.parentElement).toBe(document.body) // escaped the sticky sidebar
+    block.dispatchEvent(new MouseEvent('mouseenter'))
+    expect(popover.classList.contains('is-open')).toBe(true)
+    block.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(popover.classList.contains('is-open')).toBe(false)
+  })
+
+  it('stays open on mouseleave while a link inside still has focus (keyboard)', () => {
+    renderWorktimeBlock()
+    wireWorktimeDetail()
+    const block = document.querySelector<HTMLElement>('.header-worktime')!
+    const popover = document.getElementById('worktime-detail')!
+
+    document.getElementById('worktime-day')!.focus()
+    block.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    expect(popover.classList.contains('is-open')).toBe(true)
+    // Mouse leaves, but focus is still within the block → must NOT close.
+    block.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(popover.classList.contains('is-open')).toBe(true)
   })
 })
 

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -159,9 +159,16 @@ function positionWorktimeDetail(): void {
   const width = popover.offsetWidth
   const height = popover.offsetHeight
   const collapsed = document.documentElement.getAttribute('data-sidebar-collapsed') === 'true'
+  const rightDock = document.documentElement.getAttribute('data-nav-side') === 'right'
 
-  // Rail: flank the block. Expanded column: sit above it, left edges aligned.
-  let left = collapsed ? rect.right + gap : rect.left
+  // Rail: flank the block (right of a left rail, left of a right rail). Expanded
+  // column: sit above it, aligned to the block's near edge.
+  let left
+  if (collapsed) {
+    left = rightDock ? rect.left - width - gap : rect.right + gap
+  } else {
+    left = rightDock ? rect.right - width : rect.left
+  }
   let top = collapsed ? rect.top : rect.top - height - gap
 
   // Keep it within the viewport.

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -178,6 +178,45 @@ function positionWorktimeDetail(): void {
   popover.style.top = `${Math.round(top)}px`
 }
 
+/**
+ * Portal the IST/SOLL popover to <body> and drive it from JS. The sidebar
+ * (#page-header) is position:sticky, which creates a stacking context, so a
+ * popover left inside it can't paint above the body-level resize handle no matter
+ * its z-index. Moving it to <body> frees it; open/close is then a JS-toggled
+ * class (mouse + keyboard) instead of the CSS :hover that needed a parent.
+ */
+function wireWorktimeDetail(): void {
+  const block = document.querySelector<HTMLElement>('.header-worktime')
+  const popover = document.getElementById('worktime-detail')
+  if (block === null || popover === null) {
+    return
+  }
+  if (popover.parentElement !== document.body) {
+    document.body.appendChild(popover)
+  }
+  const open = (): void => {
+    // Add the class first: positionWorktimeDetail() bails while the popover is
+    // visibility:hidden, so it must be visible before we measure/place it.
+    popover.classList.add('is-open')
+    positionWorktimeDetail()
+  }
+  const close = (): void => popover.classList.remove('is-open')
+  block.addEventListener('mouseenter', open)
+  block.addEventListener('mouseleave', close)
+  block.addEventListener('focusin', open)
+  block.addEventListener('focusout', (event) => {
+    // Keep it open while focus moves between the block's own links.
+    if (!block.contains(event.relatedTarget as Node | null)) {
+      close()
+    }
+  })
+  window.addEventListener('resize', () => {
+    if (popover.classList.contains('is-open')) {
+      positionWorktimeDetail()
+    }
+  })
+}
+
 // Exported so the SolidJS worklog can refresh the header's today/week/month
 // totals right after it saves, edits or deletes an entry — otherwise the header
 // sums (loaded once on init) go stale until a full page reload (#446).
@@ -595,15 +634,7 @@ export function initHeaderDynamics(config: AppConfig): void {
     link.setAttribute('aria-keyshortcuts', `Alt+${i + 1}`)
   })
   void updateWorktime()
-  // Position the IST/SOLL popover on demand (fixed-positioned to escape the
-  // sidebar column's clip). Hover and keyboard focus both open it (CSS); resize
-  // keeps an open one anchored.
-  const worktime = document.querySelector('.header-worktime')
-  if (worktime !== null) {
-    worktime.addEventListener('mouseenter', positionWorktimeDetail)
-    worktime.addEventListener('focusin', positionWorktimeDetail)
-    window.addEventListener('resize', positionWorktimeDetail)
-  }
+  wireWorktimeDetail()
   setTimeout(() => {
     pollLoginStatus(config)
   }, STATUS_POLL_INTERVAL_MS)

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -185,7 +185,7 @@ function positionWorktimeDetail(): void {
  * its z-index. Moving it to <body> frees it; open/close is then a JS-toggled
  * class (mouse + keyboard) instead of the CSS :hover that needed a parent.
  */
-function wireWorktimeDetail(): void {
+export function wireWorktimeDetail(): void {
   const block = document.querySelector<HTMLElement>('.header-worktime')
   const popover = document.getElementById('worktime-detail')
   if (block === null || popover === null) {
@@ -201,12 +201,18 @@ function wireWorktimeDetail(): void {
     positionWorktimeDetail()
   }
   const close = (): void => popover.classList.remove('is-open')
+  // Stay open while EITHER hovered or focus is within the block (matching the old
+  // CSS ":hover OR :focus-within"); only close when neither holds — so a keyboard
+  // user who opened it via focus doesn't lose it by moving the mouse away.
   block.addEventListener('mouseenter', open)
-  block.addEventListener('mouseleave', close)
+  block.addEventListener('mouseleave', () => {
+    if (!block.contains(document.activeElement)) {
+      close()
+    }
+  })
   block.addEventListener('focusin', open)
   block.addEventListener('focusout', (event) => {
-    // Keep it open while focus moves between the block's own links.
-    if (!block.contains(event.relatedTarget as Node | null)) {
+    if (!block.contains(event.relatedTarget as Node | null) && !block.matches(':hover')) {
       close()
     }
   })

--- a/frontend/src/lib/navLayoutPref.ts
+++ b/frontend/src/lib/navLayoutPref.ts
@@ -6,14 +6,19 @@
 // data-nav-layout (see app.css); switching only flips the attribute and asks the
 // shared header script to re-run its priority-overflow pass.
 
-export type NavLayout = 'top' | 'side'
+// 'side-right' shares all the left-sidebar styling (data-nav-layout='side') and
+// only adds data-nav-side='right' for the mirroring rules (column on the right,
+// resize handle on its left edge, popover flying left) — so it reuses the whole
+// left-sidebar CSS instead of duplicating it.
+export type NavLayout = 'top' | 'side' | 'side-right'
 
 const KEY = 'timetracker-nav-layout'
 
 export function getNavLayout(): NavLayout {
   try {
-    if (localStorage.getItem(KEY) === 'side') {
-      return 'side'
+    const stored = localStorage.getItem(KEY)
+    if (stored === 'side' || stored === 'side-right') {
+      return stored
     }
   } catch {
     // localStorage unavailable (private mode) — fall through to the default.
@@ -24,17 +29,23 @@ export function getNavLayout(): NavLayout {
 
 function apply(layout: NavLayout): void {
   const root = document.documentElement
-  if (layout === 'side') {
+  if (layout === 'side' || layout === 'side-right') {
     root.setAttribute('data-nav-layout', 'side')
+    if (layout === 'side-right') {
+      root.setAttribute('data-nav-side', 'right')
+    } else {
+      root.removeAttribute('data-nav-side')
+    }
   } else {
     root.removeAttribute('data-nav-layout')
+    root.removeAttribute('data-nav-side')
   }
 }
 
 export function setNavLayout(value: NavLayout): void {
   try {
-    if (value === 'side') {
-      localStorage.setItem(KEY, 'side')
+    if (value === 'side' || value === 'side-right') {
+      localStorage.setItem(KEY, value)
     } else {
       localStorage.removeItem(KEY)
     }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -37,6 +37,7 @@ const FONT_SIZES: { value: FontSize; label: () => string }[] = [
 const NAV_LAYOUTS: { value: NavLayout; label: () => string }[] = [
   { value: 'top', label: () => m.settings_layout_top() },
   { value: 'side', label: () => m.settings_layout_side() },
+  { value: 'side-right', label: () => m.settings_layout_side_right() },
 ]
 
 interface SaveResponse {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2939,8 +2939,10 @@ th[aria-sort='descending'] .th-sort-glyph {
     pointer-events: none;
   }
 
-  :root[data-nav-layout='side'] .header-worktime:hover .worktime-detail,
-  :root[data-nav-layout='side'] .header-worktime:focus-within .worktime-detail {
+  /* Shown via a JS-toggled class, not :hover — header.ts portals the popover to
+     <body> so it escapes the sticky sidebar's stacking context (else the resize
+     handle, a body-level fixed element, paints over it). */
+  :root[data-nav-layout='side'] .worktime-detail.is-open {
     opacity: 1;
     visibility: visible;
     transform: translateY(0);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2700,6 +2700,32 @@ th[aria-sort='descending'] .th-sort-glyph {
     min-height: 100vh;
   }
 
+  /* ── Right-docked sidebar ─────────────────────────────────────────────────
+     data-nav-side='right' is set ALONGSIDE data-nav-layout='side', so the whole
+     left-sidebar ruleset applies unchanged; these rules only mirror the
+     directional bits: column on the right, resize handle on its left edge, and
+     the collapse chevron. (The worktime popover flips in header.ts.) */
+  :root[data-nav-side='right'] body {
+    flex-direction: row-reverse;
+  }
+
+  :root[data-nav-side='right'] .sidebar-resize {
+    left: auto;
+    right: var(--sidebar-width, 13em);
+    margin-left: 0;
+    margin-right: -4px;
+  }
+
+  /* Chevron points toward the edge the rail collapses to: right when expanded on
+     a right dock, back to left (inward) once collapsed. */
+  :root[data-nav-side='right'] .sidebar-collapse svg {
+    transform: scaleX(-1);
+  }
+
+  :root[data-nav-side='right'][data-sidebar-collapsed='true'] .sidebar-collapse svg {
+    transform: none;
+  }
+
   :root[data-nav-layout='side'] #page-header {
     flex: 0 0 var(--sidebar-width, 13em);
     width: var(--sidebar-width, 13em);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2704,12 +2704,16 @@ th[aria-sort='descending'] .th-sort-glyph {
      data-nav-side='right' is set ALONGSIDE data-nav-layout='side', so the whole
      left-sidebar ruleset applies unchanged; these rules only mirror the
      directional bits: column on the right, resize handle on its left edge, and
-     the collapse chevron. (The worktime popover flips in header.ts.) */
-  :root[data-nav-side='right'] body {
+     the collapse chevron. (The worktime popover flips in header.ts.)
+     NB: the [data-nav-layout='side'] prefix is included for SPECIFICITY — the base
+     .sidebar-resize rule sets `left` and appears later in the file, so without the
+     extra attribute these overrides would lose on source order and the resize
+     handle would stay on the left (a stray vertical line). */
+  :root[data-nav-layout='side'][data-nav-side='right'] body {
     flex-direction: row-reverse;
   }
 
-  :root[data-nav-side='right'] .sidebar-resize {
+  :root[data-nav-layout='side'][data-nav-side='right'] .sidebar-resize {
     left: auto;
     right: var(--sidebar-width, 13em);
     margin-left: 0;
@@ -2718,11 +2722,11 @@ th[aria-sort='descending'] .th-sort-glyph {
 
   /* Chevron points toward the edge the rail collapses to: right when expanded on
      a right dock, back to left (inward) once collapsed. */
-  :root[data-nav-side='right'] .sidebar-collapse svg {
+  :root[data-nav-layout='side'][data-nav-side='right'] .sidebar-collapse svg {
     transform: scaleX(-1);
   }
 
-  :root[data-nav-side='right'][data-sidebar-collapsed='true'] .sidebar-collapse svg {
+  :root[data-nav-layout='side'][data-nav-side='right'][data-sidebar-collapsed='true'] .sidebar-collapse svg {
     transform: none;
   }
 

--- a/templates/partials/nav-layout-init.html.twig
+++ b/templates/partials/nav-layout-init.html.twig
@@ -10,10 +10,17 @@
 (function () {
     var root = document.documentElement;
     try {
-        if (window.localStorage.getItem('timetracker-nav-layout') === 'side') {
+        var navLayout = window.localStorage.getItem('timetracker-nav-layout');
+        if (navLayout === 'side' || navLayout === 'side-right') {
             root.setAttribute('data-nav-layout', 'side');
+            if (navLayout === 'side-right') {
+                root.setAttribute('data-nav-side', 'right');
+            } else {
+                root.removeAttribute('data-nav-side');
+            }
         } else {
             root.removeAttribute('data-nav-layout');
+            root.removeAttribute('data-nav-side');
         }
         var width = window.localStorage.getItem('timetracker-sidebar-width');
         if (width && /^[0-9]{2,3}$/.test(width)) {

--- a/templates/partials/sidebar-behavior.html.twig
+++ b/templates/partials/sidebar-behavior.html.twig
@@ -117,7 +117,12 @@
                 event.preventDefault();
             });
             handle.addEventListener('pointermove', function (event) {
-                if (dragging) { setWidth(event.clientX); }
+                if (dragging) {
+                    // Right-docked: the handle is on the sidebar's LEFT edge, so the
+                    // width grows as the pointer moves left → measure from the right.
+                    var right = root.getAttribute('data-nav-side') === 'right';
+                    setWidth(right ? (window.innerWidth - event.clientX) : event.clientX);
+                }
             });
             var endDrag = function (event) {
                 if (!dragging) { return; }
@@ -133,7 +138,11 @@
             handle.addEventListener('keydown', function (event) {
                 if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
                     event.preventDefault();
-                    var width = setWidth(currentWidth() + (event.key === 'ArrowRight' ? STEP : -STEP));
+                    // Grow-key is Right for a left dock, Left for a right dock (the
+                    // key that moves toward the content area shrinks the sidebar).
+                    var right = root.getAttribute('data-nav-side') === 'right';
+                    var grow = right ? (event.key === 'ArrowLeft') : (event.key === 'ArrowRight');
+                    var width = setWidth(currentWidth() + (grow ? STEP : -STEP));
                     persist('timetracker-sidebar-width', String(width));
                 }
             });

--- a/templates/partials/sidebar-behavior.html.twig
+++ b/templates/partials/sidebar-behavior.html.twig
@@ -120,8 +120,11 @@
                 if (dragging) {
                     // Right-docked: the handle is on the sidebar's LEFT edge, so the
                     // width grows as the pointer moves left → measure from the right.
+                    // clientWidth excludes the scrollbar, matching event.clientX's
+                    // client-area coordinate space (window.innerWidth would offset
+                    // the right-dock width by the scrollbar width).
                     var right = root.getAttribute('data-nav-side') === 'right';
-                    setWidth(right ? (window.innerWidth - event.clientX) : event.clientX);
+                    setWidth(right ? (document.documentElement.clientWidth - event.clientX) : event.clientX);
                 }
             });
             var endDrag = function (event) {


### PR DESCRIPTION
## Summary

Adds the third **Navigation Layout** option you asked for — **Right sidebar** — docking the rail on the right instead of the left.

Implemented as a `data-nav-side='right'` dimension set *alongside* `data-nav-layout='side'`, so the entire existing left-sidebar ruleset applies unchanged and only the directional bits are mirrored (no ~50-rule duplication):

- **`navLayoutPref.ts`**: `NavLayout` gains `'side-right'`; `apply()` sets `data-nav-side='right'`.
- **Settings**: a "Right sidebar" option (+ en/de messages).
- **`nav-layout-init`**: pre-paints the attributes (no flash).
- **`sidebar-behavior`**: resize drag/keys invert for a right dock (width grows as the pointer moves left; grow-key is ArrowLeft).
- **`app.css` `[data-nav-side='right']`**: `body` `row-reverse` (column on the right), resize handle on the sidebar's left edge, collapse chevron mirrored.
- **`header.ts`**: the IST/SOLL popover flies left of the block in the right rail and right-aligns in the expanded right column.

## Test plan
- `frontend`: `bun run test`, `typecheck`, `lint` — green.
- **Verified on a real running dev instance** (logged in, `data-nav-side='right'` applied): sidebar docks right, content shifts left, worktime footer + popover mirror correctly (popover flies left). Screenshot attached in the session.

https://claude.ai/code/session_01PG6BQp6gyXhm1UdQnT5cMn
