### PR TITLE
feat(agent): well-known URIs + LLM/agent discovery (Tier 1–2)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -106,6 +106,9 @@ security:
         - { path: ^/images, roles: PUBLIC_ACCESS }
         - { path: ^/status/check, roles: PUBLIC_ACCESS }
         - { path: ^/status/page, roles: PUBLIC_ACCESS }
+        # Public agent/discovery affordances (RFC 8615 well-known URIs, llms.txt).
+        - { path: ^/\.well-known, roles: PUBLIC_ACCESS }
+        - { path: ^/llms\.txt, roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: ROLE_ADMIN }
         # Profiler/web-debug-toolbar routes exist only in the `profiling` env,
         # where the `dev` firewall is narrowed so these fall through to `main`;

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -107,8 +107,10 @@ security:
         - { path: ^/status/check, roles: PUBLIC_ACCESS }
         - { path: ^/status/page, roles: PUBLIC_ACCESS }
         # Public agent/discovery affordances (RFC 8615 well-known URIs, llms.txt).
-        - { path: ^/\.well-known, roles: PUBLIC_ACCESS }
-        - { path: ^/llms\.txt, roles: PUBLIC_ACCESS }
+        # Anchored (trailing slash / end-of-string) so a look-alike path such as
+        # /.well-known-x or /llms.txt.bak can't inherit PUBLIC_ACCESS.
+        - { path: ^/\.well-known/, roles: PUBLIC_ACCESS }
+        - { path: ^/llms\.txt$, roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: ROLE_ADMIN }
         # Profiler/web-debug-toolbar routes exist only in the `profiling` env,
         # where the `dev` firewall is narrowed so these fall through to `main`;

--- a/docs/agent-readiness.md
+++ b/docs/agent-readiness.md
@@ -1,0 +1,43 @@
+# Agent Readiness & Well-Known URIs
+
+TimeTracker exposes a set of standard discovery affordances so LLMs and coding
+agents can find and understand the application. It is a **private, authenticated**
+app, so the stance is: help *authenticated* agents discover the API, and tell
+*unauthenticated* crawlers there is nothing here to index or train on.
+
+## What is served
+
+| Path | Standard | Purpose |
+|------|----------|---------|
+| `/.well-known/security.txt` | [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) | Security contact; `Expires` is stamped one year out on each request so it never goes stale. |
+| `/.well-known/change-password` | [W3C](https://w3c.github.io/webappsec-change-password-url/) | 302 → `/ui/settings` (the self-service password change, ADR-018). |
+| `/.well-known/api-catalog` | [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727) | `application/linkset+json` pointing at the OpenAPI (`service-desc`) and the help page (`service-doc`). |
+| `/llms.txt` | [llmstxt.org](https://llmstxt.org/) | A concise, agent-oriented map of the app and its API. |
+| `/robots.txt` | robots + [Content Signals](https://content-signals.org/) | `Content-Signal: search=no, ai-input=no, ai-train=no` on `*`, plus explicit `disallow: /` groups for GPTBot/ClaudeBot/CCBot/Google-Extended/PerplexityBot/Bytespider. |
+| `Link` response headers | [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) / [RFC 8631](https://www.rfc-editor.org/rfc/rfc8631) | Every response advertises `rel="service-desc"` (the OpenAPI) and `rel="api-catalog"`. |
+| JSON-LD in the SPA shell | [schema.org](https://schema.org/WebApplication) | `WebApplication` structured data, hex-escaped like `APP_CONFIG`. |
+
+All well-known routes are public (`config/packages/security.yaml` `access_control`)
+and served by `App\Controller\WellKnown\WellKnownController`; the `Link` headers
+come from `App\EventSubscriber\DiscoveryLinkHeaderSubscriber`. Covered by
+`tests/Controller/WellKnownControllerTest.php`.
+
+## Crawlers vs. agents
+
+`robots.txt` governs **unauthenticated crawlers** — and there is no public content
+to crawl, so training/scraping bots are disallowed. An **authenticated AI agent**
+acting for a user is unaffected: it logs in and uses the HTTP API. The two are
+different audiences, and the discovery files above serve the agent while the
+robots directives address the crawler.
+
+## Deferred (paired with API-token auth)
+
+The HTTP API (`/api.yml`) is currently **session-cookie authenticated** — an agent
+can *discover and read* it but cannot authenticate programmatically. Two follow-ups
+depend on adding API-token auth (a dedicated ADR):
+
+- **`/.well-known/agent-skills.json`** ([Cloudflare Agent Skills Discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc)) — a discovery index of `SKILL.md` skills (e.g. "log time", "query worklog"). A useful skill must be able to *call* the API, so it waits on token auth.
+- **MCP server** — a thin wrapper over the token-authenticated API for MCP-native clients (Claude Desktop/Code). No new capability over the API; adds turnkey client integration.
+
+The security contact in `security.txt` (`mailto:security@netresearch.de`) should be
+confirmed against the actual Netresearch security channel.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,23 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 user-agent: *
+# Content Signals (content-signals.org): this is a private, authenticated
+# time-tracking app — no public content to index, ground, or train on.
+content-signal: search=no, ai-input=no, ai-train=no
 allow: /$
 allow: /login$
+disallow: /
+
+# AI training/scraping crawlers: nothing here is public, so disallow explicitly.
+# (Authenticated AI *agents* acting for a user are unaffected — they log in and
+# use the API; robots.txt governs unauthenticated crawlers only.)
+user-agent: GPTBot
+user-agent: OAI-SearchBot
+user-agent: ChatGPT-User
+user-agent: ClaudeBot
+user-agent: Claude-User
+user-agent: CCBot
+user-agent: Google-Extended
+user-agent: PerplexityBot
+user-agent: Bytespider
 disallow: /

--- a/src/Controller/WellKnown/WellKnownController.php
+++ b/src/Controller/WellKnown/WellKnownController.php
@@ -11,6 +11,7 @@ namespace App\Controller\WellKnown;
 
 use App\Service\ClockInterface;
 use DateInterval;
+use DateTimeZone;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -38,7 +39,12 @@ final class WellKnownController extends AbstractController
     public function securityTxt(Request $request): Response
     {
         $base = $request->getSchemeAndHttpHost();
-        $expires = $this->clock->now()->add(new DateInterval('P1Y'))->format('Y-m-d\TH:i:s\Z');
+        // Normalise to UTC before stamping the literal 'Z' — the clock may run in
+        // the server's local timezone, which would otherwise mislabel the offset.
+        $expires = $this->clock->now()
+            ->add(new DateInterval('P1Y'))
+            ->setTimezone(new DateTimeZone('UTC'))
+            ->format('Y-m-d\TH:i:s\Z');
 
         $body = 'Contact: ' . self::SECURITY_CONTACT . "\n"
             . "Expires: {$expires}\n"

--- a/src/Controller/WellKnown/WellKnownController.php
+++ b/src/Controller/WellKnown/WellKnownController.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\WellKnown;
+
+use App\Service\ClockInterface;
+use DateInterval;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Well-known URIs (RFC 8615) and LLM/agent discovery affordances. All are public
+ * (see security.yaml access_control) and read-only. See docs/agent-readiness.md.
+ */
+final class WellKnownController extends AbstractController
+{
+    private const string SECURITY_CONTACT = 'mailto:security@netresearch.de';
+
+    public function __construct(private readonly ClockInterface $clock)
+    {
+    }
+
+    /**
+     * security.txt (RFC 9116). Expires is stamped one year out so it never goes
+     * stale without maintenance.
+     */
+    #[Route(path: '/.well-known/security.txt', name: 'well_known_security_txt', methods: ['GET'])]
+    public function securityTxt(Request $request): Response
+    {
+        $base = $request->getSchemeAndHttpHost();
+        $expires = $this->clock->now()->add(new DateInterval('P1Y'))->format('Y-m-d\TH:i:s\Z');
+
+        $body = 'Contact: ' . self::SECURITY_CONTACT . "\n"
+            . "Expires: {$expires}\n"
+            . "Preferred-Languages: en, de\n"
+            . "Canonical: {$base}/.well-known/security.txt\n";
+
+        return new Response($body, Response::HTTP_OK, ['Content-Type' => 'text/plain; charset=utf-8']);
+    }
+
+    /**
+     * change-password (W3C Well-Known URL). Redirects to the SPA settings page,
+     * whose security section performs the self-service password change (ADR-018).
+     */
+    #[Route(path: '/.well-known/change-password', name: 'well_known_change_password', methods: ['GET'])]
+    public function changePassword(): RedirectResponse
+    {
+        return $this->redirect('/ui/settings', Response::HTTP_FOUND);
+    }
+
+    /**
+     * api-catalog (RFC 9727) — a link set (RFC 9264) pointing agents at the
+     * OpenAPI description and the human docs.
+     */
+    #[Route(path: '/.well-known/api-catalog', name: 'well_known_api_catalog', methods: ['GET'])]
+    public function apiCatalog(Request $request): JsonResponse
+    {
+        $base = $request->getSchemeAndHttpHost();
+
+        $response = new JsonResponse([
+            'linkset' => [
+                [
+                    'anchor' => $base . '/',
+                    'service-desc' => [
+                        ['href' => $base . '/api.yml', 'type' => 'application/yaml'],
+                    ],
+                    'service-doc' => [
+                        ['href' => $base . '/ui/help', 'type' => 'text/html'],
+                    ],
+                ],
+            ],
+        ]);
+        $response->headers->set('Content-Type', 'application/linkset+json');
+
+        return $response;
+    }
+
+    /**
+     * llms.txt (llmstxt.org) — a concise, agent-oriented map of the application.
+     */
+    #[Route(path: '/llms.txt', name: 'llms_txt', methods: ['GET'])]
+    public function llmsTxt(Request $request): Response
+    {
+        $base = $request->getSchemeAndHttpHost();
+
+        $body = <<<MD
+            # TimeTracker
+
+            > Netresearch TimeTracker: a time-tracking web application with Jira and LDAP
+            > integration and XLSX export. Access requires authentication; most functionality
+            > is available only to a logged-in user, so an agent needs valid credentials.
+
+            ## API
+
+            - [OpenAPI specification]({$base}/api.yml): the HTTP API. Authentication is
+              session-based (login cookie); there is no public API token yet.
+            - [API catalog]({$base}/.well-known/api-catalog): machine-readable API discovery (RFC 9727).
+
+            ## Documentation
+
+            - [Help and user guide]({$base}/ui/help)
+
+            ## Security
+
+            - [security.txt]({$base}/.well-known/security.txt)
+            - [Change password]({$base}/.well-known/change-password)
+            MD;
+
+        return new Response($body . "\n", Response::HTTP_OK, ['Content-Type' => 'text/markdown; charset=utf-8']);
+    }
+}

--- a/src/EventSubscriber/DiscoveryLinkHeaderSubscriber.php
+++ b/src/EventSubscriber/DiscoveryLinkHeaderSubscriber.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Advertise the machine-readable API description on every response via Web Linking
+ * (RFC 8288) headers, so an agent that fetches any page discovers the API without
+ * parsing HTML: `service-desc` → the OpenAPI (RFC 8631), `api-catalog` → the
+ * RFC 9727 link set. See docs/agent-readiness.md.
+ */
+final class DiscoveryLinkHeaderSubscriber implements EventSubscriberInterface
+{
+    private const array LINKS = [
+        '</api.yml>; rel="service-desc"; type="application/yaml"',
+        '</.well-known/api-catalog>; rel="api-catalog"',
+    ];
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::RESPONSE => 'onKernelResponse'];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $headers = $event->getResponse()->headers;
+        foreach (self::LINKS as $link) {
+            $headers->set('Link', $link, false);
+        }
+    }
+}

--- a/templates/ui/index.html.twig
+++ b/templates/ui/index.html.twig
@@ -6,6 +6,17 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ apptitle }}</title>
+        {# Structured data for agents/search (schema.org). Hex-escaped like APP_CONFIG
+           so a crafted app title can't break out of the script element. #}
+        <script type="application/ld+json">{{ {
+            '@context': 'https://schema.org',
+            '@type': 'WebApplication',
+            'name': apptitle,
+            'applicationCategory': 'BusinessApplication',
+            'operatingSystem': 'Web browser',
+            'description': 'Time tracking with Jira and LDAP integration and XLSX export.',
+            'browserRequirements': 'Requires JavaScript. Requires authentication.'
+        }|json_encode(jsonHexFlags)|raw }}</script>
         {% include 'partials/theme-init.html.twig' %}
         {% include 'partials/density-init.html.twig' %}
         {% include 'partials/font-init.html.twig' %}

--- a/tests/Controller/WellKnownControllerTest.php
+++ b/tests/Controller/WellKnownControllerTest.php
@@ -45,7 +45,7 @@ final class WellKnownControllerTest extends AbstractWebTestCase
         self::assertSame('/ui/settings', $response->headers->get('Location'));
     }
 
-    public function testApiCatalogIsAlinksetPointingAtTheOpenApi(): void
+    public function testApiCatalogIsALinkSetPointingAtTheOpenApi(): void
     {
         $this->client->request(Request::METHOD_GET, '/.well-known/api-catalog');
 

--- a/tests/Controller/WellKnownControllerTest.php
+++ b/tests/Controller/WellKnownControllerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\AbstractWebTestCase;
+
+/**
+ * The well-known / agent-discovery endpoints are public (no session) and
+ * standards-shaped. See docs/agent-readiness.md.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class WellKnownControllerTest extends AbstractWebTestCase
+{
+    public function testSecurityTxtIsPublicPlainTextWithRequiredFields(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/.well-known/security.txt');
+
+        $response = $this->client->getResponse();
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/plain', (string) $response->headers->get('Content-Type'));
+        $body = (string) $response->getContent();
+        self::assertStringContainsString('Contact:', $body);
+        self::assertStringContainsString('Expires:', $body);
+        self::assertStringContainsString('Canonical:', $body);
+    }
+
+    public function testChangePasswordRedirectsToSettings(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/.well-known/change-password');
+
+        $response = $this->client->getResponse();
+        self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        self::assertSame('/ui/settings', $response->headers->get('Location'));
+    }
+
+    public function testApiCatalogIsAlinksetPointingAtTheOpenApi(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/.well-known/api-catalog');
+
+        $response = $this->client->getResponse();
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/linkset+json', (string) $response->headers->get('Content-Type'));
+        $body = (string) $response->getContent();
+        $data = json_decode($body, true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('linkset', $data);
+        self::assertStringContainsString('/api.yml', $body);
+    }
+
+    public function testLlmsTxtIsPublicMarkdown(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/llms.txt');
+
+        $response = $this->client->getResponse();
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/markdown', (string) $response->headers->get('Content-Type'));
+        self::assertStringContainsString('# TimeTracker', (string) $response->getContent());
+    }
+
+    public function testDiscoveryLinkHeaderAdvertisesTheApi(): void
+    {
+        // The subscriber adds two Web Linking headers to every main response.
+        $this->client->request(Request::METHOD_GET, '/.well-known/security.txt');
+
+        $links = implode(', ', $this->client->getResponse()->headers->all('Link'));
+        self::assertStringContainsString('rel="service-desc"', $links);
+        self::assertStringContainsString('rel="api-catalog"', $links);
+    }
+}


### PR DESCRIPTION
First step of agent-readiness (Tier 1–2). Adds the standard discovery surface so LLMs/coding agents can find and understand timetracker. It's a **private, authenticated** app, so the stance is: point *authenticated* agents at the API, and tell *unauthenticated* crawlers there's nothing to index or train on.

## What's served
| Path | Standard |
|---|---|
| `/.well-known/security.txt` | RFC 9116 (Expires stamped 1y out per request) |
| `/.well-known/change-password` | W3C — 302 → `/ui/settings` (ADR-018 self-service change) |
| `/.well-known/api-catalog` | RFC 9727 `application/linkset+json` → the OpenAPI |
| `/llms.txt` | llmstxt.org |
| `Link` headers (every response) | RFC 8288/8631 — `service-desc` + `api-catalog` |
| JSON-LD in the SPA shell | schema.org `WebApplication` (hex-escaped like `APP_CONFIG`) |
| `robots.txt` | `Content-Signal: search=no, ai-input=no, ai-train=no` + explicit disallow for GPTBot/ClaudeBot/CCBot/Google-Extended/PerplexityBot/Bytespider |

Routes are public (`access_control`) and read-only; verified protected routes still redirect unauth.

## Tests
`WellKnownControllerTest` (5): each endpoint's status + content-type, the change-password redirect target, api-catalog points at `/api.yml`, and both discovery `Link` headers. PHPStan L10, Rector, cs-fixer clean; live-probed on the e2e stack (correct content-types, `Link` headers, 302).

## Deferred (next, with API-token auth)
- **`/.well-known/agent-skills.json`** ([Cloudflare RFC](https://github.com/cloudflare/agent-skills-discovery-rfc)) — a `SKILL.md` index (e.g. "log time"); a useful skill must *call* the API.
- **MCP server** — thin wrapper over the token-auth API for MCP-native clients; no new capability, just turnkey integration.
- **API-token auth** — the real prerequisite for agents to *act* (own ADR). Today the API is session-cookie only.

## Note
The `security.txt` contact (`mailto:security@netresearch.de`) should be confirmed against the real Netresearch security channel.