### PR TITLE
fix(tracking): keep the row-actions kebab popup inside the viewport

### DIFF
--- a/e2e/worklog.spec.ts
+++ b/e2e/worklog.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from './helpers/auth';
+import { login, TEST_USERS } from './helpers/auth';
 import { goToWorklogPage } from './helpers/navigation';
 
 /**
@@ -7,13 +7,49 @@ import { goToWorklogPage } from './helpers/navigation';
  * /ui/tracking.
  */
 test.describe('Worklog grid', () => {
-  test.beforeEach(async ({ page }) => {
-    await login(page);
-  });
-
   test('the Worklog header link opens the SolidJS grid', async ({ page }) => {
+    await login(page);
     await goToWorklogPage(page);
     // The grid exposes the WAI-ARIA grid role (use:gridNav).
     await expect(page.locator('table.tracking-table[role="grid"]')).toBeVisible();
+  });
+
+  test('the row-actions kebab popup stays inside the viewport', async ({ page }) => {
+    // The default `developer` user has no entries in the frozen 3-day window; only
+    // `i.myself` seeds rows on 2024-01-15, so sign in as that user to get a row (and
+    // therefore a kebab) to click.
+    await login(page, TEST_USERS.myself.username, TEST_USERS.myself.password);
+    // Navigate at the default width (the header nav collapses on narrow viewports),
+    // then shrink so the per-row action icons collapse into the kebab menu
+    // (.is-thin-2+). This is exactly the case where the popup used to open off the
+    // right edge — it was measured before layout (width 0) so the horizontal clamp
+    // couldn't work. position:fixed + a next-frame measure keeps it inside.
+    await goToWorklogPage(page);
+    await expect(page.locator('table.tracking-table[role="grid"]')).toBeVisible();
+    // Guard against an empty grid (no rows → no kebab): i.myself has seed rows here.
+    await expect(page.locator('table.tracking-table tbody tr').first()).toBeVisible();
+    await page.setViewportSize({ width: 420, height: 760 });
+
+    const kebab = page.locator('.action-menu button[aria-haspopup="menu"]').first();
+    await kebab.waitFor();
+    // The kebab is the last column of a horizontally-scrollable table at this width;
+    // bring it in first so the hover lands on it.
+    await kebab.scrollIntoViewIfNeeded();
+    // Hover, not click: with a mouse pointer the menu opens on pointerenter (the
+    // button's click merely toggles, so a click after the hover-open would close it).
+    await kebab.hover();
+    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
+
+    const pop = page.locator('.action-menu-pop');
+    await expect(pop).toBeVisible();
+
+    const box = await pop.boundingBox();
+    const viewport = page.viewportSize()!;
+    expect(box).not.toBeNull();
+    // Fully within the viewport on every edge (±1px for sub-pixel rounding).
+    expect(box!.x).toBeGreaterThanOrEqual(-1);
+    expect(box!.y).toBeGreaterThanOrEqual(-1);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport.width + 1);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height + 1);
   });
 });

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -924,7 +924,9 @@ describe('Tracking (Worklog grid)', () => {
     expect(menu.querySelectorAll("[role='menuitem']").length).toBe(4)
 
     // Choosing Continue clones the row (same effect as the icon button) and closes the menu.
-    fireEvent.click(getByRole('menuitem', { name: /Continue/ }))
+    // The popup starts visibility:hidden and is revealed on the next frame once positioned,
+    // so wait for the item to be accessible (getByRole ignores visibility:hidden nodes).
+    fireEvent.click(await waitFor(() => getByRole('menuitem', { name: /Continue/ })))
     await waitFor(() => expect(getAllByRole('row').length).toBeGreaterThan(2))
     expect(container.querySelector('.action-menu-pop')).not.toBeInTheDocument()
 

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -240,6 +240,11 @@ export default function Tracking() {
   // button and opened below it, flipping above when it would overflow the viewport
   // bottom; clamped horizontally so it never leaves the viewport.
   const positionActionsMenu = (popup: HTMLElement): void => {
+    // Hide until positioned: the ref fires before layout, so without this the popup
+    // paints one frame at its unpositioned (static) coordinates — a visible flicker —
+    // before the next-frame clamp runs. A visibility:hidden box still has layout, so
+    // the getBoundingClientRect() below stays accurate.
+    popup.style.visibility = 'hidden'
     // Measure on the NEXT frame: at ref-callback time the popup isn't laid out yet,
     // so popup.getBoundingClientRect() reports width/height 0 — the clamp below would
     // then leave left at anchor.right and the menu would open off the right edge of
@@ -260,6 +265,7 @@ export default function Tracking() {
       const flipUp = below + menu.height > window.innerHeight && anchor.top - menu.height - gap >= 0
       popup.style.left = `${left}px`
       popup.style.top = `${flipUp ? anchor.top - menu.height - gap : below}px`
+      popup.style.visibility = 'visible'
     })
   }
   // The fixed popup would strand from its button on scroll/resize; attach a dismiss

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -240,21 +240,27 @@ export default function Tracking() {
   // button and opened below it, flipping above when it would overflow the viewport
   // bottom; clamped horizontally so it never leaves the viewport.
   const positionActionsMenu = (popup: HTMLElement): void => {
-    // The kebab is the .action-menu's own trigger (aria-haspopup=menu) — target it
-    // explicitly, not the first descendant button, which would also match the
-    // menuitem buttons inside this very popup.
-    const button = popup.parentElement?.querySelector('[aria-haspopup="menu"]')
-    if (!button) {
-      return
-    }
-    const anchor = button.getBoundingClientRect()
-    const menu = popup.getBoundingClientRect()
-    const gap = 2
-    const left = Math.max(4, Math.min(anchor.right - menu.width, window.innerWidth - menu.width - 4))
-    const below = anchor.bottom + gap
-    const flipUp = below + menu.height > window.innerHeight && anchor.top - menu.height - gap >= 0
-    popup.style.left = `${left}px`
-    popup.style.top = `${flipUp ? anchor.top - menu.height - gap : below}px`
+    // Measure on the NEXT frame: at ref-callback time the popup isn't laid out yet,
+    // so popup.getBoundingClientRect() reports width/height 0 — the clamp below would
+    // then leave left at anchor.right and the menu would open off the right edge of
+    // the viewport. rAF gives it a real box before we position it.
+    requestAnimationFrame(() => {
+      // The kebab is the .action-menu's own trigger (aria-haspopup=menu) — target it
+      // explicitly, not the first descendant button, which would also match the
+      // menuitem buttons inside this very popup.
+      const button = popup.parentElement?.querySelector('[aria-haspopup="menu"]')
+      if (!button || !popup.isConnected) {
+        return
+      }
+      const anchor = button.getBoundingClientRect()
+      const menu = popup.getBoundingClientRect()
+      const gap = 2
+      const left = Math.max(4, Math.min(anchor.right - menu.width, window.innerWidth - menu.width - 4))
+      const below = anchor.bottom + gap
+      const flipUp = below + menu.height > window.innerHeight && anchor.top - menu.height - gap >= 0
+      popup.style.left = `${left}px`
+      popup.style.top = `${flipUp ? anchor.top - menu.height - gap : below}px`
+    })
   }
   // The fixed popup would strand from its button on scroll/resize; attach a dismiss
   // handler only while a menu is open, rather than a permanent global listener.


### PR DESCRIPTION
## Problem

At narrow widths the per-row action icons collapse into a kebab menu. Its popup opened partly off the **right edge** of the viewport.

## Cause

`positionActionsMenu` runs from a Solid `ref` callback, which fires **before layout**. `popup.getBoundingClientRect()` therefore returned width/height `0`, so the horizontal clamp (`window.innerWidth - menu.width - 4`) computed against a zero-width box and left the menu anchored at `anchor.right`.

## Fix

Defer the measurement to `requestAnimationFrame` so the popup has a real box before it is positioned, and guard `popup.isConnected` in case the menu closes before the frame runs. This builds on #542 (the popup is `position: fixed` to escape the table's `overflow` clip).

## Test

`e2e/worklog.spec.ts` gains a regression that signs in as `i.myself` (the user with seed rows on the frozen date), shrinks to 420px so the kebab appears, hovers to open it (mouse pointer → `pointerenter`), and asserts the popup's bounding box is within the viewport on every edge. It fails against the pre-fix synchronous measure.