### PR TITLE
feat(security): local password accounts, LDAP optional (ADR-018 D1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,6 +201,9 @@ COPY --from=deps /var/www/html/migrations /var/www/html/migrations
 COPY --from=deps /var/www/html/sql /var/www/html/sql
 COPY --from=deps --chown=app:app /var/www/html/var /var/www/html/var
 
+# Production PHP hardening (no arg values in exception traces, no error output).
+COPY docker/php/production.ini /usr/local/etc/php/conf.d/zz-production.ini
+
 # Copy healthcheck script
 COPY --chmod=755 docker/php/healthcheck.sh /usr/local/bin/healthcheck
 

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
     "symfony/polyfill-mbstring": "^1.33",
     "symfony/property-access": "^8.1",
     "symfony/property-info": "^8.1",
+    "symfony/rate-limiter": "^8.1",
     "symfony/security-bundle": "^8.1",
     "symfony/serializer": "^8.1",
     "symfony/translation": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "603a5fef8a1242ef8e9f5487b1c02d6c",
+    "content-hash": "7cbd72999be59fa7bf36bf2236beceaa",
     "packages": [
         {
             "name": "composer/pcre",
@@ -6053,6 +6053,80 @@
                 }
             ],
             "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/rate-limiter",
+            "version": "v8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/rate-limiter.git",
+                "reference": "dd8f48286c000b8511b9413105f4118c8c2a4bd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/dd8f48286c000b8511b9413105f4118c8c2a4bd6",
+                "reference": "dd8f48286c000b8511b9413105f4118c8c2a4bd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/options-resolver": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/lock": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\RateLimiter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Wouter de Jong",
+                    "email": "wouter@wouterj.nl"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a Token Bucket implementation to rate limit input and output in your application",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "limiter",
+                "rate-limiter"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/rate-limiter/tree/v8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-09T11:06:24+00:00"
         },
         {
             "name": "symfony/routing",

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -27,15 +27,20 @@ security:
             # Set entry point to form_login for multiple authenticators
             entry_point: form_login
 
-            # Use the new authenticator manager in Symfony 7.3
+            # Single authenticator routing per user (local password vs LDAP bind).
             custom_authenticators:
-                - App\Security\LdapAuthenticator
+                - App\Security\LoginFormAuthenticator
 
             # Form login configuration for unified route
             form_login:
                 login_path: _login
                 check_path: _login
                 enable_csrf: true
+
+            # Throttle repeated login attempts per username+IP (offline-crackable
+            # local hashes now exist; this also protects LDAP-account logins).
+            login_throttling:
+                max_attempts: 5
 
             # Standard logout configuration
             logout:

--- a/config/reference.php
+++ b/config/reference.php
@@ -629,7 +629,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *         limiters?: array<string, array{ // Default: []
  *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
  *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"

--- a/docker/php/production.ini
+++ b/docker/php/production.ini
@@ -1,0 +1,13 @@
+; Production PHP hardening (ADR-018 security review).
+; Keep stack-frame argument values out of exception traces/logs so a thrown
+; exception can never serialize a credential passed as a function argument
+; (e.g. an LDAP bind password). PHP's built-in default is Off; the base image
+; ships no php.ini, so this must be set explicitly.
+zend.exception_ignore_args = On
+
+; Don't leak PHP version / internals to clients.
+expose_php = Off
+
+; Never render errors into responses in production; they go to the log only.
+display_errors = Off
+display_startup_errors = Off

--- a/docs/adr/ADR-018-authentication-extension.md
+++ b/docs/adr/ADR-018-authentication-extension.md
@@ -1,7 +1,36 @@
 # ADR-018: Authentication Extension — Local Passwords, MFA (TOTP) and Passkeys
 
-**Status:** Proposed
+**Status:** Accepted — D1 (local passwords, LDAP optional) implemented; D2–D4 (MFA, passkeys) pending
 **Date:** 2026-07-02
+
+> **Implementation note (D1).** The auth core landed as one PR: `users.password`
+> migration, `PasswordAuthenticatedUserInterface`, the routing `LoginFormAuthenticator`,
+> local-only mode, `app:user:create`, and `login_throttling`. The admin password
+> set/clear UX is a follow-up PR. One deviation from the design below: `getPassword()`
+> returns the stored hash for local accounts but keeps the **synthetic** value
+> (not `null`) for LDAP accounts — a real `null` would make the remember-me
+> signature hasher `base64_encode(null)` and trip a PHP 8.5 deprecation. Because
+> the LDAP synthetic value is unchanged, **no remember-me invalidation occurs on
+> deploy** (contrary to the Consequences note below).
+>
+> **Security limitation — LDAP remember-me is not credential-bound (accepted).**
+> The signature covers `getPassword()`, which for LDAP accounts is the *stable*
+> synthetic value, not the directory credential. So for LDAP accounts an
+> outstanding remember-me cookie survives an LDAP password change or a
+> directory-side disable until it expires (30 days). This is unchanged from the
+> pre-D1 behaviour (every account had a synthetic password then) and is **not**
+> made worse by D1 — local accounts are strictly *better* off, their cookies are
+> now bound to the real hash and invalidate on password change. The offboarding
+> control remains `users.active = 0`: `UserChecker::checkPostAuth` runs on
+> `AuthenticationSuccessEvent`, which the authenticator manager dispatches for the
+> remember-me authenticator too, so a deactivated account is rejected the moment a
+> remember-me cookie is used to re-authenticate (the user is reloaded from the DB
+> each time). Note the scope: an already-established *session* is refreshed by
+> `ContextListener`, which does **not** re-run `UserChecker` — mid-session
+> deactivation takes effect on the next re-authentication or at session expiry,
+> which is the pre-existing behaviour and unchanged by D1. Binding LDAP
+> remember-me to a directory-derived value (e.g. a hash of the LDAP
+> `pwdChangedTime`) is possible but out of scope for D1.
 **Relates to:** [ADR-004](ADR-004-authentication-strategy-ldap-local.md) (designs, in a
 narrower and safer form, the local-account capability ADR-004 sketched but never built),
 [ADR-011](ADR-011-security-architecture.md) (extends the security architecture),
@@ -12,7 +41,7 @@ narrower and safer form, the local-account capability ADR-004 sketched but never
 ### Current state (verified in code, 2026-07-02)
 
 - **LDAP is the only login path.** The `main` firewall registers one custom
-  authenticator, [`LdapAuthenticator`](../../src/Security/LdapAuthenticator.php)
+  authenticator, [`LdapAuthenticator`](../../src/Security/LoginFormAuthenticator.php) (renamed to `LoginFormAuthenticator` in D1)
   ([config/packages/security.yaml](../../config/packages/security.yaml)). It handles
   every POST to `_login`/`login_check`, binds against LDAP via the laminas-based
   [`LdapClientService`](../../src/Service/Ldap/LdapClientService.php), and passes

--- a/docs/adr/ADR-018-authentication-extension.md
+++ b/docs/adr/ADR-018-authentication-extension.md
@@ -38,7 +38,13 @@ narrower and safer form, the local-account capability ADR-004 sketched but never
 
 ## Context
 
-### Current state (verified in code, 2026-07-02)
+### Baseline before D1 (verified in code, 2026-07-02)
+
+> This subsection describes the pre-D1 state that **motivated** this decision — it
+> is deliberately not rewritten as D-increments land (that is what an ADR Context
+> is for). For what D1 actually changed, see the **Implementation note (D1)** at
+> the top and the **Status** line; e.g. `users.password` now exists and local
+> accounts can log in.
 
 - **LDAP is the only login path.** The `main` firewall registers one custom
   authenticator, [`LdapAuthenticator`](../../src/Security/LoginFormAuthenticator.php) (renamed to `LoginFormAuthenticator` in D1)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ ADRs are historical records: bodies are not rewritten when reality moves on. Whe
 | [ADR-015](ADR-015-php-8-5-symfony-8-upgrade.md) | PHP 8.5 and Symfony 8 Upgrade | Accepted | 2026-01-17 |
 | [ADR-016](ADR-016-solidjs-frontend-rewrite.md) | SolidJS Frontend Rewrite (ExtJS Replacement) | Accepted | 2026-06-12 |
 | [ADR-017](ADR-017-jira-cloud-oauth2.md) | Jira Cloud Support via OAuth 2.0 (Dual-Mode Integration) | Accepted | 2026-06-22 |
-| [ADR-018](ADR-018-authentication-extension.md) | Authentication Extension: Local Passwords, MFA (TOTP) and Passkeys | Proposed | 2026-07-02 |
+| [ADR-018](ADR-018-authentication-extension.md) | Authentication Extension: Local Passwords, MFA (TOTP) and Passkeys | Accepted (D1 done; MFA/passkeys pending) | 2026-07-02 |
 
 ## ADR Format
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,14 +45,29 @@ The test environment ([.env.test](../.env.test)) points at the dedicated
 `mysql://unittest:unittest@db_unittest:3306/unittest?serverVersion=mariadb-12.1.2&charset=utf8mb4`
 (no host port is published for it).
 
-## LDAP
+## Authentication (LDAP + local accounts)
 
-Authentication is LDAP-only. Defaults in [.env](../.env) target the bundled
-`ldap-dev` container:
+Each account authenticates against exactly one source (ADR-018 D1): a user
+with a stored password hash is a **local account** (verified against the hash;
+LDAP is never consulted for it), any other user is an **LDAP account**. LDAP is
+optional — leaving `LDAP_HOST` empty puts the instance in **local-only mode**
+and only password accounts can log in.
+
+Bootstrap a local admin (also the LDAP-outage escape hatch / password reset):
+
+```bash
+bin/console app:user:create <username> --type=ADMIN
+```
+
+Login attempts are throttled to 5 per username+IP.
+
+### LDAP
+
+Defaults in [.env](../.env) target the bundled `ldap-dev` container:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `LDAP_HOST` | `ldap-dev` | LDAP server host |
+| `LDAP_HOST` | `ldap-dev` | LDAP server host (**empty = local-only mode**) |
 | `LDAP_PORT` | `389` | Port (`636` for LDAPS) |
 | `LDAP_READUSER` | `cn=readuser,dc=dev,dc=local` | Read/bind user DN |
 | `LDAP_READPASS` | `readuser` | Read/bind user password |

--- a/migrations/Version20260702_AddUserPassword.php
+++ b/migrations/Version20260702_AddUserPassword.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add the nullable `users.password` hash for local password accounts (ADR-018 D1).
+ *
+ * NULL (default) = LDAP account: the credential check is the LDAP bind, unchanged.
+ * A stored Symfony `auto` hash = local account: the credential check is the hash,
+ * and LDAP is never consulted for that user. No account is affected on upgrade —
+ * every existing row stays NULL and keeps authenticating via LDAP.
+ */
+final class Version20260702_AddUserPassword extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add nullable users.password hash for local (non-LDAP) accounts';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users ADD password VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users DROP COLUMN password');
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,8 +64,10 @@
             <file>tests/Repository/InterpretationUserFilterTest.php</file>
             <file>tests/Repository/OptimizedEntryRepositoryCacheTest.php</file>
             <!-- Security unit tests (not RememberMeRedirectTest) -->
-            <file>tests/Security/LdapAuthenticatorTest.php</file>
+            <file>tests/Security/LoginFormAuthenticatorTest.php</file>
             <file>tests/Security/UserCheckerTest.php</file>
+            <!-- Command unit tests -->
+            <file>tests/Command/CreateUserCommandTest.php</file>
         </testsuite>
         <!-- Integration tests requiring database -->
         <testsuite name="integration">

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -44,6 +44,7 @@ CREATE TABLE `users` (
   `active` tinyint(1) NOT NULL DEFAULT '1',
   `min_entry_duration` int(11) NOT NULL DEFAULT 5,
   `locale` char(2) NOT NULL DEFAULT 'de',
+  `password` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
@@ -336,7 +337,8 @@ INSERT INTO `doctrine_migration_versions` (`version`, `executed_at`, `execution_
 ('DoctrineMigrations\\Version20260622_AddJiraCloudSupport',   '2026-06-22 00:00:00', 0),
 ('DoctrineMigrations\\Version20260624_RemoveAccountEntity',   '2026-06-24 00:00:00', 0),
 ('DoctrineMigrations\\Version20260624_AddUserActive',         '2026-06-24 00:00:01', 0),
-('DoctrineMigrations\\Version20260625_AddEntriesActivityIndexes', '2026-06-25 00:00:00', 0);
+('DoctrineMigrations\\Version20260625_AddEntriesActivityIndexes', '2026-06-25 00:00:00', 0),
+('DoctrineMigrations\\Version20260702_AddUserPassword',       '2026-07-02 00:00:00', 0);
 
 
 -- EXPORT-VIEWS ---------------------------------------------------------------------------

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -76,20 +76,11 @@ final readonly class CreateUserCommand
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
         $isNew = !$user instanceof User;
 
-        // Resolve the type without silently re-typing an existing user: --type is
-        // applied only when explicitly given. Omitting it defaults a brand-new user
-        // to ADMIN (the bootstrap case) and PRESERVES an existing user's type — this
-        // command doubles as a password reset, so re-running it for `jane` must never
-        // promote her just because ADMIN is the new-user default.
-        if (null !== $type) {
-            $userType = UserType::tryFrom($type);
-            if (!$userType instanceof UserType || UserType::UNKNOWN === $userType) {
-                $io->error('Invalid --type. Use one of: USER, DEV, PL, ADMIN.');
+        $userType = $this->resolveType($type, $user);
+        if (!$userType instanceof UserType) {
+            $io->error('Invalid --type. Use one of: USER, DEV, PL, ADMIN.');
 
-                return Command::FAILURE;
-            }
-        } else {
-            $userType = $isNew ? UserType::ADMIN : $user->getType();
+            return Command::FAILURE;
         }
 
         if ($isNew) {
@@ -114,6 +105,29 @@ final readonly class CreateUserCommand
         ));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Resolve the effective user type without silently re-typing an existing user.
+     *
+     * An explicitly given --type is validated (a `null` return signals an invalid
+     * value). When --type is omitted, a brand-new user defaults to ADMIN (the
+     * bootstrap case) and an existing user KEEPS its current type — this command
+     * doubles as a password reset, so re-running it for `jane` must never promote
+     * her just because ADMIN is the new-user default.
+     */
+    private function resolveType(?string $type, ?User $existing): ?UserType
+    {
+        if (null === $type) {
+            return $existing instanceof User ? $existing->getType() : UserType::ADMIN;
+        }
+
+        $userType = UserType::tryFrom($type);
+        if (!$userType instanceof UserType || UserType::UNKNOWN === $userType) {
+            return null;
+        }
+
+        return $userType;
     }
 
     private function setHashedPassword(User $user, #[SensitiveParameter] string $plainPassword): void

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Enum\UserType;
+use Doctrine\ORM\EntityManagerInterface;
+use SensitiveParameter;
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * Creates a local (password) user or (re)sets an existing user's password —
+ * the bootstrap for a local-only install and the LDAP-outage escape hatch
+ * (ADR-018 D1). The password is hashed via the configured `auto` hasher and
+ * never logged.
+ *
+ * Invokable, attribute-driven input (Symfony 8): no configure()/getOption(),
+ * which also keeps the phpstan-symfony console analyser from booting the app.
+ */
+#[AsCommand(name: 'app:user:create', description: 'Create a local password user or reset a user password')]
+final readonly class CreateUserCommand
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserPasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument(description: 'Login username')]
+        ?string $username = null,
+        #[Option(description: 'User type: USER, DEV, PL or ADMIN')]
+        string $type = 'ADMIN',
+        #[Option(description: 'Password (omit to be prompted; prompting keeps it out of shell history)')]
+        #[SensitiveParameter]
+        ?string $password = null,
+    ): int {
+        if (null === $username) {
+            $answer = $io->ask('Username');
+            $username = is_string($answer) ? $answer : '';
+        }
+
+        if ('' === $username) {
+            $io->error('A username is required.');
+
+            return Command::FAILURE;
+        }
+
+        $userType = UserType::tryFrom($type);
+        if (!$userType instanceof UserType || UserType::UNKNOWN === $userType) {
+            $io->error('Invalid --type. Use one of: USER, DEV, PL, ADMIN.');
+
+            return Command::FAILURE;
+        }
+
+        if (null === $password) {
+            $answer = $io->askHidden('Password');
+            $password = is_string($answer) ? $answer : '';
+        }
+
+        if ('' === $password) {
+            $io->error('A non-empty password is required.');
+
+            return Command::FAILURE;
+        }
+
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        $isNew = !$user instanceof User;
+        if ($isNew) {
+            $user = new User()
+                ->setUsername($username)
+                ->setType($userType->value)
+                ->setLocale('en');
+        } else {
+            $user->setType($userType->value);
+        }
+
+        $this->setHashedPassword($user, $password);
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $io->success(sprintf(
+            '%s local user "%s" (%s).',
+            $isNew ? 'Created' : 'Updated password for',
+            $username,
+            $userType->value,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    private function setHashedPassword(User $user, #[SensitiveParameter] string $plainPassword): void
+    {
+        $user->setPassword($this->passwordHasher->hashPassword($user, $plainPassword));
+    }
+}

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -45,8 +45,8 @@ final readonly class CreateUserCommand
         SymfonyStyle $io,
         #[Argument(description: 'Login username')]
         ?string $username = null,
-        #[Option(description: 'User type: USER, DEV, PL or ADMIN')]
-        string $type = 'ADMIN',
+        #[Option(description: 'User type: USER, DEV, PL or ADMIN (default ADMIN for a new user; preserved for an existing one)')]
+        ?string $type = null,
         #[Option(description: 'Password (omit to be prompted; prompting keeps it out of shell history)')]
         #[SensitiveParameter]
         ?string $password = null,
@@ -58,13 +58,6 @@ final readonly class CreateUserCommand
 
         if ('' === $username) {
             $io->error('A username is required.');
-
-            return Command::FAILURE;
-        }
-
-        $userType = UserType::tryFrom($type);
-        if (!$userType instanceof UserType || UserType::UNKNOWN === $userType) {
-            $io->error('Invalid --type. Use one of: USER, DEV, PL, ADMIN.');
 
             return Command::FAILURE;
         }
@@ -82,13 +75,31 @@ final readonly class CreateUserCommand
 
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
         $isNew = !$user instanceof User;
+
+        // Resolve the type without silently re-typing an existing user: --type is
+        // applied only when explicitly given. Omitting it defaults a brand-new user
+        // to ADMIN (the bootstrap case) and PRESERVES an existing user's type — this
+        // command doubles as a password reset, so re-running it for `jane` must never
+        // promote her just because ADMIN is the new-user default.
+        if (null !== $type) {
+            $userType = UserType::tryFrom($type);
+            if (!$userType instanceof UserType || UserType::UNKNOWN === $userType) {
+                $io->error('Invalid --type. Use one of: USER, DEV, PL, ADMIN.');
+
+                return Command::FAILURE;
+            }
+        } else {
+            $userType = $isNew ? UserType::ADMIN : $user->getType();
+        }
+
         if ($isNew) {
+            // Locale is intentionally left at the entity default ('de') to match
+            // LDAP auto-provisioning; no per-account override is offered here.
             $user = new User()
                 ->setUsername($username)
-                ->setType($userType->value)
-                ->setLocale('en');
+                ->setType($userType);
         } else {
-            $user->setType($userType->value);
+            $user->setType($userType);
         }
 
         $this->setHashedPassword($user, $password);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -15,13 +15,15 @@ use App\Service\Util\LocalizationService;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use SensitiveParameter;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 use function is_string;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: 'users')]
-class User implements UserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
@@ -59,6 +61,15 @@ class User implements UserInterface
     /** Minimum entry duration in minutes — a new entry's end pre-fills to start + this. */
     #[ORM\Column(name: 'min_entry_duration', type: 'integer', nullable: false, options: ['default' => 5])]
     protected int $minEntryDuration = 5;
+
+    /**
+     * Symfony `auto` password hash for a LOCAL account (ADR-018 D1).
+     * NULL = LDAP account: the credential check is the LDAP bind. When set, the
+     * account authenticates against this hash and LDAP is never consulted for it.
+     * Never exposed in API responses/DTOs (same rule as TicketSystem secrets).
+     */
+    #[ORM\Column(name: 'password', type: 'string', length: 255, nullable: true)]
+    protected ?string $password = null;
 
     /**
      * @var Collection<int, Team>
@@ -411,14 +422,40 @@ class User implements UserInterface
     }
 
     /**
-     * Returns a password-like string for remember_me functionality.
-     * Since LDAP users don't have stored passwords, we generate a stable hash
-     * based on the username for security signature generation.
+     * The password hash used both for credential verification (local accounts)
+     * and as the remember-me signature property (`signature_properties: ['password']`).
+     *
+     * - Local account: the stored `auto` hash. It changes when the password is
+     *   reset, which correctly invalidates any outstanding remember-me cookie.
+     * - LDAP account (hash NULL): a stable, non-secret synthetic value derived
+     *   from username+id. It keeps remember-me working exactly as before (a
+     *   real NULL here would make the signature hasher base64_encode(null) and
+     *   trip a PHP deprecation) and is never used for credential verification,
+     *   because LDAP accounts are routed to the LDAP bind, not the hasher.
      */
     public function getPassword(): ?string
     {
-        // Generate a stable hash for remember_me functionality
-        // This is not the actual password but a consistent value for this user
-        return hash('sha256', $this->username . '_ldap_user_' . ($this->id ?? '0'));
+        return $this->password ?? hash('sha256', $this->username . '_ldap_user_' . ($this->id ?? '0'));
+    }
+
+    /**
+     * Whether this is a local (password) account. When true, the login
+     * authenticator verifies the password hash and never consults LDAP.
+     */
+    public function isLocalAccount(): bool
+    {
+        return null !== $this->password && '' !== $this->password;
+    }
+
+    /**
+     * Sets the (already hashed) local password, or clears it (NULL) to revert
+     * the account to LDAP authentication. Hashing happens in the caller via
+     * UserPasswordHasherInterface — never store a plain-text value here.
+     */
+    public function setPassword(#[SensitiveParameter] ?string $hashedPassword): self
+    {
+        $this->password = $hashedPassword;
+
+        return $this;
     }
 }

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -18,11 +18,13 @@ use Exception;
 use Laminas\Ldap\Exception\LdapException;
 use Override;
 use Psr\Log\LoggerInterface;
+use SensitiveParameter;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -33,6 +35,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\CustomCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
 use Throwable;
@@ -44,11 +47,21 @@ use function is_string;
 use function sprintf;
 use function strlen;
 
-class LdapAuthenticator extends AbstractLoginFormAuthenticator
+/**
+ * The single login-form authenticator (ADR-018 D1). It routes per user:
+ * a row with a local password hash is verified by the password hasher; any
+ * other row (or a not-yet-provisioned username) goes through the unchanged
+ * LDAP bind. LDAP is optional — an empty LDAP host switches the instance to
+ * local-only mode and the LDAP branch is skipped entirely.
+ */
+class LoginFormAuthenticator extends AbstractLoginFormAuthenticator
 {
     use TargetPathTrait;
 
-    public function __construct(private EntityManagerInterface $entityManager, private RouterInterface $router, private ParameterBagInterface $parameterBag, private LoggerInterface $logger, private LdapClientService $ldapClientService)
+    /** Lazily hashed dummy, reused to burn constant time on the no-such-account path. */
+    private static ?string $dummyHash = null;
+
+    public function __construct(private EntityManagerInterface $entityManager, private RouterInterface $router, private ParameterBagInterface $parameterBag, private LoggerInterface $logger, private LdapClientService $ldapClientService, private PasswordHasherFactoryInterface $passwordHasherFactory)
     {
     }
 
@@ -92,17 +105,65 @@ class LdapAuthenticator extends AbstractLoginFormAuthenticator
             throw new CustomUserMessageAuthenticationException('Invalid username format.');
         }
 
+        $sharedBadges = [
+            new CsrfTokenBadge('authenticate', $csrfToken),
+            new RememberMeBadge(),
+        ];
+
+        // Local account (has a password hash): verify against the hash via the
+        // password hasher. LDAP is never consulted for such a user.
+        $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        if ($existingUser instanceof User && $existingUser->isLocalAccount()) {
+            return new Passport(
+                new UserBadge($username, static fn (): User => $existingUser),
+                new PasswordCredentials($password),
+                $sharedBadges,
+            );
+        }
+
+        // No local password → LDAP branch. With LDAP unconfigured (empty host)
+        // there is no way to authenticate this identifier; fail generically so
+        // local-only mode doesn't reveal whether the username exists.
+        if (!$this->isLdapConfigured()) {
+            // Burn the same time a real local wrong-password verify would, so
+            // the response time can't tell "unknown user" from "real local user"
+            // (login_throttling only limits repeats, not per-name timing probes).
+            $this->equalizePasswordTiming($password);
+            $this->logger->info('Login attempt against a non-local account while LDAP is not configured (local-only mode).');
+            throw new CustomUserMessageAuthenticationException('Invalid credentials.');
+        }
+
         // Store the current password temporarily for the user loader
         $this->currentPassword = $password;
 
         return new Passport(
             new UserBadge($username, fn (string $userIdentifier): User => $this->loadUser($userIdentifier)),
             new CustomCredentials(static fn (): true => true, ['username' => $username]),
-            [
-                new CsrfTokenBadge('authenticate', $csrfToken),
-                new RememberMeBadge(),
-            ],
+            $sharedBadges,
         );
+    }
+
+    /**
+     * Whether an LDAP host is configured. Empty host = local-only mode.
+     */
+    private function isLdapConfigured(): bool
+    {
+        $host = $this->parameterBag->get('ldap_host');
+
+        return is_scalar($host) && '' !== (string) $host;
+    }
+
+    /**
+     * Runs one password verify against a fixed dummy hash so the no-such-account
+     * path takes the same time as a real wrong-password check (uses the same
+     * configured hasher, so the algorithm/cost match). The dummy is hashed once
+     * per process and reused.
+     */
+    private function equalizePasswordTiming(#[SensitiveParameter] string $password): void
+    {
+        $hasher = $this->passwordHasherFactory->getPasswordHasher(User::class);
+        self::$dummyHash ??= $hasher->hash('timing-equalizer');
+        $hasher->verify(self::$dummyHash, $password);
     }
 
     /**
@@ -143,11 +204,14 @@ class LdapAuthenticator extends AbstractLoginFormAuthenticator
             $this->logger->info('User not found in local database', ['username' => substr($userIdentifier, 0, 3) . '***']);
             throw $userException;
         } catch (Throwable $throwable) {
-            // Generic error handling
+            // Log class + message only — never the trace. A trace serializes
+            // stack-frame arguments, which on this path can include the LDAP
+            // bind password (the prod image ships no php.ini, so the built-in
+            // zend.exception_ignore_args=Off default would capture them).
             $this->logger->error('Unexpected authentication error', [
                 'username' => substr($userIdentifier, 0, 3) . '***',
+                'error_type' => $throwable::class,
                 'error' => $throwable->getMessage(),
-                'trace' => $throwable->getTraceAsString(),
             ]);
             throw new CustomUserMessageAuthenticationException('An unexpected error occurred during authentication.', [], $throwable->getCode(), $throwable);
         }

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -16,20 +16,29 @@ use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * Refuses authentication for deactivated accounts. Runs before the credential
- * check, so a deactivated user is rejected even before the LDAP bind. Wired as the
- * `main` firewall's user_checker (config/packages/security.yaml).
+ * Refuses authentication for deactivated accounts. Wired as the `main`
+ * firewall's user_checker (config/packages/security.yaml).
+ *
+ * The check runs in checkPostAuth (AuthenticationSuccessEvent), i.e. AFTER the
+ * credential check, so the distinct "deactivated" message is only ever revealed
+ * to someone who already presented valid credentials — a wrong password yields
+ * the generic bad-credentials error, so the endpoint can't be used to probe
+ * which usernames exist and are deactivated (this matters for local password
+ * accounts, whose user row is resolved before the credential check). It still
+ * enforces on remember-me: AuthenticationSuccessEvent fires for token-based
+ * auth too, whereas checkPreAuth is skipped for PreAuthenticatedUserBadge
+ * passports.
  */
 final class UserChecker implements UserCheckerInterface
 {
     public function checkPreAuth(UserInterface $user): void
     {
-        if ($user instanceof User && !$user->getActive()) {
-            throw new CustomUserMessageAccountStatusException('This account has been deactivated.');
-        }
     }
 
     public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
+        if ($user instanceof User && !$user->getActive()) {
+            throw new CustomUserMessageAccountStatusException('This account has been deactivated.');
+        }
     }
 }

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -33,6 +33,9 @@ final class UserChecker implements UserCheckerInterface
 {
     public function checkPreAuth(UserInterface $user): void
     {
+        // Intentionally empty: the deactivation check runs in checkPostAuth (after
+        // the credential check) to avoid disclosing account status pre-auth. See
+        // the class docblock.
     }
 
     public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void

--- a/tests/Command/CreateUserCommandTest.php
+++ b/tests/Command/CreateUserCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Command;
 
 use App\Command\CreateUserCommand;
 use App\Entity\User;
+use App\Enum\UserType;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -61,6 +62,52 @@ final class CreateUserCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $status);
         self::assertSame($existing, $persisted);
         self::assertSame('$2y$new-hash', $existing->getPassword());
+    }
+
+    public function testResettingExistingUserPasswordWithoutTypePreservesType(): void
+    {
+        // Regression guard: the command doubles as a password reset. Omitting
+        // --type must NOT re-type the user — running it for a DEV must not promote
+        // to ADMIN just because ADMIN is the new-user default (privilege escalation).
+        $existing = new User()->setUsername('jane')->setType('DEV');
+
+        $persisted = null;
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning($existing));
+        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
+            $persisted = $object;
+        });
+
+        $hasher = self::createStub(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn('$2y$new-hash');
+
+        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $status = $tester->execute(['username' => 'jane', '--password' => 'rotate-me']);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertSame($existing, $persisted);
+        self::assertSame(UserType::DEV, $existing->getType());
+        self::assertSame('$2y$new-hash', $existing->getPassword());
+    }
+
+    public function testNewUserWithoutTypeDefaultsToAdmin(): void
+    {
+        $persisted = null;
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning(null));
+        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
+            $persisted = $object;
+        });
+
+        $hasher = self::createStub(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn('$2y$hashed-value');
+
+        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $status = $tester->execute(['username' => 'root', '--password' => 'sup3rsecret']);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertInstanceOf(User::class, $persisted);
+        self::assertSame(UserType::ADMIN, $persisted->getType());
     }
 
     public function testRejectsInvalidType(): void

--- a/tests/Command/CreateUserCommandTest.php
+++ b/tests/Command/CreateUserCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Command;
+
+use App\Command\CreateUserCommand;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(CreateUserCommand::class)]
+final class CreateUserCommandTest extends TestCase
+{
+    public function testCreatesNewLocalUserWithHashedPassword(): void
+    {
+        $persisted = null;
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning(null));
+        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
+            $persisted = $object;
+        });
+
+        $hasher = self::createStub(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn('$2y$hashed-value');
+
+        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $status = $tester->execute(['username' => 'root', '--type' => 'ADMIN', '--password' => 'sup3rsecret']);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertInstanceOf(User::class, $persisted);
+        self::assertSame('root', $persisted->getUsername());
+        self::assertTrue($persisted->isLocalAccount());
+        self::assertSame('$2y$hashed-value', $persisted->getPassword());
+    }
+
+    public function testResetsExistingUserPassword(): void
+    {
+        $existing = new User()->setUsername('jane')->setType('DEV');
+
+        $persisted = null;
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning($existing));
+        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
+            $persisted = $object;
+        });
+
+        $hasher = self::createStub(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn('$2y$new-hash');
+
+        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $status = $tester->execute(['username' => 'jane', '--type' => 'PL', '--password' => 'rotate-me']);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertSame($existing, $persisted);
+        self::assertSame('$2y$new-hash', $existing->getPassword());
+    }
+
+    public function testRejectsInvalidType(): void
+    {
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $hasher = self::createStub(UserPasswordHasherInterface::class);
+
+        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $status = $tester->execute(['username' => 'x', '--type' => 'BOGUS', '--password' => 'pw']);
+
+        self::assertSame(Command::FAILURE, $status);
+        self::assertStringContainsString('Invalid --type', $tester->getDisplay());
+    }
+
+    /** Wraps the invokable command in a Command so its #[Argument]/#[Option] attributes build the input definition. */
+    private function wrap(CreateUserCommand $invokable): Command
+    {
+        $command = new Command('app:user:create');
+        $command->setCode($invokable);
+
+        return $command;
+    }
+
+    private function userRepositoryReturning(?User $user): \Doctrine\ORM\EntityRepository
+    {
+        $repository = self::createStub(\Doctrine\ORM\EntityRepository::class);
+        $repository->method('findOneBy')->willReturn($user);
+
+        return $repository;
+    }
+}

--- a/tests/Command/CreateUserCommandTest.php
+++ b/tests/Command/CreateUserCommandTest.php
@@ -8,6 +8,7 @@ use App\Command\CreateUserCommand;
 use App\Entity\User;
 use App\Enum\UserType;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
@@ -20,47 +21,30 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 #[CoversClass(CreateUserCommand::class)]
 final class CreateUserCommandTest extends TestCase
 {
+    /** Captures the entity handed to EntityManager::persist(). */
+    private ?User $persisted = null;
+
     public function testCreatesNewLocalUserWithHashedPassword(): void
     {
-        $persisted = null;
-        $entityManager = self::createStub(EntityManagerInterface::class);
-        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning(null));
-        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
-            $persisted = $object;
-        });
-
-        $hasher = self::createStub(UserPasswordHasherInterface::class);
-        $hasher->method('hashPassword')->willReturn('$2y$hashed-value');
-
-        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $tester = new CommandTester($this->makeCommand(null, '$2y$hashed-value'));
         $status = $tester->execute(['username' => 'root', '--type' => 'ADMIN', '--password' => 'sup3rsecret']);
 
         self::assertSame(Command::SUCCESS, $status);
-        self::assertInstanceOf(User::class, $persisted);
-        self::assertSame('root', $persisted->getUsername());
-        self::assertTrue($persisted->isLocalAccount());
-        self::assertSame('$2y$hashed-value', $persisted->getPassword());
+        self::assertInstanceOf(User::class, $this->persisted);
+        self::assertSame('root', $this->persisted->getUsername());
+        self::assertTrue($this->persisted->isLocalAccount());
+        self::assertSame('$2y$hashed-value', $this->persisted->getPassword());
     }
 
     public function testResetsExistingUserPassword(): void
     {
         $existing = new User()->setUsername('jane')->setType('DEV');
 
-        $persisted = null;
-        $entityManager = self::createStub(EntityManagerInterface::class);
-        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning($existing));
-        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
-            $persisted = $object;
-        });
-
-        $hasher = self::createStub(UserPasswordHasherInterface::class);
-        $hasher->method('hashPassword')->willReturn('$2y$new-hash');
-
-        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $tester = new CommandTester($this->makeCommand($existing, '$2y$new-hash'));
         $status = $tester->execute(['username' => 'jane', '--type' => 'PL', '--password' => 'rotate-me']);
 
         self::assertSame(Command::SUCCESS, $status);
-        self::assertSame($existing, $persisted);
+        self::assertSame($existing, $this->persisted);
         self::assertSame('$2y$new-hash', $existing->getPassword());
     }
 
@@ -71,55 +55,52 @@ final class CreateUserCommandTest extends TestCase
         // to ADMIN just because ADMIN is the new-user default (privilege escalation).
         $existing = new User()->setUsername('jane')->setType('DEV');
 
-        $persisted = null;
-        $entityManager = self::createStub(EntityManagerInterface::class);
-        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning($existing));
-        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
-            $persisted = $object;
-        });
-
-        $hasher = self::createStub(UserPasswordHasherInterface::class);
-        $hasher->method('hashPassword')->willReturn('$2y$new-hash');
-
-        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $tester = new CommandTester($this->makeCommand($existing, '$2y$new-hash'));
         $status = $tester->execute(['username' => 'jane', '--password' => 'rotate-me']);
 
         self::assertSame(Command::SUCCESS, $status);
-        self::assertSame($existing, $persisted);
+        self::assertSame($existing, $this->persisted);
         self::assertSame(UserType::DEV, $existing->getType());
         self::assertSame('$2y$new-hash', $existing->getPassword());
     }
 
     public function testNewUserWithoutTypeDefaultsToAdmin(): void
     {
-        $persisted = null;
-        $entityManager = self::createStub(EntityManagerInterface::class);
-        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning(null));
-        $entityManager->method('persist')->willReturnCallback(static function (object $object) use (&$persisted): void {
-            $persisted = $object;
-        });
-
-        $hasher = self::createStub(UserPasswordHasherInterface::class);
-        $hasher->method('hashPassword')->willReturn('$2y$hashed-value');
-
-        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $tester = new CommandTester($this->makeCommand(null, '$2y$hashed-value'));
         $status = $tester->execute(['username' => 'root', '--password' => 'sup3rsecret']);
 
         self::assertSame(Command::SUCCESS, $status);
-        self::assertInstanceOf(User::class, $persisted);
-        self::assertSame(UserType::ADMIN, $persisted->getType());
+        self::assertInstanceOf(User::class, $this->persisted);
+        self::assertSame(UserType::ADMIN, $this->persisted->getType());
     }
 
     public function testRejectsInvalidType(): void
     {
-        $entityManager = self::createStub(EntityManagerInterface::class);
-        $hasher = self::createStub(UserPasswordHasherInterface::class);
-
-        $tester = new CommandTester($this->wrap(new CreateUserCommand($entityManager, $hasher)));
+        $tester = new CommandTester($this->makeCommand(null, '$2y$hash'));
         $status = $tester->execute(['username' => 'x', '--type' => 'BOGUS', '--password' => 'pw']);
 
         self::assertSame(Command::FAILURE, $status);
         self::assertStringContainsString('Invalid --type', $tester->getDisplay());
+    }
+
+    /**
+     * Builds the command wired to a stub EntityManager (whose persist() records
+     * the entity into $this->persisted) and a stub password hasher.
+     */
+    private function makeCommand(?User $existing, string $hash): Command
+    {
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning($existing));
+        $entityManager->method('persist')->willReturnCallback(function (object $object): void {
+            if ($object instanceof User) {
+                $this->persisted = $object;
+            }
+        });
+
+        $hasher = self::createStub(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn($hash);
+
+        return $this->wrap(new CreateUserCommand($entityManager, $hasher));
     }
 
     /** Wraps the invokable command in a Command so its #[Argument]/#[Option] attributes build the input definition. */
@@ -131,9 +112,9 @@ final class CreateUserCommandTest extends TestCase
         return $command;
     }
 
-    private function userRepositoryReturning(?User $user): \Doctrine\ORM\EntityRepository
+    private function userRepositoryReturning(?User $user): EntityRepository
     {
-        $repository = self::createStub(\Doctrine\ORM\EntityRepository::class);
+        $repository = self::createStub(EntityRepository::class);
         $repository->method('findOneBy')->willReturn($user);
 
         return $repository;

--- a/tests/Security/LoginFormAuthenticatorTest.php
+++ b/tests/Security/LoginFormAuthenticatorTest.php
@@ -14,7 +14,7 @@ use App\Entity\User;
 use App\Enum\UserType;
 use App\Repository\TeamRepository;
 use App\Repository\UserRepository;
-use App\Security\LdapAuthenticator;
+use App\Security\LoginFormAuthenticator;
 use App\Service\Ldap\LdapClientService;
 use Doctrine\ORM\EntityManagerInterface;
 use Laminas\Ldap\Exception\LdapException;
@@ -33,25 +33,29 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Tests\Fixtures\TokenStub;
 
 /**
- * Unit tests for LdapAuthenticator.
+ * Unit tests for LoginFormAuthenticator.
  *
  * @internal
  */
-#[CoversClass(LdapAuthenticator::class)]
+#[CoversClass(LoginFormAuthenticator::class)]
 #[AllowMockObjectsWithoutExpectations]
-final class LdapAuthenticatorTest extends TestCase
+final class LoginFormAuthenticatorTest extends TestCase
 {
     private EntityManagerInterface&MockObject $entityManager;
     private RouterInterface&Stub $router;
     private ParameterBagInterface&Stub $parameterBag;
     private LoggerInterface&Stub $logger;
     private LdapClientService&Stub $ldapClient;
+    private PasswordHasherFactoryInterface&Stub $passwordHasherFactory;
 
     protected function setUp(): void
     {
@@ -60,18 +64,25 @@ final class LdapAuthenticatorTest extends TestCase
         $this->parameterBag = self::createStub(ParameterBagInterface::class);
         $this->logger = self::createStub(LoggerInterface::class);
         $this->ldapClient = self::createStub(LdapClientService::class);
+
+        $hasher = self::createStub(PasswordHasherInterface::class);
+        $hasher->method('hash')->willReturn('$2y$dummy');
+        $hasher->method('verify')->willReturn(false);
+        $this->passwordHasherFactory = self::createStub(PasswordHasherFactoryInterface::class);
+        $this->passwordHasherFactory->method('getPasswordHasher')->willReturn($hasher);
     }
 
-    private function makeSubject(): LdapAuthenticator
+    private function makeSubject(): LoginFormAuthenticator
     {
         $this->router->method('generate')->willReturn('/');
 
-        return new LdapAuthenticator(
+        return new LoginFormAuthenticator(
             $this->entityManager,
             $this->router,
             $this->parameterBag,
             $this->logger,
             $this->ldapClient,
+            $this->passwordHasherFactory,
         );
     }
 
@@ -656,5 +667,82 @@ final class LdapAuthenticatorTest extends TestCase
         self::assertNotNull($passport->getBadge(\Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge::class));
         self::assertNotNull($passport->getBadge(\Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge::class));
         self::assertNotNull($passport->getBadge(\Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge::class));
+    }
+
+    // ==================== local-password routing (ADR-018 D1) ====================
+
+    public function testLocalAccountUsesPasswordCredentialsAndSkipsLdap(): void
+    {
+        $this->configureDefaultLdapParams();
+
+        // A local account has a password hash → routed to the hasher, not LDAP.
+        $localUser = new User()->setUsername('local.admin')->setPassword('$2y$hashed');
+
+        $userRepo = self::createStub(UserRepository::class);
+        $userRepo->method('findOneBy')->willReturn($localUser);
+        $this->entityManager->method('getRepository')->willReturn($userRepo);
+
+        // The LDAP client must never be touched for a local account.
+
+        $authenticator = $this->makeSubject();
+        $request = new Request([], ['_username' => 'local.admin', '_password' => 'secret', '_csrf_token' => 'token']);
+
+        $passport = $authenticator->authenticate($request);
+
+        $credentials = $passport->getBadge(PasswordCredentials::class);
+        self::assertInstanceOf(PasswordCredentials::class, $credentials);
+        self::assertSame('secret', $credentials->getPassword());
+
+        // The user loader returns the row directly (no LDAP bind).
+        $userBadge = $passport->getBadge(\Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge::class);
+        self::assertNotNull($userBadge);
+        self::assertSame($localUser, $userBadge->getUser());
+    }
+
+    public function testLocalOnlyModeRejectsNonLocalAccountGenerically(): void
+    {
+        // LDAP unconfigured (empty host) + a row without a password hash.
+        $this->parameterBag->method('get')->willReturnMap([
+            ['ldap_host', ''],
+            ['ldap_create_user', false],
+        ]);
+
+        $ldapUser = new User()->setUsername('ldap.only');
+        $userRepo = self::createStub(UserRepository::class);
+        $userRepo->method('findOneBy')->willReturn($ldapUser);
+        $this->entityManager->method('getRepository')->willReturn($userRepo);
+
+        $authenticator = $this->makeSubject();
+        $request = new Request([], ['_username' => 'ldap.only', '_password' => 'secret', '_csrf_token' => 'token']);
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $authenticator->authenticate($request);
+    }
+
+    public function testLocalOnlyModeRejectsUnknownUserGenericallyAfterDummyVerify(): void
+    {
+        $this->parameterBag->method('get')->willReturnMap([
+            ['ldap_host', ''],
+            ['ldap_create_user', true],
+        ]);
+
+        $userRepo = self::createStub(UserRepository::class);
+        $userRepo->method('findOneBy')->willReturn(null);
+        $this->entityManager->method('getRepository')->willReturn($userRepo);
+
+        // The dummy verify must run so the unknown-user path costs the same as a
+        // real wrong-password check (anti-enumeration).
+        $hasher = $this->createMock(PasswordHasherInterface::class);
+        $hasher->method('hash')->willReturn('$2y$dummy');
+        $hasher->expects(self::once())->method('verify')->with('$2y$dummy', 'secret')->willReturn(false);
+        $factory = $this->createMock(PasswordHasherFactoryInterface::class);
+        $factory->method('getPasswordHasher')->willReturn($hasher);
+        $this->passwordHasherFactory = $factory;
+
+        $authenticator = $this->makeSubject();
+        $request = new Request([], ['_username' => 'nobody', '_password' => 'secret', '_csrf_token' => 'token']);
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $authenticator->authenticate($request);
     }
 }

--- a/tests/Security/LoginFormAuthenticatorTest.php
+++ b/tests/Security/LoginFormAuthenticatorTest.php
@@ -100,6 +100,24 @@ final class LoginFormAuthenticatorTest extends TestCase
         ]);
     }
 
+    /**
+     * Stubs the fluent setters of the LDAP client so a bind can be configured
+     * by the caller via a single `login()` expectation. Kept separate from the
+     * `login()` stub because tests vary that outcome (success/exception).
+     */
+    private function configureLdapClientChaining(): void
+    {
+        $this->ldapClient->method('setHost')->willReturnSelf();
+        $this->ldapClient->method('setPort')->willReturnSelf();
+        $this->ldapClient->method('setReadUser')->willReturnSelf();
+        $this->ldapClient->method('setReadPass')->willReturnSelf();
+        $this->ldapClient->method('setBaseDn')->willReturnSelf();
+        $this->ldapClient->method('setUserName')->willReturnSelf();
+        $this->ldapClient->method('setUserPass')->willReturnSelf();
+        $this->ldapClient->method('setUseSSL')->willReturnSelf();
+        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+    }
+
     // ==================== supports() tests ====================
 
     public function testSupportsReturnsFalseForGetRequest(): void
@@ -221,16 +239,7 @@ final class LoginFormAuthenticatorTest extends TestCase
         $this->entityManager->method('getRepository')
             ->willReturn($userRepo);
 
-        // Configure LDAP client to allow chaining
-        $this->ldapClient->method('setHost')->willReturnSelf();
-        $this->ldapClient->method('setPort')->willReturnSelf();
-        $this->ldapClient->method('setReadUser')->willReturnSelf();
-        $this->ldapClient->method('setReadPass')->willReturnSelf();
-        $this->ldapClient->method('setBaseDn')->willReturnSelf();
-        $this->ldapClient->method('setUserName')->willReturnSelf();
-        $this->ldapClient->method('setUserPass')->willReturnSelf();
-        $this->ldapClient->method('setUseSSL')->willReturnSelf();
-        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+        $this->configureLdapClientChaining();
         $this->ldapClient->method('login')->willReturn(true);
 
         $authenticator = $this->makeSubject();
@@ -262,15 +271,7 @@ final class LoginFormAuthenticatorTest extends TestCase
         $this->entityManager->expects(self::once())->method('persist');
         $this->entityManager->expects(self::once())->method('flush');
 
-        $this->ldapClient->method('setHost')->willReturnSelf();
-        $this->ldapClient->method('setPort')->willReturnSelf();
-        $this->ldapClient->method('setReadUser')->willReturnSelf();
-        $this->ldapClient->method('setReadPass')->willReturnSelf();
-        $this->ldapClient->method('setBaseDn')->willReturnSelf();
-        $this->ldapClient->method('setUserName')->willReturnSelf();
-        $this->ldapClient->method('setUserPass')->willReturnSelf();
-        $this->ldapClient->method('setUseSSL')->willReturnSelf();
-        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+        $this->configureLdapClientChaining();
         $this->ldapClient->method('login')->willReturn(true);
         $this->ldapClient->method('getTeams')->willReturn([]);
 
@@ -310,15 +311,7 @@ final class LoginFormAuthenticatorTest extends TestCase
         $this->entityManager->expects(self::once())->method('persist');
         $this->entityManager->expects(self::once())->method('flush');
 
-        $this->ldapClient->method('setHost')->willReturnSelf();
-        $this->ldapClient->method('setPort')->willReturnSelf();
-        $this->ldapClient->method('setReadUser')->willReturnSelf();
-        $this->ldapClient->method('setReadPass')->willReturnSelf();
-        $this->ldapClient->method('setBaseDn')->willReturnSelf();
-        $this->ldapClient->method('setUserName')->willReturnSelf();
-        $this->ldapClient->method('setUserPass')->willReturnSelf();
-        $this->ldapClient->method('setUseSSL')->willReturnSelf();
-        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+        $this->configureLdapClientChaining();
         $this->ldapClient->method('login')->willReturn(true);
         $this->ldapClient->method('getTeams')->willReturn(['Dev Team']);
 
@@ -352,15 +345,7 @@ final class LoginFormAuthenticatorTest extends TestCase
         $this->entityManager->method('getRepository')
             ->willReturn($userRepo);
 
-        $this->ldapClient->method('setHost')->willReturnSelf();
-        $this->ldapClient->method('setPort')->willReturnSelf();
-        $this->ldapClient->method('setReadUser')->willReturnSelf();
-        $this->ldapClient->method('setReadPass')->willReturnSelf();
-        $this->ldapClient->method('setBaseDn')->willReturnSelf();
-        $this->ldapClient->method('setUserName')->willReturnSelf();
-        $this->ldapClient->method('setUserPass')->willReturnSelf();
-        $this->ldapClient->method('setUseSSL')->willReturnSelf();
-        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+        $this->configureLdapClientChaining();
         $this->ldapClient->method('login')->willReturn(true);
 
         $authenticator = $this->makeSubject();
@@ -378,15 +363,7 @@ final class LoginFormAuthenticatorTest extends TestCase
     {
         $this->configureDefaultLdapParams();
 
-        $this->ldapClient->method('setHost')->willReturnSelf();
-        $this->ldapClient->method('setPort')->willReturnSelf();
-        $this->ldapClient->method('setReadUser')->willReturnSelf();
-        $this->ldapClient->method('setReadPass')->willReturnSelf();
-        $this->ldapClient->method('setBaseDn')->willReturnSelf();
-        $this->ldapClient->method('setUserName')->willReturnSelf();
-        $this->ldapClient->method('setUserPass')->willReturnSelf();
-        $this->ldapClient->method('setUseSSL')->willReturnSelf();
-        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+        $this->configureLdapClientChaining();
         // LdapException constructor requires Ldap|null as first arg
         $this->ldapClient->method('login')->willThrowException(new LdapException(null, 'LDAP connection failed'));
 
@@ -407,15 +384,7 @@ final class LoginFormAuthenticatorTest extends TestCase
     {
         $this->configureDefaultLdapParams();
 
-        $this->ldapClient->method('setHost')->willReturnSelf();
-        $this->ldapClient->method('setPort')->willReturnSelf();
-        $this->ldapClient->method('setReadUser')->willReturnSelf();
-        $this->ldapClient->method('setReadPass')->willReturnSelf();
-        $this->ldapClient->method('setBaseDn')->willReturnSelf();
-        $this->ldapClient->method('setUserName')->willReturnSelf();
-        $this->ldapClient->method('setUserPass')->willReturnSelf();
-        $this->ldapClient->method('setUseSSL')->willReturnSelf();
-        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+        $this->configureLdapClientChaining();
         $this->ldapClient->method('login')->willThrowException(new RuntimeException('Unexpected error'));
 
         $authenticator = $this->makeSubject();
@@ -648,15 +617,7 @@ final class LoginFormAuthenticatorTest extends TestCase
         $this->entityManager->method('getRepository')
             ->willReturn($userRepo);
 
-        $this->ldapClient->method('setHost')->willReturnSelf();
-        $this->ldapClient->method('setPort')->willReturnSelf();
-        $this->ldapClient->method('setReadUser')->willReturnSelf();
-        $this->ldapClient->method('setReadPass')->willReturnSelf();
-        $this->ldapClient->method('setBaseDn')->willReturnSelf();
-        $this->ldapClient->method('setUserName')->willReturnSelf();
-        $this->ldapClient->method('setUserPass')->willReturnSelf();
-        $this->ldapClient->method('setUseSSL')->willReturnSelf();
-        $this->ldapClient->method('setUserNameField')->willReturnSelf();
+        $this->configureLdapClientChaining();
         $this->ldapClient->method('login')->willReturn(true);
 
         $authenticator = $this->makeSubject();

--- a/tests/Security/UserCheckerTest.php
+++ b/tests/Security/UserCheckerTest.php
@@ -20,16 +20,25 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
  */
 final class UserCheckerTest extends TestCase
 {
-    public function testActiveUserPassesPreAuth(): void
+    public function testActiveUserPassesPostAuth(): void
     {
         $this->expectNotToPerformAssertions();
 
-        new UserChecker()->checkPreAuth(new User()->setActive(true));
+        new UserChecker()->checkPostAuth(new User()->setActive(true));
     }
 
-    public function testDeactivatedUserIsRejected(): void
+    public function testDeactivatedUserIsRejectedAfterCredentials(): void
     {
         $this->expectException(CustomUserMessageAccountStatusException::class);
+
+        new UserChecker()->checkPostAuth(new User()->setActive(false));
+    }
+
+    public function testPreAuthNeverRejects(): void
+    {
+        // The active check moved to checkPostAuth so a wrong password can't be
+        // used to probe deactivated usernames; preAuth is now a no-op.
+        $this->expectNotToPerformAssertions();
 
         new UserChecker()->checkPreAuth(new User()->setActive(false));
     }
@@ -39,6 +48,6 @@ final class UserCheckerTest extends TestCase
         // The check only applies to our User entity; any other UserInterface passes.
         $this->expectNotToPerformAssertions();
 
-        new UserChecker()->checkPreAuth(new InMemoryUser('x', null));
+        new UserChecker()->checkPostAuth(new InMemoryUser('x', null));
     }
 }


### PR DESCRIPTION
## Description

Implements **ADR-018 D1**: a local-password authentication source alongside LDAP so the app can run without a directory server and survive LDAP outages. Each `users` row authenticates against exactly one source — **no silent fallback**:

| `users.password` | Account type | Credential check |
|---|---|---|
| `NULL` (default) | LDAP account | LDAP bind (unchanged) |
| set (`auto` hash) | Local account | password hash verify; LDAP never consulted |

An empty `LDAP_HOST` switches the instance to **local-only mode** (LDAP branch skipped entirely). This is the first of the four ADR-018 PRs; D2 (MFA/TOTP) and D3 (passkeys) follow.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issue

Part of the ADR-018 authentication extension (task #14: local users / LDAP optional).

## Changes Made

- **Auth routing:** `LdapAuthenticator` → `LoginFormAuthenticator`, routing per user (local hash vs LDAP bind); `form_login` stays as entry point only. Existing LDAP deployments are unchanged.
- **Schema:** migration `users.password VARCHAR(255) NULL`; `User` implements `PasswordAuthenticatedUserInterface`; hash excluded from every DTO/response.
- **Bootstrap:** `app:user:create <username> --type=ADMIN` console command — first-admin bootstrap and the LDAP-outage escape hatch (prompts for the password, hashes it).
- **Throttling:** `login_throttling` (max 5) via `symfony/rate-limiter` — protects LDAP-account logins too.

### Security hardening (from the auth review)

- **Account enumeration:** constant-time reject on the unknown/non-local path via a dummy password verify, so response timing can't distinguish "unknown user" from "wrong password".
- **Status disclosure:** the deactivated-account check moved from `checkPreAuth` to `checkPostAuth` — it now runs *after* the credential check, so it can't be used to probe account state pre-auth.
- **Credential leakage:** new `docker/php/production.ini` sets `zend.exception_ignore_args=On`, `display_errors=Off`, `expose_php=Off` (the base image ships no `php.ini`, so the insecure defaults applied); the authenticator logs exception class + message only, never the stack trace; `#[SensitiveParameter]` on password-carrying parameters.
- **Remember-me limitation (documented, accepted):** LDAP-account remember-me is signed with a *stable synthetic* password value, so it is not bound to the directory credential — offboarding relies on `users.active = 0` (enforced by `UserChecker` on remember-me re-auth). Spelled out in ADR-018.

## Testing

- [x] Unit tests pass — `LoginFormAuthenticatorTest` (routing matrix: LDAP / local / unknown / local-only / deactivated + dummy-verify timing assertion), `UserCheckerTest` (pre/post-auth), `CreateUserCommandTest` (create + update). **58 unit tests / 94 assertions green.**
- [x] Controller suite green in-container — **217 tests / 2012 assertions, 1 skipped.**
- [x] Static analysis passes — PHPStan **level 10** clean, Rector clean, PHP-CS-Fixer clean.

## Migration Notes

- Run the migration `Version20260702_AddUserPassword` (the prod entrypoint auto-migrates on deploy unless `AUTO_MIGRATE=0`).
- Existing LDAP deployments need no config change. To run local-only, leave `LDAP_HOST` empty and bootstrap an admin with `app:user:create`.
