### PR TITLE
fix(ui): give the worklog days filter an id and name

### DIFF
--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -919,8 +919,11 @@ export default function Tracking() {
           <span id="tracking-days-lbl">{m.tracking_days_label()}</span>
           <div class="days-combo" ref={(el) => { daysComboRef = el }}>
             <input
+              id="tracking-days-input"
+              name="days"
               type="text"
               inputmode="numeric"
+              autocomplete="off"
               class="tracking-days-input"
               role="combobox"
               aria-labelledby="tracking-days-lbl"


### PR DESCRIPTION
## What

The day-range combobox on the tracking (worklog) page had an accessible name via `aria-labelledby`, but **no `id` or `name`** — so Chrome flagged it: *"A form field element has neither an id nor a name attribute,"* which prevents reliable autofill and is a form-hygiene warning.

## Fix

Add `id="tracking-days-input"`, `name="days"`, and `autocomplete="off"` (it's a filter control, not a field the browser should offer to fill). Accessibility is unchanged — the `aria-labelledby` association stays.

Reported by the user from the browser console. Frontend-only; all 39 Tracking tests still pass, lint + typecheck clean.