### PR TITLE
feat(security): passkeys / WebAuthn (ADR-018 D3)

### DIFF
--- a/.env
+++ b/.env
@@ -57,3 +57,10 @@ APP_SHOW_BILLABLE_FIELD_IN_EXPORT=false
 # Generate: openssl rand -base64 32
 # APP_ENCRYPTION_KEY=
 ###< Application Configuration ###
+
+###> web-auth/webauthn-symfony-bundle ###
+# Passkeys (ADR-018 D3). RP id = the registrable domain (no scheme/port);
+# ALLOWED_ORIGINS = comma-separated full origins the ceremony accepts.
+WEBAUTHN_RP_ID=localhost
+WEBAUTHN_ALLOWED_ORIGINS=http://localhost
+###< web-auth/webauthn-symfony-bundle ###

--- a/.env
+++ b/.env
@@ -60,7 +60,7 @@ APP_SHOW_BILLABLE_FIELD_IN_EXPORT=false
 
 ###> web-auth/webauthn-symfony-bundle ###
 # Passkeys (ADR-018 D3). RP id = the registrable domain (no scheme/port);
-# ALLOWED_ORIGINS = comma-separated full origins the ceremony accepts.
+# ALLOWED_ORIGINS = the ONE full origin the ceremony accepts (scheme+host[:port]).
 WEBAUTHN_RP_ID=localhost
 WEBAUTHN_ALLOWED_ORIGINS=http://localhost
 ###< web-auth/webauthn-symfony-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
     "symfony/twig-bundle": "^8.1",
     "symfony/validator": "^8.1",
     "symfony/yaml": "^8.1",
-    "twig/twig": "^3.21"
+    "twig/twig": "^3.21",
+    "web-auth/webauthn-symfony-bundle": "^5.3"
   },
   "require-dev": {
     "captainhook/captainhook": "^5.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,67 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e2f6dc652bbd80fd6b20f211ffb2533",
+    "content-hash": "0b342e28c4d2dbdd4e8ab755e02c6f53",
     "packages": [
+        {
+            "name": "brick/math",
+            "version": "0.17.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "2.1.22",
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "bignumber",
+                "brick",
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.17.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-25T20:34:43+00:00"
+        },
         {
             "name": "composer/pcre",
             "version": "3.4.0",
@@ -2170,6 +2229,182 @@
             "time": "2026-03-22T11:41:50+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
             "name": "phpoffice/phpspreadsheet",
             "version": "5.8.0",
             "source": {
@@ -3196,6 +3431,77 @@
             "time": "2026-04-01T14:50:32+00:00"
         },
         {
+            "name": "spomky-labs/cbor-php",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/cbor-php.git",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "roave/security-advisories": "dev-latest",
+                "symfony/error-handler": "^6.4|^7.1|^8.0",
+                "symfony/var-dumper": "^6.4|^7.1|^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath extensions will drastically improve the library performance. BCMath extension needed to handle the Big Float and Decimal Fraction Tags",
+                "ext-gmp": "GMP or BCMath extensions will drastically improve the library performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CBOR\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/cbor-php/contributors"
+                }
+            ],
+            "description": "CBOR Encoder/Decoder for PHP",
+            "keywords": [
+                "Concise Binary Object Representation",
+                "RFC7049",
+                "cbor"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-01T12:15:20+00:00"
+        },
+        {
             "name": "spomky-labs/otphp",
             "version": "11.5.0",
             "source": {
@@ -3264,6 +3570,116 @@
                 }
             ],
             "time": "2026-06-06T23:41:24+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0|^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-03-23T22:56:56+00:00"
         },
         {
             "name": "symfony/asset",
@@ -6110,6 +6526,89 @@
             "time": "2026-05-26T02:25:22+00:00"
         },
         {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-uuid": "*"
+            },
+            "suggest": {
+                "ext-uuid": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Uuid\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for uuid functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
             "name": "symfony/property-access",
             "version": "v8.1.0",
             "source": {
@@ -7653,6 +8152,84 @@
             "time": "2026-05-29T05:06:50+00:00"
         },
         {
+            "name": "symfony/uid",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/uid.git",
+                "reference": "7393f157a55f7e70a4de0334435c55a5a8fe749a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/7393f157a55f7e70a4de0334435c55a5a8fe749a",
+                "reference": "7393f157a55f7e70a4de0334435c55a5a8fe749a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-uuid": "^1.15"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Uid\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to generate and represent UIDs",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "UID",
+                "ulid",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/uid/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
             "name": "symfony/validator",
             "version": "v8.1.0",
             "source": {
@@ -8074,6 +8651,312 @@
                 }
             ],
             "time": "2026-05-30T17:09:26+00:00"
+        },
+        {
+            "name": "web-auth/cose-lib",
+            "version": "4.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/cose-lib.git",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/cose-lib/zipball/5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "php": ">=8.1",
+                "spomky-labs/pki-framework": "^1.0"
+            },
+            "require-dev": {
+                "spomky-labs/cbor-php": "^3.2.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "ext-gmp": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "spomky-labs/cbor-php": "For COSE Signature support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cose\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/cose/contributors"
+                }
+            ],
+            "description": "CBOR Object Signing and Encryption (COSE) For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "COSE",
+                "RFC8152"
+            ],
+            "support": {
+                "issues": "https://github.com/web-auth/cose-lib/issues",
+                "source": "https://github.com/web-auth/cose-lib/tree/4.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-03T09:49:50+00:00"
+        },
+        {
+            "name": "web-auth/webauthn-lib",
+            "version": "5.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/webauthn-lib.git",
+                "reference": "9e0986d999f4102e24ac8a598d3a80d98b56c19f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/9e0986d999f4102e24ac8a598d3a80d98b56c19f",
+                "reference": "9e0986d999f4102e24ac8a598d3a80d98b56c19f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "paragonie/constant_time_encoding": "^2.6|^3.0",
+                "php": ">=8.2",
+                "phpdocumentor/reflection-docblock": "^5.3|^6.0",
+                "psr/clock": "^1.0",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "spomky-labs/cbor-php": "^3.0",
+                "spomky-labs/pki-framework": "^1.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^3.2",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "web-auth/cose-lib": "^4.2.3"
+            },
+            "suggest": {
+                "psr/log-implementation": "Recommended to receive logs from the library",
+                "symfony/event-dispatcher": "Recommended to use dispatched events",
+                "web-token/jwt-library": "Mandatory for fetching Metadata Statement from distant sources"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/web-auth/webauthn-framework",
+                    "name": "web-auth/webauthn-framework"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webauthn\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/webauthn-library/contributors"
+                }
+            ],
+            "description": "FIDO2/Webauthn Support For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "FIDO2",
+                "fido",
+                "webauthn"
+            ],
+            "support": {
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-31T15:00:08+00:00"
+        },
+        {
+            "name": "web-auth/webauthn-symfony-bundle",
+            "version": "5.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/webauthn-symfony-bundle.git",
+                "reference": "7bf9d0e5e1f6d6bcad97c6bd93dc11a61d6fbd83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/webauthn-symfony-bundle/zipball/7bf9d0e5e1f6d6bcad97c6bd93dc11a61d6fbd83",
+                "reference": "7bf9d0e5e1f6d6bcad97c6bd93dc11a61d6fbd83",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/security-bundle": "^6.4|^7.0|^8.0",
+                "symfony/security-core": "^6.4|^7.0|^8.0",
+                "symfony/security-http": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^3.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "web-auth/webauthn-lib": "self.version"
+            },
+            "suggest": {
+                "symfony/security-bundle": "Symfony firewall using a JSON API (perfect for script applications)"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/web-auth/webauthn-framework",
+                    "name": "web-auth/webauthn-framework"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webauthn\\Bundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/webauthn-symfony-bundle/contributors"
+                }
+            ],
+            "description": "FIDO2/Webauthn Security Bundle For Symfony",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "FIDO2",
+                "bundle",
+                "fido",
+                "symfony",
+                "symfony-bundle",
+                "webauthn"
+            ],
+            "support": {
+                "source": "https://github.com/web-auth/webauthn-symfony-bundle/tree/5.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-24T09:55:30+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
+            },
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "packages-dev": [

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -15,4 +15,5 @@ return [
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true, 'profiling' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true, 'profiling' => true],
     Scheb\TwoFactorBundle\SchebTwoFactorBundle::class => ['all' => true],
+    Webauthn\Bundle\WebauthnBundle::class => ['all' => true],
 ];

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -81,6 +81,21 @@ security:
                 parameter: simulateUserId
                 role: ROLE_ALLOWED_TO_SWITCH
 
+            # Passkey / WebAuthn login (ADR-018 D3). Sits alongside form_login as
+            # an additional authenticator — it only claims the two ceremony paths
+            # below, so password login is undisturbed. A passkey is inherently
+            # two-factor, so it is not sent through the TOTP challenge (scheb keys
+            # its trigger on token class; WebauthnToken is not listed).
+            webauthn:
+                user_provider: app_user_provider
+                success_handler: App\Security\Webauthn\PasskeyLoginSuccessHandler
+                failure_handler: App\Security\Webauthn\PasskeyLoginFailureHandler
+                authentication:
+                    profile: default
+                    routes:
+                        options_path: /login/options
+                        result_path: /login/passkey
+
     # Access control settings
     access_control:
         - { path: ^/login, roles: PUBLIC_ACCESS }

--- a/config/packages/webauthn.yaml
+++ b/config/packages/webauthn.yaml
@@ -1,0 +1,44 @@
+# Passkeys / WebAuthn (ADR-018 D3). Discoverable (resident-key) credentials with
+# user verification, so a passkey is a full two-factor authenticator on its own.
+webauthn:
+    # App-provided storage (both required — the bundle defaults are throwing stubs).
+    credential_repository: App\Repository\WebauthnCredentialRepository
+    user_repository: App\Repository\WebauthnUserEntityRepository
+
+    # The full origin the ceremony accepts (env, as a single list item — a
+    # per-item env scalar is allowed where the whole array node is not). RP id
+    # below is the registrable domain (no scheme/port).
+    allowed_origins:
+        - '%env(WEBAUTHN_ALLOWED_ORIGINS)%'
+
+    # Registration: passkey (resident key + user verification), no attestation.
+    creation_profiles:
+        default:
+            rp:
+                id: '%env(WEBAUTHN_RP_ID)%'
+                name: '%app_title%'
+            attestation_conveyance: none
+            authenticator_selection_criteria:
+                user_verification: required
+                resident_key: required
+                require_resident_key: true
+
+    # Usernameless / discoverable login.
+    request_profiles:
+        default:
+            rp_id: '%env(WEBAUTHN_RP_ID)%'
+            user_verification: required
+
+    # Standalone "add a passkey" ceremony for the logged-in user (Settings →
+    # Security). CurrentUserEntityGuesser resolves the authenticated user, so this
+    # is NOT anonymous self-registration.
+    controllers:
+        enabled: true
+        creation:
+            settings_passkey:
+                options_path: /settings/security/passkeys/options
+                result_path: /settings/security/passkeys
+                profile: default
+                user_entity_guesser: Webauthn\Bundle\Security\Guesser\CurrentUserEntityGuesser
+                success_handler: App\Security\Webauthn\PasskeyRegisterSuccessHandler
+                hide_existing_credentials: true

--- a/config/reference.php
+++ b/config/reference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // This file is auto-generated and is for apps only. Bundles SHOULD NOT rely on its content.
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;

--- a/config/reference.php
+++ b/config/reference.php
@@ -646,7 +646,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
  *         name_based_uuid_version?: 5|3|Param, // Default: 5
  *         name_based_uuid_namespace?: scalar|Param|null,

--- a/config/reference.php
+++ b/config/reference.php
@@ -802,6 +802,40 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
  *             storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
  *         },
+ *         webauthn?: array{
+ *             user_provider?: scalar|Param|null, // Default: null
+ *             options_storage?: scalar|Param|null, // Deprecated: The child node "options_storage" at path "security.firewalls..webauthn.options_storage" is deprecated. Please use the root option "options_storage" instead. // Default: null
+ *             success_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultSuccessHandler"
+ *             failure_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultFailureHandler"
+ *             secured_rp_ids?: array<string, scalar|Param|null>,
+ *             authentication?: bool|array{
+ *                 enabled?: bool|Param, // Default: true
+ *                 profile?: scalar|Param|null, // Default: "default"
+ *                 options_builder?: scalar|Param|null, // Default: null
+ *                 routes?: array{
+ *                     host?: scalar|Param|null, // Default: null
+ *                     options_method?: scalar|Param|null, // Default: "POST"
+ *                     options_path?: scalar|Param|null, // Default: "/login/options"
+ *                     result_method?: scalar|Param|null, // Default: "POST"
+ *                     result_path?: scalar|Param|null, // Default: "/login"
+ *                 },
+ *                 options_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultRequestOptionsHandler"
+ *             },
+ *             registration?: bool|array{
+ *                 enabled?: bool|Param, // Default: false
+ *                 hide_existing_credentials?: bool|Param, // Default: true
+ *                 profile?: scalar|Param|null, // Default: "default"
+ *                 options_builder?: scalar|Param|null, // Default: null
+ *                 routes?: array{
+ *                     host?: scalar|Param|null, // Default: null
+ *                     options_method?: scalar|Param|null, // Default: "POST"
+ *                     options_path?: scalar|Param|null, // Default: "/register/options"
+ *                     result_method?: scalar|Param|null, // Default: "POST"
+ *                     result_path?: scalar|Param|null, // Default: "/register"
+ *                 },
+ *                 options_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultCreationOptionsHandler"
+ *             },
+ *         },
  *         x509?: array{
  *             provider?: scalar|Param|null,
  *             user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
@@ -1573,6 +1607,130 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         template?: scalar|Param|null, // Default: "@SchebTwoFactor/Authentication/form.html.twig"
  *     },
  * }
+ * @psalm-type WebauthnConfig = array{
+ *     fake_credential_generator?: scalar|Param|null, // A service that implements the FakeCredentialGenerator to generate fake credentials for preventing username enumeration. // Default: "Webauthn\\SimpleFakeCredentialGenerator"
+ *     clock?: scalar|Param|null, // PSR-20 Clock service. // Default: "webauthn.clock.default"
+ *     options_storage?: scalar|Param|null, // Service responsible of the options/user entity storage during the ceremony // Default: "Webauthn\\Bundle\\Security\\Storage\\SessionStorage"
+ *     event_dispatcher?: scalar|Param|null, // PSR-14 Event Dispatcher service. // Default: "Psr\\EventDispatcher\\EventDispatcherInterface"
+ *     http_client?: scalar|Param|null, // A Symfony HTTP client. // Default: "webauthn.http_client.default"
+ *     logger?: scalar|Param|null, // A PSR-3 logger to receive logs during the processes // Default: "webauthn.logger.default"
+ *     credential_repository?: scalar|Param|null, // This repository is responsible of the credential storage // Default: "Webauthn\\Bundle\\Repository\\DummyPublicKeyCredentialSourceRepository"
+ *     user_repository?: scalar|Param|null, // This repository is responsible of the user storage // Default: "Webauthn\\Bundle\\Repository\\DummyPublicKeyCredentialUserEntityRepository"
+ *     allowed_origins?: array<string, scalar|Param|null>,
+ *     allow_subdomains?: bool|Param, // Default: false
+ *     secured_rp_ids?: array<string, scalar|Param|null>,
+ *     counter_checker?: scalar|Param|null, // This service will check if the counter is valid. By default it throws an exception (recommended). // Default: "Webauthn\\Counter\\ThrowExceptionIfInvalid"
+ *     top_origin_validator?: scalar|Param|null, // For cross origin (e.g. iframe), this service will be in charge of verifying the top origin. // Default: null
+ *     creation_profiles?: bool|array<string, array{ // Default: []
+ *         rp?: array{
+ *             id?: scalar|Param|null, // Default: null
+ *             name?: scalar|Param|null, // Deprecated: The child node "name" at path "webauthn.creation_profiles..rp.name" is deprecated and will be removed in the next major release. // Default: ""
+ *             icon?: scalar|Param|null, // Deprecated: The child node "icon" at path "webauthn.creation_profiles..rp.icon" is deprecated and has no effect. // Default: null
+ *         },
+ *         challenge_length?: int|Param, // Default: 32
+ *         timeout?: int|Param, // Default: null
+ *         authenticator_selection_criteria?: array{
+ *             authenticator_attachment?: scalar|Param|null, // Default: null
+ *             require_resident_key?: bool|Param, // Default: false
+ *             user_verification?: scalar|Param|null, // Default: "preferred"
+ *             resident_key?: scalar|Param|null, // Default: "preferred"
+ *         },
+ *         extensions?: array<string, scalar|Param|null>,
+ *         public_key_credential_parameters?: list<int|Param>,
+ *         attestation_conveyance?: scalar|Param|null, // Default: "none"
+ *         conditional_create?: bool|Param, // Enable Conditional Create (auto-register) for this profile. When true, user presence can be false after password authentication. See https://github.com/w3c/webauthn/wiki/Explainer:-Conditional-Create // Default: false
+ *     }>,
+ *     request_profiles?: bool|array<string, array{ // Default: []
+ *         rp_id?: scalar|Param|null, // Default: null
+ *         challenge_length?: int|Param, // Default: 32
+ *         timeout?: int|Param, // Default: null
+ *         user_verification?: scalar|Param|null, // Default: "preferred"
+ *         extensions?: array<string, scalar|Param|null>,
+ *     }>,
+ *     client_override_policy?: array{ // Configuration for allowing client request values to override profile configuration
+ *         user_verification?: array{
+ *             enabled?: bool|Param, // Whether to allow client requests to override the user verification requirement // Default: false
+ *             allowed_values?: list<scalar|Param|null>,
+ *         },
+ *         authenticator_attachment?: array{
+ *             enabled?: bool|Param, // Whether to allow client requests to override the authenticator attachment // Default: true
+ *             allowed_values?: list<scalar|Param|null>,
+ *         },
+ *         resident_key?: array{
+ *             enabled?: bool|Param, // Whether to allow client requests to override the resident key requirement // Default: true
+ *             allowed_values?: list<scalar|Param|null>,
+ *         },
+ *         attestation_conveyance?: array{
+ *             enabled?: bool|Param, // Whether to allow client requests to override the attestation conveyance preference // Default: true
+ *             allowed_values?: list<scalar|Param|null>,
+ *         },
+ *         extensions?: array{
+ *             enabled?: bool|Param, // Whether to allow client requests to override extensions // Default: true
+ *         },
+ *         mediation?: array{
+ *             enabled?: bool|Param, // Whether to allow client requests to request the conditional mediation flow (auto-register). // Default: false
+ *             allowed_values?: list<scalar|Param|null>,
+ *         },
+ *     },
+ *     metadata?: bool|array{ // Enable the support of the Metadata Statements. Please read the documentation for this feature.
+ *         enabled?: bool|Param, // Default: false
+ *         mds_repository?: scalar|Param|null, // The Metadata Statement repository.
+ *         status_report_repository?: scalar|Param|null, // The Status Report repository.
+ *         certificate_chain_checker?: scalar|Param|null, // A Certificate Chain checker. // Default: "Webauthn\\MetadataService\\CertificateChain\\PhpCertificateChainValidator"
+ *     },
+ *     controllers?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         creation?: array<string, array{ // Default: []
+ *             options_method?: scalar|Param|null, // Default: "POST"
+ *             options_path?: scalar|Param|null,
+ *             result_method?: scalar|Param|null, // Default: "POST"
+ *             result_path?: scalar|Param|null, // Default: null
+ *             host?: scalar|Param|null, // Default: null
+ *             profile?: scalar|Param|null, // Default: "default"
+ *             options_builder?: scalar|Param|null, // When set, corresponds to the ID of the Public Key Credential Creation Builder. The profile-based ebuilder is ignored. // Default: null
+ *             user_entity_guesser?: scalar|Param|null,
+ *             hide_existing_credentials?: scalar|Param|null, // In order to prevent username enumeration, the existing credentials can be hidden. This is highly recommended when the attestation ceremony is performed by anonymous users. // Default: false
+ *             options_storage?: scalar|Param|null, // Deprecated: The child node "options_storage" at path "webauthn.controllers.creation..options_storage" is deprecated. Please use the root option "options_storage" instead. // Service responsible of the options/user entity storage during the ceremony // Default: null
+ *             success_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Service\\DefaultSuccessHandler"
+ *             failure_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Service\\DefaultFailureHandler"
+ *             options_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultCreationOptionsHandler"
+ *             allowed_origins?: array<string, scalar|Param|null>,
+ *             allow_subdomains?: bool|Param, // Default: false
+ *             secured_rp_ids?: array<string, scalar|Param|null>,
+ *         }>,
+ *         request?: array<string, array{ // Default: []
+ *             options_method?: scalar|Param|null, // Default: "POST"
+ *             options_path?: scalar|Param|null,
+ *             result_method?: scalar|Param|null, // Default: "POST"
+ *             result_path?: scalar|Param|null, // Default: null
+ *             host?: scalar|Param|null, // Default: null
+ *             profile?: scalar|Param|null, // Default: "default"
+ *             options_builder?: scalar|Param|null, // When set, corresponds to the ID of the Public Key Credential Creation Builder. The profile-based ebuilder is ignored. // Default: null
+ *             options_storage?: scalar|Param|null, // Deprecated: The child node "options_storage" at path "webauthn.controllers.request..options_storage" is deprecated. Please use the root option "options_storage" instead. // Service responsible of the options/user entity storage during the ceremony // Default: null
+ *             success_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Service\\DefaultSuccessHandler"
+ *             failure_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Service\\DefaultFailureHandler"
+ *             options_handler?: scalar|Param|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultRequestOptionsHandler"
+ *             allowed_origins?: array<string, scalar|Param|null>,
+ *             allow_subdomains?: bool|Param, // Default: false
+ *             secured_rp_ids?: array<string, scalar|Param|null>,
+ *         }>,
+ *     },
+ *     passkey_endpoints?: bool|array{ // Enable the .well-known/passkey-endpoints discovery endpoint as defined in the W3C Passkey Endpoints specification.
+ *         enabled?: bool|Param, // Default: false
+ *         enroll?: string|array{ // URL to the passkey enrollment/creation interface.
+ *             path?: scalar|Param|null, // The absolute HTTPS URL or Symfony route name.
+ *             params?: list<mixed>,
+ *         },
+ *         manage?: string|array{ // URL to the passkey management interface.
+ *             path?: scalar|Param|null, // The absolute HTTPS URL or Symfony route name.
+ *             params?: list<mixed>,
+ *         },
+ *         prf_usage_details?: string|array{ // URL to informational page about PRF (Pseudo-Random Function) extension usage.
+ *             path?: scalar|Param|null, // The absolute HTTPS URL or Symfony route name.
+ *             params?: list<mixed>,
+ *         },
+ *     },
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1588,6 +1746,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     web_profiler?: WebProfilerConfig,
  *     debug?: DebugConfig,
  *     scheb_two_factor?: SchebTwoFactorConfig,
+ *     webauthn?: WebauthnConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1604,6 +1763,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         web_profiler?: WebProfilerConfig,
  *         debug?: DebugConfig,
  *         scheb_two_factor?: SchebTwoFactorConfig,
+ *         webauthn?: WebauthnConfig,
  *     },
  *     "when@profiling"?: array{
  *         imports?: ImportsConfig,
@@ -1620,6 +1780,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         web_profiler?: WebProfilerConfig,
  *         debug?: DebugConfig,
  *         scheb_two_factor?: SchebTwoFactorConfig,
+ *         webauthn?: WebauthnConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1636,6 +1797,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         web_profiler?: WebProfilerConfig,
  *         debug?: DebugConfig,
  *         scheb_two_factor?: SchebTwoFactorConfig,
+ *         webauthn?: WebauthnConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/config/routes/webauthn.yaml
+++ b/config/routes/webauthn.yaml
@@ -1,0 +1,6 @@
+# The bundle builds its ceremony routes (login/registration options + result)
+# dynamically from webauthn.yaml via a custom loader — importing type: webauthn
+# is what actually registers them (ADR-018 D3).
+webauthn:
+    resource: '.'
+    type: webauthn

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -6,6 +6,7 @@
       "name": "timetracker-frontend",
       "dependencies": {
         "@ark-ui/solid": "^5.37.1",
+        "@simplewebauthn/browser": "^13.3.0",
         "@solidjs/router": "~0.16.1",
         "@tanstack/solid-query": "^5.101.2",
         "solid-js": "~1.9.14",
@@ -202,6 +203,8 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.31.28", "", {}, "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ=="],
 

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -493,5 +493,13 @@
   "login_2fa_code": "Bestätigungscode",
   "login_2fa_submit": "Bestätigen",
   "login_2fa_error": "Dieser Code ist ungültig. Prüfe deine Authenticator-App und versuche es erneut.",
-  "login_2fa_back": "Zurück zur Anmeldung"
+  "login_2fa_back": "Zurück zur Anmeldung",
+  "settings_passkey_heading": "Passkeys",
+  "settings_passkey_hint": "Melde dich mit Fingerabdruck, Gesicht oder Sicherheitsschlüssel an – ohne Passwort.",
+  "settings_passkey_label": "Passkey",
+  "settings_passkey_add": "Passkey hinzufügen",
+  "settings_passkey_remove": "Entfernen",
+  "settings_passkey_error": "Der Passkey-Vorgang konnte nicht abgeschlossen werden.",
+  "login_passkey": "Mit Passkey anmelden",
+  "login_passkey_error": "Die Passkey-Anmeldung wurde nicht abgeschlossen. Versuche es erneut oder nutze dein Passwort."
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -493,5 +493,13 @@
   "login_2fa_code": "Verification code",
   "login_2fa_submit": "Verify",
   "login_2fa_error": "That code is not valid. Check your authenticator and try again.",
-  "login_2fa_back": "Back to sign-in"
+  "login_2fa_back": "Back to sign-in",
+  "settings_passkey_heading": "Passkeys",
+  "settings_passkey_hint": "Sign in with your fingerprint, face, or a security key — no password to type.",
+  "settings_passkey_label": "Passkey",
+  "settings_passkey_add": "Add a passkey",
+  "settings_passkey_remove": "Remove",
+  "settings_passkey_error": "The passkey operation could not be completed.",
+  "login_passkey": "Sign in with a passkey",
+  "login_passkey_error": "Passkey sign-in didn't complete. Try again, or use your password."
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -493,5 +493,13 @@
   "login_2fa_code": "Código de verificación",
   "login_2fa_submit": "Verificar",
   "login_2fa_error": "Ese código no es válido. Comprueba tu aplicación de autenticación e inténtalo de nuevo.",
-  "login_2fa_back": "Volver al inicio de sesión"
+  "login_2fa_back": "Volver al inicio de sesión",
+  "settings_passkey_heading": "Claves de acceso",
+  "settings_passkey_hint": "Inicia sesión con tu huella, rostro o una llave de seguridad, sin contraseña.",
+  "settings_passkey_label": "Clave de acceso",
+  "settings_passkey_add": "Añadir una clave de acceso",
+  "settings_passkey_remove": "Eliminar",
+  "settings_passkey_error": "No se pudo completar la operación con la clave de acceso.",
+  "login_passkey": "Iniciar sesión con una clave de acceso",
+  "login_passkey_error": "El inicio de sesión con clave de acceso no se completó. Inténtalo de nuevo o usa tu contraseña."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -493,5 +493,13 @@
   "login_2fa_code": "Code de vérification",
   "login_2fa_submit": "Vérifier",
   "login_2fa_error": "Ce code n'est pas valide. Vérifiez votre application d'authentification et réessayez.",
-  "login_2fa_back": "Retour à la connexion"
+  "login_2fa_back": "Retour à la connexion",
+  "settings_passkey_heading": "Clés d'accès",
+  "settings_passkey_hint": "Connectez-vous avec votre empreinte, votre visage ou une clé de sécurité — sans mot de passe.",
+  "settings_passkey_label": "Clé d'accès",
+  "settings_passkey_add": "Ajouter une clé d'accès",
+  "settings_passkey_remove": "Supprimer",
+  "settings_passkey_error": "L'opération de clé d'accès n'a pas pu être effectuée.",
+  "login_passkey": "Se connecter avec une clé d'accès",
+  "login_passkey_error": "La connexion par clé d'accès n'a pas abouti. Réessayez ou utilisez votre mot de passe."
 }

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -493,5 +493,13 @@
   "login_2fa_code": "Код подтверждения",
   "login_2fa_submit": "Подтвердить",
   "login_2fa_error": "Этот код недействителен. Проверьте приложение-аутентификатор и попробуйте снова.",
-  "login_2fa_back": "Вернуться ко входу"
+  "login_2fa_back": "Вернуться ко входу",
+  "settings_passkey_heading": "Passkey-ключи",
+  "settings_passkey_hint": "Входите по отпечатку, лицу или ключу безопасности — без пароля.",
+  "settings_passkey_label": "Passkey",
+  "settings_passkey_add": "Добавить passkey",
+  "settings_passkey_remove": "Удалить",
+  "settings_passkey_error": "Не удалось выполнить операцию с passkey.",
+  "login_passkey": "Войти по passkey",
+  "login_passkey_error": "Вход по passkey не завершён. Попробуйте снова или используйте пароль."
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@ark-ui/solid": "^5.37.1",
+    "@simplewebauthn/browser": "^13.3.0",
     "@solidjs/router": "~0.16.1",
     "@tanstack/solid-query": "^5.101.2",
     "solid-js": "~1.9.14"

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 import { createSignal, Show } from 'solid-js'
 
 import type { LoginConfig } from '../loginConfig'
+import { loginWithPasskey, passkeysSupported } from '../lib/passkeys'
 import { m } from '../paraglide/messages.js'
 
 /**
@@ -103,6 +104,22 @@ export function LoginForm(props: { config: LoginConfig }) {
       setError(m.login_2fa_error())
     } catch {
       setError(m.login_2fa_error())
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const signInWithPasskey = async () => {
+    if (submitting()) {
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      globalThis.location.assign(await loginWithPasskey())
+    } catch {
+      // Includes the user dismissing the native prompt — a quiet inline message.
+      setError(m.login_passkey_error())
     } finally {
       setSubmitting(false)
     }
@@ -213,6 +230,12 @@ export function LoginForm(props: { config: LoginConfig }) {
           <button type="submit" id="form-submit" class="primary-button login-submit" disabled={submitting()}>
             {submitting() ? m.login_submitting() : m.login_submit()}
           </button>
+
+          <Show when={passkeysSupported()}>
+            <button type="button" class="login-passkey" disabled={submitting()} onClick={() => void signInWithPasskey()}>
+              {m.login_passkey()}
+            </button>
+          </Show>
         </form>
       </Show>
     </main>

--- a/frontend/src/components/SecuritySection.test.tsx
+++ b/frontend/src/components/SecuritySection.test.tsx
@@ -11,6 +11,19 @@ vi.mock('../api/client', () => ({
   postJson: (...args: unknown[]) => postJson(...args),
 }))
 
+// Passkeys (WebAuthn) — unsupported in jsdom, so the browser ceremony is stubbed.
+const registerPasskey = vi.fn()
+const deletePasskey = vi.fn()
+const listPasskeys = vi.fn()
+let passkeysAvailable = false
+
+vi.mock('../lib/passkeys', () => ({
+  passkeysSupported: () => passkeysAvailable,
+  registerPasskey: (...a: unknown[]) => registerPasskey(...a),
+  deletePasskey: (...a: unknown[]) => deletePasskey(...a),
+  listPasskeys: (...a: unknown[]) => listPasskeys(...a),
+}))
+
 // Imported after the mock so the component picks up the stubbed client.
 const { SecuritySection } = await import('./SecuritySection')
 
@@ -22,6 +35,10 @@ function configure(overrides: { totpEnabled?: boolean; localAccount?: boolean })
 describe('SecuritySection', () => {
   beforeEach(() => {
     postJson.mockReset()
+    registerPasskey.mockReset()
+    deletePasskey.mockReset()
+    listPasskeys.mockReset().mockResolvedValue([])
+    passkeysAvailable = false
     configure({})
   })
   afterEach(cleanup)
@@ -94,6 +111,36 @@ describe('SecuritySection', () => {
     postJson.mockResolvedValueOnce({ provisioningUri: 'otpauth://totp/y', secret: 'SECRET2' })
     fireEvent.click(screen.getByRole('button', { name: 'Enable two-factor' }))
     await waitFor(() => expect((screen.getByLabelText('Verification code') as HTMLInputElement).value).toBe(''))
+  })
+
+  it('hides the passkey section when the browser has no WebAuthn support', () => {
+    passkeysAvailable = false
+    render(() => <SecuritySection />)
+    expect(screen.queryByRole('button', { name: 'Add a passkey' })).toBeNull()
+  })
+
+  it('registers a passkey and refreshes the list', async () => {
+    passkeysAvailable = true
+    listPasskeys.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 7, fingerprint: 'abcdef0123', transports: ['internal'] }])
+    registerPasskey.mockResolvedValue(undefined)
+    render(() => <SecuritySection />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add a passkey' }))
+
+    await waitFor(() => expect(registerPasskey).toHaveBeenCalled())
+    // The refreshed list renders the new passkey with a remove control.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy())
+  })
+
+  it('removes a passkey', async () => {
+    passkeysAvailable = true
+    listPasskeys.mockResolvedValue([{ id: 7, fingerprint: 'abcdef0123', transports: ['internal'] }])
+    deletePasskey.mockResolvedValue(undefined)
+    render(() => <SecuritySection />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => expect(deletePasskey).toHaveBeenCalledWith(7))
   })
 
   it('disables TOTP when already enabled and confirmed', async () => {

--- a/frontend/src/components/SecuritySection.tsx
+++ b/frontend/src/components/SecuritySection.tsx
@@ -1,7 +1,8 @@
-import { createSignal, Show, For, type JSX } from 'solid-js'
+import { createResource, createSignal, Show, For, type JSX } from 'solid-js'
 
 import { apiErrorMessage, postJson } from '../api/client'
 import { appConfig } from '../config'
+import { deletePasskey, listPasskeys, passkeysSupported, registerPasskey } from '../lib/passkeys'
 import { m } from '../paraglide/messages.js'
 
 /** Server response from POST /settings/2fa/totp/start. */
@@ -37,10 +38,79 @@ export function SecuritySection(): JSX.Element {
         <p class="settings-section-hint">{m.settings_section_security_hint()}</p>
 
         <TwoFactorControls initiallyEnabled={config.totpEnabled} />
+        <Show when={passkeysSupported()}>
+          <PasskeyControls />
+        </Show>
         <Show when={config.localAccount}>
           <PasswordChange />
         </Show>
       </fieldset>
+    </div>
+  )
+}
+
+/** Register / list / remove passkeys (WebAuthn) — ADR-018 D3. */
+function PasskeyControls(): JSX.Element {
+  const [passkeys, { refetch }] = createResource(listPasskeys)
+  const [busy, setBusy] = createSignal(false)
+  const [error, setError] = createSignal('')
+
+  async function add(): Promise<void> {
+    setBusy(true)
+    setError('')
+    try {
+      await registerPasskey()
+      await refetch()
+    } catch (caught) {
+      // A user cancelling the native prompt throws too — keep the message quiet.
+      setError(apiErrorMessage(caught, m.settings_passkey_error()))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function remove(id: number): Promise<void> {
+    setBusy(true)
+    setError('')
+    try {
+      await deletePasskey(id)
+      await refetch()
+    } catch (caught) {
+      setError(apiErrorMessage(caught, m.settings_passkey_error()))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div class="security-block">
+      <h3 class="security-heading">{m.settings_passkey_heading()}</h3>
+      <p class="field-hint">{m.settings_passkey_hint()}</p>
+
+      <Show when={(passkeys()?.length ?? 0) > 0}>
+        <ul class="security-passkey-list">
+          <For each={passkeys()}>
+            {(passkey) => (
+              <li>
+                <span class="security-passkey-name">{m.settings_passkey_label()} · <code>{passkey.fingerprint.slice(0, 10)}</code></span>
+                <button type="button" class="ghost-button" disabled={busy()} onClick={() => void remove(passkey.id)}>
+                  {m.settings_passkey_remove()}
+                </button>
+              </li>
+            )}
+          </For>
+        </ul>
+      </Show>
+
+      <div class="security-row">
+        <button type="button" class="primary-button" disabled={busy()} onClick={() => void add()}>
+          {busy() ? m.app_saving() : m.settings_passkey_add()}
+        </button>
+      </div>
+
+      <Show when={error()}>
+        <span role="alert" class="form-status is-error">{error()}</span>
+      </Show>
     </div>
   )
 }

--- a/frontend/src/lib/passkeys.ts
+++ b/frontend/src/lib/passkeys.ts
@@ -1,0 +1,45 @@
+import { browserSupportsWebAuthn, startAuthentication, startRegistration } from '@simplewebauthn/browser'
+import type { PublicKeyCredentialCreationOptionsJSON, PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/browser'
+
+import { getJson, postJson } from '../api/client'
+
+/** One of the current user's registered passkeys (from the list endpoint). */
+export interface Passkey {
+  id: number
+  fingerprint: string
+  transports: string[]
+}
+
+/** Whether this browser can do WebAuthn at all (hide the passkey UI otherwise). */
+export const passkeysSupported = browserSupportsWebAuthn
+
+/**
+ * Register a passkey for the logged-in user: fetch creation options, run the
+ * browser attestation ceremony, post the result. The server persists the
+ * credential and returns {success:true}. Throws (incl. the user cancelling the
+ * native prompt) — callers surface the message.
+ */
+export async function registerPasskey(): Promise<void> {
+  const optionsJSON = await postJson<PublicKeyCredentialCreationOptionsJSON>('/settings/security/passkeys/options', {})
+  const attestation = await startRegistration({ optionsJSON })
+  // The attestation is the standard PublicKeyCredential JSON the ceremony
+  // controller deserializes; cast past postJson's Record signature.
+  await postJson('/settings/security/passkeys', attestation as unknown as Record<string, unknown>)
+}
+
+/** Discoverable ("usernameless") passkey login; resolves to the redirect target. */
+export async function loginWithPasskey(): Promise<string> {
+  const optionsJSON = await postJson<PublicKeyCredentialRequestOptionsJSON>('/login/options', {})
+  const assertion = await startAuthentication({ optionsJSON })
+  const result = await postJson<{ ok?: boolean; redirect?: string }>('/login/passkey', assertion as unknown as Record<string, unknown>)
+
+  return result.redirect ?? '/'
+}
+
+export async function listPasskeys(): Promise<Passkey[]> {
+  return (await getJson<{ passkeys: Passkey[] }>('/settings/security/passkeys/list')).passkeys
+}
+
+export async function deletePasskey(id: number): Promise<void> {
+  await postJson('/settings/security/passkeys/delete', { id })
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1005,6 +1005,43 @@ main {
   letter-spacing: 0.05em;
 }
 
+/* Registered passkeys, one per row with a remove control. */
+.security-passkey-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.security-passkey-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.4rem 0.7rem;
+}
+.security-passkey-name code {
+  font-size: 0.85em;
+  color: var(--color-text-muted);
+}
+
+/* Passkey sign-in on the login card: a quiet text-style alternative under the
+   primary submit, only shown when the browser supports WebAuthn. */
+.login-passkey {
+  background: none;
+  border: 0;
+  color: var(--color-link);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.95rem;
+  margin-top: 0.4rem;
+  min-height: 44px;
+  text-decoration: underline;
+}
+
 /* Secondary action (cancel enrolment, disable 2FA): same shape as .primary-button
    but outlined, so the primary action stays visually dominant. */
 .ghost-button {

--- a/migrations/Version20260703_AddWebauthnCredentials.php
+++ b/migrations/Version20260703_AddWebauthnCredentials.php
@@ -29,12 +29,18 @@ final class Version20260703_AddWebauthnCredentials extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE webauthn_credentials (public_key_credential_id LONGTEXT NOT NULL, type VARCHAR(255) NOT NULL, transports JSON NOT NULL, attestation_type VARCHAR(255) NOT NULL, trust_path JSON NOT NULL, aaguid TINYTEXT NOT NULL, credential_public_key LONGTEXT NOT NULL, user_handle VARCHAR(255) NOT NULL, counter INT NOT NULL, other_ui JSON DEFAULT NULL, backup_eligible TINYINT DEFAULT NULL, backup_status TINYINT DEFAULT NULL, uv_initialized TINYINT DEFAULT NULL, id INT AUTO_INCREMENT NOT NULL, PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        // KEY on user_handle: the credential list query filters by it. (No FK — the
+        // handle is the WebAuthn identity, decoupled from the users PK on purpose.)
+        $this->addSql('CREATE TABLE webauthn_credentials (public_key_credential_id LONGTEXT NOT NULL, type VARCHAR(255) NOT NULL, transports JSON NOT NULL, attestation_type VARCHAR(255) NOT NULL, trust_path JSON NOT NULL, aaguid TINYTEXT NOT NULL, credential_public_key LONGTEXT NOT NULL, user_handle VARCHAR(255) NOT NULL, counter INT NOT NULL, other_ui JSON DEFAULT NULL, backup_eligible TINYINT DEFAULT NULL, backup_status TINYINT DEFAULT NULL, uv_initialized TINYINT DEFAULT NULL, id INT AUTO_INCREMENT NOT NULL, INDEX IDX_webauthn_user_handle (user_handle), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        // One handle per user (multiple NULLs allowed — a unique index treats NULLs
+        // as distinct), indexed for the per-assertion findOneByUserHandle lookup.
         $this->addSql('ALTER TABLE users ADD webauthn_user_handle VARCHAR(36) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_users_webauthn_user_handle ON users (webauthn_user_handle)');
     }
 
     public function down(Schema $schema): void
     {
+        $this->addSql('DROP INDEX UNIQ_users_webauthn_user_handle ON users');
         $this->addSql('ALTER TABLE users DROP COLUMN webauthn_user_handle');
         $this->addSql('DROP TABLE webauthn_credentials');
     }

--- a/migrations/Version20260703_AddWebauthnCredentials.php
+++ b/migrations/Version20260703_AddWebauthnCredentials.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Passkeys / WebAuthn credential storage (ADR-018 D3).
+ *
+ * `webauthn_credentials` persists a registered passkey (columns map to the
+ * bundle's Webauthn\CredentialRecord mapped-superclass). `users.webauthn_user_handle`
+ * is the stable, non-enumerable handle a passkey is bound to — NULL until the
+ * account registers its first passkey, so no existing row is affected on upgrade.
+ */
+final class Version20260703_AddWebauthnCredentials extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add webauthn_credentials table and users.webauthn_user_handle for passkeys';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE webauthn_credentials (public_key_credential_id LONGTEXT NOT NULL, type VARCHAR(255) NOT NULL, transports JSON NOT NULL, attestation_type VARCHAR(255) NOT NULL, trust_path JSON NOT NULL, aaguid TINYTEXT NOT NULL, credential_public_key LONGTEXT NOT NULL, user_handle VARCHAR(255) NOT NULL, counter INT NOT NULL, other_ui JSON DEFAULT NULL, backup_eligible TINYINT DEFAULT NULL, backup_status TINYINT DEFAULT NULL, uv_initialized TINYINT DEFAULT NULL, id INT AUTO_INCREMENT NOT NULL, PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE users ADD webauthn_user_handle VARCHAR(36) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users DROP COLUMN webauthn_user_handle');
+        $this->addSql('DROP TABLE webauthn_credentials');
+    }
+}

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -49,7 +49,8 @@ CREATE TABLE `users` (
   `backup_codes` json DEFAULT NULL,
   `webauthn_user_handle` varchar(36) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `username` (`username`)
+  UNIQUE KEY `username` (`username`),
+  UNIQUE KEY `webauthn_user_handle` (`webauthn_user_handle`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 
@@ -71,7 +72,8 @@ CREATE TABLE `webauthn_credentials` (
   `backup_eligible` tinyint(1) DEFAULT NULL,
   `backup_status` tinyint(1) DEFAULT NULL,
   `uv_initialized` tinyint(1) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `webauthn_user_handle` (`user_handle`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -47,9 +47,32 @@ CREATE TABLE `users` (
   `password` varchar(255) DEFAULT NULL,
   `totp_secret` varchar(255) DEFAULT NULL,
   `backup_codes` json DEFAULT NULL,
+  `webauthn_user_handle` varchar(36) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+
+
+--
+-- Tabellenstruktur für Tabelle `webauthn_credentials` (ADR-018 D3 passkeys)
+--
+CREATE TABLE `webauthn_credentials` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `public_key_credential_id` longtext NOT NULL,
+  `type` varchar(255) NOT NULL,
+  `transports` json NOT NULL,
+  `attestation_type` varchar(255) NOT NULL,
+  `trust_path` json NOT NULL,
+  `aaguid` tinytext NOT NULL,
+  `credential_public_key` longtext NOT NULL,
+  `user_handle` varchar(255) NOT NULL,
+  `counter` int(11) NOT NULL,
+  `other_ui` json DEFAULT NULL,
+  `backup_eligible` tinyint(1) DEFAULT NULL,
+  `backup_status` tinyint(1) DEFAULT NULL,
+  `uv_initialized` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 --

--- a/src/Controller/Settings/PasskeyDeleteAction.php
+++ b/src/Controller/Settings/PasskeyDeleteAction.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Controller\BaseController;
+use App\Entity\User;
+use App\Entity\WebauthnCredential;
+use App\Model\JsonResponse;
+use App\Repository\WebauthnCredentialRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Remove one of the current user's passkeys (ADR-018 D3). Ownership is enforced
+ * by the user-handle match — a user can only delete a credential bound to their
+ * own handle, never another account's by guessing an id.
+ */
+final class PasskeyDeleteAction extends BaseController
+{
+    public function __construct(private readonly WebauthnCredentialRepository $credentials)
+    {
+    }
+
+    #[Route(path: '/settings/security/passkeys/delete', name: 'settings_passkey_delete', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(Request $request, #[CurrentUser] User $user): JsonResponse
+    {
+        $id = (int) $request->getPayload()->get('id', 0);
+        $handle = $user->getWebauthnUserHandle();
+
+        $credential = $id > 0 ? $this->credentials->find($id) : null;
+        if (!$credential instanceof WebauthnCredential || null === $handle || $credential->userHandle !== $handle) {
+            $response = new JsonResponse(['success' => false, 'message' => $this->translate('That passkey could not be found.')]);
+            $response->setStatusCode(Response::HTTP_NOT_FOUND);
+
+            return $response;
+        }
+
+        $manager = $this->doctrineRegistry->getManager();
+        $manager->remove($credential);
+        $manager->flush();
+
+        return new JsonResponse(['success' => true]);
+    }
+}

--- a/src/Controller/Settings/PasskeyListAction.php
+++ b/src/Controller/Settings/PasskeyListAction.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Settings;
+
+use App\Controller\BaseController;
+use App\Entity\User;
+use App\Entity\WebauthnCredential;
+use App\Model\JsonResponse;
+use App\Repository\WebauthnCredentialRepository;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function rtrim;
+use function strtr;
+
+/**
+ * The current user's registered passkeys, for the Settings Security list (ADR-018
+ * D3). Only surfaces the local id (for removal) and a short base64url fingerprint
+ * of the credential id — never the public key or trust path.
+ */
+final class PasskeyListAction extends BaseController
+{
+    public function __construct(private readonly WebauthnCredentialRepository $credentials)
+    {
+    }
+
+    #[Route(path: '/settings/security/passkeys/list', name: 'settings_passkey_list', methods: ['GET'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(#[CurrentUser] User $user): JsonResponse
+    {
+        $handle = $user->getWebauthnUserHandle();
+        $passkeys = null === $handle ? [] : $this->credentials->findByUserHandle($handle);
+
+        return new JsonResponse([
+            'passkeys' => array_map(
+                static fn (WebauthnCredential $credential): array => [
+                    'id' => $credential->getId(),
+                    // A short, non-reversible display handle (base64url of the raw
+                    // credential id) so the user can tell two passkeys apart.
+                    'fingerprint' => rtrim(strtr(base64_encode($credential->publicKeyCredentialId), '+/', '-_'), '='),
+                    'transports' => $credential->transports,
+                ],
+                $passkeys,
+            ),
+        ]);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -96,6 +96,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TotpTwo
     protected ?array $backupCodes = null;
 
     /**
+     * Stable, non-enumerable WebAuthn user handle (ADR-018 D3) — the opaque id
+     * passkeys are bound to. NULL until the user registers their first passkey;
+     * a random UUID is then assigned (never the integer PK, which is guessable).
+     */
+    #[ORM\Column(name: 'webauthn_user_handle', type: 'string', length: 36, nullable: true)]
+    protected ?string $webauthnUserHandle = null;
+
+    /**
      * The DECRYPTED TOTP secret — a transient, non-persisted field. Populated
      * from {@see $totpSecret} by UserTwoFactorSubscriber::postLoad and on
      * enrolment. scheb reads it via getTotpAuthenticationConfiguration().
@@ -492,6 +500,19 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TotpTwo
     public function isLocalAccount(): bool
     {
         return null !== $this->password && '' !== $this->password;
+    }
+
+    /** The WebAuthn user handle, or null until the first passkey is registered. */
+    public function getWebauthnUserHandle(): ?string
+    {
+        return $this->webauthnUserHandle;
+    }
+
+    public function setWebauthnUserHandle(?string $webauthnUserHandle): self
+    {
+        $this->webauthnUserHandle = $webauthnUserHandle;
+
+        return $this;
     }
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -100,7 +100,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TotpTwo
      * passkeys are bound to. NULL until the user registers their first passkey;
      * a random UUID is then assigned (never the integer PK, which is guessable).
      */
-    #[ORM\Column(name: 'webauthn_user_handle', type: 'string', length: 36, nullable: true)]
+    #[ORM\Column(name: 'webauthn_user_handle', type: 'string', length: 36, unique: true, nullable: true)]
     protected ?string $webauthnUserHandle = null;
 
     /**

--- a/src/Entity/WebauthnCredential.php
+++ b/src/Entity/WebauthnCredential.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\WebauthnCredentialRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Webauthn\CredentialRecord;
+
+/**
+ * A registered passkey / WebAuthn credential (ADR-018 D3).
+ *
+ * All ceremony fields (credential id, public key, sign counter, transports,
+ * AAGUID, trust path, backup/UV flags) are inherited from {@see CredentialRecord},
+ * a Doctrine mapped-superclass the bundle registers automatically; this subclass
+ * only adds the local surrogate id so the rows are addressable. The `userHandle`
+ * column ties the credential to a {@see User} via that user's non-enumerable
+ * webauthn_user_handle (never the integer PK).
+ */
+#[ORM\Entity(repositoryClass: WebauthnCredentialRepository::class)]
+#[ORM\Table(name: 'webauthn_credentials')]
+class WebauthnCredential extends CredentialRecord
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/src/Repository/WebauthnCredentialRepository.php
+++ b/src/Repository/WebauthnCredentialRepository.php
@@ -68,6 +68,30 @@ class WebauthnCredentialRepository extends ServiceEntityRepository implements Pu
         return $records;
     }
 
+    /**
+     * The app's own credential rows for a user handle (with their surrogate ids),
+     * for the Settings passkey list/remove UI — distinct from the bundle's
+     * findAllForUserEntity, which returns the abstract CredentialRecord.
+     *
+     * @return array<WebauthnCredential>
+     */
+    public function findByUserHandle(string $userHandle): array
+    {
+        // A DQL query (not findBy) so PHPStan's Doctrine plugin doesn't trip over
+        // userHandle being mapped on the XML mapped-superclass, not this subclass.
+        /** @var array<WebauthnCredential> $records */
+        $records = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->from(WebauthnCredential::class, 'c')
+            ->select('c')
+            ->where('c.userHandle = :userHandle')
+            ->setParameter('userHandle', $userHandle)
+            ->getQuery()
+            ->getResult();
+
+        return $records;
+    }
+
     public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
     {
         /** @var CredentialRecord|null $record */

--- a/src/Repository/WebauthnCredentialRepository.php
+++ b/src/Repository/WebauthnCredentialRepository.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\WebauthnCredential;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+use function base64_encode;
+
+/**
+ * Persists registered passkeys (ADR-018 D3). Implements the bundle's v5 record
+ * interfaces (not the deprecated PublicKeyCredentialSource ones); the ceremony
+ * controllers read via {@see findAllForUserEntity}/{@see findOneByCredentialId}
+ * and write via {@see saveCredentialRecord}. Mirrors the query shape of the
+ * bundle's own DoctrineCredentialSourceRepository (userHandle match; base64 id).
+ *
+ * @extends ServiceEntityRepository<WebauthnCredential>
+ *
+ * @phpstan-ignore class.implementsDeprecatedInterface (the bundle's DI aliases the
+ *   deprecated marker to the configured repo; implementing it is required until 6.0)
+ */
+class WebauthnCredentialRepository extends ServiceEntityRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialRecord
+{
+    // PublicKeyCredentialSourceRepositoryInterface is an (deprecated) empty marker
+    // extending CredentialRecordRepositoryInterface — the bundle aliases both to
+    // the configured repo, so we implement the marker to satisfy the DI alias
+    // while defining only the current CredentialRecord-based methods below.
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, WebauthnCredential::class);
+    }
+
+    public function saveCredentialRecord(CredentialRecord $credentialRecord): void
+    {
+        $manager = $this->getEntityManager();
+        $manager->persist($credentialRecord);
+        $manager->flush();
+    }
+
+    /**
+     * @return array<CredentialRecord>
+     */
+    public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
+    {
+        /** @var array<CredentialRecord> $records */
+        $records = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->from(WebauthnCredential::class, 'c')
+            ->select('c')
+            ->where('c.userHandle = :userHandle')
+            ->setParameter('userHandle', $publicKeyCredentialUserEntity->id)
+            ->getQuery()
+            ->getResult();
+
+        return $records;
+    }
+
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+    {
+        /** @var CredentialRecord|null $record */
+        $record = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->from(WebauthnCredential::class, 'c')
+            ->select('c')
+            ->where('c.publicKeyCredentialId = :publicKeyCredentialId')
+            ->setParameter('publicKeyCredentialId', base64_encode($publicKeyCredentialId))
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $record;
+    }
+}

--- a/src/Repository/WebauthnUserEntityRepository.php
+++ b/src/Repository/WebauthnUserEntityRepository.php
@@ -38,9 +38,17 @@ final readonly class WebauthnUserEntityRepository implements PublicKeyCredential
         }
 
         if (null === $user->getWebauthnUserHandle()) {
-            // First passkey interaction for this account — assign a stable handle.
-            $user->setWebauthnUserHandle(Uuid::v4()->toRfc4122());
-            $this->entityManager->flush();
+            // Assign a stable handle exactly once, ATOMICALLY: the guarded UPDATE
+            // wins for at most one concurrent request (the rest touch zero rows),
+            // so there is no lost-update race, the unique index forbids duplicates,
+            // and — unlike a read-modify-write flush — an existing handle can never
+            // be overwritten (matters because the login-options builder can reach
+            // this method with a request-supplied username).
+            $this->entityManager->getConnection()->executeStatement(
+                'UPDATE users SET webauthn_user_handle = :handle WHERE id = :id AND webauthn_user_handle IS NULL',
+                ['handle' => Uuid::v4()->toRfc4122(), 'id' => $user->getId()],
+            );
+            $this->entityManager->refresh($user);
         }
 
         return $this->toUserEntity($user);

--- a/src/Repository/WebauthnUserEntityRepository.php
+++ b/src/Repository/WebauthnUserEntityRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+use function assert;
+
+/**
+ * Maps the app's {@see User} onto the WebAuthn user-entity the ceremonies need
+ * (ADR-018 D3). The credential is bound to the user's non-enumerable
+ * webauthn_user_handle, which is lazily minted (a random UUID) the first time a
+ * user is looked up by name for a registration ceremony — so an account only
+ * gains a handle once it actually starts using passkeys.
+ */
+final readonly class WebauthnUserEntityRepository implements PublicKeyCredentialUserEntityRepositoryInterface
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function findOneByUsername(string $username): ?PublicKeyCredentialUserEntity
+    {
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        if (!$user instanceof User) {
+            return null;
+        }
+
+        if (null === $user->getWebauthnUserHandle()) {
+            // First passkey interaction for this account — assign a stable handle.
+            $user->setWebauthnUserHandle(Uuid::v4()->toRfc4122());
+            $this->entityManager->flush();
+        }
+
+        return $this->toUserEntity($user);
+    }
+
+    public function findOneByUserHandle(string $userHandle): ?PublicKeyCredentialUserEntity
+    {
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['webauthnUserHandle' => $userHandle]);
+
+        return $user instanceof User ? $this->toUserEntity($user) : null;
+    }
+
+    private function toUserEntity(User $user): PublicKeyCredentialUserEntity
+    {
+        $handle = $user->getWebauthnUserHandle();
+        assert(null !== $handle);
+
+        return PublicKeyCredentialUserEntity::create(
+            $user->getUserIdentifier(),
+            $handle,
+            $user->getAbbr() ?? $user->getUserIdentifier(),
+        );
+    }
+}

--- a/src/Security/Webauthn/PasskeyLoginFailureHandler.php
+++ b/src/Security/Webauthn/PasskeyLoginFailureHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\Webauthn;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Throwable;
+use Webauthn\Bundle\Security\Handler\FailureHandler;
+
+/**
+ * Passkey LOGIN failed (ADR-018 D3). Returns the SPA's {ok:false, error} shape so
+ * the login form can show an inline message and fall back to password sign-in.
+ */
+final class PasskeyLoginFailureHandler implements FailureHandler, AuthenticationFailureHandlerInterface
+{
+    public function onFailure(Request $request, ?Throwable $exception = null): Response
+    {
+        return new JsonResponse(
+            ['ok' => false, 'error' => $exception?->getMessage() ?? 'Authentication failed'],
+            Response::HTTP_UNAUTHORIZED,
+        );
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        return $this->onFailure($request, $exception);
+    }
+}

--- a/src/Security/Webauthn/PasskeyLoginFailureHandler.php
+++ b/src/Security/Webauthn/PasskeyLoginFailureHandler.php
@@ -23,15 +23,15 @@ use Webauthn\Bundle\Security\Handler\FailureHandler;
  */
 final class PasskeyLoginFailureHandler implements FailureHandler, AuthenticationFailureHandlerInterface
 {
-    public function onFailure(Request $request, ?Throwable $exception = null): Response
+    public function onFailure(Request $request, ?Throwable $exception = null): JsonResponse
     {
-        return new JsonResponse(
-            ['ok' => false, 'error' => $exception?->getMessage() ?? 'Authentication failed'],
-            Response::HTTP_UNAUTHORIZED,
-        );
+        // Never echo the raw exception message — a WebAuthn verification failure can
+        // carry internal detail (RP/origin mismatch, counter regression). The SPA
+        // shows its own localized message; a generic marker is enough on the wire.
+        return new JsonResponse(['ok' => false, 'error' => 'passkey_authentication_failed'], Response::HTTP_UNAUTHORIZED);
     }
 
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): JsonResponse
     {
         return $this->onFailure($request, $exception);
     }

--- a/src/Security/Webauthn/PasskeyLoginSuccessHandler.php
+++ b/src/Security/Webauthn/PasskeyLoginSuccessHandler.php
@@ -11,7 +11,6 @@ namespace App\Security\Webauthn;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
@@ -38,11 +37,11 @@ final class PasskeyLoginSuccessHandler implements SuccessHandler, Authentication
         ?PublicKeyCredential $publicKeyCredential = null,
         ?PublicKeyCredentialOptions $publicKeyCredentialOptions = null,
         ?PublicKeyCredentialUserEntity $userEntity = null,
-    ): Response {
+    ): JsonResponse {
         return $this->jsonRedirect($request);
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): JsonResponse
     {
         return $this->jsonRedirect($request);
     }

--- a/src/Security/Webauthn/PasskeyLoginSuccessHandler.php
+++ b/src/Security/Webauthn/PasskeyLoginSuccessHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\Webauthn;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+use Webauthn\Bundle\Security\Handler\SuccessHandler;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Passkey LOGIN succeeded (ADR-018 D3). Returns the SPA's usual login shape
+ * ({ok, redirect}) instead of the bundle's default {status:ok}, honouring a deep
+ * link saved before login (TargetPathTrait) — same behaviour as the password and
+ * TOTP success handlers. A passkey with user-verification is inherently two
+ * factors (device + biometric/PIN), so it is NOT sent through the TOTP challenge:
+ * scheb matches its trigger token by exact class and a WebauthnToken is not in
+ * the configured security_tokens list.
+ */
+final class PasskeyLoginSuccessHandler implements SuccessHandler, AuthenticationSuccessHandlerInterface
+{
+    use TargetPathTrait;
+
+    public function onSuccess(
+        Request $request,
+        ?PublicKeyCredential $publicKeyCredential = null,
+        ?PublicKeyCredentialOptions $publicKeyCredentialOptions = null,
+        ?PublicKeyCredentialUserEntity $userEntity = null,
+    ): Response {
+        return $this->jsonRedirect($request);
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
+    {
+        return $this->jsonRedirect($request);
+    }
+
+    private function jsonRedirect(Request $request): JsonResponse
+    {
+        $targetPath = $request->hasSession()
+            ? $this->getTargetPath($request->getSession(), 'main')
+            : null;
+        $redirect = null !== $targetPath && '' !== $targetPath ? $targetPath : '/';
+
+        return new JsonResponse(['ok' => true, 'redirect' => $redirect]);
+    }
+}

--- a/src/Security/Webauthn/PasskeyRegisterSuccessHandler.php
+++ b/src/Security/Webauthn/PasskeyRegisterSuccessHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\Webauthn;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Webauthn\Bundle\Security\Handler\SuccessHandler;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * A passkey was REGISTERED from the Settings Security section (ADR-018 D3). The
+ * credential is already persisted by the ceremony controller; this returns the
+ * settings-write shape ({success:true}) the SPA expects so it can refresh the
+ * passkey list.
+ */
+final class PasskeyRegisterSuccessHandler implements SuccessHandler
+{
+    public function onSuccess(
+        Request $request,
+        ?PublicKeyCredential $publicKeyCredential = null,
+        ?PublicKeyCredentialOptions $publicKeyCredentialOptions = null,
+        ?PublicKeyCredentialUserEntity $userEntity = null,
+    ): Response {
+        return new JsonResponse(['success' => true], Response::HTTP_CREATED);
+    }
+}

--- a/src/Security/Webauthn/PasskeyRegisterSuccessHandler.php
+++ b/src/Security/Webauthn/PasskeyRegisterSuccessHandler.php
@@ -30,7 +30,7 @@ final class PasskeyRegisterSuccessHandler implements SuccessHandler
         ?PublicKeyCredential $publicKeyCredential = null,
         ?PublicKeyCredentialOptions $publicKeyCredentialOptions = null,
         ?PublicKeyCredentialUserEntity $userEntity = null,
-    ): Response {
+    ): JsonResponse {
         return new JsonResponse(['success' => true], Response::HTTP_CREATED);
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -292,6 +292,15 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/uid": {
+        "version": "8.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.0",
+            "ref": "0df5844274d871b37fc3816c57a768ffc60a43a5"
+        }
+    },
     "symfony/validator": {
         "version": "4.4",
         "recipe": {
@@ -318,5 +327,8 @@
             "config/packages/test/web_profiler.yaml",
             "config/routes/dev/web_profiler.yaml"
         ]
+    },
+    "web-auth/webauthn-symfony-bundle": {
+        "version": "5.3.5"
     }
 }

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -86,6 +86,9 @@ final class ArchitectureTest
                 // (TotpTwoFactorInterface, BackupCodeInterface, TotpConfiguration)
                 // — a framework contract like Symfony's UserInterface. ADR-018 D2.
                 Selector::inNamespace('Scheb\TwoFactorBundle\Model'),
+                // WebAuthn credential model the passkey entity extends (ADR-018 D3),
+                // another framework-contract superclass like the scheb one above.
+                Selector::inNamespace('Webauthn'),
                 Selector::classname(self::CLASSNAME_EXCEPTION, true),
             )
             ->because('Entities stay data-centric: relations, ORM metadata, validation');
@@ -136,6 +139,9 @@ final class ArchitectureTest
                 Selector::inNamespace('Doctrine'),
                 Selector::inNamespace('Symfony'),
                 Selector::inNamespace('Psr'),
+                // WebAuthn credential/user-entity contracts the passkey repositories
+                // implement + return (ADR-018 D3) — the bundle's data-layer types.
+                Selector::inNamespace('Webauthn'),
                 Selector::classname(self::CLASSNAME_EXCEPTION, true),
             )
             ->because('Repositories handle data access (plus the query-helper services they delegate to)');

--- a/tests/Controller/PasskeyCeremonyTest.php
+++ b/tests/Controller/PasskeyCeremonyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+use function is_string;
+
+/**
+ * Covers that the WebAuthn ceremonies are wired and start correctly (ADR-018 D3):
+ * the registration and login option endpoints return valid PublicKey*Options JSON
+ * with a challenge. The credential crypto round-trip (attestation/assertion
+ * verification) needs a browser virtual authenticator and is exercised by the e2e
+ * suite, not here.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class PasskeyCeremonyTest extends AbstractWebTestCase
+{
+    public function testRegistrationCeremonyReturnsCreationOptions(): void
+    {
+        // setUp logged the unittest user in; the ceremony resolves it via the
+        // CurrentUserEntityGuesser and mints its webauthn_user_handle on first use.
+        $this->client->request(
+            Request::METHOD_POST,
+            '/settings/security/passkeys/options',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{}',
+        );
+
+        $this->assertStatusCode(200);
+        $body = $this->getJsonResponse($this->client->getResponse());
+        self::assertArrayHasKey('challenge', $body, 'creation options must carry a challenge');
+        self::assertArrayHasKey('rp', $body);
+        self::assertArrayHasKey('user', $body);
+
+        // The handle is now assigned, so a later ceremony reuses the same identity.
+        self::assertNotNull($this->storedUserHandle(1));
+    }
+
+    public function testLoginCeremonyReturnsRequestOptions(): void
+    {
+        // Discoverable login is public — no session needed for the options step.
+        $this->client->getCookieJar()->clear();
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/login/options',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{}',
+        );
+
+        $this->assertStatusCode(200);
+        $body = $this->getJsonResponse($this->client->getResponse());
+        self::assertArrayHasKey('challenge', $body, 'request options must carry a challenge');
+    }
+
+    private function storedUserHandle(int $userId): ?string
+    {
+        self::assertNotNull($this->serviceContainer);
+        $manager = $this->serviceContainer->get('doctrine')->getManager();
+        $user = $manager->getRepository(User::class)->find($userId);
+        self::assertInstanceOf(User::class, $user);
+        $handle = $user->getWebauthnUserHandle();
+
+        return is_string($handle) ? $handle : null;
+    }
+}

--- a/tests/Controller/PasskeyCeremonyTest.php
+++ b/tests/Controller/PasskeyCeremonyTest.php
@@ -70,6 +70,26 @@ final class PasskeyCeremonyTest extends AbstractWebTestCase
         self::assertArrayHasKey('challenge', $body, 'request options must carry a challenge');
     }
 
+    public function testPasskeyListStartsEmpty(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/settings/security/passkeys/list', [], [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(200);
+        $body = $this->getJsonResponse($this->client->getResponse());
+        self::assertArrayHasKey('passkeys', $body);
+        self::assertSame([], $body['passkeys']);
+    }
+
+    public function testDeletingAnUnknownPasskeyIsRejected(): void
+    {
+        // The ownership guard also covers "not mine" — a missing/foreign id 404s
+        // rather than deleting anything.
+        $this->client->request(Request::METHOD_POST, '/settings/security/passkeys/delete', ['id' => '999999'], [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(404);
+        self::assertFalse($this->getJsonResponse($this->client->getResponse())['success'] ?? true);
+    }
+
     private function storedUserHandle(int $userId): ?string
     {
         self::assertNotNull($this->serviceContainer);


### PR DESCRIPTION
## What

Adds **passkeys** (WebAuthn discoverable credentials) — the final piece of the ADR-018 account-security work. Built on `web-auth/webauthn-symfony-bundle` 5.3.

This PR opens with the **backend increment** (verified working); the SPA UI + e2e follow as commits on this branch.

## Backend (this commit)

- **Storage**: `WebauthnCredential` entity (extends the bundle's `CredentialRecord` mapped-superclass) + migration for `webauthn_credentials` and `users.webauthn_user_handle` — a non-enumerable UUID minted on first passkey use (never the integer PK).
- **Repositories**: credential store (find/save) + `User → PublicKeyCredentialUserEntity` mapping, implementing the v5 record interfaces.
- **Login**: a `webauthn` firewall authenticator on `main` for usernameless sign-in (`/login/options` → `/login/passkey`), alongside form_login — it only claims those paths, so password login is undisturbed.
- **Registration**: a logged-in "add a passkey" ceremony (`/settings/security/passkeys[/options]`) via `CurrentUserEntityGuesser`.
- **JSON handlers**: login returns the SPA's `{ok, redirect}` (honouring a saved deep link); registration returns `{success}`.

## Key security property

A **passkey login is NOT sent through the TOTP challenge** — scheb keys its trigger on the exact token class, and a `WebauthnToken` is not in `security_tokens`. A passkey with user-verification is already two factors (device + biometric/PIN), so this is correct.

## Config

RP id + allowed origin are env-driven (`WEBAUTHN_RP_ID`, `WEBAUTHN_ALLOWED_ORIGINS`; `localhost` defaults for dev/test). phpat entity/repository allowlists extended for the `Webauthn` namespace.

## Tests

`PasskeyCeremonyTest` proves both ceremonies **start** — the registration and login options endpoints return valid `PublicKey*Options` JSON with a challenge, and the user handle is minted. The credential **crypto round-trip** (attestation/assertion verification) needs a browser virtual authenticator and lands with the SPA UI + e2e.

Container lint, `doctrine:schema:validate`, PHPStan L10, and phpat all clean.

Refs ADR-018, completes the MFA/passkeys epic (#512/#513/#518/#521)