### PR TITLE
test(e2e): stabilise the a11y scan against the sticky-header contrast flake

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -44,7 +44,9 @@ async function expectNoSeriousA11y(page: Page, scopeSelector?: string): Promise<
     // a phantom colour-contrast failure. Blur that focus, let any pending
     // scroll-into-view run, THEN reset every scroll container to the top as the LAST
     // action before the scan, so no row sits under the sticky header when axe samples.
-    (document.activeElement as HTMLElement | null)?.blur();
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
     window.scrollTo(0, 0);
     document.querySelectorAll('.table-scroll, .modal-page-body').forEach((el) => { el.scrollTop = 0; });

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -38,6 +38,14 @@ async function expectNoSeriousA11y(page: Page, scopeSelector?: string): Promise<
   // Then settle two animation frames so the scan sees a fully painted, stable DOM.
   await page.evaluate(async () => {
     await document.fonts?.ready; // no-op if the Font Loading API is absent
+    // The worklog grid auto-focuses a row on load, whose scroll-into-view can push
+    // a body row UNDER the position:sticky <th> even after an initial scroll reset —
+    // axe then composites the header colour with the row peeking beneath and reports
+    // a phantom colour-contrast failure. Blur that focus, let any pending
+    // scroll-into-view run, THEN reset every scroll container to the top as the LAST
+    // action before the scan, so no row sits under the sticky header when axe samples.
+    (document.activeElement as HTMLElement | null)?.blur();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
     window.scrollTo(0, 0);
     document.querySelectorAll('.table-scroll, .modal-page-body').forEach((el) => { el.scrollTop = 0; });
     await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));


### PR DESCRIPTION
The `/ui/tracking` color-contrast a11y check flakes intermittently and has blocked merges repeatedly (#537, #540, #542). 

**Cause:** the worklog grid auto-focuses a row on load; its scroll-into-view pushes a body row under the `position: sticky` `<th>` *after* the existing scroll reset (#536), and axe composites the header colour with the row peeking beneath (`#92969a` on `#e9f3f5` — neither a real token) → phantom `color-contrast` failure.

**Fix:** blur the auto-focused row so it can't scroll-into-view, settle a frame, then reset every scroll container to the top **as the last action** before the scan — so no row is under the sticky header when axe samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)