### PR TITLE
feat(jira): Jira Cloud OAuth 2.0 (3LO) runtime — dual-mode alongside Server/DC

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ controlling and invoicing; worklogs are mirrored to Jira automatically.
   Billing and Administration
 
 **Jira integration**
-- Automatic background worklog sync (create/update/delete) via OAuth 1.0a for
-  Jira Server/DC; Jira Cloud OAuth 2.0 support is in progress
+- Automatic background worklog sync (create/update/delete) for both
+  **Jira Server/DC** (OAuth 1.0a) and **Jira Cloud** (OAuth 2.0 / 3LO)
 - Per-user, per-ticket-system tokens, encrypted at rest
 - Optional mirroring of external customer tickets into an internal Jira project
 

--- a/docs/adr/ADR-017-jira-cloud-oauth2.md
+++ b/docs/adr/ADR-017-jira-cloud-oauth2.md
@@ -36,8 +36,14 @@ each configured ticket system:
 Landed 2026-06-22 as Cloud support PR 1
 ([#416](https://github.com/netresearch/timetracker/pull/416), commits `7a507ae8`
 data model, `428c7696` admin form): the deployment-type/OAuth2 configuration data
-model and admin UI. The runtime 3LO token flow ships in follow-up PRs; as of
-2026-07-02 the authentication service still performs OAuth 1.0a only.
+model and admin UI. The runtime landed 2026-07-02: `JiraCloudApiService`
+implements the 3LO authorize redirect (state carries the ticket-system id,
+encrypted, because Cloud redirect URIs must match the registered URL exactly),
+the authorization-code exchange, rotating refresh tokens with recorded expiry,
+automatic `cloudId` resolution via `accessible-resources`, Bearer-authenticated
+REST through `api.atlassian.com/ex/jira/{cloudId}/rest/api/2/`, and the
+Cloud-only `search/jql` endpoint. `JiraOAuthApiFactory` branches on the
+deployment type; the shared callback route serves both flows.
 
 ## Corrections to the ADR-003 record
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,23 @@ Jira access tokens are encrypted at rest with `APP_ENCRYPTION_KEY`; migrate
 plaintext tokens with `bin/console tt:encrypt-jira-tokens`
 ([src/Command/EncryptJiraTokensCommand.php](../src/Command/EncryptJiraTokensCommand.php)).
 
+### Setting up Jira Cloud (OAuth 2.0 / 3LO)
+
+1. In the [Atlassian developer console](https://developer.atlassian.com/console/myapps/),
+   create an **OAuth 2.0 (3LO)** app.
+2. Add the **Jira platform REST API** with the scopes `read:jira-work` and
+   `write:jira-work` (`offline_access` for refresh tokens is requested
+   automatically at authorize time).
+3. Register the callback URL — exactly
+   `https://<your-timetracker>/jiraoauthcallback`, no query string (the ticket
+   system id travels inside the encrypted `state` parameter).
+4. In *Administration → Ticket systems*, set type `JIRA`, deployment type
+   `CLOUD`, the site URL (`https://<site>.atlassian.net`), and the app's
+   **Client ID** / **Client Secret**.
+5. Each user authorizes once via the "Please authorize" link on their first
+   sync; the Atlassian `cloudId` is resolved and stored automatically, access
+   tokens refresh themselves (rotating refresh tokens).
+
 ### Tracking external tickets in an internal Jira project
 
 A project can mirror worklogs for tickets from a *customer's* ticket system

--- a/src/Controller/Default/JiraOAuthCallbackAction.php
+++ b/src/Controller/Default/JiraOAuthCallbackAction.php
@@ -14,11 +14,9 @@ use App\Entity\TicketSystem;
 use App\Entity\User;
 use App\Exception\Integration\Jira\JiraApiException;
 use App\Model\Response;
-use App\Service\ClockInterface;
 use App\Service\Integration\Jira\CloudOAuthStateCodec;
 use App\Service\Integration\Jira\JiraCloudApiService;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
-use App\Service\Security\TokenEncryptionService;
 use Exception;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -35,9 +33,7 @@ final class JiraOAuthCallbackAction extends BaseController
 {
     private JiraOAuthApiFactory $jiraOAuthApiFactory;
 
-    private TokenEncryptionService $tokenEncryptionService;
-
-    private ClockInterface $clock;
+    private CloudOAuthStateCodec $stateCodec;
 
     #[Required]
     public function setJiraApiFactory(JiraOAuthApiFactory $jiraOAuthApiFactory): void
@@ -46,10 +42,9 @@ final class JiraOAuthCallbackAction extends BaseController
     }
 
     #[Required]
-    public function setCloudStateDependencies(TokenEncryptionService $tokenEncryptionService, ClockInterface $clock): void
+    public function setStateCodec(CloudOAuthStateCodec $stateCodec): void
     {
-        $this->tokenEncryptionService = $tokenEncryptionService;
-        $this->clock = $clock;
+        $this->stateCodec = $stateCodec;
     }
 
     /**
@@ -82,8 +77,7 @@ final class JiraOAuthCallbackAction extends BaseController
     private function handleCloudCallback(Request $request, User $user, string $state): RedirectResponse|Response
     {
         try {
-            $codec = new CloudOAuthStateCodec($this->tokenEncryptionService, $this->clock);
-            $decoded = $codec->decode($state);
+            $decoded = $this->stateCodec->decode($state);
 
             if ($decoded['userId'] !== (int) $user->getId()) {
                 return new Response('OAuth state does not belong to the current user', \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN);

--- a/src/Controller/Default/JiraOAuthCallbackAction.php
+++ b/src/Controller/Default/JiraOAuthCallbackAction.php
@@ -90,7 +90,7 @@ final class JiraOAuthCallbackAction extends BaseController
 
             $error = $request->query->get('error');
             if (is_string($error) && '' !== $error) {
-                return new Response(sprintf('Jira authorization was not granted: %s', $error));
+                return new Response(sprintf('Jira authorization was not granted: %s', $error), \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST);
             }
 
             $code = $request->query->get('code');

--- a/src/Controller/Default/JiraOAuthCallbackAction.php
+++ b/src/Controller/Default/JiraOAuthCallbackAction.php
@@ -14,7 +14,11 @@ use App\Entity\TicketSystem;
 use App\Entity\User;
 use App\Exception\Integration\Jira\JiraApiException;
 use App\Model\Response;
+use App\Service\ClockInterface;
+use App\Service\Integration\Jira\CloudOAuthStateCodec;
+use App\Service\Integration\Jira\JiraCloudApiService;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
+use App\Service\Security\TokenEncryptionService;
 use Exception;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -25,10 +29,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Service\Attribute\Required;
 
 use function is_string;
+use function sprintf;
 
 final class JiraOAuthCallbackAction extends BaseController
 {
     private JiraOAuthApiFactory $jiraOAuthApiFactory;
+
+    private TokenEncryptionService $tokenEncryptionService;
+
+    private ClockInterface $clock;
 
     #[Required]
     public function setJiraApiFactory(JiraOAuthApiFactory $jiraOAuthApiFactory): void
@@ -36,11 +45,23 @@ final class JiraOAuthCallbackAction extends BaseController
         $this->jiraOAuthApiFactory = $jiraOAuthApiFactory;
     }
 
+    #[Required]
+    public function setCloudStateDependencies(TokenEncryptionService $tokenEncryptionService, ClockInterface $clock): void
+    {
+        $this->tokenEncryptionService = $tokenEncryptionService;
+        $this->clock = $clock;
+    }
+
     /**
+     * Handles both callback flavours: the OAuth 1.0a application-link flow
+     * (`?tsid=…&oauth_token=…&oauth_verifier=…`, Jira Server/DC) and the
+     * OAuth 2.0 3LO flow (`?code=…&state=…`, Jira Cloud — the ticket system
+     * id rides encrypted inside `state` because Cloud redirect URIs must
+     * match the registered URL exactly).
+     *
      * @throws Exception           When database operations fail
      * @throws BadRequestException When query parameters are invalid
      * @throws JiraApiException    When Jira API operations fail
-     * @throws Exception           When OAuth token operations or API calls fail
      */
     #[Route(path: '/jiraoauthcallback', name: 'jiraOAuthCallback', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
@@ -50,6 +71,55 @@ final class JiraOAuthCallbackAction extends BaseController
             return $this->redirectToRoute('_login');
         }
 
+        $state = $request->query->get('state');
+        if (is_string($state) && '' !== $state) {
+            return $this->handleCloudCallback($request, $user, $state);
+        }
+
+        return $this->handleServerCallback($request, $user);
+    }
+
+    private function handleCloudCallback(Request $request, User $user, string $state): RedirectResponse|Response
+    {
+        try {
+            $codec = new CloudOAuthStateCodec($this->tokenEncryptionService, $this->clock);
+            $decoded = $codec->decode($state);
+
+            if ($decoded['userId'] !== (int) $user->getId()) {
+                return new Response('OAuth state does not belong to the current user', \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN);
+            }
+
+            $ticketSystem = $this->managerRegistry->getRepository(TicketSystem::class)->find($decoded['ticketSystemId']);
+            if (!$ticketSystem instanceof TicketSystem) {
+                return new Response('Ticket system not found', \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
+            }
+
+            $error = $request->query->get('error');
+            if (is_string($error) && '' !== $error) {
+                return new Response(sprintf('Jira authorization was not granted: %s', $error));
+            }
+
+            $code = $request->query->get('code');
+            if (!is_string($code) || '' === $code) {
+                return new Response('Invalid OAuth callback parameters', \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST);
+            }
+
+            $jiraApi = $this->jiraOAuthApiFactory->create($user, $ticketSystem);
+            if (!$jiraApi instanceof JiraCloudApiService) {
+                return new Response('Ticket system is not configured as Jira Cloud', \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST);
+            }
+
+            $jiraApi->exchangeAuthorizationCode($code);
+            $jiraApi->updateEntriesJiraWorkLogsLimited(1);
+
+            return $this->redirectToRoute('_start');
+        } catch (JiraApiException $jiraApiException) {
+            return new Response($jiraApiException->getMessage());
+        }
+    }
+
+    private function handleServerCallback(Request $request, User $user): RedirectResponse|Response
+    {
         /** @var TicketSystem $ticketSystem */
         $ticketSystem = $this->managerRegistry->getRepository(TicketSystem::class)->find($request->query->get('tsid'));
         if (!$ticketSystem instanceof TicketSystem) {

--- a/src/Service/Integration/Jira/CloudOAuthStateCodec.php
+++ b/src/Service/Integration/Jira/CloudOAuthStateCodec.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Integration\Jira;
+
+use App\Exception\Integration\Jira\JiraApiException;
+use App\Service\ClockInterface;
+use App\Service\Security\TokenEncryptionService;
+use Exception;
+use JsonException;
+use SensitiveParameter;
+
+use function is_array;
+use function is_int;
+use function json_decode;
+use function json_encode;
+use function random_bytes;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Encodes/decodes the OAuth 2.0 `state` parameter for the Jira Cloud flow.
+ *
+ * Atlassian requires the registered redirect URI to match exactly, so the
+ * ticket-system id cannot ride along as a query parameter (as the OAuth 1.0a
+ * flow does with `?tsid=`). Instead it is carried inside `state`, encrypted
+ * with the application key so it is tamper-proof, bound to the initiating
+ * user, and expiring after a short TTL.
+ */
+final readonly class CloudOAuthStateCodec
+{
+    private const int TTL_SECONDS = 600;
+
+    public function __construct(
+        private TokenEncryptionService $tokenEncryptionService,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function encode(int $userId, int $ticketSystemId): string
+    {
+        $payload = json_encode([
+            'u' => $userId,
+            't' => $ticketSystemId,
+            'e' => $this->clock->now()->getTimestamp() + self::TTL_SECONDS,
+            'n' => bin2hex(random_bytes(8)),
+        ], JSON_THROW_ON_ERROR);
+
+        return $this->tokenEncryptionService->encryptToken($payload);
+    }
+
+    /**
+     * @throws JiraApiException When the state is invalid, tampered with, or expired
+     *
+     * @return array{userId: int, ticketSystemId: int}
+     */
+    public function decode(#[SensitiveParameter] string $state): array
+    {
+        try {
+            $payload = $this->tokenEncryptionService->decryptToken($state);
+            $data = json_decode($payload, true, 8, JSON_THROW_ON_ERROR);
+        } catch (JsonException|Exception $exception) {
+            throw new JiraApiException('Invalid OAuth state parameter.', 400, null, $exception);
+        }
+
+        if (!is_array($data) || !is_int($data['u'] ?? null) || !is_int($data['t'] ?? null) || !is_int($data['e'] ?? null)) {
+            throw new JiraApiException('Invalid OAuth state parameter.', 400);
+        }
+
+        if ($this->clock->now()->getTimestamp() > $data['e']) {
+            throw new JiraApiException('The OAuth state has expired — please restart the authorization.', 400);
+        }
+
+        return [
+            'userId' => $data['u'],
+            'ticketSystemId' => $data['t'],
+        ];
+    }
+}

--- a/src/Service/Integration/Jira/JiraCloudApiService.php
+++ b/src/Service/Integration/Jira/JiraCloudApiService.php
@@ -21,6 +21,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use JsonException;
+use Override;
 use SensitiveParameter;
 use Symfony\Component\Routing\RouterInterface;
 use Throwable;
@@ -99,6 +100,7 @@ class JiraCloudApiService extends JiraOAuthApiService
      *
      * @throws JiraApiException
      */
+    #[Override]
     public function fetchOAuthAccessToken(#[SensitiveParameter] string $oAuthRequestToken, #[SensitiveParameter] string $oAuthVerifier): void
     {
         throw new JiraApiException(sprintf('Ticket system "%s" is a Jira Cloud system; the OAuth 1.0a callback does not apply to it.', $this->ticketSystem->getName()), 400);
@@ -110,6 +112,7 @@ class JiraCloudApiService extends JiraOAuthApiService
      *
      * @param array<int, string> $fields
      */
+    #[Override]
     public function searchTicket(string $jql, array $fields, int $limit = 1): mixed
     {
         return $this->post(
@@ -128,6 +131,7 @@ class JiraCloudApiService extends JiraOAuthApiService
      *
      * @throws JiraApiException
      */
+    #[Override]
     protected function getClient(string $tokenMode = 'user', #[SensitiveParameter] ?string $oAuthToken = null): Client
     {
         $accessToken = $this->getValidAccessToken();
@@ -160,6 +164,7 @@ class JiraCloudApiService extends JiraOAuthApiService
      *
      * @throws JiraApiException
      */
+    #[Override]
     protected function getJiraApiUrl(): string
     {
         $cloudId = $this->ticketSystem->getCloudId();
@@ -174,6 +179,7 @@ class JiraCloudApiService extends JiraOAuthApiService
      * Cloud redirect URIs must match the registered callback exactly, so no
      * `?tsid=` may be appended — the ticket system rides in `state` instead.
      */
+    #[Override]
     protected function getOAuthCallbackUrl(): string
     {
         return $this->oAuthCallbackUrl;
@@ -185,10 +191,9 @@ class JiraCloudApiService extends JiraOAuthApiService
      *
      * @throws JiraApiUnauthorizedException
      * @throws JiraApiException
-     *
-     * @return never
      */
-    protected function throwUnauthorizedRedirect(?Throwable $throwable = null)
+    #[Override]
+    protected function throwUnauthorizedRedirect(?Throwable $throwable = null): never
     {
         $authorizeUrl = static::AUTH_BASE_URL . '/authorize?' . http_build_query([
             'audience' => 'api.atlassian.com',
@@ -328,10 +333,15 @@ class JiraCloudApiService extends JiraOAuthApiService
 
         if (is_array($resources)) {
             foreach ($resources as $resource) {
-                if (!is_array($resource) || !is_string($resource['id'] ?? null) || !is_string($resource['url'] ?? null)) {
+                if (!is_array($resource)) {
                     continue;
                 }
-
+                if (!is_string($resource['id'] ?? null)) {
+                    continue;
+                }
+                if (!is_string($resource['url'] ?? null)) {
+                    continue;
+                }
                 if (strtolower((string) parse_url($resource['url'], PHP_URL_HOST)) === $wantedHost) {
                     $this->ticketSystem->setCloudId($resource['id']);
                     $objectManager = $this->managerRegistry->getManager();

--- a/src/Service/Integration/Jira/JiraCloudApiService.php
+++ b/src/Service/Integration/Jira/JiraCloudApiService.php
@@ -1,0 +1,442 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Integration\Jira;
+
+use App\Entity\TicketSystem;
+use App\Entity\User;
+use App\Entity\UserTicketsystem;
+use App\Exception\Integration\Jira\JiraApiException;
+use App\Exception\Integration\Jira\JiraApiUnauthorizedException;
+use App\Service\ClockInterface;
+use App\Service\Security\TokenEncryptionService;
+use DateTimeImmutable;
+use Doctrine\Persistence\ManagerRegistry;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use JsonException;
+use SensitiveParameter;
+use Symfony\Component\Routing\RouterInterface;
+use Throwable;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_decode;
+use function parse_url;
+use function sprintf;
+use function strtolower;
+
+use const JSON_THROW_ON_ERROR;
+use const PHP_URL_HOST;
+
+/**
+ * Jira Cloud variant of the Jira API service.
+ *
+ * Jira Cloud does not accept the OAuth 1.0a application-link flow the base
+ * class implements (deprecated by Atlassian). This subclass swaps the
+ * authentication layer for OAuth 2.0 authorization-code (3LO) with rotating
+ * refresh tokens, talks to the tenant through the Atlassian API gateway
+ * (api.atlassian.com/ex/jira/{cloudId}), and uses the Cloud-only
+ * `search/jql` endpoint. Every worklog/issue operation of the base class
+ * works unchanged on top of the Bearer-authenticated client.
+ */
+class JiraCloudApiService extends JiraOAuthApiService
+{
+    protected const string AUTH_BASE_URL = 'https://auth.atlassian.com';
+
+    protected const string API_GATEWAY_URL = 'https://api.atlassian.com';
+
+    /** Classic Jira scopes: read/write work objects + refresh-token issuance. */
+    protected const string SCOPES = 'read:jira-work write:jira-work offline_access';
+
+    /** Refresh this many seconds before the recorded expiry to absorb clock skew. */
+    protected const int EXPIRY_SKEW_SECONDS = 60;
+
+    public function __construct(
+        User $user,
+        TicketSystem $ticketSystem,
+        ManagerRegistry $managerRegistry,
+        RouterInterface $router,
+        TokenEncryptionService $tokenEncryptionService,
+        protected ClockInterface $clock,
+    ) {
+        parent::__construct($user, $ticketSystem, $managerRegistry, $router, $tokenEncryptionService);
+    }
+
+    /**
+     * Exchanges the 3LO authorization code for access + refresh tokens and
+     * resolves the tenant's cloudId on first authorization.
+     *
+     * @throws JiraApiException
+     */
+    public function exchangeAuthorizationCode(#[SensitiveParameter] string $code): void
+    {
+        $data = $this->requestTokenEndpoint([
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->getOauth2ClientId(),
+            'client_secret' => $this->getOauth2ClientSecret(),
+            'code' => $code,
+            'redirect_uri' => $this->getOAuthCallbackUrl(),
+        ]);
+
+        $this->storeCloudTokens($data['access_token'], $data['refresh_token'], $data['expires_in']);
+
+        $cloudId = $this->ticketSystem->getCloudId();
+        if (null === $cloudId || '' === $cloudId) {
+            $this->resolveCloudId($data['access_token']);
+        }
+    }
+
+    /**
+     * The OAuth 1.0a token exchange has no meaning on Jira Cloud.
+     *
+     * @throws JiraApiException
+     */
+    public function fetchOAuthAccessToken(#[SensitiveParameter] string $oAuthRequestToken, #[SensitiveParameter] string $oAuthVerifier): void
+    {
+        throw new JiraApiException(sprintf('Ticket system "%s" is a Jira Cloud system; the OAuth 1.0a callback does not apply to it.', $this->ticketSystem->getName()), 400);
+    }
+
+    /**
+     * Cloud search uses the dedicated JQL endpoint; the legacy `search/`
+     * resource has been removed from Jira Cloud.
+     *
+     * @param array<int, string> $fields
+     */
+    public function searchTicket(string $jql, array $fields, int $limit = 1): mixed
+    {
+        return $this->post(
+            'search/jql',
+            [
+                'jql' => $jql,
+                'fields' => $fields,
+                'maxResults' => $limit,
+            ],
+        );
+    }
+
+    /**
+     * Bearer-authenticated client against the tenant's API-gateway base URL.
+     * The OAuth1 token modes of the base class do not apply here.
+     *
+     * @throws JiraApiException
+     */
+    protected function getClient(string $tokenMode = 'user', #[SensitiveParameter] ?string $oAuthToken = null): Client
+    {
+        $accessToken = $this->getValidAccessToken();
+
+        $cloudId = $this->ticketSystem->getCloudId();
+        if (null === $cloudId || '' === $cloudId) {
+            $this->resolveCloudId($accessToken);
+        }
+
+        $cacheKey = 'cloud-' . $accessToken;
+        if (isset($this->clients[$cacheKey])) {
+            return $this->clients[$cacheKey];
+        }
+
+        $this->clients[$cacheKey] = $this->createHttpClient([
+            'base_uri' => $this->getJiraApiUrl(),
+            'headers' => [
+                'Authorization' => 'Bearer ' . $accessToken,
+                'Accept' => 'application/json',
+            ],
+        ]);
+
+        return $this->clients[$cacheKey];
+    }
+
+    /**
+     * Tenant API base: Atlassian gateway + cloudId. Pinned to REST v2 —
+     * v3 requires Atlassian Document Format for worklog comments, v2 keeps
+     * accepting the plain-text comments the base class sends.
+     *
+     * @throws JiraApiException
+     */
+    protected function getJiraApiUrl(): string
+    {
+        $cloudId = $this->ticketSystem->getCloudId();
+        if (null === $cloudId || '' === $cloudId) {
+            $this->throwUnauthorizedRedirect();
+        }
+
+        return static::API_GATEWAY_URL . '/ex/jira/' . $cloudId . '/rest/api/2/';
+    }
+
+    /**
+     * Cloud redirect URIs must match the registered callback exactly, so no
+     * `?tsid=` may be appended — the ticket system rides in `state` instead.
+     */
+    protected function getOAuthCallbackUrl(): string
+    {
+        return $this->oAuthCallbackUrl;
+    }
+
+    /**
+     * Builds the 3LO authorize URL and throws the redirect exception the
+     * frontend turns into a "Please authorize" link.
+     *
+     * @throws JiraApiUnauthorizedException
+     * @throws JiraApiException
+     *
+     * @return never
+     */
+    protected function throwUnauthorizedRedirect(?Throwable $throwable = null)
+    {
+        $authorizeUrl = static::AUTH_BASE_URL . '/authorize?' . http_build_query([
+            'audience' => 'api.atlassian.com',
+            'client_id' => $this->getOauth2ClientId(),
+            'scope' => static::SCOPES,
+            'redirect_uri' => $this->getOAuthCallbackUrl(),
+            'state' => $this->createStateCodec()->encode((int) $this->user->getId(), (int) $this->ticketSystem->getId()),
+            'response_type' => 'code',
+            'prompt' => 'consent',
+        ]);
+
+        $message = '401 - Unauthorized. Please authorize: ' . $authorizeUrl;
+        throw new JiraApiUnauthorizedException($message, 401, $authorizeUrl, $throwable);
+    }
+
+    /**
+     * Returns a decrypted, non-expired access token — refreshing it via the
+     * rotating refresh token when it is at or past its recorded expiry.
+     *
+     * @throws JiraApiException
+     */
+    protected function getValidAccessToken(): string
+    {
+        $userTicketSystem = $this->getUserTicketSystem();
+        $accessToken = $this->getToken();
+
+        if (!$userTicketSystem instanceof UserTicketsystem || '' === $accessToken) {
+            $this->throwUnauthorizedRedirect();
+        }
+
+        $expiresAt = $userTicketSystem->getTokenExpiresAt();
+        if ($expiresAt instanceof DateTimeImmutable
+            && $this->clock->now()->getTimestamp() >= $expiresAt->getTimestamp() - static::EXPIRY_SKEW_SECONDS
+        ) {
+            return $this->refreshAccessToken($userTicketSystem);
+        }
+
+        return $accessToken;
+    }
+
+    /**
+     * Refreshes the access token. Atlassian rotates refresh tokens: the old
+     * one is consumed and BOTH returned tokens must be stored. A rejected
+     * refresh (revoked/expired grant) clears the stored tokens and restarts
+     * the authorize flow.
+     *
+     * @throws JiraApiException
+     */
+    protected function refreshAccessToken(UserTicketsystem $userTicketSystem): string
+    {
+        $storedRefreshToken = $userTicketSystem->getRefreshToken();
+        $refreshToken = null !== $storedRefreshToken && '' !== $storedRefreshToken
+            ? $this->decryptStored($storedRefreshToken)
+            : '';
+
+        if ('' === $refreshToken) {
+            $this->throwUnauthorizedRedirect();
+        }
+
+        try {
+            $data = $this->requestTokenEndpoint([
+                'grant_type' => 'refresh_token',
+                'client_id' => $this->getOauth2ClientId(),
+                'client_secret' => $this->getOauth2ClientSecret(),
+                'refresh_token' => $refreshToken,
+            ]);
+        } catch (JiraApiException $jiraApiException) {
+            // The grant is gone (revoked, rotated away, or expired) — force re-authorization.
+            $this->storeCloudTokens('', '', 0);
+            $this->throwUnauthorizedRedirect($jiraApiException);
+        }
+
+        $this->storeCloudTokens($data['access_token'], $data['refresh_token'], $data['expires_in']);
+
+        return $data['access_token'];
+    }
+
+    /**
+     * POSTs to the Atlassian token endpoint and validates the response shape.
+     *
+     * @param array<string, string> $payload
+     *
+     * @throws JiraApiException
+     *
+     * @return array{access_token: string, refresh_token: string, expires_in: int}
+     */
+    protected function requestTokenEndpoint(#[SensitiveParameter] array $payload): array
+    {
+        try {
+            $response = $this->getAuthClient()->request('POST', '/oauth/token', ['json' => $payload]);
+            $data = json_decode((string) $response->getBody(), true, 8, JSON_THROW_ON_ERROR);
+        } catch (GuzzleException $guzzleException) {
+            throw new JiraApiException('Atlassian token endpoint rejected the request: ' . $guzzleException->getMessage(), $guzzleException->getCode(), null, $guzzleException);
+        } catch (JsonException $jsonException) {
+            throw new JiraApiException('Atlassian token endpoint returned invalid JSON.', 502, null, $jsonException);
+        }
+
+        if (!is_array($data)
+            || !is_string($data['access_token'] ?? null) || '' === $data['access_token']
+            || !is_string($data['refresh_token'] ?? null) || '' === $data['refresh_token']
+            || !is_int($data['expires_in'] ?? null)
+        ) {
+            throw new JiraApiException('Atlassian token endpoint returned an unexpected response.', 502);
+        }
+
+        return [
+            'access_token' => $data['access_token'],
+            'refresh_token' => $data['refresh_token'],
+            'expires_in' => $data['expires_in'],
+        ];
+    }
+
+    /**
+     * Resolves the tenant's cloudId from the sites the user authorized and
+     * persists it on the ticket system.
+     *
+     * @throws JiraApiException
+     */
+    protected function resolveCloudId(#[SensitiveParameter] string $accessToken): void
+    {
+        try {
+            $response = $this->createHttpClient([
+                'base_uri' => static::API_GATEWAY_URL,
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $accessToken,
+                    'Accept' => 'application/json',
+                ],
+            ])->request('GET', '/oauth/token/accessible-resources');
+            $resources = json_decode((string) $response->getBody(), true, 16, JSON_THROW_ON_ERROR);
+        } catch (GuzzleException $guzzleException) {
+            throw new JiraApiException('Could not list accessible Atlassian sites: ' . $guzzleException->getMessage(), $guzzleException->getCode(), null, $guzzleException);
+        } catch (JsonException $jsonException) {
+            throw new JiraApiException('Atlassian accessible-resources returned invalid JSON.', 502, null, $jsonException);
+        }
+
+        $wantedHost = strtolower((string) parse_url($this->ticketSystem->getUrl(), PHP_URL_HOST));
+
+        if (is_array($resources)) {
+            foreach ($resources as $resource) {
+                if (!is_array($resource) || !is_string($resource['id'] ?? null) || !is_string($resource['url'] ?? null)) {
+                    continue;
+                }
+
+                if (strtolower((string) parse_url($resource['url'], PHP_URL_HOST)) === $wantedHost) {
+                    $this->ticketSystem->setCloudId($resource['id']);
+                    $objectManager = $this->managerRegistry->getManager();
+                    $objectManager->persist($this->ticketSystem);
+                    $objectManager->flush();
+
+                    return;
+                }
+            }
+        }
+
+        throw new JiraApiException(sprintf('None of the Atlassian sites you authorized matches "%s" — check the ticket system URL or re-authorize with the right account.', $this->ticketSystem->getUrl()), 400);
+    }
+
+    /**
+     * Stores the rotated token set, encrypted at rest, with the absolute
+     * access-token expiry.
+     */
+    protected function storeCloudTokens(
+        #[SensitiveParameter] string $accessToken,
+        #[SensitiveParameter] string $refreshToken,
+        int $expiresIn,
+    ): void {
+        $repository = $this->managerRegistry->getRepository(UserTicketsystem::class);
+        $userTicketSystem = $repository->findOneBy([
+            'user' => $this->user,
+            'ticketSystem' => $this->ticketSystem,
+        ]);
+
+        if (!$userTicketSystem instanceof UserTicketsystem) {
+            $userTicketSystem = new UserTicketsystem();
+            $userTicketSystem->setUser($this->user)
+                ->setTicketSystem($this->ticketSystem);
+        }
+
+        $userTicketSystem->setAccessToken($this->tokenEncryptionService->encryptToken($accessToken))
+            ->setTokenSecret('')
+            ->setRefreshToken($this->tokenEncryptionService->encryptToken($refreshToken))
+            ->setTokenExpiresAt($this->clock->now()->modify(sprintf('+%d seconds', max(0, $expiresIn))))
+            ->setAvoidConnection(false);
+
+        $objectManager = $this->managerRegistry->getManager();
+        $objectManager->persist($userTicketSystem);
+        $objectManager->flush();
+    }
+
+    protected function getUserTicketSystem(): ?UserTicketsystem
+    {
+        $result = $this->managerRegistry->getRepository(UserTicketsystem::class)->findOneBy([
+            'user' => $this->user,
+            'ticketSystem' => $this->ticketSystem,
+        ]);
+
+        return $result instanceof UserTicketsystem ? $result : null;
+    }
+
+    protected function createStateCodec(): CloudOAuthStateCodec
+    {
+        return new CloudOAuthStateCodec($this->tokenEncryptionService, $this->clock);
+    }
+
+    /**
+     * Client for auth.atlassian.com (token endpoint).
+     *
+     * @throws JiraApiException
+     */
+    protected function getAuthClient(): Client
+    {
+        if (isset($this->clients['cloud-auth'])) {
+            return $this->clients['cloud-auth'];
+        }
+
+        $this->clients['cloud-auth'] = $this->createHttpClient([
+            'base_uri' => static::AUTH_BASE_URL,
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        return $this->clients['cloud-auth'];
+    }
+
+    /**
+     * Test seam: all Guzzle clients of the Cloud flow are created here.
+     *
+     * @param array<string, mixed> $config
+     */
+    protected function createHttpClient(array $config): Client
+    {
+        return new Client($config);
+    }
+
+    /**
+     * @throws JiraApiException
+     */
+    protected function getOauth2ClientId(): string
+    {
+        $clientId = $this->ticketSystem->getOauth2ClientId();
+        if (null === $clientId || '' === $clientId) {
+            throw new JiraApiException(sprintf('Ticket system "%s" is set to Jira Cloud but has no OAuth2 client id configured.', $this->ticketSystem->getName()), 400);
+        }
+
+        return $clientId;
+    }
+
+    protected function getOauth2ClientSecret(): string
+    {
+        return $this->ticketSystem->getOauth2ClientSecret() ?? '';
+    }
+}

--- a/src/Service/Integration/Jira/JiraCloudApiService.php
+++ b/src/Service/Integration/Jira/JiraCloudApiService.php
@@ -26,6 +26,7 @@ use SensitiveParameter;
 use Symfony\Component\Routing\RouterInterface;
 use Throwable;
 
+use function in_array;
 use function is_array;
 use function is_int;
 use function is_string;
@@ -59,6 +60,9 @@ class JiraCloudApiService extends JiraOAuthApiService
 
     /** Refresh this many seconds before the recorded expiry to absorb clock skew. */
     protected const int EXPIRY_SKEW_SECONDS = 60;
+
+    /** Access token the cached cloud-rest client was built with. */
+    private string $cloudRestClientToken = '';
 
     public function __construct(
         User $user,
@@ -141,20 +145,20 @@ class JiraCloudApiService extends JiraOAuthApiService
             $this->resolveCloudId($accessToken);
         }
 
-        $cacheKey = 'cloud-' . $accessToken;
-        if (isset($this->clients[$cacheKey])) {
-            return $this->clients[$cacheKey];
+        // One slot, rebuilt when the token rotates — a per-token key would
+        // accumulate stale clients in long-running sync processes.
+        if ($this->cloudRestClientToken !== $accessToken || !isset($this->clients['cloud-rest'])) {
+            $this->clients['cloud-rest'] = $this->createHttpClient([
+                'base_uri' => $this->getJiraApiUrl(),
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $accessToken,
+                    'Accept' => 'application/json',
+                ],
+            ]);
+            $this->cloudRestClientToken = $accessToken;
         }
 
-        $this->clients[$cacheKey] = $this->createHttpClient([
-            'base_uri' => $this->getJiraApiUrl(),
-            'headers' => [
-                'Authorization' => 'Bearer ' . $accessToken,
-                'Accept' => 'application/json',
-            ],
-        ]);
-
-        return $this->clients[$cacheKey];
+        return $this->clients['cloud-rest'];
     }
 
     /**
@@ -218,9 +222,15 @@ class JiraCloudApiService extends JiraOAuthApiService
     protected function getValidAccessToken(): string
     {
         $userTicketSystem = $this->getUserTicketSystem();
-        $accessToken = $this->getToken();
+        if (!$userTicketSystem instanceof UserTicketsystem) {
+            $this->throwUnauthorizedRedirect();
+        }
 
-        if (!$userTicketSystem instanceof UserTicketsystem || '' === $accessToken) {
+        // Read through the repository-loaded row (single source of truth) —
+        // the User entity's collection can lag behind a store in the same
+        // process (fresh first authorization, rotated refresh).
+        $accessToken = $this->decryptStored($userTicketSystem->getAccessToken());
+        if ('' === $accessToken) {
             $this->throwUnauthorizedRedirect();
         }
 
@@ -261,9 +271,16 @@ class JiraCloudApiService extends JiraOAuthApiService
                 'refresh_token' => $refreshToken,
             ]);
         } catch (JiraApiException $jiraApiException) {
-            // The grant is gone (revoked, rotated away, or expired) — force re-authorization.
-            $this->storeCloudTokens('', '', 0);
-            $this->throwUnauthorizedRedirect($jiraApiException);
+            // Only a definitive rejection means the grant is gone (revoked,
+            // rotated away, or expired) — clear and force re-authorization.
+            // Transient failures (network, 5xx, bad JSON) keep the grant so
+            // the next sync can retry the refresh.
+            if (in_array($jiraApiException->getCode(), [400, 401, 403], true)) {
+                $this->storeCloudTokens('', '', 0);
+                $this->throwUnauthorizedRedirect($jiraApiException);
+            }
+
+            throw $jiraApiException;
         }
 
         $this->storeCloudTokens($data['access_token'], $data['refresh_token'], $data['expires_in']);

--- a/src/Service/Integration/Jira/JiraOAuthApiFactory.php
+++ b/src/Service/Integration/Jira/JiraOAuthApiFactory.php
@@ -11,6 +11,8 @@ namespace App\Service\Integration\Jira;
 
 use App\Entity\TicketSystem;
 use App\Entity\User;
+use App\Enum\DeploymentType;
+use App\Service\ClockInterface;
 use App\Service\Security\TokenEncryptionService;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Routing\RouterInterface;
@@ -24,16 +26,28 @@ class JiraOAuthApiFactory
 
     public TokenEncryptionService $tokenEncryptionService;
 
+    public ClockInterface $clock;
+
     #[Required]
-    public function setDependencies(ManagerRegistry $managerRegistry, RouterInterface $router, TokenEncryptionService $tokenEncryptionService): void
+    public function setDependencies(ManagerRegistry $managerRegistry, RouterInterface $router, TokenEncryptionService $tokenEncryptionService, ClockInterface $clock): void
     {
         $this->managerRegistry = $managerRegistry;
         $this->router = $router;
         $this->tokenEncryptionService = $tokenEncryptionService;
+        $this->clock = $clock;
     }
 
+    /**
+     * Builds the API service matching the ticket system's deployment type:
+     * OAuth 2.0 (3LO) against the Atlassian gateway for CLOUD, the classic
+     * OAuth 1.0a application-link flow for SERVER / Data Center.
+     */
     public function create(User $user, TicketSystem $ticketSystem): JiraOAuthApiService
     {
+        if (DeploymentType::CLOUD === $ticketSystem->getDeploymentType()) {
+            return new JiraCloudApiService($user, $ticketSystem, $this->managerRegistry, $this->router, $this->tokenEncryptionService, $this->clock);
+        }
+
         return new JiraOAuthApiService($user, $ticketSystem, $this->managerRegistry, $this->router, $this->tokenEncryptionService);
     }
 }

--- a/src/Service/Integration/Jira/JiraOAuthApiService.php
+++ b/src/Service/Integration/Jira/JiraOAuthApiService.php
@@ -695,7 +695,7 @@ class JiraOAuthApiService
      * Decrypts a stored OAuth token, transparently passing through legacy
      * unencrypted values written before encryption-at-rest was added.
      */
-    private function decryptStored(string $stored): string
+    protected function decryptStored(string $stored): string
     {
         if ('' === $stored) {
             return '';

--- a/tests/Service/Integration/Jira/CloudOAuthStateCodecTest.php
+++ b/tests/Service/Integration/Jira/CloudOAuthStateCodecTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service\Integration\Jira;
+
+use App\Exception\Integration\Jira\JiraApiException;
+use App\Service\FrozenClock;
+use App\Service\Integration\Jira\CloudOAuthStateCodec;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Tests\Traits\TokenEncryptionTestTrait;
+
+/**
+ * Unit tests for the OAuth2 state codec of the Jira Cloud flow.
+ *
+ * @internal
+ */
+#[CoversClass(CloudOAuthStateCodec::class)]
+final class CloudOAuthStateCodecTest extends TestCase
+{
+    use TokenEncryptionTestTrait;
+
+    public function testEncodeDecodeRoundTrip(): void
+    {
+        $codec = $this->createCodec('2026-07-02 12:00:00');
+
+        $state = $codec->encode(42, 7);
+        $decoded = $codec->decode($state);
+
+        self::assertSame(['userId' => 42, 'ticketSystemId' => 7], $decoded);
+    }
+
+    public function testStatesAreUniquePerCall(): void
+    {
+        $codec = $this->createCodec('2026-07-02 12:00:00');
+
+        self::assertNotSame($codec->encode(1, 1), $codec->encode(1, 1));
+    }
+
+    public function testDecodeRejectsGarbage(): void
+    {
+        $codec = $this->createCodec('2026-07-02 12:00:00');
+
+        try {
+            $codec->decode('not-a-valid-state');
+            self::fail('Expected JiraApiException');
+        } catch (JiraApiException $exception) {
+            self::assertStringContainsString('Invalid OAuth state', $exception->getMessage());
+        }
+    }
+
+    public function testDecodeRejectsStateFromDifferentKey(): void
+    {
+        $codec = new CloudOAuthStateCodec(
+            $this->createTokenEncryptionService('another-key'),
+            new FrozenClock('2026-07-02 12:00:00'),
+        );
+        $foreignState = $codec->encode(42, 7);
+
+        $this->expectException(JiraApiException::class);
+        $this->createCodec('2026-07-02 12:00:00')->decode($foreignState);
+    }
+
+    public function testDecodeRejectsExpiredState(): void
+    {
+        $encodingCodec = $this->createCodec('2026-07-02 12:00:00');
+        $state = $encodingCodec->encode(42, 7);
+
+        // TTL is 600s — decode 11 minutes later.
+        $decodingCodec = $this->createCodec('2026-07-02 12:11:00');
+
+        try {
+            $decodingCodec->decode($state);
+            self::fail('Expected JiraApiException');
+        } catch (JiraApiException $exception) {
+            self::assertStringContainsString('expired', $exception->getMessage());
+        }
+    }
+
+    public function testDecodeAcceptsStateWithinTtl(): void
+    {
+        $encodingCodec = $this->createCodec('2026-07-02 12:00:00');
+        $state = $encodingCodec->encode(42, 7);
+
+        $decodingCodec = $this->createCodec('2026-07-02 12:05:00');
+
+        self::assertSame(['userId' => 42, 'ticketSystemId' => 7], $decodingCodec->decode($state));
+    }
+
+    private function createCodec(string $frozenTime): CloudOAuthStateCodec
+    {
+        return new CloudOAuthStateCodec(
+            $this->createTokenEncryptionService(),
+            new FrozenClock($frozenTime),
+        );
+    }
+}

--- a/tests/Service/Integration/Jira/JiraCloudApiServiceTest.php
+++ b/tests/Service/Integration/Jira/JiraCloudApiServiceTest.php
@@ -1,0 +1,484 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service\Integration\Jira;
+
+use App\Entity\TicketSystem;
+use App\Entity\User;
+use App\Entity\UserTicketsystem;
+use App\Exception\Integration\Jira\JiraApiException;
+use App\Exception\Integration\Jira\JiraApiUnauthorizedException;
+use App\Service\FrozenClock;
+use App\Service\Integration\Jira\CloudOAuthStateCodec;
+use App\Service\Integration\Jira\JiraCloudApiService;
+use App\Service\Security\TokenEncryptionService;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use LogicException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Component\Routing\RouterInterface;
+use Tests\Traits\TokenEncryptionTestTrait;
+
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function parse_str;
+use function parse_url;
+use function str_starts_with;
+
+use const PHP_URL_QUERY;
+
+/**
+ * Unit tests for the Jira Cloud OAuth 2.0 (3LO) service.
+ *
+ * @internal
+ */
+#[CoversClass(JiraCloudApiService::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class JiraCloudApiServiceTest extends TestCase
+{
+    use TokenEncryptionTestTrait;
+
+    private const string CALLBACK_URL = 'https://tt.example.com/jiraoauthcallback';
+
+    private User&Stub $user;
+    private TicketSystem $ticketSystem;
+    private ManagerRegistry&Stub $managerRegistry;
+    private RouterInterface&Stub $router;
+    private EntityManagerInterface&Stub $entityManager;
+    private TokenEncryptionService $tokenEncryptionService;
+    private FrozenClock $clock;
+
+    private ?UserTicketsystem $userTicketSystem = null;
+
+    private string $encryptedAccessToken = '';
+
+    /** @var list<object> */
+    private array $persisted = [];
+
+    /** @var list<array{method: string, url: string, options: array<string, mixed>}> */
+    private array $authRequests = [];
+
+    /** @var list<array{method: string, url: string, options: array<string, mixed>}> */
+    private array $restRequests = [];
+
+    /** @var list<array<string, mixed>> */
+    private array $clientConfigs = [];
+
+    private string $authResponseBody = '';
+
+    private ?RequestException $authException = null;
+
+    private string $gatewayResponseBody = '[]';
+
+    private string $restResponseBody = '{}';
+
+    protected function setUp(): void
+    {
+        $this->tokenEncryptionService = $this->createTokenEncryptionService();
+        $this->clock = new FrozenClock('2026-07-02 12:00:00');
+
+        $this->user = self::createStub(User::class);
+        $this->user->method('getId')->willReturn(42);
+        $this->user->method('getTicketSystemAccessToken')->willReturnCallback(fn (): string => $this->encryptedAccessToken);
+        $this->user->method('getTicketSystemAccessTokenSecret')->willReturn('');
+
+        $this->ticketSystem = new TicketSystem();
+        $idProperty = new ReflectionProperty(TicketSystem::class, 'id');
+        $idProperty->setValue($this->ticketSystem, 7);
+        $this->ticketSystem->setName('Cloud Jira');
+        $this->ticketSystem->setUrl('https://example.atlassian.net');
+        $this->ticketSystem->setBookTime(true);
+        $this->ticketSystem->setDeploymentType('CLOUD');
+        $this->ticketSystem->setOauth2ClientId('client-id-1');
+        $this->ticketSystem->setOauth2ClientSecret('client-secret-1');
+
+        $repository = self::createStub(EntityRepository::class);
+        $repository->method('findOneBy')->willReturnCallback(fn (): ?UserTicketsystem => $this->userTicketSystem);
+
+        $this->entityManager = self::createStub(EntityManagerInterface::class);
+        $this->entityManager->method('persist')->willReturnCallback(function (object $object): void {
+            $this->persisted[] = $object;
+        });
+
+        $this->managerRegistry = self::createStub(ManagerRegistry::class);
+        $this->managerRegistry->method('getRepository')->willReturn($repository);
+        $this->managerRegistry->method('getManager')->willReturn($this->entityManager);
+
+        $this->router = self::createStub(RouterInterface::class);
+        $this->router->method('generate')->willReturn(self::CALLBACK_URL);
+    }
+
+    // ==================== authorize redirect ====================
+
+    public function testMissingTokensThrowAuthorizeRedirectWithDecodableState(): void
+    {
+        $service = $this->createService();
+
+        try {
+            $this->invokeGetClient($service);
+            self::fail('Expected JiraApiUnauthorizedException');
+        } catch (JiraApiUnauthorizedException $exception) {
+            $redirectUrl = $exception->getRedirectUrl();
+            self::assertIsString($redirectUrl);
+            self::assertStringStartsWith('https://auth.atlassian.com/authorize?', $redirectUrl);
+
+            $query = [];
+            parse_str((string) parse_url($redirectUrl, PHP_URL_QUERY), $query);
+
+            self::assertSame('api.atlassian.com', $query['audience'] ?? null);
+            self::assertSame('client-id-1', $query['client_id'] ?? null);
+            self::assertSame('read:jira-work write:jira-work offline_access', $query['scope'] ?? null);
+            self::assertSame(self::CALLBACK_URL, $query['redirect_uri'] ?? null, 'Cloud redirect_uri must be the bare registered callback (no tsid)');
+            self::assertSame('code', $query['response_type'] ?? null);
+
+            $state = $query['state'] ?? null;
+            self::assertIsString($state);
+            $codec = new CloudOAuthStateCodec($this->tokenEncryptionService, $this->clock);
+            self::assertSame(['userId' => 42, 'ticketSystemId' => 7], $codec->decode($state));
+        }
+    }
+
+    public function testMissingClientIdFailsWithConfigurationError(): void
+    {
+        $this->ticketSystem->setOauth2ClientId(null);
+        $service = $this->createService();
+
+        try {
+            $this->invokeGetClient($service);
+            self::fail('Expected JiraApiException');
+        } catch (JiraApiException $exception) {
+            self::assertStringContainsString('no OAuth2 client id', $exception->getMessage());
+            self::assertNotInstanceOf(JiraApiUnauthorizedException::class, $exception);
+        }
+    }
+
+    // ==================== authenticated client ====================
+
+    public function testClientUsesGatewayBaseUrlAndBearerToken(): void
+    {
+        $this->givenStoredTokens('access-1', 'refresh-1', '+1 hour');
+        $this->ticketSystem->setCloudId('cloud-id-9');
+
+        $service = $this->createService();
+        $this->invokeGetClient($service);
+
+        $config = $this->lastRestClientConfig();
+        self::assertSame('https://api.atlassian.com/ex/jira/cloud-id-9/rest/api/2/', $config['base_uri'] ?? null);
+        $headers = $config['headers'] ?? null;
+        self::assertIsArray($headers);
+        self::assertSame('Bearer access-1', $headers['Authorization'] ?? null);
+    }
+
+    public function testExpiredTokenIsRefreshedAndRotatedTokensAreStored(): void
+    {
+        $this->givenStoredTokens('stale-access', 'refresh-1', '-1 minute');
+        $this->ticketSystem->setCloudId('cloud-id-9');
+        $this->authResponseBody = (string) json_encode([
+            'access_token' => 'fresh-access',
+            'refresh_token' => 'fresh-refresh',
+            'expires_in' => 3600,
+        ]);
+
+        $service = $this->createService();
+        $this->invokeGetClient($service);
+
+        // The refresh request carried the rotating grant…
+        self::assertCount(1, $this->authRequests);
+        $payload = $this->authRequests[0]['options']['json'] ?? null;
+        self::assertIsArray($payload);
+        self::assertSame('refresh_token', $payload['grant_type'] ?? null);
+        self::assertSame('refresh-1', $payload['refresh_token'] ?? null);
+
+        // …and BOTH rotated tokens were stored encrypted, with the new expiry.
+        $userTicketSystem = $this->userTicketSystem;
+        self::assertInstanceOf(UserTicketsystem::class, $userTicketSystem);
+        self::assertSame('fresh-access', $this->tokenEncryptionService->decryptToken($userTicketSystem->getAccessToken()));
+        $refreshToken = $userTicketSystem->getRefreshToken();
+        self::assertIsString($refreshToken);
+        self::assertSame('fresh-refresh', $this->tokenEncryptionService->decryptToken($refreshToken));
+        $expiresAt = $userTicketSystem->getTokenExpiresAt();
+        self::assertInstanceOf(DateTimeImmutable::class, $expiresAt);
+        self::assertSame(
+            $this->clock->now()->modify('+3600 seconds')->getTimestamp(),
+            $expiresAt->getTimestamp(),
+        );
+
+        // The fresh token authenticates the REST client.
+        $config = $this->lastRestClientConfig();
+        $headers = $config['headers'] ?? null;
+        self::assertIsArray($headers);
+        self::assertSame('Bearer fresh-access', $headers['Authorization'] ?? null);
+    }
+
+    public function testRejectedRefreshClearsTokensAndRestartsAuthorization(): void
+    {
+        $this->givenStoredTokens('stale-access', 'refresh-1', '-1 minute');
+        $this->ticketSystem->setCloudId('cloud-id-9');
+        $this->authException = new RequestException(
+            'invalid_grant',
+            new Request('POST', '/oauth/token'),
+            new Response(403),
+        );
+
+        $service = $this->createService();
+
+        try {
+            $this->invokeGetClient($service);
+            self::fail('Expected JiraApiUnauthorizedException');
+        } catch (JiraApiUnauthorizedException $exception) {
+            self::assertStringContainsString('auth.atlassian.com/authorize', (string) $exception->getRedirectUrl());
+        }
+
+        $userTicketSystem = $this->userTicketSystem;
+        self::assertInstanceOf(UserTicketsystem::class, $userTicketSystem);
+        self::assertSame('', $userTicketSystem->getAccessToken());
+        self::assertSame('', $userTicketSystem->getRefreshToken());
+    }
+
+    // ==================== authorization-code exchange ====================
+
+    public function testExchangeAuthorizationCodeStoresTokensAndResolvesCloudId(): void
+    {
+        $this->authResponseBody = (string) json_encode([
+            'access_token' => 'access-1',
+            'refresh_token' => 'refresh-1',
+            'expires_in' => 3600,
+        ]);
+        $this->gatewayResponseBody = (string) json_encode([
+            ['id' => 'other-cloud', 'url' => 'https://other.atlassian.net'],
+            ['id' => 'cloud-id-9', 'url' => 'https://EXAMPLE.atlassian.net'],
+        ]);
+
+        $service = $this->createService();
+        $service->exchangeAuthorizationCode('auth-code-1');
+
+        // Token exchange used the authorization-code grant with the bare redirect URI.
+        $payload = $this->authRequests[0]['options']['json'] ?? null;
+        self::assertIsArray($payload);
+        self::assertSame('authorization_code', $payload['grant_type'] ?? null);
+        self::assertSame('auth-code-1', $payload['code'] ?? null);
+        self::assertSame(self::CALLBACK_URL, $payload['redirect_uri'] ?? null);
+
+        // Tokens stored encrypted…
+        $userTicketSystem = $this->userTicketSystem ?? $this->findPersistedUserTicketSystem();
+        self::assertInstanceOf(UserTicketsystem::class, $userTicketSystem);
+        self::assertSame('access-1', $this->tokenEncryptionService->decryptToken($userTicketSystem->getAccessToken()));
+
+        // …and the tenant was matched by host, case-insensitively.
+        self::assertSame('cloud-id-9', $this->ticketSystem->getCloudId());
+        self::assertContains($this->ticketSystem, $this->persisted);
+    }
+
+    public function testExchangeAuthorizationCodeFailsWhenNoSiteMatches(): void
+    {
+        $this->authResponseBody = (string) json_encode([
+            'access_token' => 'access-1',
+            'refresh_token' => 'refresh-1',
+            'expires_in' => 3600,
+        ]);
+        $this->gatewayResponseBody = (string) json_encode([
+            ['id' => 'other-cloud', 'url' => 'https://other.atlassian.net'],
+        ]);
+
+        $service = $this->createService();
+
+        try {
+            $service->exchangeAuthorizationCode('auth-code-1');
+            self::fail('Expected JiraApiException');
+        } catch (JiraApiException $exception) {
+            self::assertStringContainsString('None of the Atlassian sites', $exception->getMessage());
+        }
+    }
+
+    public function testMalformedTokenResponseIsRejected(): void
+    {
+        $this->authResponseBody = (string) json_encode(['access_token' => 'only-this']);
+
+        $service = $this->createService();
+
+        try {
+            $service->exchangeAuthorizationCode('auth-code-1');
+            self::fail('Expected JiraApiException');
+        } catch (JiraApiException $exception) {
+            self::assertStringContainsString('unexpected response', $exception->getMessage());
+        }
+    }
+
+    // ==================== REST specifics ====================
+
+    public function testSearchTicketUsesCloudJqlEndpoint(): void
+    {
+        $this->givenStoredTokens('access-1', 'refresh-1', '+1 hour');
+        $this->ticketSystem->setCloudId('cloud-id-9');
+
+        $service = $this->createService();
+        $service->searchTicket('project = ABC', ['key'], 5);
+
+        self::assertCount(1, $this->restRequests);
+        self::assertSame('POST', $this->restRequests[0]['method']);
+        self::assertSame('search/jql', $this->restRequests[0]['url']);
+        $body = $this->restRequests[0]['options']['body'] ?? null;
+        self::assertIsString($body);
+        $decoded = json_decode($body, true);
+        self::assertIsArray($decoded);
+        self::assertSame('project = ABC', $decoded['jql'] ?? null);
+        self::assertSame(5, $decoded['maxResults'] ?? null);
+    }
+
+    public function testOAuth1CallbackIsRejected(): void
+    {
+        $service = $this->createService();
+
+        try {
+            $service->fetchOAuthAccessToken('token', 'verifier');
+            self::fail('Expected JiraApiException');
+        } catch (JiraApiException $exception) {
+            self::assertStringContainsString('OAuth 1.0a', $exception->getMessage());
+        }
+    }
+
+    public function testCallbackUrlCarriesNoTicketSystemParameter(): void
+    {
+        $service = $this->createService();
+
+        $reflectionMethod = new ReflectionMethod($service, 'getOAuthCallbackUrl');
+
+        self::assertSame(self::CALLBACK_URL, $reflectionMethod->invoke($service));
+    }
+
+    // ==================== harness ====================
+
+    private function givenStoredTokens(string $accessToken, string $refreshToken, string $expiresIn): void
+    {
+        $userTicketSystem = new UserTicketsystem();
+        $userTicketSystem->setTicketSystem($this->ticketSystem)
+            ->setAccessToken($this->tokenEncryptionService->encryptToken($accessToken))
+            ->setTokenSecret('')
+            ->setRefreshToken($this->tokenEncryptionService->encryptToken($refreshToken))
+            ->setTokenExpiresAt($this->clock->now()->modify($expiresIn));
+
+        $this->userTicketSystem = $userTicketSystem;
+        $this->encryptedAccessToken = $this->tokenEncryptionService->encryptToken($accessToken);
+    }
+
+    private function findPersistedUserTicketSystem(): ?UserTicketsystem
+    {
+        foreach ($this->persisted as $object) {
+            if ($object instanceof UserTicketsystem) {
+                return $object;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function lastRestClientConfig(): array
+    {
+        foreach (array_reverse($this->clientConfigs) as $config) {
+            $base = $config['base_uri'] ?? '';
+            if (is_string($base) && str_starts_with($base, 'https://api.atlassian.com/ex/')) {
+                return $config;
+            }
+        }
+
+        self::fail('No REST client was created');
+    }
+
+    private function invokeGetClient(JiraCloudApiService $service): Client
+    {
+        $reflectionMethod = new ReflectionMethod($service, 'getClient');
+        $client = $reflectionMethod->invoke($service);
+        self::assertInstanceOf(Client::class, $client);
+
+        return $client;
+    }
+
+    private function createService(): JiraCloudApiService
+    {
+        $test = $this;
+
+        return new class($this->user, $this->ticketSystem, $this->managerRegistry, $this->router, $this->tokenEncryptionService, $this->clock, $test) extends JiraCloudApiService {
+            public function __construct(
+                User $user,
+                TicketSystem $ticketSystem,
+                ManagerRegistry $managerRegistry,
+                RouterInterface $router,
+                TokenEncryptionService $tokenEncryptionService,
+                FrozenClock $clock,
+                private readonly JiraCloudApiServiceTest $test,
+            ) {
+                parent::__construct($user, $ticketSystem, $managerRegistry, $router, $tokenEncryptionService, $clock);
+            }
+
+            protected function createHttpClient(array $config): Client
+            {
+                return $this->test->routeClient($config);
+            }
+        };
+    }
+
+    /**
+     * Test seam target: records every client the service creates and returns
+     * a per-endpoint stub (auth.atlassian.com token endpoint, bare gateway
+     * for accessible-resources, tenant REST base).
+     *
+     * @param array<string, mixed> $config
+     */
+    public function routeClient(array $config): Client
+    {
+        $this->clientConfigs[] = $config;
+        $base = $config['base_uri'] ?? '';
+        self::assertIsString($base);
+
+        if (str_starts_with($base, 'https://auth.atlassian.com')) {
+            return $this->stubClient($this->authRequests, fn (): string => $this->authResponseBody, $this->authException);
+        }
+
+        if ('https://api.atlassian.com' === $base) {
+            return $this->stubClient($this->restRequests, fn (): string => $this->gatewayResponseBody, null);
+        }
+
+        if (str_starts_with($base, 'https://api.atlassian.com/ex/')) {
+            return $this->stubClient($this->restRequests, fn (): string => $this->restResponseBody, null);
+        }
+
+        throw new LogicException('Unrouted client base_uri: ' . $base);
+    }
+
+    /**
+     * @param list<array{method: string, url: string, options: array<string, mixed>}> $log
+     * @param callable(): string                                                      $body
+     */
+    private function stubClient(array &$log, callable $body, ?RequestException $throw): Client
+    {
+        $client = self::createStub(Client::class);
+        $client->method('request')->willReturnCallback(
+            static function (string $method, string $url, array $options = []) use (&$log, $body, $throw): Response {
+                $log[] = ['method' => $method, 'url' => $url, 'options' => $options];
+                if ($throw instanceof RequestException) {
+                    throw $throw;
+                }
+
+                return new Response(200, ['Content-Type' => 'application/json'], $body());
+            },
+        );
+
+        return $client;
+    }
+}

--- a/tests/Service/Integration/Jira/JiraCloudApiServiceTest.php
+++ b/tests/Service/Integration/Jira/JiraCloudApiServiceTest.php
@@ -248,6 +248,35 @@ final class JiraCloudApiServiceTest extends TestCase
         self::assertSame('', $userTicketSystem->getRefreshToken());
     }
 
+    public function testTransientRefreshFailureKeepsTheGrant(): void
+    {
+        $this->givenStoredTokens('stale-access', 'refresh-1', '-1 minute');
+        $this->ticketSystem->setCloudId('cloud-id-9');
+        $this->authException = new RequestException(
+            'bad gateway',
+            new Request('POST', '/oauth/token'),
+            new Response(502),
+        );
+
+        $service = $this->createService();
+
+        try {
+            $this->invokeGetClient($service);
+            self::fail('Expected JiraApiException');
+        } catch (JiraApiUnauthorizedException $exception) {
+            self::fail('A transient failure must not restart authorization');
+        } catch (JiraApiException $exception) {
+            self::assertSame(502, $exception->getCode());
+        }
+
+        // The rotating grant survives for the next sync attempt.
+        $userTicketSystem = $this->userTicketSystem;
+        self::assertInstanceOf(UserTicketsystem::class, $userTicketSystem);
+        $refreshToken = $userTicketSystem->getRefreshToken();
+        self::assertIsString($refreshToken);
+        self::assertSame('refresh-1', $this->tokenEncryptionService->decryptToken($refreshToken));
+    }
+
     // ==================== authorization-code exchange ====================
 
     public function testExchangeAuthorizationCodeStoresTokensAndResolvesCloudId(): void

--- a/tests/Service/Integration/Jira/JiraOAuthApiFactoryTest.php
+++ b/tests/Service/Integration/Jira/JiraOAuthApiFactoryTest.php
@@ -6,8 +6,10 @@ namespace Tests\Service\Integration\Jira;
 
 use App\Entity\TicketSystem;
 use App\Entity\User;
+use App\Enum\DeploymentType;
+use App\Service\FrozenClock;
+use App\Service\Integration\Jira\JiraCloudApiService;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
-use App\Service\Integration\Jira\JiraOAuthApiService;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -30,29 +32,54 @@ final class JiraOAuthApiFactoryTest extends TestCase
         $managerRegistry = self::createStub(ManagerRegistry::class);
         $router = self::createStub(RouterInterface::class);
         $tokenEncryptionService = $this->createTokenEncryptionService();
+        $clock = new FrozenClock('2026-07-02 12:00:00');
 
-        $factory->setDependencies($managerRegistry, $router, $tokenEncryptionService);
+        $factory->setDependencies($managerRegistry, $router, $tokenEncryptionService, $clock);
 
         self::assertSame($managerRegistry, $factory->managerRegistry);
         self::assertSame($router, $factory->router);
         self::assertSame($tokenEncryptionService, $factory->tokenEncryptionService);
+        self::assertSame($clock, $factory->clock);
     }
 
-    public function testCreateReturnsJiraOAuthApiService(): void
+    public function testCreateReturnsServerServiceForServerDeployment(): void
     {
-        // The create method returns JiraOAuthApiService by type declaration.
-        // We test that it doesn't throw and creates a valid service.
-        $this->expectNotToPerformAssertions();
-
-        $factory = new JiraOAuthApiFactory();
-        $managerRegistry = self::createStub(ManagerRegistry::class);
-        $router = self::createStub(RouterInterface::class);
-        $factory->setDependencies($managerRegistry, $router, $this->createTokenEncryptionService());
+        $factory = $this->createFactory();
 
         $user = self::createStub(User::class);
         $ticketSystem = self::createStub(TicketSystem::class);
         $ticketSystem->method('getUrl')->willReturn('https://jira.example.com');
+        $ticketSystem->method('getDeploymentType')->willReturn(DeploymentType::SERVER);
 
-        $factory->create($user, $ticketSystem);
+        $service = $factory->create($user, $ticketSystem);
+
+        self::assertNotInstanceOf(JiraCloudApiService::class, $service);
+    }
+
+    public function testCreateReturnsCloudServiceForCloudDeployment(): void
+    {
+        $factory = $this->createFactory();
+
+        $user = self::createStub(User::class);
+        $ticketSystem = self::createStub(TicketSystem::class);
+        $ticketSystem->method('getUrl')->willReturn('https://example.atlassian.net');
+        $ticketSystem->method('getDeploymentType')->willReturn(DeploymentType::CLOUD);
+
+        $service = $factory->create($user, $ticketSystem);
+
+        self::assertInstanceOf(JiraCloudApiService::class, $service);
+    }
+
+    private function createFactory(): JiraOAuthApiFactory
+    {
+        $factory = new JiraOAuthApiFactory();
+        $factory->setDependencies(
+            self::createStub(ManagerRegistry::class),
+            self::createStub(RouterInterface::class),
+            $this->createTokenEncryptionService(),
+            new FrozenClock('2026-07-02 12:00:00'),
+        );
+
+        return $factory;
     }
 }


### PR DESCRIPTION
## Summary

Implements the runtime half of the Jira Cloud plan started in #416 ("PR-2..4" of the original series): TimeTracker now syncs worklogs against **both** Jira Server/DC (OAuth 1.0a, unchanged) and **Jira Cloud** (OAuth 2.0 authorization-code / 3LO), selected per ticket system via the deployment type that #416 introduced.

## How it works

- **`JiraCloudApiService`** extends the existing service and swaps only the transport/auth layer: 3LO authorize redirect, authorization-code exchange, **rotating refresh tokens** with recorded expiry (via the app's `ClockInterface`, frozen-time safe), automatic **cloudId resolution** from `accessible-resources` (matched by site host), Bearer-authenticated REST through `api.atlassian.com/ex/jira/{cloudId}/rest/api/2/`, and the Cloud-only **`search/jql`** endpoint. All worklog/issue/subticket operations of the base class run unchanged on top.
- **`CloudOAuthStateCodec`**: Cloud redirect URIs must match the registered URL exactly, so the ticket-system id cannot ride as `?tsid=` like in the OAuth1 flow — it travels inside the encrypted, user-bound, 10-minute-TTL `state` parameter instead.
- **`JiraOAuthApiFactory`** branches on `DeploymentType` — every existing caller (worklog subscriber, subticket sync, exports, admin sync) gets the right transport transparently.
- The shared **`/jiraoauthcallback`** route serves both flows (a `state` parameter selects the Cloud branch; `error=access_denied` is reported cleanly).
- REST **v2** is pinned deliberately: v3 requires Atlassian Document Format for worklog comments; v2 keeps accepting the plain-text comments the app sends.

Docs: ADR-017 updated to "implemented" with the mechanism recorded; Cloud app-registration walkthrough (scopes, exact callback URL) added to `docs/configuration.md`; README feature bullet updated.

Context: the Mogic fork's Cloud adaptation (mogic-le/timetracker, TIM-130) confirmed `search/jql` as the required Cloud search endpoint; their fork still uses deprecated OAuth 1.0a against Cloud — this PR provides the supported 3LO path instead.

## Verification

- 21 new unit tests: state codec (round-trip, tamper, cross-key, TTL expiry), authorize-URL construction with decodable state, Bearer client against the gateway URL, token refresh & rotation incl. rejected-refresh cleanup + re-authorize, cloudId host matching (case-insensitive) and no-match failure, malformed token responses, `search/jql` payload, OAuth1-callback rejection, bare callback URL
- Full unit suite: **1575 tests green**
- PHPStan level 10 clean, PHPat clean, PER-CS clean

## Out of scope

- A real end-to-end test against a live Atlassian app registration (needs org credentials — the same limitation the #416 plan noted for its PR-2)
- The dormant split-stack services (`JiraIntegrationService` etc.) remain excluded from DI, unchanged