### PR TITLE
perf(admin): fetch-join relations in the admin list queries

### DIFF
--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -75,11 +75,15 @@ class CustomerRepository extends ServiceEntityRepository
      */
     public function getAllCustomers(): array
     {
+        // Fetch-join the teams relation: iterating getTeams() below would otherwise
+        // lazy-load one collection per customer (N+1 — the dominant cost of /getAllCustomers).
         /** @var Customer[] $customers */
-        $customers = $this->findBy(
-            [],
-            ['name' => 'ASC'],
-        );
+        $customers = $this->createQueryBuilder('customer')
+            ->leftJoin('customer.teams', 'team')
+            ->addSelect('team')
+            ->orderBy('customer.name', 'ASC')
+            ->getQuery()
+            ->getResult();
 
         $lastActivity = $this->lastActivityBy('customer_id');
 

--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -97,8 +97,11 @@ class ProjectRepository extends ServiceEntityRepository
      */
     public function getAllProjectsForAdmin(): array
     {
+        // addSelect hydrates the joined customer: getName() below would otherwise
+        // initialize one customer proxy per project (N+1 lazy loads).
         $queryBuilder = $this->createQueryBuilder('p')
             ->leftJoin('p.customer', 'c')
+            ->addSelect('c')
             ->orderBy('p.name', 'ASC');
 
         /** @var Project[] $projects */

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -93,11 +93,15 @@ class UserRepository extends ServiceEntityRepository
      */
     public function getAllUsers(): array
     {
+        // Fetch-join the teams relation: iterating getTeams() below would otherwise
+        // lazy-load one collection per user (N+1, same pattern as getAllCustomers).
         /** @var User[] $users */
-        $users = $this->findBy(
-            [],
-            ['username' => 'ASC'],
-        );
+        $users = $this->createQueryBuilder('user')
+            ->leftJoin('user.teams', 'team')
+            ->addSelect('team')
+            ->orderBy('user.username', 'ASC')
+            ->getQuery()
+            ->getResult();
 
         $lastActivity = $this->lastActivityBy('user_id');
 

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -143,6 +143,37 @@ class AdminControllerTest extends AbstractWebTestCase
         self::assertEqualsCanonicalizing([1, 2], $rows[0]['teams']);
     }
 
+    public function testGetAllUsersReturnsUserInTwoTeamsOnce(): void
+    {
+        // Same fetch-join dedup guard as for customers, on getAllUsers():
+        // a user in two teams must hydrate into ONE row with both team ids.
+        $this->client->request('POST', '/user/save', [], [], ['CONTENT_TYPE' => 'application/json'], (string) json_encode([
+            'id' => 0,
+            'username' => 'two.teams',
+            'abbr' => 'TTM',
+            'type' => 'DEV',
+            'locale' => 'de',
+            'teams' => [1, 2],
+        ]));
+        $this->assertStatusCode(200);
+
+        $this->client->request('GET', '/getAllUsers');
+        $this->assertStatusCode(200);
+
+        $rows = [];
+        foreach ($this->getJsonResponse($this->client->getResponse()) as $row) {
+            self::assertIsArray($row);
+            self::assertIsArray($row['user']);
+            if ('two.teams' === $row['user']['username']) {
+                $rows[] = $row['user'];
+            }
+        }
+
+        self::assertCount(1, $rows, 'User assigned to two teams must appear exactly once');
+        self::assertIsArray($rows[0]['teams']);
+        self::assertEqualsCanonicalizing([1, 2], $rows[0]['teams']);
+    }
+
     public function testGetCustomersActionWithNonPl(): void
     {
         // /getAllCustomers now requires ROLE_ADMIN after auth modernization

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -112,6 +112,37 @@ class AdminControllerTest extends AbstractWebTestCase
         self::assertEquals($expectedJson, $this->getJsonResponse($this->client->getResponse()));
     }
 
+    public function testGetCustomersActionReturnsCustomerInMultipleTeamsOnce(): void
+    {
+        // Guard for the fetch-joined teams query in getAllCustomers(): a customer in
+        // two teams arrives as two SQL rows; hydration must collapse them into ONE
+        // response row carrying both team ids.
+        $this->client->request('POST', '/customer/save', [], [], ['CONTENT_TYPE' => 'application/json'], (string) json_encode([
+            'id' => 1,
+            'name' => 'Der Bäcker von nebenan',
+            'active' => true,
+            'global' => false,
+            'teams' => [1, 2],
+        ]));
+        $this->assertStatusCode(200);
+
+        $this->client->request('GET', '/getAllCustomers');
+        $this->assertStatusCode(200);
+
+        $rows = [];
+        foreach ($this->getJsonResponse($this->client->getResponse()) as $row) {
+            self::assertIsArray($row);
+            self::assertIsArray($row['customer']);
+            if (1 === $row['customer']['id']) {
+                $rows[] = $row['customer'];
+            }
+        }
+
+        self::assertCount(1, $rows, 'Customer assigned to two teams must appear exactly once');
+        self::assertIsArray($rows[0]['teams']);
+        self::assertEqualsCanonicalizing([1, 2], $rows[0]['teams']);
+    }
+
     public function testGetCustomersActionWithNonPl(): void
     {
         // /getAllCustomers now requires ROLE_ADMIN after auth modernization


### PR DESCRIPTION
## Summary

Production shows `GET /getAllCustomers` at **891 ms**. Code-path analysis found classic N+1s in the admin list repositories:

| Endpoint | Before | After | Cause |
|---|---|---|---|
| /getAllCustomers | 1 + N + 1 queries (measured 5 @ 3 rows) | **2** | teams collection lazy-loaded per customer |
| /getAllUsers | 1 + N + 1 (measured 7 @ 5 rows) | **2** | same pattern |
| /getProjects | 1 + N proxies (measured 3 @ 3 rows) | **1** | joined customer not selected → per-row proxy init for getName() |

Fix: `leftJoin`+`addSelect` in the existing query builders — ordering and JSON shape stay byte-identical (frontend consumes these shapes directly). Checked-and-left-unchanged: the last-activity MAX(day) aggregate (single indexed query) and `GetAllProjectsAction`'s `findAll()` path (proxy `getId()` doesn't initialize — exactly 1 query).

## Verification

- Query counts measured before/after via `SHOW SESSION STATUS LIKE 'Questions'` against the unittest MariaDB (numbers above)
- New controller regression test: a customer assigned to two teams appears **exactly once** with both team ids (root-entity dedup is the one behavior risk a fetch-join introduces)
- PHPStan level 10, PER-CS, unit suite green (pre-commit gate)

With ~hundreds of customers/users in production this removes hundreds of round-trips per admin-list call; the 891 ms figure should collapse to the cost of two queries.