### PR TITLE
fix(ui): weekday instead of a bare day number at the narrowest date rung

### DIFF
--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -559,10 +559,18 @@ describe('Tracking (Worklog grid)', () => {
     await waitFor(() => expect(getByRole('gridcell', { name: 'Newest' })).toBeInTheDocument())
 
     // Dates render in ISO (yyyy-mm-dd), one consistent format everywhere.
-    // The date cell renders three responsive widths (full / MM-DD / DD); read the
-    // full-date span rather than the whole cell's concatenated text.
+    // The date cell renders three responsive widths (full / MM-DD / weekday);
+    // read the full-date span rather than the whole cell's concatenated text.
     const dates = Array.from(container.querySelectorAll('tbody tr td[data-col-key="date"] .dt-full')).map((el) => el.textContent)
     expect(dates).toEqual(['2026-06-16', '2026-06-15', '2026-06-14'])
+
+    // The narrower rungs keep orienting information: month-day, then the localized
+    // weekday — never a bare day-of-month, which reads as noise (issue #520).
+    const mids = Array.from(container.querySelectorAll('tbody tr td[data-col-key="date"] .dt-mid')).map((el) => el.textContent)
+    expect(mids).toEqual(['06-16', '06-15', '06-14'])
+    const shorts = Array.from(container.querySelectorAll('tbody tr td[data-col-key="date"] .dt-short')).map((el) => el.textContent)
+    // 2026-06-16 is a Tuesday (en test locale).
+    expect(shorts).toEqual(['Tue', 'Mon', 'Sun'])
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -145,16 +145,30 @@ function displayDate(value: string): string {
   return formatUserDate(dmyToIso(value) ?? value)
 }
 
+// Localized short weekday ("Fri" / "Fr.") — one formatter per page load, the
+// app locale never changes without a reload. Construct and format in UTC (the
+// same pattern as dateFormat.ts formatAuto) so a DST transition or timezone
+// mismatch can never shift a date-only value onto the neighbouring weekday.
+let weekdayFormat: Intl.DateTimeFormat | undefined
+function shortWeekday(iso: string): string {
+  weekdayFormat ??= new Intl.DateTimeFormat(appConfig().locale, { weekday: 'short', timeZone: 'UTC' })
+  const [year, month, day] = iso.split('-').map(Number)
+
+  return weekdayFormat.format(new Date(Date.UTC(year!, month! - 1, day!)))
+}
+
 // Three widths of the same date so the responsive table can shrink the Date
-// column purely in CSS: full (the user's preferred format), then MM-DD, then DD.
+// column purely in CSS: full (the user's preferred format), then MM-DD, then the
+// weekday. The narrowest rung is the weekday, not the bare day-of-month — a lone
+// "03" says nothing without its month/year, while "Fri" orients the reader in a
+// recent-entries worklog (issue #520).
 function dateParts(value: string): { full: string; mid: string; short: string } {
   const full = displayDate(value)
   const iso = dmyToIso(value) ?? value
-  const parts = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
-  const month = parts?.[2]
-  const day = parts?.[3]
-  if (month !== undefined && day !== undefined) {
-    return { full, mid: `${month}-${day}`, short: day }
+  const match = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
+  const isoDate = match?.[1]
+  if (isoDate !== undefined) {
+    return { full, mid: isoDate.slice(5), short: shortWeekday(isoDate) }
   }
 
   return { full, mid: full, short: full }


### PR DESCRIPTION
## What

When the responsive worklog table shrinks the Date column, the narrowest rung showed **only the day-of-month** — a bare `03` with no month or year, which is exactly the complaint in #520 (and still true after #522, which fixed the actions half but kept the day-only rung).

The three-rung ladder stays; the last rung becomes genuinely informative:

| rung | before | after |
|------|--------|-------|
| full | `2026-07-03` (user format) | `2026-07-03` |
| mid | `07-03` | `07-03` |
| short | `03` | **`Fri`** (localized, Intl `weekday: 'short'` in the app locale) |

A weekday orients the reader in a recent-entries worklog far better than a context-free digit.

## Tests

The date-render test now pins all three rungs (`2026-06-16` / `06-16` / `Tue`). All 42 Tracking tests green; typecheck + lint clean.

Follow-up to the #520 discussion.