### PR TITLE
fix(ui): close the hover gap between the kebab button and its menu

### DIFF
--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -938,4 +938,45 @@ describe('Tracking (Worklog grid)', () => {
 
     unmount()
   })
+
+  it('gives the kebab hover menu a close grace period (survives a brief pointer exit)', async () => {
+    mockTracking({
+      entries: [{ entry: { ...DEFAULT_ENTRY, id: 1, date: '16/06/2026', ticket: 'ABC-1', customer: 1, project: 4 } }],
+    })
+    const { container, unmount } = renderTracking()
+    await waitFor(() => expect(container.querySelector('.action-menu')).toBeInTheDocument())
+    const wrapper = container.querySelector('.action-menu')!
+
+    // pointerenter/leave don't bubble and jsdom has no PointerEvent — dispatch
+    // plain events carrying the pointerType the handlers check.
+    const pointer = (type: string): Event => Object.assign(new Event(type), { pointerType: 'mouse' })
+
+    // Hover opens (Solid signals apply synchronously).
+    wrapper.dispatchEvent(pointer('pointerenter'))
+    expect(container.querySelector('.action-menu-pop')).toBeInTheDocument()
+
+    vi.useFakeTimers()
+    try {
+      // Leaving does NOT close immediately — the cursor may be crossing the
+      // small gap between the button and the popup.
+      wrapper.dispatchEvent(pointer('pointerleave'))
+      expect(container.querySelector('.action-menu-pop')).toBeInTheDocument()
+      vi.advanceTimersByTime(100)
+      expect(container.querySelector('.action-menu-pop')).toBeInTheDocument()
+
+      // Re-entering within the grace period cancels the pending close for good.
+      wrapper.dispatchEvent(pointer('pointerenter'))
+      vi.advanceTimersByTime(500)
+      expect(container.querySelector('.action-menu-pop')).toBeInTheDocument()
+
+      // Leaving for longer than the grace period closes it.
+      wrapper.dispatchEvent(pointer('pointerleave'))
+      vi.advanceTimersByTime(200)
+      expect(container.querySelector('.action-menu-pop')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    unmount()
+  })
 })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -208,7 +208,18 @@ export default function Tracking() {
   // the popup is hoverable — it lives inside the hovered wrapper — dismissible
   // via Escape/click-outside, and persistent until dismissed).
   const [actionsMenuRow, setActionsMenuRow] = createSignal<number | null>(null)
-  const closeActionsMenu = (): void => { setActionsMenuRow(null) }
+  // Closing on pointerleave is deferred by a short grace period: a slow or
+  // diagonal move from the kebab to its popup may clip past the hoverable area
+  // for a moment, and an immediate close makes the menu vanish mid-transit.
+  // Re-entering (or opening another row's menu) cancels the pending close.
+  let actionsMenuCloseTimer: ReturnType<typeof setTimeout> | undefined
+  const cancelActionsMenuClose = (): void => { clearTimeout(actionsMenuCloseTimer) }
+  const closeActionsMenu = (): void => { cancelActionsMenuClose(); setActionsMenuRow(null) }
+  const scheduleActionsMenuClose = (id: number): void => {
+    cancelActionsMenuClose()
+    actionsMenuCloseTimer = setTimeout(() => { if (actionsMenuRow() === id) { setActionsMenuRow(null) } }, 150)
+  }
+  onCleanup(cancelActionsMenuClose)
   onMount(() => {
     const onDocPointer = (event: PointerEvent): void => {
       if (daysComboRef !== undefined && !daysComboRef.contains(event.target as Node)) {
@@ -1155,8 +1166,8 @@ export default function Tracking() {
                               the menu — mid-entry saving must not cost an extra click. */}
                           <span
                             class="action-menu"
-                            onPointerEnter={(event) => { if (event.pointerType === 'mouse') { setActionsMenuRow(id) } }}
-                            onPointerLeave={(event) => { if (event.pointerType === 'mouse' && actionsMenuRow() === id) { closeActionsMenu() } }}
+                            onPointerEnter={(event) => { if (event.pointerType === 'mouse') { cancelActionsMenuClose(); setActionsMenuRow(id) } }}
+                            onPointerLeave={(event) => { if (event.pointerType === 'mouse' && actionsMenuRow() === id) { scheduleActionsMenuClose(id) } }}
                             onKeyDown={(event) => { if (event.key === 'Escape') { closeActionsMenu() } }}
                           >
                             <button

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1582,6 +1582,21 @@ kbd {
   white-space: nowrap;
 }
 
+/* Invisible hover bridge over the 2px visual gap between the kebab button and
+   the popup (plus side slack for diagonal movement): the cursor never crosses a
+   non-hoverable strip, so the wrapper's pointerleave can't fire mid-transit.
+   Exactly the gap's height — any taller and it would overlap the button's
+   bottom edge (the popup is z-index 30) and swallow clicks meant to toggle it.
+   Diagonal paths that leave the strip are covered by the JS close grace. */
+.action-menu-pop::before {
+  content: '';
+  position: absolute;
+  top: -2px;
+  right: -6px;
+  left: -6px;
+  height: 2px;
+}
+
 .action-menu-pop [role='menuitem'] {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

Moving the mouse **slowly** from the worklog row-actions kebab (☰) to its hover popup made the menu disappear before the cursor reached it.

## Root cause

The popup sits at `top: calc(100% + 2px)` — a 2px dead zone between the button's and the popup's hit boxes. Crossing it fires the wrapper's `pointerleave`, which closed the menu immediately (the popup is a DOM child of the wrapper, so hovering *it* is fine — only the gap in between was fatal).

## Fix (two complementary layers)

1. **Invisible hover bridge** — an `::before` strip on the popup spans the 2px gap (plus 6px side slack for diagonal approaches), so the direct path is continuously hoverable and `pointerleave` can't fire mid-transit.
2. **150 ms close grace** — `pointerleave` now schedules the close instead of closing instantly; re-entering (button or popup) cancels it. Absorbs jitter and paths the bridge can't cover.

Click/tap toggling, Escape, and click-outside dismissal are unchanged (WCAG 1.4.13 hoverable/dismissible/persistent still holds — the popup remains persistent until dismissed).

## Tests

New regression test: leaving does **not** close immediately; still open after 100 ms; re-entering within the grace period cancels the close; leaving past the grace period closes. All 43 Tracking tests green; typecheck + lint clean.