### PR TITLE
fix(ui): engage side-by-side form layout in admin dialogs, cap control width

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -754,12 +754,17 @@ main {
   container-type: inline-size;
 }
 
-@container (min-width: 30rem) {
+@container (min-width: 26em) {
   .stack-form .field {
     display: grid;
     /* em (not rem) so the label column tracks the --font-scale text-size
-       preference (ADR-014), keeping long labels from clipping when scaled up. */
-    grid-template-columns: 11em minmax(0, 1fr);
+       preference (ADR-014). The label column is WIDE enough that ordinary
+       (German) labels stay on one line — at 11em "Minimale Eintragsdauer
+       (Minuten)" broke onto three. The control column is CAPPED — a language
+       select or a minutes field doesn't earn the whole card width; leftover
+       space stays right. Fixed widths (not max-content) keep the columns
+       aligned ACROSS fields, since each .field is its own grid. */
+    grid-template-columns: 18em minmax(0, 22em);
     align-items: center;
     gap: 0.3rem 1.2rem;
   }
@@ -2653,7 +2658,12 @@ th[aria-sort='descending'] .th-sort-glyph {
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: 16px;
-  max-width: 30rem;
+  /* em (not rem): the dialog hosts text and must grow with the user's
+     text-size preference (ADR-014), like the field columns inside it. Wide
+     enough that the .stack-form inside (this minus the padding) clears the
+     side-by-side container breakpoint — it previously sat just below it and
+     the admin edit forms silently stayed stacked. */
+  max-width: 36em;
   padding: 1.4rem;
   width: 100%;
 }


### PR DESCRIPTION
## What (both visually verified before/after)

**1. Admin edit dialogs never got the side-by-side label/control layout.**
Root cause is an off-by-a-hair: `.modal` caps at `30rem`, minus its `1.4rem` padding the `.stack-form` *container* measures ~27.2rem — just under the `@container (min-width: 30rem)` breakpoint, so dialog forms silently stayed stacked while Settings (a 46rem modal) got the new layout. The modal is now `36rem` and the breakpoint `26rem`; the user edit form now lays out side-by-side and fits without scrolling.

**2. The control column ate all remaining width (`minmax(0, 1fr)`).**
A language `<select>` or a "minutes" number field stretched to ~500px in the Settings card. The control column is now capped at `22em`; leftover space stays to the right of the control. Textareas, multiselects and `.field-row` pairs keep their full-width exceptions.

## Evidence

Verified in a live browser (1440×900, dev stack): Settings inputs shrink from ~505px to ~330px with clean right-hand breathing room; the admin user edit dialog switches from stacked to side-by-side and no longer scrolls.

Frontend suite 382/382 green; lint + typecheck clean.