### PR TITLE
feat(ui): passkey glyph on the login dialog's passkey button

### DIFF
--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 import { createSignal, Show } from 'solid-js'
 
 import type { LoginConfig } from '../loginConfig'
+import { PasskeyIcon } from '../lib/icons'
 import { loginWithPasskey, passkeysSupported } from '../lib/passkeys'
 import { m } from '../paraglide/messages.js'
 
@@ -233,7 +234,10 @@ export function LoginForm(props: { config: LoginConfig }) {
 
           <Show when={passkeysSupported()}>
             <button type="button" class="login-passkey" disabled={submitting()} onClick={() => void signInWithPasskey()}>
-              {m.login_passkey()}
+              {/* No whitespace text node between the two children: the button is a
+                  flex row with gap, so a stray space would become a third flex
+                  item and double the gap. */}
+              <PasskeyIcon /><span>{m.login_passkey()}</span>
             </button>
           </Show>
         </form>

--- a/frontend/src/lib/icons.tsx
+++ b/frontend/src/lib/icons.tsx
@@ -72,3 +72,15 @@ export function ResetIcon(): JSX.Element {
 export function KebabIcon(): JSX.Element {
   return <Icon><circle cx="12" cy="5" r="1.8" fill="currentColor" stroke="none" /><circle cx="12" cy="12" r="1.8" fill="currentColor" stroke="none" /><circle cx="12" cy="19" r="1.8" fill="currentColor" stroke="none" /></Icon>
 }
+
+// Passkey (person + key): the standard passkey glyph, from Google's Material
+// Symbols "passkey" icon (Apache-2.0) — the same mark the platform passkey UIs
+// use, so users recognise the button. Fill-based with the Material viewBox, so
+// it doesn't share the stroke-based Icon shell above.
+export function PasskeyIcon(): JSX.Element {
+  return (
+    <svg class="passkey-ico" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true">
+      <path d="M120-160v-112q0-34 17.5-62.5T184-378q62-31 126-46.5T440-440q20 0 40 1.5t40 4.5q-4 58 21 109.5t73 84.5v80H120ZM760-40l-60-60v-186q-44-13-72-49.5T600-420q0-58 41-99t99-41q58 0 99 41t41 99q0 45-25.5 80T790-290l50 50-60 60 60 60-80 80ZM440-480q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47Zm300 80q17 0 28.5-11.5T780-440q0-17-11.5-28.5T740-480q-17 0-28.5 11.5T700-440q0 17 11.5 28.5T740-400Z" />
+    </svg>
+  )
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1031,15 +1031,26 @@ main {
 /* Passkey sign-in on the login card: a quiet text-style alternative under the
    primary submit, only shown when the browser supports WebAuthn. */
 .login-passkey {
+  align-items: center;
   background: none;
   border: 0;
   color: var(--color-link);
   cursor: pointer;
+  display: inline-flex;
   font: inherit;
   font-size: 0.95rem;
+  gap: 0.45em;
+  justify-content: center;
   margin-top: 0.4rem;
   min-height: 44px;
   text-decoration: underline;
+}
+
+/* The passkey glyph next to the button label, scaled to the text. */
+.passkey-ico {
+  flex-shrink: 0;
+  height: 1.25em;
+  width: 1.25em;
 }
 
 /* Secondary action (cancel enrolment, disable 2FA): same shape as .primary-button


### PR DESCRIPTION
## What

Adds the recognizable passkey mark (person + key) as an **inline SVG** next to "Sign in with a passkey" on the login dialog, so the button matches the platform passkey prompts users already know. Visually verified in the browser (icon scales with the text and inherits the link color).

## Why Material Symbols and not the FIDO file

The FIDO Alliance distributes its icon only behind a [usage-agreement form](https://fidoalliance.org/get-the-passkey-icon/). Google's Material Symbols [`passkey` icon](https://fonts.google.com/icons?selected=Material+Symbols+Outlined:passkey:) is the license-clean (Apache-2.0) twin of the same mark — it's what Google's own passkey UX renders — so that's what ships, as a fill-based `PasskeyIcon` component beside the stroke-based icon shell.

LoginForm tests 8/8 green; typecheck + lint clean.