### PR TITLE
feat(auth): passkey autofill (Conditional UI) on the login page

### DIFF
--- a/frontend/src/components/LoginForm.test.tsx
+++ b/frontend/src/components/LoginForm.test.tsx
@@ -1,9 +1,31 @@
-import { fireEvent, render, waitFor } from '@solidjs/testing-library'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, waitFor } from '@solidjs/testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
+import { ApiError } from '../api/client'
 import type { LoginConfig } from '../loginConfig'
-import { LoginForm } from './LoginForm'
+
+// Passkeys (WebAuthn) — unsupported in jsdom, so the ceremonies are stubbed.
+// Defaults keep the passkey UI hidden and autofill inert, matching real jsdom,
+// so tests that don't opt in behave exactly as before.
+const passkeysSupported = vi.fn(() => false)
+const passkeyAutofillSupported = vi.fn(() => Promise.resolve(false))
+const loginWithPasskey = vi.fn<(...args: unknown[]) => Promise<string>>(() => Promise.resolve('/'))
+const loginWithPasskeyAutofill = vi.fn<(...args: unknown[]) => Promise<string>>(() => Promise.resolve('/'))
+const cancelPasskeyCeremony = vi.fn()
+
+vi.mock('../lib/passkeys', () => ({
+  passkeysSupported: () => passkeysSupported(),
+  passkeyAutofillSupported: () => passkeyAutofillSupported(),
+  loginWithPasskey: (...args: unknown[]) => loginWithPasskey(...args),
+  loginWithPasskeyAutofill: (...args: unknown[]) => loginWithPasskeyAutofill(...args),
+  cancelPasskeyCeremony: () => cancelPasskeyCeremony(),
+}))
+
+const { LoginForm } = await import('./LoginForm')
+
+// A microtask flush so an onMount async catch settles before an absence assert.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 const config: LoginConfig = {
   locale: 'en',
@@ -27,12 +49,119 @@ function mockFetchOnce(status: number, body: unknown) {
   return fetchMock
 }
 
+beforeEach(() => {
+  passkeysSupported.mockReset().mockReturnValue(false)
+  passkeyAutofillSupported.mockReset().mockResolvedValue(false)
+  loginWithPasskey.mockReset().mockResolvedValue('/')
+  loginWithPasskeyAutofill.mockReset().mockResolvedValue('/')
+  cancelPasskeyCeremony.mockReset()
+})
+
 afterEach(() => {
+  cleanup() // remove each render's DOM so landmarks (a11y) and state don't leak
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
 
 describe('LoginForm', () => {
+  it('marks the username field for passkey autofill (webauthn autocomplete token)', () => {
+    const { container, unmount } = render(() => <LoginForm config={config} />)
+
+    expect(container.querySelector('input[name="_username"]')).toHaveAttribute('autocomplete', 'username webauthn')
+
+    unmount()
+  })
+
+  it('starts conditional-UI passkey autofill on mount and redirects when one is chosen', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { ...window.location, assign })
+    passkeyAutofillSupported.mockResolvedValue(true)
+    loginWithPasskeyAutofill.mockResolvedValue('/ui/tracking')
+
+    const { unmount } = render(() => <LoginForm config={config} />)
+
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/ui/tracking'))
+
+    unmount()
+  })
+
+  it('leaves the password form usable when autofill is unsupported or unused', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { ...window.location, assign })
+    passkeyAutofillSupported.mockResolvedValue(false)
+
+    const { getByRole, unmount } = render(() => <LoginForm config={config} />)
+
+    await waitFor(() => expect(passkeyAutofillSupported).toHaveBeenCalled())
+    expect(loginWithPasskeyAutofill).not.toHaveBeenCalled()
+    expect(assign).not.toHaveBeenCalled()
+    expect(getByRole('button', { name: 'Sign in' })).toBeInTheDocument()
+
+    unmount()
+  })
+
+  it('surfaces an error when the server rejects a passkey the user selected (ApiError)', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+    loginWithPasskeyAutofill.mockRejectedValue(new ApiError(401, 'nope'))
+
+    const { getByRole, unmount } = render(() => <LoginForm config={config} />)
+
+    await waitFor(() => expect(getByRole('alert')).toBeInTheDocument())
+
+    unmount()
+  })
+
+  it('stays silent when the autofill ceremony is aborted or dismissed', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+    // A DOMException/AbortError from the ceremony — NOT an ApiError.
+    loginWithPasskeyAutofill.mockRejectedValue(new Error('The operation was aborted.'))
+
+    const { container, unmount } = render(() => <LoginForm config={config} />)
+
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+    await flush()
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+
+    unmount()
+  })
+
+  it('passes an abort signal to the autofill request so it can be torn down', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+
+    const { unmount } = render(() => <LoginForm config={config} />)
+
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+    expect(loginWithPasskeyAutofill).toHaveBeenCalledWith(expect.any(AbortSignal))
+
+    unmount()
+  })
+
+  it('tears down the autofill request when switching to the 2FA code step', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+    // Capture the signal handed to the autofill request so we can assert it aborts.
+    let signal: AbortSignal | undefined
+    loginWithPasskeyAutofill.mockImplementation((...args: unknown[]) => {
+      signal = args[0] as AbortSignal | undefined
+
+      return new Promise<string>(() => {}) // never resolves — a live conditional ceremony
+    })
+    const fetchMock = mockFetchOnce(200, { twoFactorRequired: true })
+
+    const { container, getByRole, unmount } = render(() => <LoginForm config={config} />)
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+    fireEvent.input(container.querySelector('input[name="_username"]')!, { target: { value: 'jane' } })
+    fireEvent.input(container.querySelector('input[name="_password"]')!, { target: { value: 'pw' } })
+    fireEvent.click(getByRole('button', { name: 'Sign in' }))
+
+    // Password accepted → 2FA phase → both teardown paths fire.
+    await waitFor(() => expect(getByRole('button', { name: 'Verify' })).toBeInTheDocument())
+    expect(cancelPasskeyCeremony).toHaveBeenCalled()
+    expect(signal?.aborted).toBe(true)
+    expect(fetchMock).toHaveBeenCalled()
+
+    unmount()
+  })
   it('renders the firewall field names and the #form-submit button', () => {
     const { container, getByRole, unmount } = render(() => <LoginForm config={config} />)
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,8 +1,9 @@
-import { createSignal, Show } from 'solid-js'
+import { createEffect, createSignal, onCleanup, onMount, Show } from 'solid-js'
 
+import { ApiError } from '../api/client'
 import type { LoginConfig } from '../loginConfig'
 import { PasskeyIcon } from '../lib/icons'
-import { loginWithPasskey, passkeysSupported } from '../lib/passkeys'
+import { cancelPasskeyCeremony, loginWithPasskey, loginWithPasskeyAutofill, passkeyAutofillSupported, passkeysSupported } from '../lib/passkeys'
 import { m } from '../paraglide/messages.js'
 
 /**
@@ -132,6 +133,52 @@ export function LoginForm(props: { config: LoginConfig }) {
     setError(null)
   }
 
+  // Conditional UI (passkey autofill): from page load, quietly ask the browser
+  // to offer the user's discoverable passkeys in the username field's autofill.
+  // It resolves to a redirect once the user picks one — no button, no modal
+  // until they engage. Ceremony rejections (unsupported, dismissed, or aborted
+  // by the explicit button starting its own) are intentionally silent; only a
+  // server rejection of a passkey the user actually selected surfaces an error.
+  // Owns the background autofill request so it can be torn down when the form
+  // leaves the credentials phase or unmounts.
+  const passkeyAutofill = new AbortController()
+
+  onMount(() => {
+    void (async () => {
+      try {
+        if (!(await passkeyAutofillSupported())) {
+          return
+        }
+        globalThis.location.assign(await loginWithPasskeyAutofill(passkeyAutofill.signal))
+      } catch (caught) {
+        // An ApiError means the ceremony produced an assertion but the server
+        // rejected it — worth telling the user. Everything else (abort, dismiss,
+        // unsupported, and the in-try support probe rejecting) stays silent so
+        // the password form is never disrupted.
+        if (caught instanceof ApiError) {
+          setError(m.login_passkey_error())
+        }
+      }
+    })()
+  })
+
+  // Tear the autofill request down completely: the AbortController stops it in
+  // the /login/options window (before any ceremony exists), and cancelCeremony
+  // aborts an already-started navigator.credentials.get(). A password submit is
+  // a plain fetch and aborts neither on its own, so do both when the form
+  // switches to the 2FA code step (else a late selection could redirect
+  // mid-2FA) and on unmount.
+  const teardownPasskeyAutofill = (): void => {
+    passkeyAutofill.abort()
+    cancelPasskeyCeremony()
+  }
+  createEffect(() => {
+    if (phase() === 'code') {
+      teardownPasskeyAutofill()
+    }
+  })
+  onCleanup(teardownPasskeyAutofill)
+
   return (
     <main class="login-page">
       <Show
@@ -195,7 +242,9 @@ export function LoginForm(props: { config: LoginConfig }) {
             <input
               type="text"
               name="_username"
-              autocomplete="username"
+              // The 'webauthn' token is what lets the browser surface passkeys
+              // in this field's autofill for the Conditional-UI login above.
+              autocomplete="username webauthn"
               autocapitalize="off"
               autocorrect="off"
               spellcheck={false}

--- a/frontend/src/lib/passkeys.test.ts
+++ b/frontend/src/lib/passkeys.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const startAuthentication = vi.fn()
+const startRegistration = vi.fn()
+const cancelCeremony = vi.fn()
+const getJson = vi.fn()
+const postJson = vi.fn()
+
+// Mock the browser WebAuthn primitives and the API client so the real
+// requestPasskeyLogin body runs — this is exactly the boundary LoginForm's
+// tests mock away, so the endpoint sequence + mediation branching is proven here.
+vi.mock('@simplewebauthn/browser', () => ({
+  browserSupportsWebAuthn: () => true,
+  browserSupportsWebAuthnAutofill: () => Promise.resolve(true),
+  startAuthentication: (...args: unknown[]) => startAuthentication(...args),
+  startRegistration: (...args: unknown[]) => startRegistration(...args),
+  WebAuthnAbortService: { cancelCeremony: () => cancelCeremony() },
+}))
+vi.mock('../api/client', () => ({
+  getJson: (...args: unknown[]) => getJson(...args),
+  postJson: (...args: unknown[]) => postJson(...args),
+}))
+
+const { loginWithPasskey, loginWithPasskeyAutofill, cancelPasskeyCeremony } = await import('./passkeys')
+
+describe('passkeys login', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('autofill login uses conditional mediation and posts options then the assertion', async () => {
+    postJson
+      .mockResolvedValueOnce({ challenge: 'c' })                 // /login/options
+      .mockResolvedValueOnce({ ok: true, redirect: '/ui/tracking' }) // /login/passkey
+    startAuthentication.mockResolvedValueOnce({ id: 'assertion' })
+
+    const redirect = await loginWithPasskeyAutofill()
+
+    expect(postJson).toHaveBeenNthCalledWith(1, '/login/options', {})
+    expect(startAuthentication).toHaveBeenCalledWith(expect.objectContaining({ useBrowserAutofill: true }))
+    expect(postJson).toHaveBeenNthCalledWith(2, '/login/passkey', { id: 'assertion' })
+    expect(redirect).toBe('/ui/tracking')
+  })
+
+  it('explicit login uses modal mediation (no autofill)', async () => {
+    postJson.mockResolvedValueOnce({}).mockResolvedValueOnce({ redirect: '/' })
+    startAuthentication.mockResolvedValueOnce({ id: 'x' })
+
+    await loginWithPasskey()
+
+    expect(startAuthentication).toHaveBeenCalledWith(expect.objectContaining({ useBrowserAutofill: false }))
+  })
+
+  it('falls back to / when the server sends no redirect', async () => {
+    postJson.mockResolvedValueOnce({}).mockResolvedValueOnce({ ok: true })
+    startAuthentication.mockResolvedValueOnce({ id: 'x' })
+
+    expect(await loginWithPasskeyAutofill()).toBe('/')
+  })
+
+  it('cancelPasskeyCeremony aborts the in-flight ceremony', () => {
+    cancelPasskeyCeremony()
+
+    expect(cancelCeremony).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects without any request when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(loginWithPasskeyAutofill(controller.signal)).rejects.toThrow()
+    expect(postJson).not.toHaveBeenCalled()
+    expect(startAuthentication).not.toHaveBeenCalled()
+  })
+
+  it('rejects after fetching options — before starting the ceremony — when the signal fires mid-flight', async () => {
+    const controller = new AbortController()
+    // The options fetch resolves, but the caller aborted while it was in flight.
+    postJson.mockImplementationOnce(() => {
+      controller.abort()
+
+      return Promise.resolve({ challenge: 'c' })
+    })
+
+    await expect(loginWithPasskeyAutofill(controller.signal)).rejects.toThrow()
+    expect(postJson).toHaveBeenCalledTimes(1) // options only; the assertion POST never runs
+    expect(startAuthentication).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/passkeys.ts
+++ b/frontend/src/lib/passkeys.ts
@@ -1,4 +1,4 @@
-import { browserSupportsWebAuthn, startAuthentication, startRegistration } from '@simplewebauthn/browser'
+import { browserSupportsWebAuthn, browserSupportsWebAuthnAutofill, startAuthentication, startRegistration, WebAuthnAbortService } from '@simplewebauthn/browser'
 import type { PublicKeyCredentialCreationOptionsJSON, PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/browser'
 
 import { getJson, postJson } from '../api/client'
@@ -27,13 +27,65 @@ export async function registerPasskey(): Promise<void> {
   await postJson('/settings/security/passkeys', attestation as unknown as Record<string, unknown>)
 }
 
-/** Discoverable ("usernameless") passkey login; resolves to the redirect target. */
-export async function loginWithPasskey(): Promise<string> {
+/** Whether the browser can surface passkeys inline via autofill (Conditional UI). */
+export const passkeyAutofillSupported = browserSupportsWebAuthnAutofill
+
+function abortedError(): DOMException {
+  return new DOMException('Passkey ceremony aborted.', 'AbortError')
+}
+
+/**
+ * Discoverable ("usernameless") passkey login. `useBrowserAutofill` picks the
+ * mediation: false = an immediate native modal (the explicit button); true =
+ * Conditional UI, which resolves only once the user selects a passkey from the
+ * username field's autofill. Both post the assertion to /login/passkey and
+ * resolve to the redirect target.
+ *
+ * `signal` closes the SPA race the background (autofill) caller has: the phase
+ * can switch or the form unmount DURING the /login/options fetch, before any
+ * WebAuthn ceremony exists for cancelPasskeyCeremony() to abort. Checking it
+ * around that await stops startAuthentication from firing a stray prompt after
+ * the caller has moved on.
+ */
+async function requestPasskeyLogin(useBrowserAutofill: boolean, signal?: AbortSignal): Promise<string> {
+  if (signal?.aborted) {
+    throw abortedError()
+  }
   const optionsJSON = await postJson<PublicKeyCredentialRequestOptionsJSON>('/login/options', {})
-  const assertion = await startAuthentication({ optionsJSON })
+  if (signal?.aborted) {
+    throw abortedError()
+  }
+  const assertion = await startAuthentication({ optionsJSON, useBrowserAutofill })
   const result = await postJson<{ ok?: boolean; redirect?: string }>('/login/passkey', assertion as unknown as Record<string, unknown>)
 
   return result.redirect ?? '/'
+}
+
+/** Explicit ("Sign in with a passkey" button) modal login. */
+export function loginWithPasskey(): Promise<string> {
+  return requestPasskeyLogin(false)
+}
+
+/**
+ * Conditional-UI ("autofill") passkey login, started in the background from
+ * page load. Resolves to a redirect once the user picks a passkey from the
+ * username field's autofill; rejects if aborted (via `signal` before the
+ * ceremony, or {@see cancelPasskeyCeremony} during it) or on error — callers
+ * stay quiet on the ceremony rejections and surface only a server rejection.
+ */
+export function loginWithPasskeyAutofill(signal?: AbortSignal): Promise<string> {
+  return requestPasskeyLogin(true, signal)
+}
+
+/**
+ * Cancel any in-flight passkey ceremony. The background autofill request must
+ * not outlive the login form's credentials phase — otherwise it could resolve
+ * and redirect the user mid-2FA. A NEW startAuthentication (the explicit button)
+ * already aborts a prior ceremony on its own; this is for the paths that don't
+ * start one (leaving the credentials phase, unmounting).
+ */
+export function cancelPasskeyCeremony(): void {
+  WebAuthnAbortService.cancelCeremony()
 }
 
 export async function listPasskeys(): Promise<Passkey[]> {


### PR DESCRIPTION
## What

A returning passkey user no longer has to click **"Sign in with a passkey"**. From page load, the browser silently offers their discoverable passkeys in the username field's autofill (Conditional UI); picking one signs them in. No modal until the user engages, the password field stays fully usable, and no client-side flag is needed — the platform already tracks the passkeys for this RP.

You chose this over an auto-popping modal for returning users: it's the Google/Apple-recommended pattern, the most reliable across browsers (Safari blocks modal-on-load), and it never traps someone who'd rather type a password.

## Scope: frontend only

The `/login/options` + `/login/passkey` endpoints already serve discoverable credentials and are `PUBLIC_ACCESS`, so conditional mediation reuses them unchanged — **no backend change**.

- **`passkeys.ts`** — `loginWithPasskey` (modal) and `loginWithPasskeyAutofill` (conditional) share `requestPasskeyLogin(useBrowserAutofill)`; `passkeyAutofillSupported` wraps `browserSupportsWebAuthnAutofill`; `cancelPasskeyCeremony` wraps the abort service.
- **`LoginForm.tsx`** — `autocomplete="username webauthn"` on the username field, and an `onMount` that starts the conditional request when supported.

## Correctness (a security-auditor pass drove these)

- **Ceremony lifecycle**: a password submit is a plain `fetch` and does **not** abort the pending conditional ceremony. So it's explicitly cancelled on the credentials→2FA phase switch and on unmount — otherwise a late passkey selection could resolve and `location.assign` **mid-2FA**. (@simplewebauthn's abort service is a singleton, so the explicit button already aborts it; only the fetch paths needed handling.)
- **Error feedback**: ceremony rejections (unsupported / dismissed / aborted by the explicit button) stay silent; only a **server rejection of a passkey the user actually selected** (`ApiError`) surfaces a message — so a real failure isn't invisible, while benign dismissals don't nag.
- The support probe sits inside the `try`, so a quirky `isConditionalMediationAvailable()` can't leak an unhandled rejection.

## Tests

- **`passkeys.test.ts`** (new) — mocks only `@simplewebauthn/browser` + the API client so the real `requestPasskeyLogin` runs: proves `useBrowserAutofill` branching (true for autofill, false for the button), the `/login/options`→`/login/passkey` sequence, the redirect fallback, and `cancelPasskeyCeremony`. This closes the gap where LoginForm's tests mock the whole passkeys module.
- **`LoginForm.tsx`** cases — autocomplete token; autofill starts on mount and redirects; unsupported → inert; **ApiError surfaces an alert**; **abort/dismiss stays silent**; **phase switch cancels** the ceremony.

Full frontend suite **393 green**; typecheck + lint clean. Verified live in a real browser: the conditional `POST /login/options` fires automatically on page load, both paths coexist, no console errors from the feature.

The actual passkey pick needs a real authenticator — please confirm in your browser once deployed.