### PR TITLE
feat(ui): tighter ultra-compact table rows + thinner row-class borders

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2555,8 +2555,16 @@ th[aria-sort='descending'] .th-sort-glyph {
 }
 
 :root[data-density='ultra-compact'] .data-table tbody td {
-  --cell-pad-y: 0.15rem;
-  --cell-pad-x: 0.4rem;
+  --cell-pad-y: 0.05rem;
+  --cell-pad-x: 0.3rem;
+}
+
+/* Row-class cue borders (day-break / pause / overlap) — thinner in ultra-compact
+   so they don't dominate the tightened rows; still a visible redundant cue. */
+:root[data-density='ultra-compact'] .tracking-row.is-daybreak > td,
+:root[data-density='ultra-compact'] .tracking-row.is-pause > td,
+:root[data-density='ultra-compact'] .tracking-row.is-overlap > td {
+  border-bottom-width: 2px;
 }
 
 :root[data-density='ultra-compact'] .tracking-toolbar,

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2559,7 +2559,7 @@ th[aria-sort='descending'] .th-sort-glyph {
   --cell-pad-x: 0.3rem;
 }
 
-/* Row-class cue borders (day-break / pause / overlap) — thinner in ultra-compact
+/* Row-class cue borders (daybreak / pause / overlap) — thinner in ultra-compact
    so they don't dominate the tightened rows; still a visible redundant cue. */
 :root[data-density='ultra-compact'] .tracking-row.is-daybreak > td,
 :root[data-density='ultra-compact'] .tracking-row.is-pause > td,


### PR DESCRIPTION
## Summary

Ultra-compact density now goes further on the tables, as requested:

- **Cell spacing:** `.data-table` cell padding in ultra-compact `0.15rem/0.4rem` → **`0.05rem/0.3rem`** (noticeably denser rows).
- **Row-class cue borders:** the day-break / pause / overlap bottom borders (`.tracking-row.is-*`) shrink from **4px → 2px** in ultra-compact only, so they don't dominate the tightened rows — still a visible redundant cue (colour + the value itself).

Comfortable and compact densities are unchanged.

## Test plan
- Verified on a **real running instance** (dev :8765, ultra-compact, seeded day-break/pause/overlap rows): daybreak border measured **4px → 2px**, cell `padding-top` **2.4px → 0.8px**; rows visibly tighter with thin colored cues. Seed rows removed afterward.
- `bun run build` clean.

https://claude.ai/code/session_01PG6BQp6gyXhm1UdQnT5cMn
