### PR TITLE
fix(security): persist passkey registrations as the entity subclass

### DIFF
--- a/config/packages/webauthn.yaml
+++ b/config/packages/webauthn.yaml
@@ -41,4 +41,6 @@ webauthn:
                 profile: default
                 user_entity_guesser: Webauthn\Bundle\Security\Guesser\CurrentUserEntityGuesser
                 success_handler: App\Security\Webauthn\PasskeyRegisterSuccessHandler
+                # The bundle default echoes raw exception messages to the client.
+                failure_handler: App\Security\Webauthn\PasskeyRegisterFailureHandler
                 hide_existing_credentials: true

--- a/frontend/src/components/SecuritySection.tsx
+++ b/frontend/src/components/SecuritySection.tsx
@@ -66,9 +66,10 @@ export function PasskeyControls(props: Readonly<{ onRegistered?: () => void }> =
       await registerPasskey()
       await refetch()
       props.onRegistered?.()
-    } catch (caught) {
-      // A user cancelling the native prompt throws too — keep the message quiet.
-      setError(apiErrorMessage(caught, m.settings_passkey_error()))
+    } catch {
+      // Always the localized message: the failure handler's body is a machine
+      // marker (not prose), and a user cancelling the native prompt throws too.
+      setError(m.settings_passkey_error())
     } finally {
       setBusy(false)
     }

--- a/src/Repository/WebauthnCredentialRepository.php
+++ b/src/Repository/WebauthnCredentialRepository.php
@@ -48,6 +48,29 @@ class WebauthnCredentialRepository extends ServiceEntityRepository implements Pu
 
     public function saveCredentialRecord(CredentialRecord $credentialRecord): void
     {
+        // Registration hands us the BASE CredentialRecord (the attestation
+        // validator constructs it) — convert it into the id-bearing entity
+        // subclass, or Doctrine cannot persist it ("entity has no identity").
+        // Login counter-updates pass back the managed entity from
+        // findOneByCredentialId and are persisted as-is.
+        if (!$credentialRecord instanceof WebauthnCredential) {
+            $credentialRecord = new WebauthnCredential(
+                $credentialRecord->publicKeyCredentialId,
+                $credentialRecord->type,
+                $credentialRecord->transports,
+                $credentialRecord->attestationType,
+                $credentialRecord->trustPath,
+                $credentialRecord->aaguid,
+                $credentialRecord->credentialPublicKey,
+                $credentialRecord->userHandle,
+                $credentialRecord->counter,
+                $credentialRecord->otherUI,
+                $credentialRecord->backupEligible,
+                $credentialRecord->backupStatus,
+                $credentialRecord->uvInitialized,
+            );
+        }
+
         $manager = $this->getEntityManager();
         $manager->persist($credentialRecord);
         $manager->flush();

--- a/src/Security/Webauthn/PasskeyRegisterFailureHandler.php
+++ b/src/Security/Webauthn/PasskeyRegisterFailureHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\Webauthn;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use Webauthn\Bundle\Security\Handler\FailureHandler;
+
+/**
+ * Passkey REGISTRATION failed (ADR-018 D3). The bundle's default handler echoes
+ * the raw exception message to the client — which can carry internals (ceremony
+ * validation detail, ORM errors). Log the real cause server-side and answer with
+ * a generic marker; the SPA shows its own localized message.
+ */
+final readonly class PasskeyRegisterFailureHandler implements FailureHandler
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    public function onFailure(Request $request, ?Throwable $exception = null): JsonResponse
+    {
+        // PSR-3 context: the exception key must hold a Throwable, never null.
+        $this->logger->error('Passkey registration failed.', $exception instanceof Throwable ? ['exception' => $exception] : []);
+
+        return new JsonResponse(['success' => false, 'error' => 'passkey_registration_failed'], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/tests/Repository/WebauthnCredentialRepositoryTest.php
+++ b/tests/Repository/WebauthnCredentialRepositoryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\WebauthnCredential;
+use App\Repository\WebauthnCredentialRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+use Tests\AbstractWebTestCase;
+use Webauthn\CredentialRecord;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+use function assert;
+use function random_bytes;
+
+/**
+ * Covers the passkey persistence path (ADR-018 D3). The registration ceremony
+ * hands saveCredentialRecord() the BASE CredentialRecord (constructed by the
+ * attestation validator, no entity id) — the repository must convert it into the
+ * id-bearing entity, or Doctrine refuses it ("entity has no identity"; the bug
+ * that broke passkey registration in production).
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class WebauthnCredentialRepositoryTest extends AbstractWebTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    private WebauthnCredentialRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (null === $this->serviceContainer) {
+            throw new RuntimeException('Service container not initialized');
+        }
+        $entityManager = $this->serviceContainer->get('doctrine.orm.entity_manager');
+        assert($entityManager instanceof EntityManagerInterface);
+        $this->entityManager = $entityManager;
+        $repository = $this->entityManager->getRepository(WebauthnCredential::class);
+        assert($repository instanceof WebauthnCredentialRepository);
+        $this->repository = $repository;
+    }
+
+    public function testSavingABaseCredentialRecordPersistsItAsTheEntity(): void
+    {
+        $credentialId = random_bytes(32);
+        $userHandle = Uuid::v4()->toRfc4122();
+
+        // What the attestation validator produces on registration: the BASE class.
+        $record = new CredentialRecord(
+            $credentialId,
+            'public-key',
+            ['internal'],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'test-public-key',
+            $userHandle,
+            0,
+        );
+
+        $this->repository->saveCredentialRecord($record);
+
+        // Round-trip from the DB: it must come back as the id-bearing entity.
+        $this->entityManager->clear();
+        $found = $this->repository->findOneByCredentialId($credentialId);
+        self::assertInstanceOf(WebauthnCredential::class, $found);
+        self::assertNotNull($found->getId());
+        self::assertSame($userHandle, $found->userHandle);
+        self::assertSame(1, $this->repository->countByUserHandle($userHandle));
+    }
+
+    public function testSavingTheManagedEntityAgainUpdatesInPlace(): void
+    {
+        $credentialId = random_bytes(32);
+        $userHandle = Uuid::v4()->toRfc4122();
+
+        $this->repository->saveCredentialRecord(new CredentialRecord(
+            $credentialId,
+            'public-key',
+            ['internal'],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'test-public-key',
+            $userHandle,
+            0,
+        ));
+
+        // The login path: load the entity, bump the sign counter, save it back.
+        $this->entityManager->clear();
+        $entity = $this->repository->findOneByCredentialId($credentialId);
+        self::assertInstanceOf(WebauthnCredential::class, $entity);
+        $entity->counter = 7;
+        $this->repository->saveCredentialRecord($entity);
+
+        $this->entityManager->clear();
+        $reloaded = $this->repository->findOneByCredentialId($credentialId);
+        self::assertInstanceOf(WebauthnCredential::class, $reloaded);
+        self::assertSame(7, $reloaded->counter, 'the counter update is persisted');
+        self::assertSame(1, $this->repository->countByUserHandle($userHandle), 'no duplicate row was created');
+    }
+}


### PR DESCRIPTION
## What

**Fixes passkey registration in production**, which failed with:

> `The given entity of type 'Webauthn\CredentialRecord' … has no identity/no id values set. It cannot be added to the identity map.`

## Root cause

On registration, the bundle's `AuthenticatorAttestationResponseValidator` constructs the **base** `Webauthn\CredentialRecord` and the attestation controller passes it straight to `saveCredentialRecord()`. Our repository persisted it as-is — but only our subclass `App\Entity\WebauthnCredential` carries the surrogate id, so Doctrine refuses the base instance. Login counter-updates never hit this (they pass back the managed entity from `findOneByCredentialId`), which is why `PasskeyCeremonyTest` stayed green: a real attestation save was never exercised.

## Changes

- `WebauthnCredentialRepository::saveCredentialRecord()` converts a non-entity record into the id-bearing `WebauthnCredential` before persisting (the canonical subclass-entity pattern for this bundle).
- **New `PasskeyRegisterFailureHandler`** wired into the creation profile: the bundle's default failure handler echoed the raw exception message — ORM internals — to the client (that's how this error surfaced). Now the client gets a generic `passkey_registration_failed` marker (422) and the real cause is logged server-side. Mirrors the existing `PasskeyLoginFailureHandler` hardening.

## Tests

**Red-first verified**: `WebauthnCredentialRepositoryTest` run against the pre-fix repository reproduces the exact production error (2 errors); with the fix, both pass.

- saving a **base** `CredentialRecord` persists it as the entity (id assigned, findable by credential id, counted by user handle)
- re-saving the managed entity (the login counter-update path) updates in place, no duplicate row

Local gates: PHPStan level 10, Rector dry-run, phpat, cs-fixer all clean; `PasskeyCeremonyTest` still green.