### PR TITLE
feat(ui): overflow-driven progressive thinning for the worklog table

### DIFF
--- a/frontend/src/lib/fitLevel.test.ts
+++ b/frontend/src/lib/fitLevel.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { smallestFittingLevel } from './fitLevel'
+
+// A monotonic width model: the table is `natural` wide at level 0 and each level
+// shaves `perLevel` off, so it fits once `natural - level * perLevel <= container`.
+function overflowModel(natural: number, perLevel: number, container: number): (level: number) => boolean {
+  return (level) => natural - level * perLevel > container
+}
+
+describe('smallestFittingLevel', () => {
+  it('returns 0 when the table already fits at level 0', () => {
+    expect(smallestFittingLevel(14, () => false)).toBe(0)
+  })
+
+  it('returns max when the table never fits', () => {
+    expect(smallestFittingLevel(14, () => true)).toBe(14)
+  })
+
+  it('returns the minimal level that fits', () => {
+    // 1000 wide, 100 off per level, 640 container → fits at level 4 (1000-400=600<=640).
+    expect(smallestFittingLevel(14, overflowModel(1000, 100, 640))).toBe(4)
+  })
+
+  it('returns the exact boundary level, not one past it', () => {
+    // Fits exactly at level 3 (1000-300=700<=700), still overflows at 2 (800>700).
+    expect(smallestFittingLevel(14, overflowModel(1000, 100, 700))).toBe(3)
+  })
+
+  it('probes O(log n) times, not linearly', () => {
+    let probes = 0
+    const overflowsAt = (level: number): boolean => {
+      probes += 1
+      return overflowModel(1000, 100, 640)(level)
+    }
+    smallestFittingLevel(14, overflowsAt)
+    // ⌈log2(15)⌉ = 4 → the search must stay well under a 15-step linear scan.
+    expect(probes).toBeLessThanOrEqual(4)
+  })
+
+  it('matches a brute-force linear scan across every container width', () => {
+    const max = 14
+    for (let container = 0; container <= 1000; container += 37) {
+      const overflowsAt = overflowModel(1000, 70, container)
+      let linear = max
+      for (let level = 0; level <= max; level += 1) {
+        if (!overflowsAt(level)) {
+          linear = level
+          break
+        }
+      }
+      expect(smallestFittingLevel(max, overflowsAt)).toBe(linear)
+    }
+  })
+})

--- a/frontend/src/lib/fitLevel.ts
+++ b/frontend/src/lib/fitLevel.ts
@@ -1,0 +1,28 @@
+/**
+ * Find the smallest "thinning level" in `[0, max]` at which a table fits.
+ *
+ * `overflowsAt(level)` applies that level to the DOM and reports whether the
+ * table still overflows its container. The table width is monotonic in the
+ * level — each successive level only truncates or hides columns, so a higher
+ * level never widens the table — which lets a binary search find the minimal
+ * fitting level in ⌈log2(max + 1)⌉ probes instead of a linear scan. That turns
+ * the worst-case ~15 synchronous layout reflows per resize into ~4.
+ *
+ * If the table never fits (overflows even at `max`), `max` is returned — the
+ * caller falls back to horizontal scroll at that level.
+ */
+export function smallestFittingLevel(max: number, overflowsAt: (level: number) => boolean): number {
+  let low = 0
+  let high = max
+  let best = max
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2)
+    if (overflowsAt(mid)) {
+      low = mid + 1
+    } else {
+      best = mid
+      high = mid - 1
+    }
+  }
+  return best
+}

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/solid-query'
-import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage, postForm, postJson, ValidationError } from '../api/client'
 import { activitiesQuery, ENTRIES_KEY, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, upsertSavedEntry, type NamedOption, type SavedEntryResult, type SummaryScope, type TrackingEntry } from '../api/queries'
@@ -262,9 +262,54 @@ export default function Tracking() {
   let tempId = -1
   // The grid element, captured in its ref — read for the keyboard-cursor row.
   let tableEl: HTMLTableElement | undefined
+  // The scroll container — the responsive controller measures overflow against it.
+  let scrollEl: HTMLDivElement | undefined
   // The grid's move handle — used to restore cell focus after a row is deleted.
   let gridHandle: GridMoveHandle | null = null
   const rows = createMemo<TrackingEntry[]>(() => [...newRows(), ...(entries.data ?? [])])
+
+  // Progressive responsive thinning: raise .is-thin-N on the table (each level
+  // shortens the date / truncates a column / hides a low-value column, in
+  // priority order — see app.css) until the table no longer overflows its scroll
+  // container. Cells are nowrap, so this fires BEFORE anything wraps, and keeps
+  // going until it fits. Re-run on container resize AND on row/content changes.
+  const MAX_THIN = 14
+  function fitTrackingTable(): void {
+    const scroll = scrollEl
+    const table = tableEl
+    if (scroll === undefined || table === undefined) {
+      return
+    }
+    for (let i = 1; i <= MAX_THIN; i++) {
+      table.classList.remove('is-thin-' + i)
+    }
+    let level = 0
+    while (scroll.scrollWidth > scroll.clientWidth + 1 && level < MAX_THIN) {
+      level += 1
+      table.classList.add('is-thin-' + level)
+    }
+  }
+  onMount(() => {
+    if (scrollEl === undefined) {
+      return
+    }
+    const observer = new ResizeObserver(() => fitTrackingTable())
+    observer.observe(scrollEl)
+    onCleanup(() => observer.disconnect())
+  })
+  // Row/content changes alter the table's natural width without resizing the
+  // container, so re-fit after they render (rAF defers past the DOM update).
+  // Chip labels resolve asynchronously from the option queries — reading them
+  // here re-fits once the IDs become (wider) names, so the table doesn't stay
+  // stuck at a level computed before the labels loaded.
+  createEffect(
+    on(
+      [rows, () => customers.data, () => projects.data, () => activities.data],
+      () => {
+        requestAnimationFrame(fitTrackingTable)
+      },
+    ),
+  )
   // The External-ticket column is read-only and often empty; when no visible row
   // has one it becomes a hide candidate for the responsive (narrow) table.
   const hasExtTicket = createMemo<boolean>(() => rows().some((row) => str(row.extTicket) !== ''))
@@ -536,7 +581,9 @@ export default function Tracking() {
       return <ReadonlyChips values={chipValues((editor.overlayRow(entry) as unknown as Record<string, unknown>)[colKey])} options={fieldSelectOptions(field, readOptionLookup)} />
     }
 
-    return displayCell(entry, colKey)
+    // A truncation box so the responsive thinning can ellipsis free-text columns
+    // (Description) — a bare <td> in an auto-layout table can't do text-overflow.
+    return <span class="cell-trunc">{displayCell(entry, colKey)}</span>
   }
 
   // The entry of the row holding the keyboard cursor (gridNav marks it
@@ -924,7 +971,7 @@ export default function Tracking() {
           last-good grid (and the user's drafts) visible+dimmed behind it, not a
           jarring "load error". A genuine error (session OK) still shows the fallback. */}
       <Show when={!entries.isError || sessionExpired()} fallback={<p role="alert">{m.app_load_error()}</p>}>
-        <div class="table-scroll">
+        <div class="table-scroll" ref={(el) => { scrollEl = el }}>
           <table
             class="data-table tracking-table"
             classList={{ 'is-fetching': entries.isFetching, 'no-extticket': !hasExtTicket() }}

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -9,6 +9,7 @@ import { num, str } from '../lib/coerce'
 import { formatUserDate } from '../lib/dateFormat'
 import { formatMinutes } from '../lib/format'
 import { gridNav, type GridMoveHandle } from '../lib/gridNavigation'
+import { smallestFittingLevel } from '../lib/fitLevel'
 import { chipValues, createInlineGridEdit, fieldSelectOptions, InlineEditor, INLINE_OVERLAY_TYPES, INLINE_TYPES, ReadonlyChips } from '../lib/inlineGridEdit'
 import { ChipSelect } from '../lib/chipSelect'
 import { registerCommands } from '../lib/commandPalette'
@@ -262,8 +263,11 @@ export default function Tracking() {
   let tempId = -1
   // The grid element, captured in its ref — read for the keyboard-cursor row.
   let tableEl: HTMLTableElement | undefined
-  // The scroll container — the responsive controller measures overflow against it.
-  let scrollEl: HTMLDivElement | undefined
+  // The scroll container — the responsive controller measures overflow against
+  // it. A signal (not a plain ref) so the observer effect below re-binds when
+  // the <Show>-wrapped table unmounts and remounts (e.g. after a load error
+  // clears), rather than staying bound to a detached element.
+  const [scrollEl, setScrollEl] = createSignal<HTMLDivElement>()
   // The grid's move handle — used to restore cell focus after a row is deleted.
   let gridHandle: GridMoveHandle | null = null
   const rows = createMemo<TrackingEntry[]>(() => [...newRows(), ...(entries.data ?? [])])
@@ -271,42 +275,56 @@ export default function Tracking() {
   // Progressive responsive thinning: raise .is-thin-N on the table (each level
   // shortens the date / truncates a column / hides a low-value column, in
   // priority order — see app.css) until the table no longer overflows its scroll
-  // container. Cells are nowrap, so this fires BEFORE anything wraps, and keeps
-  // going until it fits. Re-run on container resize AND on row/content changes.
+  // container. Cells are nowrap, so this fires BEFORE anything wraps. Width is
+  // monotonic in the level, so a binary search finds the minimal fitting level
+  // in ~4 reflows instead of a ~14-step linear scan. Re-run on container resize
+  // AND on row/content changes.
   const MAX_THIN = 14
+  function applyThinLevel(table: HTMLElement, level: number): void {
+    for (let i = 1; i <= MAX_THIN; i++) {
+      table.classList.toggle('is-thin-' + i, i <= level)
+    }
+  }
   function fitTrackingTable(): void {
-    const scroll = scrollEl
+    const scroll = scrollEl()
     const table = tableEl
     if (scroll === undefined || table === undefined) {
       return
     }
-    for (let i = 1; i <= MAX_THIN; i++) {
-      table.classList.remove('is-thin-' + i)
-    }
-    let level = 0
-    while (scroll.scrollWidth > scroll.clientWidth + 1 && level < MAX_THIN) {
-      level += 1
-      table.classList.add('is-thin-' + level)
-    }
+    // clientWidth is stable across the search (thinning changes only the table's
+    // own width), so read it once — the per-probe reflow is driven by scrollWidth.
+    const clientWidth = scroll.clientWidth
+    const level = smallestFittingLevel(MAX_THIN, (candidate) => {
+      applyThinLevel(table, candidate)
+      return scroll.scrollWidth > clientWidth + 1
+    })
+    applyThinLevel(table, level)
   }
-  onMount(() => {
-    if (scrollEl === undefined) {
+  // Manage the ResizeObserver reactively: it (re)binds whenever the scroll
+  // element becomes available and disconnects when it goes away or remounts.
+  createEffect(() => {
+    const scroll = scrollEl()
+    if (scroll === undefined) {
       return
     }
+    fitTrackingTable()
     const observer = new ResizeObserver(() => fitTrackingTable())
-    observer.observe(scrollEl)
+    observer.observe(scroll)
     onCleanup(() => observer.disconnect())
   })
   // Row/content changes alter the table's natural width without resizing the
   // container, so re-fit after they render (rAF defers past the DOM update).
   // Chip labels resolve asynchronously from the option queries — reading them
   // here re-fits once the IDs become (wider) names, so the table doesn't stay
-  // stuck at a level computed before the labels loaded.
+  // stuck at a level computed before the labels loaded. Cancelling the frame on
+  // cleanup collapses rapid successive updates into one fit and prevents a
+  // post-unmount run.
   createEffect(
     on(
       [rows, () => customers.data, () => projects.data, () => activities.data],
       () => {
-        requestAnimationFrame(fitTrackingTable)
+        const rafId = requestAnimationFrame(fitTrackingTable)
+        onCleanup(() => cancelAnimationFrame(rafId))
       },
     ),
   )
@@ -971,7 +989,7 @@ export default function Tracking() {
           last-good grid (and the user's drafts) visible+dimmed behind it, not a
           jarring "load error". A genuine error (session OK) still shows the fallback. */}
       <Show when={!entries.isError || sessionExpired()} fallback={<p role="alert">{m.app_load_error()}</p>}>
-        <div class="table-scroll" ref={(el) => { scrollEl = el }}>
+        <div class="table-scroll" ref={setScrollEl}>
           <table
             class="data-table tracking-table"
             classList={{ 'is-fetching': entries.isFetching, 'no-extticket': !hasExtTicket() }}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1192,50 +1192,55 @@ kbd {
   container-type: inline-size;
 }
 
-/* ── Responsive worklog table ─────────────────────────────────────────────────
-   As the available width shrinks, thin the table out (instead of scrolling) in
-   this priority order: Date YYYY-MM-DD → MM-DD → DD; hide an empty Ext. Ticket
-   column; hide Actions; hide Duration; then shrink Project + Description. All
-   rules are scoped to .tracking-table so the shared admin/summary tables (same
-   .table-scroll container, same data-col-key attributes) are untouched. */
-.tracking-table .dt-mid,
-.tracking-table .dt-short {
-  display: none;
+/* ── Responsive worklog table — progressive, overflow-driven ──────────────────
+   Cells never wrap; a ResizeObserver in Tracking.tsx (fitTrackingTable) raises
+   .is-thin-N on the table the instant it would overflow its .table-scroll
+   container, so it thins BEFORE any content wraps — and keeps raising the level
+   until it fits. Priority order sheds the flexible free-text first and the
+   functional Actions column last: shorten Date → truncate Description → truncate
+   Project/Customer chips → truncate Description harder → shorten Date again →
+   truncate Description harder → hide empty Ext.Ticket → truncate Ticket →
+   truncate Description to the floor → hide Duration → truncate the chips to the
+   floor → hide Actions → hide Activity. Description (the widest, most elastic
+   column) absorbs most of the reduction, so a desktop keeps Actions and never
+   over-thins; Actions only drops on a genuinely cramped viewport.
+   Real ellipsis needs an inner box (.cell-trunc / .tag-label / .ticket-link) —
+   a bare <td> in an auto-layout table can't ellipsis. Horizontal scroll is the
+   final safety net AND the no-JS fallback. Scoped to .tracking-table so the
+   shared admin/summary tables are untouched. */
+.tracking-table td, .tracking-table th { white-space: nowrap; }
+.tracking-table .dt-mid, .tracking-table .dt-short { display: none; }
+.tracking-table .cell-trunc,
+.tracking-table [data-col-key='project'] .tag-label,
+.tracking-table [data-col-key='customer'] .tag-label,
+.tracking-table [data-col-key='activity'] .tag-label,
+.tracking-table .ticket-link {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
 }
 
-@container (max-width: 1040px) {
-  .tracking-table .dt-full { display: none; }
-  .tracking-table .dt-mid { display: inline; }
-}
-
-@container (max-width: 920px) {
-  .tracking-table .dt-mid { display: none; }
-  .tracking-table .dt-short { display: inline; }
-}
-
-@container (max-width: 860px) {
-  .tracking-table.no-extticket [data-col-key='extTicket'] { display: none; }
-}
-
-@container (max-width: 780px) {
-  .tracking-table [data-col-key='actions'] { display: none; }
-}
-
-@container (max-width: 680px) {
-  .tracking-table [data-col-key='duration'] { display: none; }
-}
-
-@container (max-width: 580px) {
-  /* Auto-layout tables don't honour ellipsis on a <td>, so cap the width and let
-     the text wrap (em scales with the text-size preference) — this shrinks the
-     two widest free-text columns rather than truncating unreliably. */
-  .tracking-table [data-col-key='project'],
-  .tracking-table [data-col-key='description'] {
-    max-width: 10em;
-    white-space: normal;
-    overflow-wrap: anywhere;
-  }
-}
+.tracking-table.is-thin-1 .dt-full { display: none; }
+.tracking-table.is-thin-1 .dt-mid { display: inline; }
+.tracking-table.is-thin-2 [data-col-key='description'] .cell-trunc { max-width: 30ch; }
+.tracking-table.is-thin-3 [data-col-key='description'] .cell-trunc { max-width: 22ch; }
+.tracking-table.is-thin-4 [data-col-key='project'] .tag-label { max-width: 18ch; }
+.tracking-table.is-thin-4 [data-col-key='customer'] .tag-label { max-width: 15ch; }
+.tracking-table.is-thin-5 [data-col-key='description'] .cell-trunc { max-width: 16ch; }
+.tracking-table.is-thin-6 .dt-mid { display: none; }
+.tracking-table.is-thin-6 .dt-short { display: inline; }
+.tracking-table.is-thin-7 [data-col-key='description'] .cell-trunc { max-width: 12ch; }
+.tracking-table.is-thin-8.no-extticket [data-col-key='extTicket'] { display: none; }
+.tracking-table.is-thin-9 [data-col-key='ticket'] .ticket-link { max-width: 10ch; }
+.tracking-table.is-thin-10 [data-col-key='description'] .cell-trunc { max-width: 9ch; }
+.tracking-table.is-thin-11 [data-col-key='duration'] { display: none; }
+.tracking-table.is-thin-12 [data-col-key='project'] .tag-label { max-width: 10ch; }
+.tracking-table.is-thin-12 [data-col-key='customer'] .tag-label { max-width: 11ch; }
+.tracking-table.is-thin-12 [data-col-key='activity'] .tag-label { max-width: 12ch; }
+.tracking-table.is-thin-13 [data-col-key='actions'] { display: none; }
+.tracking-table.is-thin-14 [data-col-key='activity'] { display: none; }
 
 /* A long detail list scrolls inside its own box instead of stretching the page;
    the header stays pinned so the columns remain labelled while scrolling. */


### PR DESCRIPTION
## What

Replaces the worklog table's fixed container-query breakpoints with an
**overflow-driven progressive thinning** controller: a `ResizeObserver`
(in `Tracking.tsx`) raises `.is-thin-N` on the table until it no longer
overflows its scroll container. All cells are `white-space: nowrap`, so
the table thins **before any content wraps** — and keeps thinning until
it fits.

## Why

The previous breakpoint approach triggered **too late and not enough**:
between fixed widths, long descriptions/tickets **wrapped** to multiple
lines instead of thinning. This reacts the instant the table would
overflow, at any width.

## Priority order

Sheds the flexible free-text first and the functional Actions column last:

1. shorten Date → 2-3. truncate **Description** → 4. truncate Project/Customer chips → 5. Description harder → 6. shorten Date again → 7. Description harder → 8. hide empty Ext.Ticket → 9. truncate Ticket → 10. Description to the floor → 11. hide Duration → 12. chips to the floor → **13. hide Actions** → 14. hide Activity.

Description (the widest, most elastic column) absorbs most of the
reduction, so a desktop keeps **Actions** visible and never over-thins;
Actions only drops on a genuinely cramped viewport. Horizontal scroll is
the final safety net and the no-JS fallback.

## Verification (real dev instance, `:8765`, seeded long-content rows)

Swept the worklog across viewport widths — **no cell wraps at any width**:

| content width | thin level | Actions | wraps |
|---|---|---|---|
| 1152px | 11 | shown | 0 |
| 1016px | 13 | hidden | 0 |
| 836px | 13 | hidden | 0 |
| 696px | 14 | hidden | 0 |
| 536px | 14 | hidden (h-scroll) | 0 |

Frontend gates: 337 tests pass, typecheck + lint + build clean.
