### PR TITLE
feat(security): TOTP enrolment backend (ADR-018 D2, increment 2)

### DIFF
--- a/src/Controller/Settings/ConfirmTotpEnrollmentAction.php
+++ b/src/Controller/Settings/ConfirmTotpEnrollmentAction.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Controller\BaseController;
+use App\Entity\User;
+use App\Model\JsonResponse;
+use App\Service\Security\TwoFactorEnrollmentService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+
+/**
+ * Confirm TOTP enrolment (ADR-018 D2): verify a first code against the pending
+ * secret from the session, then persist the encrypted secret and issue the
+ * one-time backup codes (returned once). A wrong code leaves 2FA off.
+ */
+final class ConfirmTotpEnrollmentAction extends BaseController
+{
+    public function __construct(private readonly TwoFactorEnrollmentService $enrollment)
+    {
+    }
+
+    #[Route(path: '/settings/2fa/totp/confirm', name: 'settings_2fa_totp_confirm', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(
+        Request $request,
+        #[CurrentUser]
+        User $user,
+    ): JsonResponse {
+        $session = $request->getSession();
+        $secret = $session->get(StartTotpEnrollmentAction::PENDING_SECRET_KEY);
+        if (!is_string($secret) || '' === $secret) {
+            return $this->jsonError('No enrolment is in progress. Start again.', Response::HTTP_BAD_REQUEST);
+        }
+
+        // getPayload() reads the body whether the SPA sends form-encoded (postForm)
+        // or JSON (postJson) — $request->request alone is empty for a JSON body.
+        $code = (string) $request->getPayload()->get('code', '');
+        $backupCodes = $this->enrollment->confirm($user, $secret, $code);
+        if (null === $backupCodes) {
+            return $this->jsonError('That code is not valid. Check your authenticator and try again.', Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($user);
+        $manager->flush();
+        $session->remove(StartTotpEnrollmentAction::PENDING_SECRET_KEY);
+
+        // The backup codes are shown to the user exactly once here — only their
+        // hashes are stored, so they cannot be recovered later.
+        return new JsonResponse([
+            'enabled' => true,
+            'backupCodes' => $backupCodes,
+        ]);
+    }
+
+    private function jsonError(string $message, int $status): JsonResponse
+    {
+        $response = new JsonResponse([
+            'enabled' => false,
+            'message' => $this->translator->trans($message),
+        ]);
+        $response->setStatusCode($status);
+
+        return $response;
+    }
+}

--- a/src/Controller/Settings/DisableTwoFactorAction.php
+++ b/src/Controller/Settings/DisableTwoFactorAction.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Controller\BaseController;
+use App\Entity\User;
+use App\Model\JsonResponse;
+use App\Service\Security\TwoFactorEnrollmentService;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Turn TOTP two-factor off (ADR-018 D2): clears the secret and any outstanding
+ * backup codes. Requires a fully-authenticated session (which, for a 2FA-enabled
+ * account, already means the current 2FA step was passed this session).
+ *
+ * NOTE: a fresh re-authentication challenge on disable is a D4 hardening item.
+ */
+final class DisableTwoFactorAction extends BaseController
+{
+    public function __construct(private readonly TwoFactorEnrollmentService $enrollment)
+    {
+    }
+
+    #[Route(path: '/settings/2fa/disable', name: 'settings_2fa_disable', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(
+        #[CurrentUser]
+        User $user,
+    ): JsonResponse {
+        $this->enrollment->disable($user);
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($user);
+        $manager->flush();
+
+        return new JsonResponse(['enabled' => false]);
+    }
+}

--- a/src/Controller/Settings/StartTotpEnrollmentAction.php
+++ b/src/Controller/Settings/StartTotpEnrollmentAction.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Controller\BaseController;
+use App\Entity\User;
+use App\Model\JsonResponse;
+use App\Service\Security\TwoFactorEnrollmentService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Begin TOTP enrolment (ADR-018 D2): generate a fresh secret, stash it in the
+ * session as pending (not yet on the user), and return the otpauth URI so the
+ * SPA can render a QR code. The secret is only persisted once the user confirms
+ * a valid code (see ConfirmTotpEnrollmentAction).
+ */
+final class StartTotpEnrollmentAction extends BaseController
+{
+    public const string PENDING_SECRET_KEY = '2fa_pending_totp_secret';
+
+    public function __construct(private readonly TwoFactorEnrollmentService $enrollment)
+    {
+    }
+
+    #[Route(path: '/settings/2fa/totp/start', name: 'settings_2fa_totp_start', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(
+        Request $request,
+        #[CurrentUser]
+        User $user,
+    ): JsonResponse {
+        $secret = $this->enrollment->generateSecret();
+        $request->getSession()->set(self::PENDING_SECRET_KEY, $secret);
+
+        return new JsonResponse([
+            'provisioningUri' => $this->enrollment->provisioningUri($user, $secret),
+            // Shown for manual entry when a QR code can't be scanned.
+            'secret' => $secret,
+        ]);
+    }
+}

--- a/src/Service/Security/TwoFactorEnrollmentService.php
+++ b/src/Service/Security/TwoFactorEnrollmentService.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Security;
+
+use App\Entity\User;
+use InvalidArgumentException;
+use OTPHP\TOTP;
+use Psr\Clock\ClockInterface;
+use SensitiveParameter;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+use function array_map;
+use function bin2hex;
+use function password_hash;
+use function random_bytes;
+
+use const PASSWORD_DEFAULT;
+
+/**
+ * TOTP enrolment (ADR-018 D2): generate a shared secret, build the QR/otpauth
+ * provisioning URI, verify a first code, and persist the ENCRYPTED secret plus
+ * a set of HASHED one-time backup codes on the user.
+ *
+ * The secret is never persisted until the user proves possession of the device
+ * by entering a valid code (confirm()). All storage goes through the User entity
+ * (encrypted secret, hashed codes); the plaintext secret and plain backup codes
+ * exist only for the duration of the enrolment request.
+ */
+final readonly class TwoFactorEnrollmentService
+{
+    /** Number of one-time recovery codes issued on enrolment. */
+    private const int BACKUP_CODE_COUNT = 8;
+
+    /** Accepted clock skew: ±1 period (30 s) each side. */
+    private const int VERIFY_LEEWAY = 1;
+
+    public function __construct(
+        private TokenEncryptionService $tokenEncryptionService,
+        private ClockInterface $clock,
+        #[Autowire('%app_title%')]
+        private string $issuer,
+    ) {
+    }
+
+    /** A fresh base32 TOTP secret, not yet stored anywhere. */
+    public function generateSecret(): string
+    {
+        return TOTP::generate($this->clock)->getSecret();
+    }
+
+    /** The otpauth:// URI for a QR code, labelled with the username and app issuer. */
+    public function provisioningUri(User $user, #[SensitiveParameter] string $secret): string
+    {
+        $label = (string) $user->getUsername();
+        $issuer = '' !== $this->issuer ? $this->issuer : 'TimeTracker';
+
+        return $this->totp($secret)
+            ->withLabel('' !== $label ? $label : 'user')
+            ->withIssuer($issuer)
+            ->getProvisioningUri();
+    }
+
+    public function verifyCode(#[SensitiveParameter] string $secret, #[SensitiveParameter] string $code): bool
+    {
+        if ('' === $secret || '' === $code) {
+            return false;
+        }
+
+        return $this->totp($secret)->verify($code, null, self::VERIFY_LEEWAY);
+    }
+
+    /**
+     * Confirm enrolment: verify the code against the pending secret, then store the
+     * encrypted secret and hashed backup codes on the user (the caller flushes).
+     *
+     * @return list<string>|null the plain backup codes to show ONCE, or null if the code is invalid
+     */
+    public function confirm(User $user, #[SensitiveParameter] string $secret, #[SensitiveParameter] string $code): ?array
+    {
+        if (!$this->verifyCode($secret, $code)) {
+            return null;
+        }
+
+        $user->setTotpSecret($this->tokenEncryptionService->encryptToken($secret), $secret);
+
+        $plainCodes = $this->generateBackupCodes();
+        $user->setBackupCodes(array_map(
+            static fn (string $code): string => password_hash($code, PASSWORD_DEFAULT),
+            $plainCodes,
+        ));
+
+        return $plainCodes;
+    }
+
+    /** Turn 2FA off: drop the secret and any outstanding backup codes. */
+    public function disable(User $user): void
+    {
+        $user->setTotpSecret(null, null);
+        $user->setBackupCodes([]);
+    }
+
+    /** Build a TOTP for a non-empty secret (otphp requires a non-empty string). */
+    private function totp(#[SensitiveParameter] string $secret): TOTP
+    {
+        if ('' === $secret) {
+            throw new InvalidArgumentException('A TOTP secret is required.');
+        }
+
+        return TOTP::createFromSecret($secret, $this->clock);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function generateBackupCodes(): array
+    {
+        $codes = [];
+        for ($i = 0; $i < self::BACKUP_CODE_COUNT; ++$i) {
+            // 10 hex chars (~40 bits) — enough entropy for a one-time, rate-limited code.
+            $codes[] = bin2hex(random_bytes(5));
+        }
+
+        return $codes;
+    }
+}

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -113,6 +113,9 @@ final class ArchitectureTest
                 Selector::inNamespace('Psr'),
                 Selector::inNamespace('GuzzleHttp'),
                 Selector::inNamespace('Laminas'),
+                // TOTP library backing the 2FA enrolment service (ADR-018 D2),
+                // an integration dependency like Laminas (LDAP) above.
+                Selector::inNamespace('OTPHP'),
                 Selector::classname(self::CLASSNAME_EXCEPTION, true),
             )
             ->because('Services orchestrate business logic over the data and integration layers');

--- a/tests/Controller/TwoFactorEnrollmentTest.php
+++ b/tests/Controller/TwoFactorEnrollmentTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use OTPHP\TOTP;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+use function is_string;
+
+/**
+ * Covers the TOTP enrolment endpoints (ADR-018 D2): start → confirm → disable,
+ * plus the confirm-without-pending-secret guard.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class TwoFactorEnrollmentTest extends AbstractWebTestCase
+{
+    public function testStartConfirmDisableRoundTrip(): void
+    {
+        $this->logInSession('unittest');
+
+        // 1) start → a provisioning URI and the pending secret (session-held).
+        $this->client->request(Request::METHOD_POST, '/settings/2fa/totp/start', [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(200);
+        $start = $this->jsonBody();
+        $uri = $start['provisioningUri'] ?? null;
+        self::assertIsString($uri);
+        self::assertStringStartsWith('otpauth://totp/', $uri);
+        $secret = $start['secret'] ?? null;
+        if (!is_string($secret) || '' === $secret) {
+            self::fail('start endpoint did not return a secret');
+        }
+
+        // 2) confirm with a valid code derived from that secret (±1 period leeway
+        //    absorbs a clock tick between generating and verifying).
+        $code = TOTP::createFromSecret($secret)->now();
+        $this->client->request(Request::METHOD_POST, '/settings/2fa/totp/confirm', ['code' => $code], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(200);
+        $confirm = $this->jsonBody();
+        self::assertTrue($confirm['enabled'] ?? false);
+        self::assertIsArray($confirm['backupCodes'] ?? null);
+        self::assertCount(8, $confirm['backupCodes']);
+
+        // The secret is now stored (encrypted, non-null) on the user.
+        self::assertNotNull($this->storedTotpSecret(1));
+
+        // 3) disable → cleared.
+        $this->client->request(Request::METHOD_POST, '/settings/2fa/disable', [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(200);
+        self::assertFalse($this->jsonBody()['enabled'] ?? true);
+        self::assertNull($this->storedTotpSecret(1));
+    }
+
+    public function testConfirmWithoutStartIsRejected(): void
+    {
+        $this->logInSession('unittest');
+
+        $this->client->request(Request::METHOD_POST, '/settings/2fa/totp/confirm', ['code' => '123456'], [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(400);
+    }
+
+    public function testInvalidCodeLeavesTwoFactorOff(): void
+    {
+        $this->logInSession('unittest');
+
+        $this->client->request(Request::METHOD_POST, '/settings/2fa/totp/start', [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(200);
+
+        $this->client->request(Request::METHOD_POST, '/settings/2fa/totp/confirm', ['code' => '000000'], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(422);
+        self::assertNull($this->storedTotpSecret(1));
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    private function jsonBody(): array
+    {
+        $content = $this->client->getResponse()->getContent();
+        self::assertIsString($content);
+        $data = json_decode($content, true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    private function storedTotpSecret(int $userId): ?string
+    {
+        $connection = $this->connection;
+        self::assertNotNull($connection);
+        $value = $connection->fetchOne('SELECT totp_secret FROM users WHERE id = ?', [$userId]);
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/tests/Service/Security/TwoFactorEnrollmentServiceTest.php
+++ b/tests/Service/Security/TwoFactorEnrollmentServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service\Security;
+
+use App\Entity\User;
+use App\Service\Security\TokenEncryptionService;
+use App\Service\Security\TwoFactorEnrollmentService;
+use OTPHP\TOTP;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+use function rawurldecode;
+use function strlen;
+
+/**
+ * @internal
+ */
+#[CoversClass(TwoFactorEnrollmentService::class)]
+final class TwoFactorEnrollmentServiceTest extends TestCase
+{
+    private const string SECRET = 'JBSWY3DPEHPK3PXP';
+
+    private function service(MockClock $clock): TwoFactorEnrollmentService
+    {
+        $encryption = self::createStub(TokenEncryptionService::class);
+        $encryption->method('encryptToken')->willReturnCallback(static fn (string $secret): string => 'ENC(' . $secret . ')');
+
+        return new TwoFactorEnrollmentService($encryption, $clock, 'TimeTracker Test');
+    }
+
+    public function testGenerateSecretReturnsBase32(): void
+    {
+        $secret = $this->service(new MockClock())->generateSecret();
+
+        self::assertMatchesRegularExpression('/^[A-Z2-7]+$/', $secret);
+        self::assertGreaterThanOrEqual(16, strlen($secret));
+    }
+
+    public function testProvisioningUriCarriesIssuerUsernameAndSecret(): void
+    {
+        $user = new User()->setUsername('jane');
+
+        $uri = rawurldecode($this->service(new MockClock())->provisioningUri($user, self::SECRET));
+
+        self::assertStringStartsWith('otpauth://totp/', $uri);
+        self::assertStringContainsString('jane', $uri);
+        self::assertStringContainsString('issuer=TimeTracker Test', $uri);
+        self::assertStringContainsString('secret=' . self::SECRET, $uri);
+    }
+
+    public function testConfirmWithValidCodeStoresEncryptedSecretAndUsableBackupCodes(): void
+    {
+        $clock = new MockClock('2026-07-03 12:00:00');
+        $service = $this->service($clock);
+        $code = TOTP::createFromSecret(self::SECRET, $clock)->now();
+
+        $user = new User()->setUsername('jane');
+        $backupCodes = $service->confirm($user, self::SECRET, $code);
+
+        self::assertIsArray($backupCodes);
+        self::assertCount(8, $backupCodes);
+        self::assertSame('ENC(' . self::SECRET . ')', $user->getTotpSecret(), 'the secret is stored ENCRYPTED');
+        self::assertTrue($user->isTotpAuthenticationEnabled());
+        // Every returned plain code verifies against its stored hash (single-use
+        // invalidation is a separate concern, covered in UserTest).
+        foreach ($backupCodes as $plain) {
+            self::assertTrue($user->isBackupCode($plain));
+        }
+        self::assertCount(8, $user->getBackupCodes());
+    }
+
+    public function testConfirmWithInvalidCodeReturnsNullAndStoresNothing(): void
+    {
+        $clock = new MockClock('2026-07-03 12:00:00');
+        $service = $this->service($clock);
+        $valid = TOTP::createFromSecret(self::SECRET, $clock)->now();
+        $wrong = '000000' === $valid ? '111111' : '000000';
+
+        $user = new User()->setUsername('jane');
+        $result = $service->confirm($user, self::SECRET, $wrong);
+
+        self::assertNull($result);
+        self::assertNull($user->getTotpSecret());
+        self::assertSame([], $user->getBackupCodes());
+        self::assertFalse($user->isTotpAuthenticationEnabled());
+    }
+
+    public function testDisableClearsSecretAndBackupCodes(): void
+    {
+        $user = new User();
+        $user->setTotpSecret('ENC(x)', 'x');
+        $user->setBackupCodes(['some-hash']);
+
+        $this->service(new MockClock())->disable($user);
+
+        self::assertNull($user->getTotpSecret());
+        self::assertSame([], $user->getBackupCodes());
+        self::assertFalse($user->isTotpAuthenticationEnabled());
+    }
+}


### PR DESCRIPTION
## Description

**MFA (ADR-018 D2) — increment 2: the TOTP enrolment backend.** Builds on the merged groundwork (#512). Still **no firewall change** — login is unaffected; this adds the API a user calls to *set up* TOTP. The firewall challenge step + SPA UI land in the next increment.

## Type of Change

- [x] New feature (non-breaking; no login behaviour change until the challenge step ships)

## Changes Made

- **`TwoFactorEnrollmentService`**: generate a base32 secret, build the `otpauth://` provisioning URI (issuer = app title, label = username), verify a code (otphp, ±1 period leeway, injected PSR clock), and on confirm store the **encrypted** secret + eight **hashed** one-time backup codes on the user (plain codes returned once).
- **Endpoints** (all `IS_AUTHENTICATED_FULLY`, JSON):
  - `POST /settings/2fa/totp/start` → `{ provisioningUri, secret }`; the secret is stashed in the **session as pending** (not yet persisted).
  - `POST /settings/2fa/totp/confirm` → verify the code against the pending secret → persist + return `{ enabled, backupCodes }` (shown once).
  - `POST /settings/2fa/disable` → clear the secret + backup codes.
- The secret is only persisted **after** the user proves possession with a valid code; plaintext secret and plain backup codes exist only for the request.

## Testing

- [x] Unit tests (frozen `MockClock`): secret/URI shape, valid + invalid confirm, backup-code issuance + verification, disable — **5 tests / 27 assertions**.
- [x] Routes registered, container compiles, **controller suite 222 pass** (login unaffected); PHPStan L10, Rector, phpat, cs-fixer clean. Added `OTPHP` to the service architecture allowlist (integration dep, like Laminas/LDAP).

## Not in this PR (next increments)

Firewall `two_factor` activation + JSON challenge handlers; SPA login challenge step + Settings "Security" UI (QR, backup codes shown once, disable); TOTP e2e. Disable currently needs only a fully-authenticated session — a fresh re-auth on disable is flagged as a D4 hardening item.
