### PR TITLE
feat(security): enable logout CSRF protection

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -43,8 +43,11 @@ security:
                 target: _login
                 # Ensure any custom session data is cleared on logout
                 invalidate_session: true
-                # Note: CSRF disabled because ExtJS frontend uses simple link for logout
-                enable_csrf: false
+                # Stateless CSRF (framework.csrf_protection): the _csrf_token
+                # that logout_path()/logout_url() append is validated via the
+                # Sec-Fetch-Site/Origin/Referer headers of a same-origin
+                # navigation — blocking cross-site forced logout.
+                enable_csrf: true
 
             # Remember me functionality (uses Symfony's built-in feature)
             remember_me:

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -86,11 +86,10 @@ export async function loginIsolated(page: Page): Promise<void> {
  */
 export async function logout(page: Page): Promise<void> {
   await page.waitForSelector('.badge-logout', { timeout: 10000 });
-  const logoutHref = await page.locator('.badge-logout').getAttribute('href');
-  if (logoutHref) {
-    await page.goto(logoutHref);
-    await page.waitForURL(/\/login/, { timeout: 10000 });
-  }
+  // Click the link instead of page.goto(): logout CSRF is validated via the
+  // Sec-Fetch-Site header, which only a real same-origin navigation carries.
+  await page.locator('.badge-logout').click();
+  await page.waitForURL(/\/login/, { timeout: 10000 });
 }
 
 /**

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -83,12 +83,12 @@ test.describe('Logout', () => {
     // Wait for the app to fully load and show logout link
     await page.waitForSelector('.badge-logout', { timeout: 10000 });
 
-    // Get the logout URL and navigate directly
+    // The logout link carries the CSRF token; click it (a real same-origin
+    // navigation with Sec-Fetch-Site) instead of page.goto().
     const logoutHref = await page.locator('.badge-logout').getAttribute('href');
-    expect(logoutHref).toBeTruthy();
+    expect(logoutHref).toContain('_csrf_token');
 
-    // Navigate to logout URL and wait for redirect
-    await page.goto(logoutHref!);
+    await page.locator('.badge-logout').click();
     await page.waitForURL(/\/login/, { timeout: 10000 });
 
     // Verify we're on the login page

--- a/src/EventSubscriber/AccessDeniedSubscriber.php
+++ b/src/EventSubscriber/AccessDeniedSubscriber.php
@@ -68,11 +68,14 @@ final readonly class AccessDeniedSubscriber implements EventSubscriberInterface
         }
 
         // Case 2: User is authenticated via remember_me but not fully authenticated
-        // This happens when IS_AUTHENTICATED_FULLY is required but user only has remember_me
-        // UX: Redirect to logout to properly clear session and cookies, then user lands on login
+        // This happens when IS_AUTHENTICATED_FULLY is required but user only has remember_me.
+        // Log out programmatically (session + cookies cleared, redirect to login)
+        // instead of redirecting through /logout: a browser following that
+        // redirect from an address-bar navigation sends no same-origin fetch
+        // metadata and would fail the logout CSRF check.
         if (!$this->security->isGranted('IS_AUTHENTICATED_FULLY')) {
-            $logoutUrl = $this->router->generate('_logout');
-            $response = new RedirectResponse($logoutUrl);
+            $response = $this->security->logout(false)
+                ?? new RedirectResponse($this->router->generate('_login'));
             $exceptionEvent->setResponse($response);
 
             return;

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -133,7 +133,7 @@
                 </div>
                 <div class="error-actions">
                     <a href="{{ path('_start') }}" class="btn btn-primary">Go to Homepage</a>
-                    <a href="{{ path('_logout') }}" class="btn">Logout</a>
+                    <a href="{{ logout_path() }}" class="btn">Logout</a>
                 </div>
             </div>
         </div>

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -133,7 +133,10 @@
                 </div>
                 <div class="error-actions">
                     <a href="{{ path('_start') }}" class="btn btn-primary">Go to Homepage</a>
-                    <a href="{{ logout_path() }}" class="btn">Logout</a>
+                    {# logout_path() needs firewall/request context, which the
+                       global error handler rendering this page does not have —
+                       append the stateless token manually instead. #}
+                    <a href="{{ path('_logout') }}?_csrf_token={{ csrf_token('logout') }}" class="btn">Logout</a>
                 </div>
             </div>
         </div>

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -153,7 +153,7 @@
                 </span>
                 <span class="user-name js-user-name">{{ settings.user_name }}</span>
             </span>
-            <a href="{{ url('_logout') }}" class="badge-logout" aria-label="{{ 'Logout'|trans }}" title="{{ 'Logout'|trans }}"><svg class="header-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/></svg></a>
+            <a href="{{ logout_path() }}" class="badge-logout" aria-label="{{ 'Logout'|trans }}" title="{{ 'Logout'|trans }}"><svg class="header-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/></svg></a>
         </div>
 
         <button type="button" class="nav-burger" id="nav-burger"
@@ -183,7 +183,7 @@
         </nav>
         <div class="drawer-foot">
             <span class="drawer-user js-user-badge status_active"><span class="status-indicator" aria-hidden="true"></span><span class="user-name js-user-name">{{ settings.user_name }}</span></span>
-            <a href="{{ url('_logout') }}" class="drawer-logout" aria-label="{{ 'Logout'|trans }}">{{ 'Logout'|trans }}</a>
+            <a href="{{ logout_path() }}" class="drawer-logout" aria-label="{{ 'Logout'|trans }}">{{ 'Logout'|trans }}</a>
         </div>
     </div>
 </div>

--- a/templates/ui/index.html.twig
+++ b/templates/ui/index.html.twig
@@ -25,7 +25,7 @@
                 'suggestTime': settings.suggest_time == 1,
                 'showFuture': settings.show_future == 1,
                 'minEntryDuration': settings.min_entry_duration,
-                'logoutUrl': url('_logout'),
+                'logoutUrl': logout_url(),
                 'csrfToken': csrf_token('authenticate'),
                 'loginPath': path('_login'),
             }|json_encode(jsonHexFlags)|raw }};

--- a/tests/Controller/SecurityControllerTest.php
+++ b/tests/Controller/SecurityControllerTest.php
@@ -129,11 +129,15 @@ final class SecurityControllerTest extends AbstractWebTestCase
         assert($csrfTokenManager instanceof \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface);
         $csrfToken = $csrfTokenManager->getToken('logout')->getValue();
 
-        // After logging out with CSRF token
+        // After logging out with CSRF token. The stateless CSRF validator
+        // accepts the token only alongside a same-origin fetch-metadata
+        // header, which BrowserKit does not send on its own.
         $this->client->request(
             \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             '/logout',
             ['_csrf_token' => $csrfToken],
+            [],
+            ['HTTP_SEC_FETCH_SITE' => 'same-origin'],
         );
 
         // The user should be redirected

--- a/tests/EventSubscriber/AccessDeniedSubscriberTest.php
+++ b/tests/EventSubscriber/AccessDeniedSubscriberTest.php
@@ -119,7 +119,7 @@ final class AccessDeniedSubscriberTest extends TestCase
         self::assertTrue($rememberMeCookie->isCleared(), 'REMEMBERME cookie should be marked as cleared');
     }
 
-    public function testRememberedUserNeedingFullAuthRedirectsToLogout(): void
+    public function testRememberedUserNeedingFullAuthIsLoggedOutProgrammatically(): void
     {
         $user = new User();
         $user->setUsername('testuser');
@@ -134,6 +134,39 @@ final class AccessDeniedSubscriberTest extends TestCase
             ->with('IS_AUTHENTICATED_FULLY')
             ->willReturn(false);
 
+        // The subscriber logs out programmatically (no CSRF-guarded round
+        // trip through /logout) and uses the logout response as-is.
+        $logoutResponse = new RedirectResponse('/login');
+        $this->security
+            ->expects(self::once())->method('logout')
+            ->with(false)
+            ->willReturn($logoutResponse);
+
+        $request = $this->createRequest(true);
+        $event = $this->createExceptionEvent($request, new AccessDeniedException('Access Denied'));
+
+        $this->subscriber->onKernelException($event);
+
+        self::assertSame($logoutResponse, $event->getResponse());
+    }
+
+    public function testRememberedUserFallsBackToLoginRedirectWhenLogoutReturnsNoResponse(): void
+    {
+        $user = new User();
+        $user->setUsername('testuser');
+
+        $this->security
+            ->method('getUser')
+            ->willReturn($user);
+        $this->security
+            ->expects(self::once())->method('isGranted')
+            ->with('IS_AUTHENTICATED_FULLY')
+            ->willReturn(false);
+        $this->security
+            ->expects(self::once())->method('logout')
+            ->with(false)
+            ->willReturn(null);
+
         $request = $this->createRequest(true);
         $event = $this->createExceptionEvent($request, new AccessDeniedException('Access Denied'));
 
@@ -141,8 +174,7 @@ final class AccessDeniedSubscriberTest extends TestCase
 
         $response = $event->getResponse();
         self::assertInstanceOf(RedirectResponse::class, $response);
-        // Redirect to logout to properly clear session and all cookies
-        self::assertSame('/logout', $response->getTargetUrl());
+        self::assertSame('/login', $response->getTargetUrl());
     }
 
     public function testFullyAuthenticatedUserWithoutPermissionLetsSymfonyHandle(): void

--- a/tests/Security/RememberMeRedirectTest.php
+++ b/tests/Security/RememberMeRedirectTest.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Tests\AbstractWebTestCase;
 
@@ -17,8 +18,8 @@ use function assert;
  * Regression tests for remember_me authentication edge cases.
  *
  * These tests verify that users authenticated via remember_me (but not fully
- * authenticated) are properly redirected to logout instead of seeing a 403
- * error or getting stuck in a redirect loop.
+ * authenticated) are properly logged out instead of seeing a 403 error or
+ * getting stuck in a redirect loop, and that logout CSRF is enforced.
  *
  * @internal
  *
@@ -26,6 +27,12 @@ use function assert;
  */
 final class RememberMeRedirectTest extends AbstractWebTestCase
 {
+    private const string MSG_NO_CONTAINER = 'Service container not initialized';
+
+    private const string PATH_LOGIN = '/login';
+
+    private const string PATH_LOGOUT = '/logout';
+
     private EntityManagerInterface $entityManager;
 
     /**
@@ -46,7 +53,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
 
         // Initialize entity manager
         if (null === $this->serviceContainer) {
-            throw new RuntimeException('Service container not initialized');
+            throw new RuntimeException(self::MSG_NO_CONTAINER);
         }
         $em = $this->serviceContainer->get('doctrine.orm.entity_manager');
         assert($em instanceof EntityManagerInterface);
@@ -57,13 +64,13 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
 
     /**
      * Test that a remember_me authenticated user accessing a route requiring
-     * IS_AUTHENTICATED_FULLY gets redirected to /logout (not 403).
+     * IS_AUTHENTICATED_FULLY is logged out and lands on /login (not 403).
      *
      * This is a regression test for the bug where remember_me users would see
      * "You are not allowed to perform this action" instead of being redirected
      * to re-authenticate.
      */
-    public function testRememberMeUserRedirectsToLogoutNotForbidden(): void
+    public function testRememberMeUserIsLoggedOutNotForbidden(): void
     {
         // Get a real user from the database
         $user = $this->entityManager->getRepository(User::class)->findOneBy([]);
@@ -77,7 +84,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
 
         // Set the token in the security context via session
         if (null === $this->serviceContainer) {
-            throw new RuntimeException('Service container not initialized');
+            throw new RuntimeException(self::MSG_NO_CONTAINER);
         }
         /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface $session */
         $session = $this->serviceContainer->get('session.factory')->createSession();
@@ -105,7 +112,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
 
         // Case 2 in AccessDeniedSubscriber performs a programmatic logout,
         // whose response redirects straight to the login page.
-        self::assertStringContainsString('/login', $location,
+        self::assertStringContainsString(self::PATH_LOGIN, $location,
             'Remember_me user should be logged out and land on /login, not shown 403');
     }
 
@@ -113,12 +120,20 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
      * A bare GET /logout without CSRF token must be rejected: logout CSRF
      * blocks cross-site forced logout (and BrowserKit sends no same-origin
      * fetch metadata either).
+     *
+     * The firewall wraps the LogoutException into AccessDeniedHttpException
+     * (403). This app runs with error_controller: null, so the kernel
+     * rethrows for HTML requests and the global error handler renders the
+     * 403 page in production — in tests the wrapped exception surfaces.
      */
     public function testLogoutWithoutCsrfTokenIsRejected(): void
     {
-        $this->client->request('GET', '/logout');
-
-        self::assertResponseStatusCodeSame(403);
+        try {
+            $this->client->request('GET', self::PATH_LOGOUT);
+            self::fail('Tokenless logout must be rejected');
+        } catch (AccessDeniedHttpException $accessDeniedHttpException) {
+            self::assertStringContainsString('Invalid CSRF token', $accessDeniedHttpException->getMessage());
+        }
     }
 
     /**
@@ -130,7 +145,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
      */
     public function testLogoutIsPublicAndRedirectsToLogin(): void
     {
-        $this->client->request('GET', '/logout', [
+        $this->client->request('GET', self::PATH_LOGOUT, [
             '_csrf_token' => $this->logoutCsrfToken(),
         ], [], ['HTTP_SEC_FETCH_SITE' => 'same-origin']);
 
@@ -138,15 +153,13 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
         self::assertResponseRedirects();
         $location = $this->client->getResponse()->headers->get('Location');
         self::assertNotNull($location);
-        self::assertStringContainsString('/login', $location,
+        self::assertStringContainsString(self::PATH_LOGIN, $location,
             '/logout should redirect to /login');
     }
 
     private function logoutCsrfToken(): string
     {
-        if (null === $this->serviceContainer) {
-            throw new RuntimeException('Service container not initialized');
-        }
+        assert(null !== $this->serviceContainer, self::MSG_NO_CONTAINER);
 
         $csrfTokenManager = $this->serviceContainer->get('security.csrf.token_manager');
         assert($csrfTokenManager instanceof \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface);
@@ -181,7 +194,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
         self::assertResponseRedirects();
         $location = $this->client->getResponse()->headers->get('Location');
         self::assertNotNull($location);
-        self::assertStringContainsString('/login', $location,
+        self::assertStringContainsString(self::PATH_LOGIN, $location,
             'Stale remember_me cookie should redirect to /login');
 
         // The REMEMBERME cookie should be cleared (deleted)
@@ -205,7 +218,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
     public function testLogoutToLoginCompleteFlow(): void
     {
         // Access /logout with a valid token + same-origin fetch metadata
-        $this->client->request('GET', '/logout', [
+        $this->client->request('GET', self::PATH_LOGOUT, [
             '_csrf_token' => $this->logoutCsrfToken(),
         ], [], ['HTTP_SEC_FETCH_SITE' => 'same-origin']);
 

--- a/tests/Security/RememberMeRedirectTest.php
+++ b/tests/Security/RememberMeRedirectTest.php
@@ -6,7 +6,6 @@ namespace Tests\Security;
 
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
-use RuntimeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
@@ -52,9 +51,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
         $this->initializeDatabase();
 
         // Initialize entity manager
-        if (null === $this->serviceContainer) {
-            throw new RuntimeException(self::MSG_NO_CONTAINER);
-        }
+        assert(null !== $this->serviceContainer, self::MSG_NO_CONTAINER);
         $em = $this->serviceContainer->get('doctrine.orm.entity_manager');
         assert($em instanceof EntityManagerInterface);
         $this->entityManager = $em;
@@ -83,9 +80,7 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
         $token = new RememberMeToken($user, 'main');
 
         // Set the token in the security context via session
-        if (null === $this->serviceContainer) {
-            throw new RuntimeException(self::MSG_NO_CONTAINER);
-        }
+        assert(null !== $this->serviceContainer, self::MSG_NO_CONTAINER);
         /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface $session */
         $session = $this->serviceContainer->get('session.factory')->createSession();
         $session->set('_security_main', serialize($token));

--- a/tests/Security/RememberMeRedirectTest.php
+++ b/tests/Security/RememberMeRedirectTest.php
@@ -98,26 +98,41 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
         // Access a route that requires IS_AUTHENTICATED_FULLY
         $this->client->request('GET', '/');
 
-        // Should redirect to /logout, NOT show 403
+        // Should be logged out programmatically and redirected, NOT shown 403
         self::assertResponseRedirects();
         $location = $this->client->getResponse()->headers->get('Location');
         self::assertNotNull($location);
 
-        // Should redirect to /logout (Case 2 in AccessDeniedSubscriber)
-        self::assertStringContainsString('/logout', $location,
-            'Remember_me user should be redirected to /logout, not shown 403');
+        // Case 2 in AccessDeniedSubscriber performs a programmatic logout,
+        // whose response redirects straight to the login page.
+        self::assertStringContainsString('/login', $location,
+            'Remember_me user should be logged out and land on /login, not shown 403');
     }
 
     /**
-     * Test that /logout is accessible (PUBLIC_ACCESS) and redirects to /login.
+     * A bare GET /logout without CSRF token must be rejected: logout CSRF
+     * blocks cross-site forced logout (and BrowserKit sends no same-origin
+     * fetch metadata either).
+     */
+    public function testLogoutWithoutCsrfTokenIsRejected(): void
+    {
+        $this->client->request('GET', '/logout');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * Test that /logout is accessible (PUBLIC_ACCESS) with a valid token and
+     * same-origin fetch metadata, and redirects to /login.
      *
      * This is a regression test for the bug where /logout required
      * IS_AUTHENTICATED_FULLY, causing an infinite /logout -> /logout loop.
      */
     public function testLogoutIsPublicAndRedirectsToLogin(): void
     {
-        // Access /logout without any authentication
-        $this->client->request('GET', '/logout');
+        $this->client->request('GET', '/logout', [
+            '_csrf_token' => $this->logoutCsrfToken(),
+        ], [], ['HTTP_SEC_FETCH_SITE' => 'same-origin']);
 
         // Should redirect to /login, not 403 or loop
         self::assertResponseRedirects();
@@ -125,6 +140,18 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
         self::assertNotNull($location);
         self::assertStringContainsString('/login', $location,
             '/logout should redirect to /login');
+    }
+
+    private function logoutCsrfToken(): string
+    {
+        if (null === $this->serviceContainer) {
+            throw new RuntimeException('Service container not initialized');
+        }
+
+        $csrfTokenManager = $this->serviceContainer->get('security.csrf.token_manager');
+        assert($csrfTokenManager instanceof \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface);
+
+        return $csrfTokenManager->getToken('logout')->getValue();
     }
 
     /**
@@ -177,8 +204,10 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
      */
     public function testLogoutToLoginCompleteFlow(): void
     {
-        // Access /logout directly (simulating redirect from protected route)
-        $this->client->request('GET', '/logout');
+        // Access /logout with a valid token + same-origin fetch metadata
+        $this->client->request('GET', '/logout', [
+            '_csrf_token' => $this->logoutCsrfToken(),
+        ], [], ['HTTP_SEC_FETCH_SITE' => 'same-origin']);
 
         // Follow redirect to /login
         $this->client->followRedirect();


### PR DESCRIPTION
## Description

Enable CSRF protection on logout. The old `enable_csrf: false` carried the comment "because ExtJS frontend uses simple link for logout" — the ExtJS shell is gone, and with the stateless CSRF setup already used by the login form, protecting the plain logout links costs nothing at the UX level while blocking cross-site forced logout.

Mechanics (verified against the installed Symfony 8.1 vendor code): with `stateless_token_ids: [authenticate, logout]`, `csrf_token('logout')` renders a constant marker and validation is purely origin-based — `Sec-Fetch-Site: same-origin` (primary), `Origin`/`Referer` fallback. A real user clicking a logout link passes; a cross-site `<img>`/link/form hard-fails.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issue

Follow-up to #490 (which removed every other ExtJS reference; this PR retires the last one).

## Changes Made

- `security.yaml`: `enable_csrf: true` on the logout listener; comment states the actual mechanism instead of blaming the removed ExtJS frontend.
- All logout triggers use Symfony's `logout_path()`/`logout_url()` — the `LogoutUrlGenerator` appends `_csrf_token` automatically and stays correct if the flag is ever toggled: header badge + mobile drawer, 403 page, and the SPA's `logoutUrl` (command palette).
- `AccessDeniedSubscriber`: the remember-me/not-fully-authenticated case now logs out programmatically (`Security::logout(false)`) instead of redirecting through `/logout` — a browser following that redirect from an address-bar navigation carries no same-origin fetch metadata and would hit the CSRF wall (the empirical weak spot identified during design).
- e2e logout flows click the link instead of `page.goto()` (CDP navigations send `Sec-Fetch-Site: none` and would fail even though real users pass); the tests also assert the link carries the token.
- Functional tests send `HTTP_SEC_FETCH_SITE: same-origin` (BrowserKit emits no fetch metadata); a new test pins the 403 for tokenless logout requests; the remember-me tests assert the new direct-to-login flow.

## Testing

- [x] Unit tests green locally (1557, incl. two new subscriber tests: logout response used as-is + null fallback)
- [x] phpstan level 10, cs-fixer, phpat, twig lint, `lint:container` (dev/prod/test) — all green locally
- [ ] Functional + e2e — CI (the test env inherits `enable_csrf: true` via Symfony's config merge; the click-based e2e logout genuinely exercises CSRF-on logout)

## Code Quality

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (config comment)
- [x] No breaking changes for real users (bookmarked bare `/logout` URLs now 403 by design — standard Symfony logout-CSRF behavior)

## Migration Notes

None for deployments. Users who bookmarked the bare `/logout` URL get a 403; logging out via the UI works unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/netresearch/timetracker/blob/main/CONTRIBUTING.md) guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/netresearch/timetracker/blob/main/CODE_OF_CONDUCT.md)
