### PR TITLE
feat(security): self-service password change for local accounts (ADR-018 D2)

### DIFF
--- a/src/Controller/Settings/ChangePasswordAction.php
+++ b/src/Controller/Settings/ChangePasswordAction.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Controller\BaseController;
+use App\Entity\User;
+use App\Model\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function mb_strlen;
+
+/**
+ * Self-service password change (ADR-018 D2).
+ *
+ * Available ONLY to local accounts: an LDAP-authenticated user has no local
+ * password and must not be able to set one here (that would silently convert the
+ * account to local — an admin/CLI-only decision). The current password is
+ * re-verified before the change; this is a change, not a reset (no mailer).
+ */
+final class ChangePasswordAction extends BaseController
+{
+    /** Minimal length floor for a new password (matches the admin Users form). */
+    private const int MIN_LENGTH = 8;
+
+    public function __construct(private readonly UserPasswordHasherInterface $passwordHasher)
+    {
+    }
+
+    #[Route(path: '/settings/password', name: 'settings_password_change', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(
+        Request $request,
+        #[CurrentUser]
+        User $user,
+    ): JsonResponse {
+        if (!$user->isLocalAccount()) {
+            // LDAP account: no local password to change, and self-service must not
+            // create one. Directory users change their password in the directory.
+            return $this->error('Your password is managed by the directory (LDAP) and cannot be changed here.', Response::HTTP_FORBIDDEN);
+        }
+
+        $payload = $request->getPayload();
+        $current = (string) $payload->get('currentPassword', '');
+        $new = (string) $payload->get('newPassword', '');
+
+        if (!$this->passwordHasher->isPasswordValid($user, $current)) {
+            return $this->error('Your current password is incorrect.', Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        if (mb_strlen($new) < self::MIN_LENGTH) {
+            return $this->error('The new password must be at least 8 characters.', Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $user->setPassword($this->passwordHasher->hashPassword($user, $new));
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($user);
+        $manager->flush();
+
+        return new JsonResponse(['success' => true]);
+    }
+
+    private function error(string $message, int $status): JsonResponse
+    {
+        $response = new JsonResponse(['success' => false, 'message' => $this->translate($message)]);
+        $response->setStatusCode($status);
+
+        return $response;
+    }
+}

--- a/tests/Controller/ChangePasswordTest.php
+++ b/tests/Controller/ChangePasswordTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+use function is_string;
+use function password_hash;
+use function password_verify;
+
+use const PASSWORD_DEFAULT;
+
+/**
+ * Self-service password change (ADR-018 D2): only local accounts, current
+ * password re-verified, minimum length enforced.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class ChangePasswordTest extends AbstractWebTestCase
+{
+    public function testLdapAccountCannotChangePassword(): void
+    {
+        $this->setStoredPassword(1, null); // LDAP account: no local password
+        $this->logInSession('unittest');
+
+        $this->post(['currentPassword' => 'anything', 'newPassword' => 'newpass12']);
+
+        $this->assertStatusCode(403);
+    }
+
+    public function testLocalAccountChangesPasswordWithCorrectCurrent(): void
+    {
+        $this->setStoredPassword(1, password_hash('oldpass12', PASSWORD_DEFAULT));
+        $this->logInSession('unittest');
+
+        $this->post(['currentPassword' => 'oldpass12', 'newPassword' => 'brandnew34']);
+
+        $this->assertStatusCode(200);
+        $stored = $this->storedPassword(1);
+        self::assertNotNull($stored);
+        self::assertTrue(password_verify('brandnew34', $stored), 'the new password is stored');
+        self::assertFalse(password_verify('oldpass12', $stored), 'the old password no longer works');
+    }
+
+    public function testWrongCurrentPasswordIsRejected(): void
+    {
+        $this->setStoredPassword(1, password_hash('oldpass12', PASSWORD_DEFAULT));
+        $this->logInSession('unittest');
+
+        $this->post(['currentPassword' => 'WRONG', 'newPassword' => 'brandnew34']);
+
+        $this->assertStatusCode(422);
+    }
+
+    public function testTooShortNewPasswordIsRejected(): void
+    {
+        $this->setStoredPassword(1, password_hash('oldpass12', PASSWORD_DEFAULT));
+        $this->logInSession('unittest');
+
+        $this->post(['currentPassword' => 'oldpass12', 'newPassword' => 'short']);
+
+        $this->assertStatusCode(422);
+    }
+
+    /**
+     * @param array<string, string> $body
+     */
+    private function post(array $body): void
+    {
+        $this->client->request(Request::METHOD_POST, '/settings/password', $body, [], ['HTTP_ACCEPT' => 'application/json']);
+    }
+
+    private function setStoredPassword(int $userId, ?string $hash): void
+    {
+        // Set via the EM (not raw SQL) so the identity map logInSession's find()
+        // reads from is consistent — otherwise it returns a stale cached entity.
+        self::assertNotNull($this->serviceContainer);
+        $manager = $this->serviceContainer->get('doctrine')->getManager();
+        $user = $manager->getRepository(User::class)->find($userId);
+        self::assertInstanceOf(User::class, $user);
+        $user->setPassword($hash);
+        $manager->flush();
+    }
+
+    private function storedPassword(int $userId): ?string
+    {
+        $connection = $this->connection;
+        self::assertNotNull($connection);
+        $value = $connection->fetchOne('SELECT password FROM users WHERE id = ?', [$userId]);
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -87,3 +87,8 @@
 "Entry data is incomplete.": "Die Eintragsdaten sind unvollständig."
 "Given ticket does not have a valid format.": "Das angegebene Ticket hat kein gültiges Format."
 "Given ticket does not have a valid prefix.": "Das angegebene Ticket hat kein gültiges Präfix."
+"Your password is managed by the directory (LDAP) and cannot be changed here.": "Dein Passwort wird über das Verzeichnis (LDAP) verwaltet und kann hier nicht geändert werden."
+"Your current password is incorrect.": "Dein aktuelles Passwort ist falsch."
+"The new password must be at least 8 characters.": "Das neue Passwort muss mindestens 8 Zeichen lang sein."
+"No enrolment is in progress. Start again.": "Es läuft keine Einrichtung. Bitte erneut starten."
+"That code is not valid. Check your authenticator and try again.": "Dieser Code ist ungültig. Prüfe deine Authenticator-App und versuche es erneut."

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -87,3 +87,8 @@
 "Entry data is incomplete.": "Los datos de la entrada están incompletos."
 "Given ticket does not have a valid format.": "El ticket indicado no tiene un formato válido."
 "Given ticket does not have a valid prefix.": "El ticket indicado no tiene un prefijo válido."
+"Your password is managed by the directory (LDAP) and cannot be changed here.": "Tu contraseña la gestiona el directorio (LDAP) y no se puede cambiar aquí."
+"Your current password is incorrect.": "Tu contraseña actual es incorrecta."
+"The new password must be at least 8 characters.": "La nueva contraseña debe tener al menos 8 caracteres."
+"No enrolment is in progress. Start again.": "No hay ninguna configuración en curso. Empieza de nuevo."
+"That code is not valid. Check your authenticator and try again.": "Ese código no es válido. Comprueba tu aplicación de autenticación e inténtalo de nuevo."

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -87,3 +87,8 @@
 "Entry data is incomplete.": "Les données de l'entrée sont incomplètes."
 "Given ticket does not have a valid format.": "Le ticket indiqué n'a pas un format valide."
 "Given ticket does not have a valid prefix.": "Le ticket indiqué n'a pas de préfixe valide."
+"Your password is managed by the directory (LDAP) and cannot be changed here.": "Votre mot de passe est géré par l'annuaire (LDAP) et ne peut pas être modifié ici."
+"Your current password is incorrect.": "Votre mot de passe actuel est incorrect."
+"The new password must be at least 8 characters.": "Le nouveau mot de passe doit comporter au moins 8 caractères."
+"No enrolment is in progress. Start again.": "Aucune configuration en cours. Recommencez."
+"That code is not valid. Check your authenticator and try again.": "Ce code n'est pas valide. Vérifiez votre application d'authentification et réessayez."

--- a/translations/messages.ru.yml
+++ b/translations/messages.ru.yml
@@ -87,3 +87,8 @@
 "Entry data is incomplete.": "Данные записи неполны."
 "Given ticket does not have a valid format.": "Указанный тикет имеет неверный формат."
 "Given ticket does not have a valid prefix.": "Указанный тикет имеет неверный префикс."
+"Your password is managed by the directory (LDAP) and cannot be changed here.": "Ваш пароль управляется каталогом (LDAP) и не может быть изменён здесь."
+"Your current password is incorrect.": "Текущий пароль неверен."
+"The new password must be at least 8 characters.": "Новый пароль должен содержать не менее 8 символов."
+"No enrolment is in progress. Start again.": "Настройка не запущена. Начните заново."
+"That code is not valid. Check your authenticator and try again.": "Этот код недействителен. Проверьте приложение-аутентификатор и попробуйте снова."


### PR DESCRIPTION
## What

Adds `POST /settings/password` — a signed-in user can change **their own** password.

## Why

Closes the gap where local-account users had no way to rotate their own password (only an admin could, via the Users form). Part of the ADR-018 account-security work (companion to the TOTP-enrolment backend in #513).

## Guardrails

- **Local accounts only.** An LDAP-authenticated user has no local password and must **not** be able to set one here — that would silently convert the account to local, which stays an admin/CLI-only decision. LDAP users get a `403`.
- **Current password re-verified** before the change (`isPasswordValid`). This is a *change*, not a reset — no mailer, no token.
- **Minimum length 8**, matching the admin Users form and the `CreateUserCommand` CLI.

| Case | Result |
|------|--------|
| LDAP account | `403` |
| Correct current + valid new | `200`, hash rotated |
| Wrong current password | `422` |
| New password < 8 chars | `422` |

## i18n

Backfills the `de/es/fr/ru` catalog entries for the new messages **and** for the TOTP-enrolment confirm errors that #513 shipped without translations (German users were falling back to English).

## Tests

`tests/Controller/ChangePasswordTest.php` — 4 cases above, all green against the isolated `db_unittest`.

Refs ADR-018