### PR TITLE
docs(adr): mark ADR-018 D2–D4 as implemented

### DIFF
--- a/docs/adr/ADR-018-authentication-extension.md
+++ b/docs/adr/ADR-018-authentication-extension.md
@@ -1,6 +1,6 @@
 # ADR-018: Authentication Extension — Local Passwords, MFA (TOTP) and Passkeys
 
-**Status:** Accepted — D1 (local passwords, LDAP optional) implemented; D2–D4 (MFA, passkeys) pending
+**Status:** Accepted — implemented. D1 (local passwords, LDAP optional), D2 (TOTP MFA + backup codes), D3 (WebAuthn passkeys), and D4 (session / remember-me interaction) all shipped, plus org-wide mandatory-2FA enforcement and admin break-glass reset of a user's 2FA and passkeys.
 **Date:** 2026-07-02
 
 > **Implementation note (D1).** The auth core landed as one PR: `users.password`


### PR DESCRIPTION
The ADR-018 status line still read "D2–D4 (MFA, passkeys) pending", but TOTP MFA (#521), passkeys (#523), the session/remember-me handling, org-wide mandatory 2FA (#526), and admin break-glass reset (#525) all shipped. Updates the one status line to match. Docs-only.

Prep for the v6.0.0 release so the ADR status is accurate at tag time.