### PR TITLE
fix(auth): add passkey autofill (conditional UI) to the re-login overlay

### DIFF
--- a/frontend/src/components/SessionExpiredOverlay.test.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.test.tsx
@@ -21,10 +21,13 @@ vi.mock('../lib/passkeys', () => ({
 const { SessionExpiredOverlay } = await import('./SessionExpiredOverlay')
 
 beforeEach(() => {
-  passkeysSupported.mockReturnValue(false)
-  passkeyAutofillSupported.mockResolvedValue(false)
-  loginWithPasskey.mockResolvedValue('/')
-  loginWithPasskeyAutofill.mockResolvedValue('/')
+  // Reset call history too (the overlay calls cancelPasskeyCeremony on every
+  // teardown, so counts would accumulate across tests otherwise).
+  passkeysSupported.mockReset().mockReturnValue(false)
+  passkeyAutofillSupported.mockReset().mockResolvedValue(false)
+  loginWithPasskey.mockReset().mockResolvedValue('/')
+  loginWithPasskeyAutofill.mockReset().mockResolvedValue('/')
+  cancelPasskeyCeremony.mockClear()
 })
 
 afterEach(() => {
@@ -191,6 +194,31 @@ describe('SessionExpiredOverlay', () => {
 
     await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
     unmount()
+    expect(cancelPasskeyCeremony).toHaveBeenCalled()
+  })
+
+  it('passes an AbortSignal to the autofill ceremony so it can be aborted', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+    loginWithPasskeyAutofill.mockReturnValue(new Promise<string>(() => {}))
+    render(() => <SessionExpiredOverlay onSuccess={vi.fn()} />)
+
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+    expect(loginWithPasskeyAutofill.mock.calls[0]![0]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('tears down the autofill when switching to the 2FA code step', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+    loginWithPasskeyAutofill.mockReturnValue(new Promise<string>(() => {}))
+    mockTwoFactorFetch(true) // password accepted → 2FA required
+    render(() => <SessionExpiredOverlay onSuccess={vi.fn()} />)
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+
+    fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'ldap-pass' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    // Entering the code phase must abort the pending autofill (cancelCeremony),
+    // so a late passkey pick can't resume the session mid-2FA.
+    await waitFor(() => expect(screen.getByLabelText('Verification code')).toBeInTheDocument())
     expect(cancelPasskeyCeremony).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/SessionExpiredOverlay.test.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.test.tsx
@@ -5,18 +5,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // exercised. The default keeps the button hidden (passkeysSupported → false),
 // matching real jsdom, so the password/2FA tests behave exactly as before.
 const passkeysSupported = vi.fn(() => false)
+const passkeyAutofillSupported = vi.fn(() => Promise.resolve(false))
 const loginWithPasskey = vi.fn<(...args: unknown[]) => Promise<string>>(() => Promise.resolve('/'))
+const loginWithPasskeyAutofill = vi.fn<(...args: unknown[]) => Promise<string>>(() => Promise.resolve('/'))
+const cancelPasskeyCeremony = vi.fn()
 
 vi.mock('../lib/passkeys', () => ({
   passkeysSupported: () => passkeysSupported(),
+  passkeyAutofillSupported: () => passkeyAutofillSupported(),
   loginWithPasskey: (...args: unknown[]) => loginWithPasskey(...args),
+  loginWithPasskeyAutofill: (...args: unknown[]) => loginWithPasskeyAutofill(...args),
+  cancelPasskeyCeremony: () => cancelPasskeyCeremony(),
 }))
 
 const { SessionExpiredOverlay } = await import('./SessionExpiredOverlay')
 
 beforeEach(() => {
   passkeysSupported.mockReturnValue(false)
+  passkeyAutofillSupported.mockResolvedValue(false)
   loginWithPasskey.mockResolvedValue('/')
+  loginWithPasskeyAutofill.mockResolvedValue('/')
 })
 
 afterEach(() => {
@@ -163,5 +171,26 @@ describe('SessionExpiredOverlay', () => {
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
     expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('starts passkey autofill (conditional UI) on mount and resumes in place when one is picked', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+    loginWithPasskeyAutofill.mockResolvedValue('/ui/tracking')
+    const onSuccess = vi.fn()
+    render(() => <SessionExpiredOverlay onSuccess={onSuccess} />)
+
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
+  })
+
+  it('tears down the passkey autofill ceremony on unmount', async () => {
+    passkeyAutofillSupported.mockResolvedValue(true)
+    // Never resolves — the background ceremony stays pending until torn down.
+    loginWithPasskeyAutofill.mockReturnValue(new Promise<string>(() => {}))
+    const { unmount } = render(() => <SessionExpiredOverlay onSuccess={vi.fn()} />)
+
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+    unmount()
+    expect(cancelPasskeyCeremony).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/SessionExpiredOverlay.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@ark-ui/solid/dialog'
-import { createEffect, createSignal, onCleanup, onMount, Show } from 'solid-js'
+import { createEffect, createSignal, onCleanup, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
 import { ApiError } from '../api/client'
@@ -146,15 +146,21 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
     setError(null)
   }
 
-  // Conditional UI (passkey autofill), same as LoginForm: from mount, quietly ask
-  // the browser to surface the user's discoverable passkeys inline in the username
-  // field's autofill (the 'webauthn' token below is what enables it). It resolves
-  // once the user picks one — then resume in place (onSuccess) instead of
-  // navigating. Ceremony rejections (unsupported, dismissed, or aborted when the
-  // explicit button / 2FA step takes over) are silent; only a server rejection of a
-  // passkey the user actually selected surfaces an error.
-  const passkeyAutofill = new AbortController()
-  onMount(() => {
+  // Conditional UI (passkey autofill), same as LoginForm but keyed on the
+  // credentials phase so it (re)starts on mount AND when returning from the 2FA
+  // step, with a FRESH AbortController each time (an aborted one can't be reused).
+  // The 'webauthn' token on the username field enables the inline surfacing; a
+  // picked passkey resumes in place (onSuccess) instead of navigating. Leaving the
+  // phase (→ 2FA) or unmounting tears it down — abort stops it in the
+  // /login/options window, cancelPasskeyCeremony aborts a started
+  // navigator.credentials.get() — so a late pick can't resume mid-2FA or after the
+  // overlay closes. Ceremony rejections (unsupported, dismissed, aborted) are
+  // silent; only a server rejection of a selected passkey surfaces an error.
+  createEffect(() => {
+    if (phase() !== 'credentials') {
+      return
+    }
+    const passkeyAutofill = new AbortController()
     void (async () => {
       try {
         if (!(await passkeyAutofillSupported())) {
@@ -168,22 +174,11 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
         }
       }
     })()
+    onCleanup(() => {
+      passkeyAutofill.abort()
+      cancelPasskeyCeremony()
+    })
   })
-  // Tear the autofill down completely: the AbortController stops it in the
-  // /login/options window (before any ceremony exists), and cancelPasskeyCeremony
-  // aborts an already-started navigator.credentials.get(). Do both when the form
-  // switches to the 2FA code step (else a late passkey pick could resume mid-2FA)
-  // and on unmount.
-  const teardownPasskeyAutofill = (): void => {
-    passkeyAutofill.abort()
-    cancelPasskeyCeremony()
-  }
-  createEffect(() => {
-    if (phase() === 'code') {
-      teardownPasskeyAutofill()
-    }
-  })
-  onCleanup(teardownPasskeyAutofill)
 
   return (
     // modal (default) inerts the page below (readable but non-interactive for AT);

--- a/frontend/src/components/SessionExpiredOverlay.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.tsx
@@ -1,10 +1,11 @@
 import { Dialog } from '@ark-ui/solid/dialog'
-import { createSignal, Show } from 'solid-js'
+import { createEffect, createSignal, onCleanup, onMount, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
+import { ApiError } from '../api/client'
 import { appConfig } from '../config'
 import { PasskeyIcon } from '../lib/icons'
-import { loginWithPasskey, passkeysSupported } from '../lib/passkeys'
+import { cancelPasskeyCeremony, loginWithPasskey, loginWithPasskeyAutofill, passkeyAutofillSupported, passkeysSupported } from '../lib/passkeys'
 import { m } from '../paraglide/messages.js'
 
 // The firewall-intercepted 2FA code path. APP_CONFIG (unlike LOGIN_CONFIG) does
@@ -145,6 +146,45 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
     setError(null)
   }
 
+  // Conditional UI (passkey autofill), same as LoginForm: from mount, quietly ask
+  // the browser to surface the user's discoverable passkeys inline in the username
+  // field's autofill (the 'webauthn' token below is what enables it). It resolves
+  // once the user picks one — then resume in place (onSuccess) instead of
+  // navigating. Ceremony rejections (unsupported, dismissed, or aborted when the
+  // explicit button / 2FA step takes over) are silent; only a server rejection of a
+  // passkey the user actually selected surfaces an error.
+  const passkeyAutofill = new AbortController()
+  onMount(() => {
+    void (async () => {
+      try {
+        if (!(await passkeyAutofillSupported())) {
+          return
+        }
+        await loginWithPasskeyAutofill(passkeyAutofill.signal)
+        props.onSuccess()
+      } catch (caught) {
+        if (caught instanceof ApiError) {
+          setError(m.login_passkey_error())
+        }
+      }
+    })()
+  })
+  // Tear the autofill down completely: the AbortController stops it in the
+  // /login/options window (before any ceremony exists), and cancelPasskeyCeremony
+  // aborts an already-started navigator.credentials.get(). Do both when the form
+  // switches to the 2FA code step (else a late passkey pick could resume mid-2FA)
+  // and on unmount.
+  const teardownPasskeyAutofill = (): void => {
+    passkeyAutofill.abort()
+    cancelPasskeyCeremony()
+  }
+  createEffect(() => {
+    if (phase() === 'code') {
+      teardownPasskeyAutofill()
+    }
+  })
+  onCleanup(teardownPasskeyAutofill)
+
   return (
     // modal (default) inerts the page below (readable but non-interactive for AT);
     // non-dismissible (no Esc / outside-click close) — only a successful re-login
@@ -201,10 +241,10 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
                   <input
                     type="text"
                     name="_username"
-                    // No 'webauthn' token: it only surfaces passkeys with an active
-                    // conditional-mediation request, which this overlay does not
-                    // start — it offers the explicit passkey button below instead.
-                    autocomplete="username"
+                    // 'webauthn' surfaces the user's passkeys inline in this field's
+                    // autofill — backed by the conditional-mediation ceremony started
+                    // on mount above (matching the /login form).
+                    autocomplete="username webauthn"
                     autocapitalize="off"
                     autocorrect="off"
                     spellcheck={false}


### PR DESCRIPTION
## Bug

The session-expired re-login overlay showed the user's passkey as a plain credential in the browser autofill, **not** under a dedicated "Passkeys" section like the real `/login` form does (screenshots).

## Cause

The two surfaces used different passkey mechanisms: `LoginForm` runs **Conditional UI / WebAuthn autofill** (`autocomplete="username webauthn"` + a background `loginWithPasskeyAutofill()` ceremony on mount), which is what makes the browser surface passkeys inline. The overlay had only the **explicit** "Sign in with a passkey" button — #538 removed its `webauthn` token because, without the background ceremony, it was dead.

## Fix

Add the ceremony to the overlay, mirroring `LoginForm`:
- start `loginWithPasskeyAutofill(signal)` on mount (AbortController), re-enable `autocomplete="username webauthn"`;
- on a picked passkey, **resume in place** (`onSuccess`) instead of navigating;
- tear down (abort + `cancelPasskeyCeremony`) when switching to the 2FA step and on unmount, so a late selection can't resume mid-2FA or after the overlay closes.

## Tests

New: autofill starts on mount and resumes on a pick; unmount tears the ceremony down. 10 overlay tests pass, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)