### PR TITLE
feat(ui): responsive side-by-side form layout (option C)

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -743,6 +743,58 @@ main {
   margin: -0.4rem 0 0;
 }
 
+/* ---- Responsive-hybrid field layout (form overhaul) ----------------------
+   Inside a .stack-form (Settings, the admin dialogs, bulk/billing forms) a
+   field's label sits BESIDE its control on a wide container and collapses back
+   to stacked on a narrow one. Bare .field (login, filter bars) is untouched, so
+   it keeps stacking. Textareas, multi-selects and two-up .field-rows keep the
+   full width with the label on top. Scoped via a container query so a narrow
+   admin modal or a mobile viewport degrades gracefully. */
+.stack-form {
+  container-type: inline-size;
+}
+
+@container (min-width: 30rem) {
+  .stack-form .field {
+    display: grid;
+    /* em (not rem) so the label column tracks the --font-scale text-size
+       preference (ADR-014), keeping long labels from clipping when scaled up. */
+    grid-template-columns: 11em minmax(0, 1fr);
+    align-items: center;
+    gap: 0.3rem 1.2rem;
+  }
+
+  /* Every control and hint stacks in the control column; only the label <span>
+     stays in column 1. Without pinning, a field's SECOND control — e.g. the
+     custom date-format <input> that appears after the <select> — would be
+     auto-placed into the narrow label column and break the row alignment. */
+  .stack-form .field > input:not([type='checkbox']):not([type='radio']),
+  .stack-form .field > select,
+  .stack-form .field > textarea,
+  .stack-form .field > .field-hint {
+    grid-column: 2;
+  }
+
+  .stack-form .field > .field-hint {
+    margin: 0.15em 0 0;
+  }
+
+  /* Full-width exceptions — a single-column grid keeps the label on top and lets
+     every child (reset from the pin above) flow naturally down that one column. */
+  .stack-form .field.multiselect,
+  .stack-form .field:has(textarea),
+  .stack-form .field-row .field {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .stack-form .field.multiselect > *,
+  .stack-form .field:has(textarea) > *,
+  .stack-form .field-row .field > * {
+    grid-column: auto;
+  }
+}
+
 /* ---- Settings: grouped preference cards ---- */
 
 /* Settings stacks two labeled cards — account-saved vs this-device — so the


### PR DESCRIPTION
## Description

The forms felt minimal with every label stacked above its control. This gives the data-entry forms a denser, more "designed" **side-by-side** layout — the responsive-hybrid ("option C") we agreed on.

## Type of Change

- [x] UI / styling (non-breaking)

## Changes Made

**CSS-only**, scoped to `.stack-form` (Settings, the admin CRUD dialogs, bulk-entry, billing):

- **Label beside control** on a wide container (`@container (min-width: 30rem)`), collapsing back to **stacked** on a narrow one — so a narrow admin modal or a phone degrades gracefully.
- **Full-width exceptions**: textareas (`:has(textarea)`) and multi-selects (`.multiselect`) keep the label on top and the control full width; two-up `.field-row`s are left alone.
- **Scoped by design**: bare `.field` forms — the **login screen** and filter bars — are untouched and keep stacking (they don't use `.stack-form`).

Because `.field` is shared, this one change lifts Settings *and* every admin dialog at once, consistently.

## Testing

- [x] `bun run typecheck`, `bun run lint`, `bun run build` clean.
- [x] **Rendered the real `app.css`** against representative `.stack-form` markup in a browser (Playwright), in **light and dark**: simple fields go side-by-side, Notes (textarea) and Teams (multiselect) stay full width, a narrow container collapses to stacked, and the login form stays stacked. Screenshots reviewed.

## Notes

Threshold (`30rem` container width) and label column (`11rem`) are easy to tune. This is the layout half of the "general forms overhaul" — a follow-up can add the visual polish (section rhythm, headers) on top.
