### PR TITLE
test(e2e): stabilise the a11y scan against the sticky-header contrast flake

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -27,6 +27,21 @@ import { goToWorklogPage, goToAuswertungPage, goToAdminPage, hideDebugToolbar } 
  */
 async function expectNoSeriousA11y(page: Page, scopeSelector?: string): Promise<void> {
   await hideDebugToolbar(page).catch(() => undefined); // APP_ENV=test injects .sf-toolbar
+  // Stabilise the render before scanning. Two intermittent sources of a phantom
+  // colour-contrast failure on the worklog table's sticky header:
+  //   1. Web fonts still swapping — wait for document.fonts.ready.
+  //   2. The grid auto-focuses a row, which can scroll a body row UNDER the
+  //      position:sticky <th>; axe mis-samples an overlapping sticky element's
+  //      background (reporting a composite colour that isn't in the CSS), so
+  //      reset every scroll container (and the window) to the top, where the
+  //      header overlaps nothing.
+  // Then settle two animation frames so the scan sees a fully painted, stable DOM.
+  await page.evaluate(async () => {
+    await document.fonts?.ready; // no-op if the Font Loading API is absent
+    window.scrollTo(0, 0);
+    document.querySelectorAll('.table-scroll, .modal-page-body').forEach((el) => { el.scrollTop = 0; });
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+  });
   let builder = new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
     .exclude('.sf-toolbar');  // Symfony web debug toolbar — not shipped code


### PR DESCRIPTION
## The flake

The `/ui/tracking` axe check has intermittently failed on colour-contrast across several PRs (#523, #535…), reporting **foreground `#92969a` on background `#e9f3f5`** — colours that exist **nowhere** in the stylesheet.

## Why it's a false positive

The header's real tokens are `--color-text-muted` (`#50555b`) on `--color-accent-soft` (`#e0f0f2`) → **≈6:1, passes AA**. The reported values are a *composite*: axe mis-samples the background of a `position: sticky` `<th>` when a body row scrolls under it (the grid auto-focuses a row, which can scroll the container), and a mid-swap webfont can shift the sampled foreground. So the CSS is fine — the scan is unstable.

## Fix (test-only, no design change)

`expectNoSeriousA11y` now stabilises the render before scanning:
1. `await document.fonts.ready` — no mid-swap font.
2. Reset every `.table-scroll` / `.modal-page-body` container **and** the window to the top, so the sticky header overlaps no body row.
3. Settle two `requestAnimationFrame`s — a fully painted, stable DOM.

No fixed sleeps (per `e2e/AGENTS.md`) — `fonts.ready` and rAF are real settle signals.

## Honest verification note

The flake is **CI-environment-specific** (slower/contended) and **does not reproduce on my machine**: I ran the spec **12× without this change → 12/12 green**, so I cannot demonstrate a local before/after. This is therefore a **mechanism-targeted mitigation**, not a reproduced-and-fixed defect. It can only *add* scan stability (waits + scroll-to-top before axe) and is confirmed not to disturb the passing case (**9/9 local with the change**). The real proof is CI stability over subsequent runs.