### PR TITLE
feat(tracking): subtickets drive ticket→project resolution (+ sync timestamp, docs, ADR)

### DIFF
--- a/docs/adr/ADR-020-subticket-ticket-resolution.md
+++ b/docs/adr/ADR-020-subticket-ticket-resolution.md
@@ -1,0 +1,74 @@
+# ADR-020: Jira Subticket Sync and Ticket→Project Resolution
+
+**Status:** Accepted — subtickets are synced from the ticket system (manual admin
+action, CLI, or cron) and participate in ticket→project resolution, with an exact
+subticket match taking precedence over the `jira_id` prefix rule.
+**Date:** 2026-07-04
+**Relates to:** [ADR-016](ADR-016-solidjs-frontend-rewrite.md) (the SolidJS rewrite that
+dropped the legacy in-app refresh timer), [ADR-017](ADR-017-jira-cloud-oauth2.md) (the
+OAuth flow whose per-user token the sync uses), [ADR-005](ADR-005-caching-strategy.md)
+(node-local caching — why a scheduled refresh, not a shared push).
+
+## Context
+
+A TimeTracker project binds to Jira through two independent axes:
+
+- **`jira_id`** — a comma/space-separated list of Jira **project prefixes** (e.g.
+  `SA, DHLSUP`). When a user types a ticket, its prefix is matched against this list to
+  auto-assign the project ([#453](https://github.com/netresearch/timetracker/pull/453)),
+  and the same rule validates the ticket on save
+  ([`SaveEntryAction::validateTicketPrefix`](../../src/Controller/Tracking/SaveEntryAction.php)).
+- **`subtickets`** — a comma-separated list of concrete **ticket keys** synced from Jira:
+  the sub-issues of the project's main ticket(s)/epic(s) in `jira_ticket`
+  ([`SubticketSyncService`](../../src/Service/SubticketSyncService.php), which walks
+  subtasks and epic-linked issues via the project lead's OAuth token).
+
+The gap this ADR closes: the subtickets were **synced and displayed but never used**.
+A ticket that belongs to a project only by being one of its synced subtickets — for
+example an epic-linked issue that lives in a *different* Jira project, so its prefix is not
+in `jira_id` — could not be auto-assigned and was rejected on save. The legacy ExtJS admin
+had the sync buttons and a 15-minute in-app timer that reloaded project data "to make
+subtickets available"; the SolidJS rewrite carried over neither until
+[#546](https://github.com/netresearch/timetracker/pull/546) (the sync UI) and this change
+(the resolution wiring).
+
+## Decision
+
+1. **Subtickets participate in ticket→project resolution, and an exact subticket key match
+   wins over a prefix match.** A synced subtickets list enumerates specific keys, so it is
+   more precise than the project-wide prefix rule; when a typed key is an exact subticket of
+   one project and a prefix match of another, the subticket owner is chosen. The frontend
+   auto-assign ([`Tracking.tsx`](../../frontend/src/pages/Tracking.tsx)) checks subtickets
+   first, then falls back to the `jira_id` prefix. The backend accepts the same on save
+   (`SaveEntryAction::isKnownSubticket`), so the client never maps a ticket the server would
+   reject.
+
+2. **The subtickets column is refreshed by an explicit sync, not an in-app poller.** Three
+   triggers, all calling the one service:
+   - the admin **"Sync subtickets"** (per project) and **"Sync all subtickets"** (toolbar)
+     actions (`POST /projects/{id}/syncsubtickets`, `POST /projects/syncsubtickets`);
+   - the CLI `tt:sync-subtickets [project]`, intended for **cron** (see
+     [subticket-sync.md](../subticket-sync.md));
+   - an implicit sync when a project is saved
+     ([`SaveProjectAction`](../../src/Controller/Admin/SaveProjectAction.php)).
+   The legacy 15-minute in-app timer is **not** restored: TanStack Query already refetches
+   reference data, a manual refresh exists, and a periodic client poll would re-run the sync
+   far more often than the data changes. Freshness is a scheduling concern, handled by cron.
+
+3. **A `projects.subtickets_synced_at` timestamp records the last sync.** Null = never
+   synced. It is stamped on every successful sync and surfaced (read-only) in the projects
+   admin, so an operator — and the cron documentation — can spot projects whose subtickets
+   have gone stale.
+
+## Consequences
+
+- A ticket from another Jira project can be tracked against a project once it appears in
+  that project's synced subtickets — the motivating n-Jira-tickets→1-project case — without
+  widening the `jira_id` prefix list (which would also admit unrelated tickets).
+- The subtickets list is only as fresh as the last sync. Without a cron job it drifts as
+  epics gain sub-issues; the timestamp column makes that visible rather than silent.
+- Resolution is a two-pass find (subtickets, then prefix) over the in-memory project list —
+  negligible for the project counts here, and the backend validation mirrors it exactly so
+  the two never disagree.
+- The sync needs the project's lead user to hold a valid Jira OAuth token; a project without
+  a ticket system, lead, or token returns a 400 (surfaced inline in the admin), unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ ADRs are historical records: bodies are not rewritten when reality moves on. Whe
 | [ADR-017](ADR-017-jira-cloud-oauth2.md) | Jira Cloud Support via OAuth 2.0 (Dual-Mode Integration) | Accepted | 2026-06-22 |
 | [ADR-018](ADR-018-authentication-extension.md) | Authentication Extension: Local Passwords, MFA (TOTP) and Passkeys | Accepted (D1 done; MFA/passkeys pending) | 2026-07-02 |
 | [ADR-019](ADR-019-session-storage-and-lock-contention.md) | Session Storage and Lock-Contention Strategy | Accepted (files + early lock-release; Valkey deferred) | 2026-07-04 |
+| [ADR-020](ADR-020-subticket-ticket-resolution.md) | Jira Subticket Sync and Ticket→Project Resolution | Accepted | 2026-07-04 |
 
 ## ADR Format
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -102,8 +102,12 @@ Worklog entries are always personal — users only manage their own entries.
   never block saving.
 - **Per-user OAuth authorization** per ticket system; TimeTracker sends the
   user to Jira's authorize page on first use and stores the token encrypted.
-- **Subticket sync** per project or across all projects (admin endpoints and
-  the `tt:sync-subtickets` console command).
+- **Subticket sync** per project or across all projects (admin buttons, the
+  `tt:sync-subtickets` console command for cron, and on project save). Synced
+  subtickets resolve a typed ticket to its project — an exact subticket match wins
+  over the `jira_id` prefix — so tickets from another Jira project can be tracked
+  without widening the prefix list. See [subticket-sync.md](subticket-sync.md)
+  ([ADR-020](adr/ADR-020-subticket-ticket-resolution.md)).
 - **Internal ticket mapping:** book on external ticket numbers and mirror
   worklogs into an internal Jira project.
 - **Time display inside Jira:** optional userscript, see

--- a/docs/subticket-sync.md
+++ b/docs/subticket-sync.md
@@ -1,0 +1,81 @@
+# Jira Subticket Sync
+
+TimeTracker can pull the **sub-issues** of a project's Jira epic(s)/main ticket(s) into
+the project and use them to resolve tracked tickets to that project — even when a ticket
+lives in a different Jira project. See
+[ADR-020](adr/ADR-020-subticket-ticket-resolution.md) for the design rationale.
+
+## What it does
+
+For a project that has a ticket system, a **main ticket** (`jira_ticket`, e.g. an epic key
+or a comma-separated list), and a **project lead** with a valid Jira OAuth token, the sync
+walks each main ticket's subtasks and epic-linked issues via the Jira API and stores the
+resulting ticket keys in the project's `subtickets` field (comma-separated). It also stamps
+`subtickets_synced_at`.
+
+Those keys then drive ticket→project resolution when a user types a ticket in the work-log:
+
+- An **exact subticket match wins** — a ticket listed in a project's subtickets is assigned
+  to that project even if its prefix is not in the project's `jira_id`.
+- Otherwise the usual **`jira_id` prefix** rule applies.
+
+The backend validates saves the same way, so a ticket the UI auto-assigns is never rejected.
+
+## Configure a project
+
+In **Administration → Projects**, a project must have:
+
+1. a **Ticket system** (the Jira instance);
+2. a **Jira ticket** (`jira_ticket`) — the epic/main issue whose sub-issues to collect;
+3. a **Project lead** who has authorized Jira via OAuth ([ADR-017](adr/ADR-017-jira-cloud-oauth2.md)),
+   because the sync uses that user's token.
+
+Missing any of these makes the sync return `400` (shown inline in the admin).
+
+## Trigger a sync
+
+- **Admin UI** — the Projects grid has a per-row **Sync subtickets** button and a
+  **Sync all subtickets** toolbar button. The **Subtickets synced** column shows when each
+  project was last refreshed (`—` = never).
+- **On project save** — saving a project re-syncs it implicitly.
+- **CLI** — for scheduled refreshes:
+
+  ```bash
+  # All projects
+  docker compose exec app php bin/console tt:sync-subtickets
+
+  # A single project by id
+  docker compose exec app php bin/console tt:sync-subtickets 42
+  ```
+
+  (Use the service/container name for your environment, e.g. `app-dev` in the dev profile.)
+
+## Keep it fresh with cron
+
+There is **no in-app polling** — the subtickets list is only as current as the last sync.
+Schedule the CLI command to keep it fresh. The `subtickets_synced_at` column makes staleness
+visible in the admin.
+
+**Host crontab** (runs the command inside the running `app` container nightly at 03:17):
+
+```cron
+17 3 * * * cd /srv/timetracker && docker compose exec -T app php bin/console tt:sync-subtickets >> /var/log/tt-subticket-sync.log 2>&1
+```
+
+**systemd timer** (alternative): a `tt-subticket-sync.service` running the same
+`docker compose exec -T app php bin/console tt:sync-subtickets`, plus a
+`tt-subticket-sync.timer` with `OnCalendar=*-*-* 03:17:00`.
+
+Pick a cadence that matches how often your epics gain sub-issues — nightly is usually
+enough. The command is idempotent: it overwrites each project's subtickets with the current
+Jira state, so re-running it is safe.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `400 No ticket system configured for project` | The project has no ticket system. |
+| `400 Project has no lead user` | Set a project lead. |
+| `400 Project user has no token for ticket system` | The lead must authorize Jira via OAuth. |
+| Subtickets empty after sync | The project's `jira_ticket` is unset, or the epic has no sub-issues. |
+| A ticket still isn't auto-assigned | It is neither in a project's subtickets nor matches a `jira_id` prefix — sync the owning project, or add the prefix. |

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -442,6 +442,7 @@
   "admin_f_internal_ref": "Interne Referenz",
   "admin_f_external_ref": "Externe Referenz",
   "admin_f_subtickets": "Subtickets",
+  "admin_f_subtickets_synced": "Subtickets synchronisiert",
   "admin_f_book_time": "Zeitbuchung",
   "admin_f_url": "URL",
   "admin_f_ticket_url": "Ticket-URL",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -442,6 +442,7 @@
   "admin_f_internal_ref": "Internal reference",
   "admin_f_external_ref": "External reference",
   "admin_f_subtickets": "Subtickets",
+  "admin_f_subtickets_synced": "Subtickets synced",
   "admin_f_book_time": "Time booking",
   "admin_f_url": "URL",
   "admin_f_ticket_url": "Ticket URL",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -442,6 +442,7 @@
   "admin_f_internal_ref": "Referencia interna",
   "admin_f_external_ref": "Referencia externa",
   "admin_f_subtickets": "Subtickets",
+  "admin_f_subtickets_synced": "Subtickets sincronizados",
   "admin_f_book_time": "Registro de tiempo",
   "admin_f_url": "URL",
   "admin_f_ticket_url": "URL del ticket",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -442,6 +442,7 @@
   "admin_f_internal_ref": "Référence interne",
   "admin_f_external_ref": "Référence externe",
   "admin_f_subtickets": "Sous-tickets",
+  "admin_f_subtickets_synced": "Sous-tickets synchronisés",
   "admin_f_book_time": "Report du temps",
   "admin_f_url": "URL",
   "admin_f_ticket_url": "URL du ticket",

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -442,6 +442,7 @@
   "admin_f_internal_ref": "Внутренняя ссылка",
   "admin_f_external_ref": "Внешняя ссылка",
   "admin_f_subtickets": "Подтикеты",
+  "admin_f_subtickets_synced": "Подтикеты синхронизированы",
   "admin_f_book_time": "Передача времени",
   "admin_f_url": "URL",
   "admin_f_ticket_url": "URL тикета",

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -1,4 +1,5 @@
 import { num, str } from '../lib/coerce'
+import { formatUserDate } from '../lib/dateFormat'
 import { m } from '../paraglide/messages.js'
 import type { EntityDescriptor, OptionLookup, OptionSource } from './types'
 
@@ -108,6 +109,8 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'billing', label: () => m.admin_f_billing(), render: (row) => billingLabel(row.billing) },
         // View-only: auto-synced from the ticket system (no matching field → read-only).
         { key: 'subtickets', label: () => m.admin_f_subtickets() },
+        // When the subtickets were last synced (— = never). The sync button refreshes it.
+        { key: 'subticketsSyncedAt', label: () => m.admin_f_subtickets_synced(), render: (row) => { const v = str(row.subticketsSyncedAt); return v === '' ? '—' : formatUserDate(v.split('T')[0] ?? v) } },
         { key: 'last_activity', label: () => m.admin_f_last_activity() },
       ],
       fields: [

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -274,6 +274,9 @@ export interface TrackingProject {
   active: boolean
   jiraId: string
   ticketSystem: number
+  // Comma-separated Jira sub-issue keys synced from the ticket system; an exact
+  // match here maps a ticket to this project even when its prefix isn't in jiraId.
+  subtickets: string
 }
 
 export function trackingProjectsQuery() {
@@ -292,6 +295,7 @@ export function trackingProjectsQuery() {
           active: coerceActive(project.active),
           jiraId: String(project.jiraId ?? project.jira_id ?? ''),
           ticketSystem: Number(project.ticket_system ?? project.ticketSystem ?? 0),
+          subtickets: String(project.subtickets ?? ''),
         })),
     staleTime: REFERENCE_STALE_TIME,
   }

--- a/frontend/src/pages/Admin.test.tsx
+++ b/frontend/src/pages/Admin.test.tsx
@@ -265,8 +265,9 @@ describe('Admin', () => {
     const { getByRole, unmount } = renderAdmin('/admin/projects')
     await waitFor(() => expect(getByRole('gridcell', { name: 'Site' })).toBeInTheDocument())
 
-    // The auto-synced subtickets column is shown (read-only).
-    expect(getByRole('columnheader', { name: /Subtickets/i })).toBeInTheDocument()
+    // The auto-synced subtickets column (read-only) and its last-synced timestamp.
+    expect(getByRole('columnheader', { name: 'Subtickets' })).toBeInTheDocument()
+    expect(getByRole('columnheader', { name: 'Subtickets synced' })).toBeInTheDocument()
 
     // The edit modal exposes the three new editable fields.
     fireEvent.click(getByRole('button', { name: 'Edit' }))

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -353,6 +353,35 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('resolves a ticket by an exact subticket over a foreign prefix match', async () => {
+    // Project 9 owns the 'FOREIGN' prefix, but the same key is an exact subticket
+    // of project 10 — the subticket match wins (more specific, and the backend
+    // accepts it the same way via isKnownSubticket).
+    mockTracking({
+      entries: [{ entry: { ...DEFAULT_ENTRY, customer: 0, project: 0, ticket: '', class: 0 } }],
+      customers: [{ customer: { id: 7, name: 'A' } }, { customer: { id: 8, name: 'B' } }],
+      projects: [
+        { project: { id: 9, name: 'Prefix owner', customer: 7, jiraId: 'FOREIGN' } },
+        { project: { id: 10, name: 'Subticket owner', customer: 8, jiraId: 'SUB', subtickets: 'FOREIGN-9, FOREIGN-10' } },
+      ],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+    })
+    postJson.mockResolvedValue({})
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
+
+    const editor = editCell(container, 'ticket')
+    fireEvent.input(editor, { target: { value: 'foreign-9' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    ;(getByRole('combobox') as HTMLElement).focus()
+
+    await waitFor(() =>
+      expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.objectContaining({ ticket: 'FOREIGN-9', project: 10, customer: 8 })),
+    )
+
+    unmount()
+  })
+
   it('shows the external ticket the backend mirrored, in its own column (#453)', async () => {
     mockTracking({
       entries: [{ entry: { ...DEFAULT_ENTRY, id: 1, ticket: 'OPSDHL-2881', extTicket: 'DHLSUP-1067002', customer: 1, project: 4 } }],

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -494,17 +494,29 @@ export default function Tracking() {
   // cell shows the fixed value immediately, not on the next refetch.
   function handleCommit(id: number, colKey: string, value: unknown): void {
     if (colKey === 'ticket') {
-      const prefix = str(value).toUpperCase().trim().split(/[-:]/)[0] ?? ''
-      if (prefix === '') {
+      const ticketKey = str(value).toUpperCase().trim()
+      if (ticketKey === '') {
         return
       }
-      // jiraId is a comma/space-separated list of allowed prefixes (the backend
-      // splits it the same way in validateTicketPrefix), so match membership —
+      const prefix = ticketKey.split(/[-:]/)[0] ?? ''
+      const candidates = projects.data ?? []
+      // Exact subticket match wins over a prefix match: the synced subtickets list
+      // enumerates specific keys (possibly from another Jira project), so it is more
+      // precise than the jiraId prefix rule — the backend accepts it the same way
+      // (SaveEntryAction::isKnownSubticket).
+      const bySubticket = candidates.find(
+        (candidate) => candidate.subtickets !== '' && candidate.subtickets.toUpperCase().split(/[\s,]+/).includes(ticketKey),
+      )
+      // Fallback: jiraId is a comma/space-separated list of allowed prefixes (the
+      // backend splits it the same way in validateTicketPrefix), so match membership —
       // an exact === missed multi-prefix projects, so an external ticket like
       // DHLSUP-1 derived the wrong/no project and the save was rejected (#453).
-      const project = (projects.data ?? []).find(
-        (candidate) => candidate.jiraId !== '' && candidate.jiraId.toUpperCase().split(/[\s,]+/).includes(prefix),
-      )
+      const byPrefix = prefix === ''
+        ? undefined
+        : candidates.find(
+            (candidate) => candidate.jiraId !== '' && candidate.jiraId.toUpperCase().split(/[\s,]+/).includes(prefix),
+          )
+      const project = bySubticket ?? byPrefix
       if (project !== undefined) {
         editor.setDraftField(id, 'project', project.id)
         if (project.customer > 0) {

--- a/migrations/Version20260704_AddProjectSubticketsSyncedAt.php
+++ b/migrations/Version20260704_AddProjectSubticketsSyncedAt.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add `projects.subtickets_synced_at` so the admin can show when each project's
+ * Jira subtickets were last refreshed and the cron/manual sync can be judged for
+ * staleness. NULL (default) = never synced; every existing row stays NULL on
+ * upgrade and is unaffected until the next sync stamps it.
+ */
+final class Version20260704_AddProjectSubticketsSyncedAt extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add nullable projects.subtickets_synced_at timestamp for subticket sync freshness';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE projects ADD subtickets_synced_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE projects DROP COLUMN subtickets_synced_at');
+    }
+}

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -200,6 +200,7 @@ CREATE TABLE `projects` (
   `internal_jira_project_key` VARCHAR(50) NULL,
   `internal_jira_ticket_system` INTEGER(11) NULL,
   `subtickets` TEXT DEFAULT '',
+  `subtickets_synced_at` DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
   PRIMARY KEY (`id`),
   KEY `customer_id` (`customer_id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -472,12 +472,7 @@ final class SaveEntryAction extends BaseTrackingController
         }
 
         $needle = strtoupper(trim($ticket));
-        foreach (explode(',', $subtickets) as $subticket) {
-            if (strtoupper(trim($subticket)) === $needle) {
-                return true;
-            }
-        }
 
-        return false;
+        return array_any(explode(',', $subtickets), static fn (string $subticket): bool => strtoupper(trim($subticket)) === $needle);
     }
 }

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -443,6 +443,13 @@ final class SaveEntryAction extends BaseTrackingController
             return new Error($this->translate('Given ticket does not have a valid format.'), Response::HTTP_BAD_REQUEST);
         }
 
+        // A ticket explicitly listed in the project's synced subtickets is accepted
+        // regardless of its prefix: subtickets can live in a different Jira project
+        // (e.g. epic-linked issues), so an exact key match wins over the prefix rule.
+        if ($this->isKnownSubticket($project, $ticket)) {
+            return null;
+        }
+
         $ticketPrefix = (string) $this->ticketService->getPrefix($ticket);
         $allowedPrefixes = array_map(trim(...), explode(',', $jiraId));
         $prefixMatches = in_array($ticketPrefix, $allowedPrefixes, true)
@@ -451,5 +458,26 @@ final class SaveEntryAction extends BaseTrackingController
         return $prefixMatches
             ? null
             : new Error($this->translate('Given ticket does not have a valid prefix.'), Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * Whether the ticket key is one of the project's synced subtickets (exact,
+     * case-insensitive match). Empty subtickets → never matches.
+     */
+    private function isKnownSubticket(Project $project, string $ticket): bool
+    {
+        $subtickets = $project->getSubtickets();
+        if (null === $subtickets || '' === $subtickets) {
+            return false;
+        }
+
+        $needle = strtoupper(trim($ticket));
+        foreach (explode(',', $subtickets) as $subticket) {
+            if (strtoupper(trim($subticket)) === $needle) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -13,6 +13,8 @@ use App\Enum\BillingType;
 use App\Model\Base;
 use App\Repository\ProjectRepository;
 use App\Service\Util\TimeCalculationService;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -69,6 +71,13 @@ class Project extends Base
      */
     #[ORM\Column(name: 'subtickets', type: 'string', length: 255, nullable: true)]
     protected $subtickets;
+
+    /**
+     * When the subtickets column was last refreshed from the ticket system.
+     * Null means it has never been synced. Set by SubticketSyncService.
+     */
+    #[ORM\Column(name: 'subtickets_synced_at', type: 'datetime_immutable', nullable: true)]
+    protected ?DateTimeImmutable $subticketsSyncedAt = null;
 
     /**
      * @var TicketSystem|null
@@ -234,6 +243,9 @@ class Project extends Base
     {
         $data = parent::toArray();
         $data['estimationText'] = new TimeCalculationService()->minutesToReadable($this->getEstimation(), false);
+        // Serialize the sync timestamp as ISO-8601 (or null) rather than leaking a
+        // DateTimeImmutable object into the JSON payload.
+        $data['subticketsSyncedAt'] = $this->subticketsSyncedAt?->format(DateTimeInterface::ATOM);
 
         return $data;
     }
@@ -420,6 +432,21 @@ class Project extends Base
     public function setSubtickets(?string $subtickets): static
     {
         $this->subtickets = $subtickets;
+
+        return $this;
+    }
+
+    /**
+     * When the subtickets were last synced from the ticket system (null = never).
+     */
+    public function getSubticketsSyncedAt(): ?DateTimeImmutable
+    {
+        return $this->subticketsSyncedAt;
+    }
+
+    public function setSubticketsSyncedAt(?DateTimeImmutable $subticketsSyncedAt): static
+    {
+        $this->subticketsSyncedAt = $subticketsSyncedAt;
 
         return $this;
     }

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -69,7 +69,10 @@ class Project extends Base
      *
      * @var string|null
      */
-    #[ORM\Column(name: 'subtickets', type: 'string', length: 255, nullable: true)]
+    // TEXT in every schema (sql/full.sql + the 004_ticketproject migration): a
+    // project's subtickets list can exceed 255 chars, and it now drives ticket→
+    // project resolution, so the mapping must not cap it at 255.
+    #[ORM\Column(name: 'subtickets', type: 'text', nullable: true)]
     protected $subtickets;
 
     /**

--- a/src/Service/SubticketSyncService.php
+++ b/src/Service/SubticketSyncService.php
@@ -80,8 +80,9 @@ class SubticketSyncService
     }
 
     /**
-     * Stamp the sync time and persist the project. Called only on a successful
-     * sync (the early guards throw before reaching here).
+     * Stamp the sync time and persist the project. Reached on any successful
+     * completion — both the normal path and the "no main ticket → empty list"
+     * path; the missing ticket-system / lead / token guards throw before this.
      */
     private function persistSynced(Project $project): void
     {

--- a/src/Service/SubticketSyncService.php
+++ b/src/Service/SubticketSyncService.php
@@ -20,7 +20,7 @@ use Doctrine\Persistence\ManagerRegistry;
 
 class SubticketSyncService
 {
-    public function __construct(private readonly ManagerRegistry $managerRegistry, private readonly JiraOAuthApiFactory $jiraOAuthApiFactory)
+    public function __construct(private readonly ManagerRegistry $managerRegistry, private readonly JiraOAuthApiFactory $jiraOAuthApiFactory, private readonly ClockInterface $clock)
     {
     }
 
@@ -47,13 +47,10 @@ class SubticketSyncService
 
         $mainTickets = $project->getJiraTicket();
         if (null === $mainTickets) {
-            if ('' !== ($project->getSubtickets() ?? '')) {
-                $project->setSubtickets('');
-
-                $em = $this->managerRegistry->getManager();
-                $em->persist($project);
-                $em->flush();
-            }
+            // A ticket-system-bound project with no main ticket has no subtickets;
+            // clear the list but still record that a sync ran.
+            $project->setSubtickets('');
+            $this->persistSynced($project);
 
             return [];
         }
@@ -77,11 +74,21 @@ class SubticketSyncService
 
         // Convert array to comma-separated string for storage
         $project->setSubtickets(implode(',', $allSubtickets));
+        $this->persistSynced($project);
+
+        return array_values($allSubtickets);
+    }
+
+    /**
+     * Stamp the sync time and persist the project. Called only on a successful
+     * sync (the early guards throw before reaching here).
+     */
+    private function persistSynced(Project $project): void
+    {
+        $project->setSubticketsSyncedAt($this->clock->now());
         $em = $this->managerRegistry->getManager();
         $em->persist($project);
         $em->flush();
-
-        return array_values($allSubtickets);
     }
 
     /**

--- a/tests/Controller/SaveEntryTicketPrefixTest.php
+++ b/tests/Controller/SaveEntryTicketPrefixTest.php
@@ -44,7 +44,7 @@ final class SaveEntryTicketPrefixTest extends AbstractWebTestCase
         ];
     }
 
-    private function configureProjectOne(?string $jiraId, ?string $internalKey = null, ?string $internalTicketSystem = null): void
+    private function configureProjectOne(?string $jiraId, ?string $internalKey = null, ?string $internalTicketSystem = null, ?string $subtickets = null): void
     {
         $container = $this->client->getContainer();
         /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
@@ -59,6 +59,9 @@ final class SaveEntryTicketPrefixTest extends AbstractWebTestCase
         }
         if (null !== $internalTicketSystem) {
             $project->setInternalJiraTicketSystem($internalTicketSystem);
+        }
+        if (null !== $subtickets) {
+            $project->setSubtickets($subtickets);
         }
 
         $em->persist($project);
@@ -93,6 +96,30 @@ final class SaveEntryTicketPrefixTest extends AbstractWebTestCase
         $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'OPSDHL-77']), [], ['HTTP_ACCEPT' => 'application/json']);
 
         $this->assertStatusCode(200);
+    }
+
+    public function testTicketListedInSyncedSubticketsIsAcceptedDespiteForeignPrefix(): void
+    {
+        $this->logInSession('unittest');
+        // Project 1 allows only the 'SA' prefix, but its synced subtickets list
+        // enumerates a key from another Jira project — that exact key must be
+        // accepted (an epic subtask can live in a different project).
+        $this->configureProjectOne('SA', null, null, 'FOREIGN-9, FOREIGN-10');
+
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'FOREIGN-9']), [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(200);
+    }
+
+    public function testForeignPrefixTicketNotInSubticketsIsStillRejected(): void
+    {
+        $this->logInSession('unittest');
+        // A foreign key that is NOT in the subtickets list stays rejected.
+        $this->configureProjectOne('SA', null, null, 'FOREIGN-9');
+
+        $this->client->request(Request::METHOD_POST, '/tracking/save', $this->saveParameters(['ticket' => 'FOREIGN-42']), [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(400);
     }
 
     public function testTicketWithUnknownPrefixIsRejected(): void

--- a/tests/Service/SubticketSyncServiceTest.php
+++ b/tests/Service/SubticketSyncServiceTest.php
@@ -12,8 +12,10 @@ namespace Tests\Service;
 use App\Entity\Project;
 use App\Entity\TicketSystem;
 use App\Entity\User;
+use App\Service\FrozenClock;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use App\Service\SubticketSyncService;
+use DateTimeImmutable;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
@@ -31,12 +33,14 @@ use function assert;
 #[AllowMockObjectsWithoutExpectations]
 final class SubticketSyncServiceTest extends TestCase
 {
+    // Fixed clock so the sync timestamp is deterministic.
+    private const SYNC_TIME = '2024-01-15 12:00:00';
+
     private function createService(
         ManagerRegistry $managerRegistry,
         JiraOAuthApiFactory $jiraOAuthApiFactory,
     ): SubticketSyncService {
-        // SubticketSyncService signature changed to (ManagerRegistry, JiraOAuthApiFactory)
-        return new SubticketSyncService($managerRegistry, $jiraOAuthApiFactory);
+        return new SubticketSyncService($managerRegistry, $jiraOAuthApiFactory, new FrozenClock(self::SYNC_TIME));
     }
 
     public function testProjectNotFoundThrows404(): void
@@ -131,7 +135,7 @@ final class SubticketSyncServiceTest extends TestCase
         $user->method('getUsername')->willReturn('dev');
 
         $mock = $this->getMockBuilder(Project::class)
-            ->onlyMethods(['getTicketSystem', 'getJiraTicket', 'getProjectLead', 'setSubtickets'])
+            ->onlyMethods(['getTicketSystem', 'getJiraTicket', 'getProjectLead', 'setSubtickets', 'setSubticketsSyncedAt'])
             ->getMock();
         $mock->method('getTicketSystem')->willReturn($ticketSystem);
         $mock->method('getJiraTicket')->willReturn('DEF-2, ABC-1');
@@ -144,6 +148,10 @@ final class SubticketSyncServiceTest extends TestCase
 
             return $expected === $actualArray;
         }));
+        // The sync stamps the (frozen) sync time on the project.
+        $mock->expects(self::once())->method('setSubticketsSyncedAt')->with(self::callback(
+            static fn (DateTimeImmutable $when): bool => self::SYNC_TIME === $when->format('Y-m-d H:i:s'),
+        ));
 
         $repo = $this->createMock(ObjectRepository::class);
         $repo->method('find')->willReturn($mock);


### PR DESCRIPTION
Completes the Jira subticket feature on top of #546 (which added the sync UI + endpoints). Design decisions confirmed with the maintainer: **exact subticket wins** over a prefix match, and a **last-synced timestamp** is tracked.

## The gap this closes

Subtickets were synced and displayed but **never used**. A ticket that belongs to a project only by being one of its synced subtickets — e.g. an epic-linked issue in a *different* Jira project, so its prefix isn't in `jira_id` — could not be auto-assigned and was rejected on save.

## What changed

**Resolution (functional wiring)**
- `Tracking.tsx` auto-assign now checks each project's `subtickets` first (exact key match), then falls back to the `jira_id` prefix. An exact subticket match wins.
- `SaveEntryAction::validateTicketPrefix` accepts a ticket present in the project's subtickets (`isKnownSubticket`), so the client never maps a ticket the server would reject.
- The tracking projects query carries `subtickets` to the client.

**Sync timestamp**
- New `projects.subtickets_synced_at` (migration + `sql/full.sql`), stamped by `SubticketSyncService` on every successful sync.
- Shown read-only as a **Subtickets synced** column in the projects admin (`—` = never).

**Sync stays explicit** — admin buttons (#546), the `tt:sync-subtickets` CLI for cron, and on project save. The legacy 15-minute in-app poller is deliberately not restored (see ADR).

**Docs**
- [ADR-020](../blob/feat/subticket-ticket-resolution/docs/adr/ADR-020-subticket-ticket-resolution.md) — resolution model + why cron over an in-app timer.
- [subticket-sync.md](../blob/feat/subticket-ticket-resolution/docs/subticket-sync.md) — configuration, triggers, cron scheduling (crontab + systemd), troubleshooting. Linked from `features.md`; indexed in the ADR README.

## Tests

- **Frontend:** exact-subticket-wins resolution (`Tracking.test.tsx`), last-synced column (`Admin.test.tsx`). Full suite 411 green.
- **Backend:** foreign-prefix ticket accepted when in subtickets / still rejected when not (`SaveEntryTicketPrefixTest`); sync stamps the timestamp (`SubticketSyncServiceTest`). PHPStan L10, php-cs-fixer, `doctrine:schema:validate` all clean; 97 affected tests green.

## Migration

Additive nullable column — every existing row stays NULL until its next sync. `sql/full.sql` updated (CI derives the unittest schema from it).