### PR TITLE
feat(ui): hide the Ext. Ticket column when no loaded row has one

### DIFF
--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -364,6 +364,41 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('hides the Ext. Ticket column entirely when no loaded row has one (#10)', async () => {
+    // Both empty shapes (null and '') count as "no value".
+    mockApiWith([
+      { entry: DEFAULT_ENTRY }, // extTicket: null
+      { entry: { ...DEFAULT_ENTRY, id: 2, start: '11:00', end: '12:00', description: 'Other', extTicket: '' } },
+    ])
+    const { container, getByRole, queryByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Other' })).toBeInTheDocument())
+
+    expect(queryByRole('columnheader', { name: 'Ext. Ticket' })).toBeNull()
+    expect(container.querySelector('[data-col-key="extTicket"]')).toBeNull()
+    // The column is dropped from the DOM (not display:none-hidden), so the
+    // grid's navigable cell count shrinks with it: 9 data columns + Actions.
+    expect(getByRole('grid').getAttribute('aria-colcount')).toBe('10')
+
+    unmount()
+  })
+
+  it('keeps the Ext. Ticket column when any loaded row has a value (#10)', async () => {
+    mockApiWith([
+      { entry: DEFAULT_ENTRY }, // extTicket: null — one empty row must not hide the column
+      { entry: { ...DEFAULT_ENTRY, id: 2, start: '11:00', end: '12:00', extTicket: 'DHLSUP-1' } },
+    ])
+    const { container, getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'DHLSUP-1' })).toBeInTheDocument())
+
+    expect(getByRole('columnheader', { name: 'Ext. Ticket' })).toBeInTheDocument()
+    // Every row renders the cell (blank where empty) so column indices stay
+    // aligned across rows: 10 data columns + Actions.
+    expect(container.querySelectorAll('td[data-col-key="extTicket"]')).toHaveLength(2)
+    expect(getByRole('grid').getAttribute('aria-colcount')).toBe('11')
+
+    unmount()
+  })
+
   it('filters the project dropdown by the row customer (cascade)', async () => {
     mockTracking({
       entries: [{ entry: { ...DEFAULT_ENTRY, customer: 7, project: 9, ticket: '', class: 0 } }],

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -277,9 +277,9 @@ export default function Tracking() {
   // priority order — see app.css) until the table no longer overflows its scroll
   // container. Cells are nowrap, so this fires BEFORE anything wraps. Width is
   // monotonic in the level, so a binary search finds the minimal fitting level
-  // in ~4 reflows instead of a ~14-step linear scan. Re-run on container resize
+  // in ~4 reflows instead of a ~13-step linear scan. Re-run on container resize
   // AND on row/content changes.
-  const MAX_THIN = 14
+  const MAX_THIN = 13
   function applyThinLevel(table: HTMLElement, level: number): void {
     for (let i = 1; i <= MAX_THIN; i++) {
       table.classList.toggle('is-thin-' + i, i <= level)
@@ -328,9 +328,14 @@ export default function Tracking() {
       },
     ),
   )
-  // The External-ticket column is read-only and often empty; when no visible row
-  // has one it becomes a hide candidate for the responsive (narrow) table.
+  // The External-ticket column is read-only and often empty; when NO loaded row
+  // has a value it is dropped from the rendered grid entirely (data-driven — it
+  // reappears as soon as a fetched row carries one). Removing the cells from the
+  // DOM (rather than display:none) keeps gridNav's live cell indices and
+  // aria-colcount consistent: a hidden-but-present cell would still be an
+  // arrow-key stop.
   const hasExtTicket = createMemo<boolean>(() => rows().some((row) => str(row.extTicket) !== ''))
+  const visibleColumns = createMemo(() => (hasExtTicket() ? COLUMNS : COLUMNS.filter((col) => col.key !== 'extTicket')))
   const allProjectOptions = createMemo<NamedOption[]>(() => (projects.data ?? []).map((project) => ({ id: project.id, label: project.name })))
 
   // id→label maps, rebuilt only when the option list changes, so resolving a
@@ -992,7 +997,7 @@ export default function Tracking() {
         <div class="table-scroll" ref={setScrollEl}>
           <table
             class="data-table tracking-table"
-            classList={{ 'is-fetching': entries.isFetching, 'no-extticket': !hasExtTicket() }}
+            classList={{ 'is-fetching': entries.isFetching }}
             // A refetch (refresh / range change) keeps the previous rows visible
             // (keepPreviousData) — aria-busy + a subtle dim are the only in-flight
             // cue a sighted user gets, since the first-load spinner won't fire.
@@ -1013,7 +1018,7 @@ export default function Tracking() {
           >
             <thead>
               <tr>
-                <For each={COLUMNS}>{(col) => <th scope="col" data-col-key={col.key} classList={{ numeric: col.numeric }}>{col.label()}</th>}</For>
+                <For each={visibleColumns()}>{(col) => <th scope="col" data-col-key={col.key} classList={{ numeric: col.numeric }}>{col.label()}</th>}</For>
                 <th scope="col" data-col-key="actions">{m.tracking_actions()}</th>
               </tr>
             </thead>
@@ -1025,7 +1030,7 @@ export default function Tracking() {
                   return (
                     <>
                     <tr class={`tracking-row ${id <= 0 ? 'is-new' : CLASS_ROW[entry.class] ?? ''}`.trimEnd()} classList={{ 'is-dirty': editor.isDirty(id) }} aria-busy={editor.savingRows[id] ? 'true' : undefined}>
-                      <For each={COLUMNS}>
+                      <For each={visibleColumns()}>
                         {(col) => {
                           const editable = FIELD_BY_KEY.has(col.key)
                           const fieldType = FIELD_BY_KEY.get(col.key)?.type
@@ -1119,7 +1124,7 @@ export default function Tracking() {
                     {/* Save error gets its own full-width row beneath the row. */}
                     <Show when={editor.rowErrors[id]}>
                       <tr class="row-error">
-                        <td colspan={COLUMNS.length + 1}>
+                        <td colspan={visibleColumns().length + 1}>
                           <span role="alert" class="form-status is-error">{editor.rowErrors[id]}</span>
                         </td>
                       </tr>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1203,11 +1203,12 @@ kbd {
    until it fits. Priority order sheds the flexible free-text first and the
    functional Actions column last: shorten Date → truncate Description → truncate
    Project/Customer chips → truncate Description harder → shorten Date again →
-   truncate Description harder → hide empty Ext.Ticket → truncate Ticket →
-   truncate Description to the floor → hide Duration → truncate the chips to the
-   floor → hide Actions → hide Activity. Description (the widest, most elastic
-   column) absorbs most of the reduction, so a desktop keeps Actions and never
-   over-thins; Actions only drops on a genuinely cramped viewport.
+   truncate Description harder → truncate Ticket → truncate Description to the
+   floor → hide Duration → truncate the chips to the floor → hide Actions →
+   hide Activity. Description (the widest, most elastic column) absorbs most of
+   the reduction, so a desktop keeps Actions and never over-thins; Actions only
+   drops on a genuinely cramped viewport. (An all-empty Ext.Ticket column needs
+   no rung: Tracking.tsx drops it from the DOM entirely, at every width.)
    Real ellipsis needs an inner box (.cell-trunc / .tag-label / .ticket-link) —
    a bare <td> in an auto-layout table can't ellipsis. Horizontal scroll is the
    final safety net AND the no-JS fallback. Scoped to .tracking-table so the
@@ -1236,15 +1237,14 @@ kbd {
 .tracking-table.is-thin-6 .dt-mid { display: none; }
 .tracking-table.is-thin-6 .dt-short { display: inline; }
 .tracking-table.is-thin-7 [data-col-key='description'] .cell-trunc { max-width: 12ch; }
-.tracking-table.is-thin-8.no-extticket [data-col-key='extTicket'] { display: none; }
-.tracking-table.is-thin-9 [data-col-key='ticket'] .ticket-link { max-width: 10ch; }
-.tracking-table.is-thin-10 [data-col-key='description'] .cell-trunc { max-width: 9ch; }
-.tracking-table.is-thin-11 [data-col-key='duration'] { display: none; }
-.tracking-table.is-thin-12 [data-col-key='project'] .tag-label { max-width: 10ch; }
-.tracking-table.is-thin-12 [data-col-key='customer'] .tag-label { max-width: 11ch; }
-.tracking-table.is-thin-12 [data-col-key='activity'] .tag-label { max-width: 12ch; }
-.tracking-table.is-thin-13 [data-col-key='actions'] { display: none; }
-.tracking-table.is-thin-14 [data-col-key='activity'] { display: none; }
+.tracking-table.is-thin-8 [data-col-key='ticket'] .ticket-link { max-width: 10ch; }
+.tracking-table.is-thin-9 [data-col-key='description'] .cell-trunc { max-width: 9ch; }
+.tracking-table.is-thin-10 [data-col-key='duration'] { display: none; }
+.tracking-table.is-thin-11 [data-col-key='project'] .tag-label { max-width: 10ch; }
+.tracking-table.is-thin-11 [data-col-key='customer'] .tag-label { max-width: 11ch; }
+.tracking-table.is-thin-11 [data-col-key='activity'] .tag-label { max-width: 12ch; }
+.tracking-table.is-thin-12 [data-col-key='actions'] { display: none; }
+.tracking-table.is-thin-13 [data-col-key='activity'] { display: none; }
 
 /* A long detail list scrolls inside its own box instead of stretching the page;
    the header stays pinned so the columns remain labelled while scrolling. */


### PR DESCRIPTION
## Summary

Implements the request from the task queue: non-editable Worklog columns disappear when they carry no data — concretely **Ext. Ticket**, which is only populated where a project mirrors external customer tickets into an internal Jira.

- Data-driven: a memo over the loaded rows filters the column set; the column reappears the moment any fetched row carries an external key
- Cells are removed from the DOM rather than CSS-hidden — `gridNavigation.ts` derives arrow stops, `aria-colcount` and cell indices from live cells, so a hidden-but-present cell would remain an invisible keyboard stop
- The responsive-thinning ladder's now-redundant "hide empty ext-ticket below width X" rung is retired (levels renumbered 14→13); a non-empty column is never hidden, as before

## Verification

- New Vitest cases for both states: all-empty → no header/cells, `aria-colcount` 10; mixed → header + a cell in every row, `aria-colcount` 11
- `bun run typecheck`, `bun run lint`, `bun run test` — 348 passing
- e2e specs select cells via `data-col-key`, no column-count assumptions (checked)