### PR TITLE
perf(repository): cache the last-activity aggregate for the admin list endpoints

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,10 @@ services:
         public: false       # Allows optimizing the container by removing unused services
         bind:
             $projectDir: '%kernel.project_dir%'
+            # Shared cache pool for repositories that opt in (nullable — null in
+            # environments without a pool). Used by the last-activity aggregate
+            # cache (LastActivityTrait) on the customer/project/user repositories.
+            $cacheItemPool: '@?cache.app'
 
     # Makes classes in src/ available to be used as services
     # This creates a service per class whose id is the fully-qualified class name

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -12,6 +12,7 @@ namespace App\Repository;
 use App\Entity\Customer;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * @extends ServiceEntityRepository<Customer>
@@ -20,9 +21,10 @@ class CustomerRepository extends ServiceEntityRepository
 {
     use LastActivityTrait;
 
-    public function __construct(ManagerRegistry $managerRegistry)
+    public function __construct(ManagerRegistry $managerRegistry, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         parent::__construct($managerRegistry, Customer::class);
+        $this->lastActivityCache = $cacheItemPool;
     }
 
     /**

--- a/src/Repository/LastActivityTrait.php
+++ b/src/Repository/LastActivityTrait.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use InvalidArgumentException;
+use Psr\Cache\CacheItemPoolInterface;
 
 use function in_array;
 use function sprintf;
@@ -20,6 +21,21 @@ use function sprintf;
  */
 trait LastActivityTrait
 {
+    /**
+     * Cache pool for the last-activity maps, set from each repository's
+     * constructor (may be null in environments without a cache pool).
+     *
+     * The aggregate is a full index scan of the whole entries table — MariaDB
+     * won't apply a loose index scan to the MAX(), so on prod (~240k rows) it
+     * costs ~150 ms and runs on every /getAllProjects (incl. the tracking page),
+     * /getAllCustomers and /getAllUsers. The value is display-only "date of last
+     * booking", so a short TTL is a safe, large win: the query drops to ~0 on a
+     * hit and the map is at most LAST_ACTIVITY_TTL seconds stale.
+     */
+    private ?CacheItemPoolInterface $lastActivityCache = null;
+
+    private const int LAST_ACTIVITY_TTL = 300;
+
     /**
      * Map of the given entry FK value => the date (Y-m-d) of the most recent
      * entry that references it. Entities with no entries are absent from the map.
@@ -33,10 +49,25 @@ trait LastActivityTrait
             throw new InvalidArgumentException(sprintf('Unsupported activity column: %s', $column));
         }
 
+        $cacheItem = null;
+        if ($this->lastActivityCache instanceof CacheItemPoolInterface) {
+            $cacheItem = $this->lastActivityCache->getItem('last_activity_' . $column);
+            if ($cacheItem->isHit()) {
+                /** @var array<int, string> $cached */
+                $cached = $cacheItem->get();
+
+                return $cached;
+            }
+        }
+
         /** @var array<int, string> $result */
         $result = $this->getEntityManager()->getConnection()->fetchAllKeyValue(
             sprintf('SELECT %1$s, MAX(day) FROM entries WHERE %1$s IS NOT NULL GROUP BY %1$s', $column),
         );
+
+        if (null !== $cacheItem && $this->lastActivityCache instanceof CacheItemPoolInterface) {
+            $this->lastActivityCache->save($cacheItem->set($result)->expiresAfter(self::LAST_ACTIVITY_TTL));
+        }
 
         return $result;
     }

--- a/src/Repository/LastActivityTrait.php
+++ b/src/Repository/LastActivityTrait.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use InvalidArgumentException;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 use function in_array;
+use function is_array;
 use function sprintf;
 
 /**
@@ -32,7 +34,7 @@ trait LastActivityTrait
      * booking", so a short TTL is a safe, large win: the query drops to ~0 on a
      * hit and the map is at most LAST_ACTIVITY_TTL seconds stale.
      */
-    private ?CacheItemPoolInterface $lastActivityCache = null;
+    protected ?CacheItemPoolInterface $lastActivityCache = null;
 
     private const int LAST_ACTIVITY_TTL = 300;
 
@@ -53,10 +55,11 @@ trait LastActivityTrait
         if ($this->lastActivityCache instanceof CacheItemPoolInterface) {
             $cacheItem = $this->lastActivityCache->getItem('last_activity_' . $column);
             if ($cacheItem->isHit()) {
-                /** @var array<int, string> $cached */
                 $cached = $cacheItem->get();
-
-                return $cached;
+                if (is_array($cached)) {
+                    /** @var array<int, string> $cached */
+                    return $cached;
+                }
             }
         }
 
@@ -65,7 +68,7 @@ trait LastActivityTrait
             sprintf('SELECT %1$s, MAX(day) FROM entries WHERE %1$s IS NOT NULL GROUP BY %1$s', $column),
         );
 
-        if (null !== $cacheItem && $this->lastActivityCache instanceof CacheItemPoolInterface) {
+        if ($cacheItem instanceof CacheItemInterface && $this->lastActivityCache instanceof CacheItemPoolInterface) {
             $this->lastActivityCache->save($cacheItem->set($result)->expiresAfter(self::LAST_ACTIVITY_TTL));
         }
 

--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -12,6 +12,7 @@ namespace App\Repository;
 use App\Entity\Project;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Cache\CacheItemPoolInterface;
 
 use function assert;
 use function count;
@@ -24,9 +25,10 @@ class ProjectRepository extends ServiceEntityRepository
 {
     use LastActivityTrait;
 
-    public function __construct(ManagerRegistry $managerRegistry)
+    public function __construct(ManagerRegistry $managerRegistry, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         parent::__construct($managerRegistry, Project::class);
+        $this->lastActivityCache = $cacheItemPool;
     }
 
     /**

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -13,6 +13,7 @@ use App\Entity\User;
 use App\Entity\WebauthnCredential;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Cache\CacheItemPoolInterface;
 
 use function assert;
 
@@ -25,9 +26,10 @@ class UserRepository extends ServiceEntityRepository
 {
     use LastActivityTrait;
 
-    public function __construct(ManagerRegistry $managerRegistry)
+    public function __construct(ManagerRegistry $managerRegistry, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         parent::__construct($managerRegistry, User::class);
+        $this->lastActivityCache = $cacheItemPool;
     }
 
     /**

--- a/tests/Repository/LastActivityCacheWiringTest.php
+++ b/tests/Repository/LastActivityCacheWiringTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Repository\CustomerRepository;
+use App\Repository\ProjectRepository;
+use App\Repository\UserRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Cache\CacheItemPoolInterface;
+use ReflectionProperty;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Guards the DI wiring, not the logic: the $cacheItemPool bind must actually
+ * inject a pool into the list repositories. A silent null (mis-bound arg) would
+ * make LastActivityTrait's cache a no-op and the aggregate would run on every
+ * request again — invisibly.
+ *
+ * @internal
+ */
+final class LastActivityCacheWiringTest extends KernelTestCase
+{
+    protected function tearDown(): void
+    {
+        // Symfony's kernel registers an exception handler during boot; restore it
+        // so PHPUnit doesn't flag the test as risky.
+        restore_exception_handler();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param class-string $repositoryClass
+     */
+    #[DataProvider('listRepositories')]
+    public function testTheListRepositoryReceivesACachePool(string $repositoryClass): void
+    {
+        self::bootKernel();
+
+        $repository = self::getContainer()->get($repositoryClass);
+
+        $cache = new ReflectionProperty($repositoryClass, 'lastActivityCache')->getValue($repository);
+        self::assertInstanceOf(
+            CacheItemPoolInterface::class,
+            $cache,
+            $repositoryClass . ' must receive a cache pool (the $cacheItemPool bind), not null.',
+        );
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function listRepositories(): iterable
+    {
+        yield 'customers' => [CustomerRepository::class];
+        yield 'projects' => [ProjectRepository::class];
+        yield 'users' => [UserRepository::class];
+    }
+}

--- a/tests/Repository/LastActivityDouble.php
+++ b/tests/Repository/LastActivityDouble.php
@@ -11,6 +11,7 @@ namespace Tests\Repository;
 
 use App\Repository\LastActivityTrait;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Concrete user of LastActivityTrait so its public method can be unit-tested (and
@@ -20,8 +21,9 @@ final class LastActivityDouble
 {
     use LastActivityTrait;
 
-    public function __construct(private readonly EntityManagerInterface $entityManager)
+    public function __construct(private readonly EntityManagerInterface $entityManager, ?CacheItemPoolInterface $cacheItemPool = null)
     {
+        $this->lastActivityCache = $cacheItemPool;
     }
 
     public function getEntityManager(): EntityManagerInterface

--- a/tests/Repository/LastActivityTraitTest.php
+++ b/tests/Repository/LastActivityTraitTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * @internal
@@ -44,5 +45,38 @@ final class LastActivityTraitTest extends TestCase
             [1 => '2026-06-24', 2 => '2025-01-01'],
             new LastActivityDouble($entityManager)->lastActivityBy('customer_id'),
         );
+    }
+
+    public function testCachesTheAggregateSoASecondCallDoesNotRequeryTheEntriesTable(): void
+    {
+        $connection = self::createMock(Connection::class);
+        // The full-table GROUP BY MAX(day) must run ONCE across two calls.
+        $connection->expects(self::once())
+            ->method('fetchAllKeyValue')
+            ->willReturn([1 => '2026-07-01']);
+
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $repository = new LastActivityDouble($entityManager, new ArrayAdapter());
+
+        self::assertSame([1 => '2026-07-01'], $repository->lastActivityBy('project_id'));
+        self::assertSame([1 => '2026-07-01'], $repository->lastActivityBy('project_id'));
+    }
+
+    public function testDifferentColumnsDoNotShareACacheEntry(): void
+    {
+        $connection = self::createMock(Connection::class);
+        // Distinct columns → distinct cache keys → one query each, no collision.
+        $connection->expects(self::exactly(2))
+            ->method('fetchAllKeyValue')
+            ->willReturn([1 => '2026-07-01']);
+
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $repository = new LastActivityDouble($entityManager, new ArrayAdapter());
+        $repository->lastActivityBy('project_id');
+        $repository->lastActivityBy('customer_id');
     }
 }


### PR DESCRIPTION
## Problem

`/getAllProjects` (also the **tracking page's** project-dropdown source), `/getAllCustomers` and `/getAllUsers` each call `LastActivityTrait::lastActivityBy()` — a `GROUP BY MAX(day)` over the entire `entries` table.

Measured on prod: `entries` ≈ **239k rows**, and MariaDB **won't apply a loose index scan** to the `MAX()` (confirmed via `EXPLAIN`: `Using index`, not `Using index for group-by`; same for `MIN`, and a derived-table rewrite was no faster). So it full-scans the `(col, day)` index every request — **~150 ms**. That's exactly why those three endpoints sat at **~220–260 ms** in the network trace while everything else was ~80 ms.

## Fix

The value is display-only "date of last booking", so cache the map in the app cache pool (APCu) with a **300 s TTL**. On a hit the aggregate drops to **~0** — for all three endpoints (and the tracking-page `getAllProjects`) at once — with at most 5 minutes of staleness, which is invisible for this column.

- `cache.app` is wired into the three list repositories via a nullable `$cacheItemPool` bind (`@?cache.app`, null-safe where no pool exists).
- No frontend change, no schema change, no correctness risk.

## Tests

- `LastActivityTraitTest`: the aggregate runs **once** across two calls (cache hit), and distinct columns don't share a key.
- **`LastActivityCacheWiringTest`** (new, kernel-boot): asserts each repository is actually handed a `CacheItemPoolInterface`, guarding against a silent `null` bind that would make the cache inert.

`composer test` (touched), `analyze` (PHPStan L10), `cs-check`, and `lint:container` all green locally.

## Follow-up (separate PR)

The bigger win — the tracking page over-fetches **1062 projects to show ~94 active** (inactive filtered client-side) — is a correctness-sensitive change (866 inactive projects are still referenced by historical entries) and will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)