### PR TITLE
fix(tracking): stop the kebab action menu being clipped by the table scroll

### DIFF
--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -947,6 +947,24 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('closes the kebab menu on scroll (the fixed popup must not strand from its button)', async () => {
+    mockTracking({
+      entries: [{ entry: { ...DEFAULT_ENTRY, id: 1, date: '16/06/2026', ticket: 'ABC-1', customer: 1, project: 4 } }],
+    })
+    const { container, getByRole, unmount } = renderTracking()
+    await waitFor(() => expect(container.querySelector('.action-menu')).toBeInTheDocument())
+
+    fireEvent.click(getByRole('button', { name: 'Row actions' }))
+    await waitFor(() => expect(container.querySelector('.action-menu-pop')).toBeInTheDocument())
+
+    // The popup is position:fixed; a scroll would leave it stranded away from its
+    // button, so a captured scroll (table or page) dismisses it.
+    fireEvent.scroll(window)
+    await waitFor(() => expect(container.querySelector('.action-menu-pop')).not.toBeInTheDocument())
+
+    unmount()
+  })
+
   it('gives the kebab hover menu a close grace period (survives a brief pointer exit)', async () => {
     mockTracking({
       entries: [{ entry: { ...DEFAULT_ENTRY, id: 1, date: '16/06/2026', ticket: 'ABC-1', customer: 1, project: 4 } }],

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -234,6 +234,25 @@ export default function Tracking() {
     actionsMenuCloseTimer = setTimeout(() => { if (actionsMenuRow() === id) { setActionsMenuRow(null) } }, 150)
   }
   onCleanup(cancelActionsMenuClose)
+  // The popup is position:fixed (to escape the table's overflow clipping), so its
+  // viewport coordinates are set here from the kebab's rect when it mounts. The
+  // kebab button is the popup's sibling inside .action-menu. Right-aligned to the
+  // button and opened below it, flipping above when it would overflow the viewport
+  // bottom; clamped horizontally so it never leaves the viewport.
+  const positionActionsMenu = (popup: HTMLElement): void => {
+    const button = popup.parentElement?.querySelector('button')
+    if (!button) {
+      return
+    }
+    const anchor = button.getBoundingClientRect()
+    const menu = popup.getBoundingClientRect()
+    const gap = 2
+    const left = Math.max(4, Math.min(anchor.right - menu.width, window.innerWidth - menu.width - 4))
+    const below = anchor.bottom + gap
+    const flipUp = below + menu.height > window.innerHeight && anchor.top - menu.height - gap >= 0
+    popup.style.left = `${left}px`
+    popup.style.top = `${flipUp ? anchor.top - menu.height - gap : below}px`
+  }
   onMount(() => {
     const onDocPointer = (event: PointerEvent): void => {
       if (daysComboRef !== undefined && !daysComboRef.contains(event.target as Node)) {
@@ -248,6 +267,16 @@ export default function Tracking() {
     }
     document.addEventListener('pointerdown', onDocPointer)
     onCleanup(() => document.removeEventListener('pointerdown', onDocPointer))
+    // The kebab popup is position:fixed, so a scroll (of the table or the page)
+    // or a resize would leave it stranded away from its button — close it instead.
+    // Capture phase so a scroll on the inner .table-scroll container is caught too.
+    const onViewportShift = (): void => { if (actionsMenuRow() !== null) { closeActionsMenu() } }
+    window.addEventListener('scroll', onViewportShift, { capture: true, passive: true })
+    window.addEventListener('resize', onViewportShift, { passive: true })
+    onCleanup(() => {
+      window.removeEventListener('scroll', onViewportShift, { capture: true })
+      window.removeEventListener('resize', onViewportShift)
+    })
   })
   const entries = useQuery(() => trackingEntriesQuery(days()))
   const customers = useQuery(trackingCustomersQuery)
@@ -1196,7 +1225,7 @@ export default function Tracking() {
                               <KebabIcon />
                             </button>
                             <Show when={actionsMenuRow() === id}>
-                              <div class="action-menu-pop" role="menu">
+                              <div class="action-menu-pop" role="menu" ref={positionActionsMenu}>
                                 <Show when={id > 0}>
                                   <button type="button" role="menuitem" onClick={() => { closeActionsMenu(); continueEntry(entry) }}><ContinueIcon /> {m.tracking_continue()}</button>
                                   <Show when={isLatestEntry(entry)}>

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -240,7 +240,10 @@ export default function Tracking() {
   // button and opened below it, flipping above when it would overflow the viewport
   // bottom; clamped horizontally so it never leaves the viewport.
   const positionActionsMenu = (popup: HTMLElement): void => {
-    const button = popup.parentElement?.querySelector('button')
+    // The kebab is the .action-menu's own trigger (aria-haspopup=menu) — target it
+    // explicitly, not the first descendant button, which would also match the
+    // menuitem buttons inside this very popup.
+    const button = popup.parentElement?.querySelector('[aria-haspopup="menu"]')
     if (!button) {
       return
     }
@@ -253,6 +256,21 @@ export default function Tracking() {
     popup.style.left = `${left}px`
     popup.style.top = `${flipUp ? anchor.top - menu.height - gap : below}px`
   }
+  // The fixed popup would strand from its button on scroll/resize; attach a dismiss
+  // handler only while a menu is open, rather than a permanent global listener.
+  createEffect(() => {
+    if (actionsMenuRow() === null) {
+      return
+    }
+    const dismiss = (): void => closeActionsMenu()
+    // Capture phase so a scroll on the inner .table-scroll container is caught too.
+    window.addEventListener('scroll', dismiss, { capture: true, passive: true })
+    window.addEventListener('resize', dismiss, { passive: true })
+    onCleanup(() => {
+      window.removeEventListener('scroll', dismiss, { capture: true })
+      window.removeEventListener('resize', dismiss)
+    })
+  })
   onMount(() => {
     const onDocPointer = (event: PointerEvent): void => {
       if (daysComboRef !== undefined && !daysComboRef.contains(event.target as Node)) {
@@ -267,16 +285,6 @@ export default function Tracking() {
     }
     document.addEventListener('pointerdown', onDocPointer)
     onCleanup(() => document.removeEventListener('pointerdown', onDocPointer))
-    // The kebab popup is position:fixed, so a scroll (of the table or the page)
-    // or a resize would leave it stranded away from its button — close it instead.
-    // Capture phase so a scroll on the inner .table-scroll container is caught too.
-    const onViewportShift = (): void => { if (actionsMenuRow() !== null) { closeActionsMenu() } }
-    window.addEventListener('scroll', onViewportShift, { capture: true, passive: true })
-    window.addEventListener('resize', onViewportShift, { passive: true })
-    onCleanup(() => {
-      window.removeEventListener('scroll', onViewportShift, { capture: true })
-      window.removeEventListener('resize', onViewportShift)
-    })
   })
   const entries = useQuery(() => trackingEntriesQuery(days()))
   const customers = useQuery(trackingCustomersQuery)

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1585,9 +1585,13 @@ kbd {
 }
 
 .action-menu-pop {
-  position: absolute;
-  top: calc(100% + 2px);
-  right: 0;
+  /* position:fixed so the menu escapes the .table-scroll overflow — an absolute
+     popup was clipped by the scroll container (overflow-x:auto forces overflow-y
+     to auto) and spawned a table scrollbar. top/left are set from the kebab's
+     rect in JS (positionActionsMenu), which also flips it above when it would
+     overflow the viewport bottom. Stays a DOM child of .action-menu so the hover
+     model and click-outside detection are unchanged. */
+  position: fixed;
   z-index: 30;
   min-width: 11em;
   padding: 4px;


### PR DESCRIPTION
## Bug

The worklog row-actions (kebab) popup was clipped and forced a table scrollbar when opened on a row near the bottom — 'Fortsetzen'/'Info' cut off (per screenshot).

## Cause

`.action-menu-pop` was `position: absolute` inside `.table-scroll`. That container has `overflow-x: auto`, which per CSS forces `overflow-y` to `auto` too — so the absolute popup was clipped by the scroll box and its overflow spawned a scrollbar.

## Fix

`.action-menu-pop` → `position: fixed` (escapes ancestor `overflow` clipping), with coordinates set from the kebab button's rect in JS: right-aligned, below the button, **flipping above** when it would overflow the viewport bottom, clamped horizontally. It stays a DOM child of `.action-menu`, so the hover model and click-outside are unchanged — verified no transformed ancestor traps `fixed` on the table chain. Because a fixed popup would strand from its button on scroll, a captured **scroll/resize dismisses it**.

## Tests

New 'closes the kebab menu on scroll' regression; 44 Tracking tests pass, typecheck + lint clean. (The pixel positioning can't be asserted in jsdom — zero rects — so the visual result is best confirmed on the built app.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)