### PR TITLE
fix(tracking): save a "Continue" (Fortsetzen) entry instead of silently dropping it (#495)

### DIFF
--- a/frontend/src/lib/inlineGridEdit.tsx
+++ b/frontend/src/lib/inlineGridEdit.tsx
@@ -200,6 +200,11 @@ export interface InlineGridEditConfig<R extends object> {
    *  is complete and may auto-save). Drives the per-cell invalid hint and gates
    *  auto-save on completeness. Omit to disable auto-save (save on leave/force). */
   invalidFields?: (draft: FormValues, row: R) => string[]
+  /** Whether a row has never been persisted (e.g. a brand-new work-log row with a
+   *  temporary id). A new row's seed IS its content, so "draft equals seed" is not
+   *  a no-op — it must still save once complete (see #495). Omit for grids that
+   *  never create in-place new rows (the default: no row is treated as new). */
+  isNewRow?: (row: R) => boolean
 }
 
 /**
@@ -256,6 +261,22 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     return row !== undefined && JSON.stringify(draft) !== JSON.stringify(config.seedDraft(row))
   }
   const isDirty = rowDirty
+
+  // A never-persisted row whose draft is complete must still be saved even though
+  // it equals its seed — the seed IS its content (e.g. a "Continue" row pre-filled
+  // from another entry). Without this, such a row reads as a clean no-op and is
+  // silently discarded instead of saved (#495). An incomplete new row is NOT
+  // persisted here, so an abandoned blank row is dropped quietly rather than
+  // raising a validation error.
+  const isNewAndComplete = (id: number, row: R): boolean => {
+    if (config.isNewRow?.(row) !== true) {
+      return false
+    }
+    const draft = drafts[id]
+
+    return draft !== undefined
+      && (config.invalidFields === undefined || config.invalidFields(draft, row).length === 0)
+  }
 
   // Drop a row's draft + field-hints + original-row snapshot — the teardown
   // shared by save-success, modal take-over, reset, and the clean-up of an
@@ -397,8 +418,13 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     setEditCell(null)
     // If the net result equals the original row (no real change, or a value
     // edited back), drop the draft so the row stays clean — and refreshHints
-    // then sees no draft and skips the (pointless) auto-save.
-    discardIfClean(cell.rowId)
+    // then sees no draft and skips the (pointless) auto-save. A complete NEW row
+    // is the exception: its seed IS its content, so dropping it here would discard
+    // a pre-filled "Continue" entry instead of saving it (#495).
+    const committedRow = rowById(cell.rowId)
+    if (committedRow === undefined || !isNewAndComplete(cell.rowId, committedRow)) {
+      discardIfClean(cell.rowId)
+    }
     // A Tab move (left/right) stays in the same row and opens the next cell's
     // editor; auto-saving now would refetch and remount that editor away (#481),
     // so defer the save to row-leave. Every other commit auto-saves as before.
@@ -526,9 +552,10 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     if (draft === undefined || row === undefined || savingRows[id]) {
       return
     }
-    // Nothing actually changed (e.g. the row was only navigated through) — drop
-    // the no-op draft instead of POSTing an identical row.
-    if (!rowDirty(id)) {
+    // Nothing changed vs a fresh seed. For an EXISTING row that's a no-op — drop
+    // the draft instead of re-POSTing an identical row. A complete NEW row is the
+    // exception: its seed is its content, so it still needs persisting (#495).
+    if (!rowDirty(id) && !isNewAndComplete(id, row)) {
       discardIfClean(id)
 
       return
@@ -613,7 +640,7 @@ export function createInlineGridEdit<R extends object>(config: InlineGridEditCon
     for (const key of Object.keys(drafts)) {
       const id = Number(key)
       const row = rowById(id)
-      if (rowDirty(id) && row !== undefined && !savingRows[id]) {
+      if (row !== undefined && !savingRows[id] && (rowDirty(id) || isNewAndComplete(id, row))) {
         // Best-effort flush on unmount; the component is gone, so swallow a
         // failure (nowhere to surface it) rather than leak an unhandled rejection.
         void config.saveRow({ ...drafts[id]! }, row).catch(() => { /* discarded */ })

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -829,4 +829,49 @@ describe('Tracking (Worklog grid)', () => {
       window.APP_CONFIG!.minEntryDuration = 5
     }
   })
+
+  it('Continue saves the pre-filled entry on commit even though nothing was edited (#495)', async () => {
+    window.APP_CONFIG!.suggestTime = true
+    window.APP_CONFIG!.minEntryDuration = 15
+    try {
+      const now = new Date()
+      const today = `${String(now.getDate()).padStart(2, '0')}/${String(now.getMonth() + 1).padStart(2, '0')}/${now.getFullYear()}`
+      // A saved entry from today ending 10:30 → Continue seeds start 10:30, end 10:45.
+      mockApiWith([{ entry: { ...DEFAULT_ENTRY, date: today, end: '10:30', class: 0 } }])
+      postJson.mockResolvedValue({})
+      const { getByRole, container, unmount } = renderTracking()
+      await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+      // Continue → a new row pre-filled with the source's customer/project/activity/
+      // ticket, start inherited (10:30) and end = start + 15 (10:45). Its draft equals
+      // its seed (nothing edited) — the case that used to be dropped as a no-op.
+      fireEvent.click(getByRole('button', { name: 'Continue' }))
+      const startInput = await waitFor(() => {
+        const el = container.querySelector<HTMLInputElement>('tbody td[data-col-key="start"] input')
+        if (el === null) throw new Error('start editor not open on the Continue row')
+
+        return el
+      })
+      expect(startInput.value).toBe('10:30')
+
+      // Commit the start cell with its seeded value unchanged — the draft still
+      // equals its seed (the #495 case), and the complete new row must SAVE.
+      fireEvent.input(startInput, { target: { value: '10:30' } })
+      fireEvent.keyDown(startInput, { key: 'Enter' })
+
+
+      await waitFor(() =>
+        expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({
+          customer: 1, project: 4, activity: 5, ticket: 'ABC-1', start: '10:30', end: '10:45',
+        })),
+      )
+      // A brand-new entry carries no id in the save payload.
+      expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.not.objectContaining({ id: expect.anything() }))
+
+      unmount()
+    } finally {
+      window.APP_CONFIG!.suggestTime = false
+      window.APP_CONFIG!.minEntryDuration = 5
+    }
+  })
 })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -440,6 +440,11 @@ export default function Tracking() {
 
   const editor = createInlineGridEdit({
     rows,
+    // Add/Continue rows carry a temporary negative id until they're first saved.
+    // A "Continue" row is pre-filled from another entry, so its draft equals its
+    // seed — mark it new so a complete one still saves instead of being dropped
+    // as a no-op (#495).
+    isNewRow: (entry) => num(entry.id) <= 0,
     fieldFor: (colKey) => FIELD_BY_KEY.get(colKey),
     isInlineEditable: (colKey) => {
       const field = FIELD_BY_KEY.get(colKey)


### PR DESCRIPTION
## Description

Fixes #495 — an entry started via **"Fortsetzen"** (the per-row Continue / play icon) could not be saved: on commit the time fields cleared and the row vanished on reload, with **no error shown**. A manually-added entry with identical data saved fine.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Closes #495

## Root cause

The inline-grid editor treats a draft that equals a fresh **seed** of its row as a no-op and discards it — this is correct for an *existing* row (navigating through it must not re-POST an identical row). But a **Continue** row is pre-filled from another entry, so its draft **always** equals its seed. It was therefore dropped as a "no-op" at commit time (`commitCell` → `discardIfClean`), so `refreshHints` saw no draft and skipped the auto-save. The overlay then fell back to the raw row's empty `start`/`end` → the reported *"time fields suddenly empty"*, and the unsaved row disappeared on reload.

A manual add-row differs because the user changes `customer/project/activity` from `0`, making the draft genuinely dirty.

## Changes Made

- `inlineGridEdit`: add an optional `isNewRow(row)` predicate. For a **never-persisted** row, "draft equals seed" is not a no-op — the seed *is* its content. `commitCell`, `flushRow` and the unmount flush now persist a **complete** new row even when it equals its seed. An **incomplete/abandoned** blank new row is still dropped quietly (no spurious validation error). `cancelCell` (Escape) is unchanged, so Escape still cancels a new row.
- `Tracking`: pass `isNewRow: (entry) => num(entry.id) <= 0` (Add/Continue rows carry a temporary negative id until first saved).
- Existing-row saves and the admin grid are unaffected — the predicate defaults to "no row is new".

## Testing

- [x] New regression test: **Continue → commit the pre-filled row unchanged → it POSTs to `/tracking/save`** with the inherited `customer/project/activity` and **no `id`**. (Fails on `main`, passes here.)
- [x] Full frontend suite **356 pass**, `bun run lint` clean, `bun run typecheck` clean.

## Notes

The current prod (`tt.netresearch.de`) runs `:profiling-a736b530`; this fix will ship on the next hot-deploy after merge.
