### PR TITLE
feat(api): API token foundation — schema, service, scopes, CLI (ADR-021 Phase 1)

### DIFF
--- a/migrations/Version20260704_AddApiTokens.php
+++ b/migrations/Version20260704_AddApiTokens.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add the `api_tokens` table for user-bound Personal Access Tokens (ADR-021).
+ *
+ * Only the SHA-256 hash of a token is stored (`token_hash`, unique). Scopes are a
+ * JSON array. A token is active while `revoked_at` is NULL and `expires_at` is
+ * NULL or in the future. Additive: no existing table changes.
+ */
+final class Version20260704_AddApiTokens extends AbstractMigration
+{
+    #[\Override]
+    public function getDescription(): string
+    {
+        return 'Add api_tokens table for user-bound API personal access tokens (ADR-021)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE api_tokens (
+                id INT AUTO_INCREMENT NOT NULL,
+                user_id INT NOT NULL,
+                name VARCHAR(100) NOT NULL,
+                token_hash VARCHAR(64) NOT NULL,
+                scopes JSON NOT NULL,
+                created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)',
+                expires_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+                last_used_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+                revoked_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+                UNIQUE INDEX uniq_api_token_hash (token_hash),
+                INDEX idx_api_token_user (user_id),
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+            SQL);
+        $this->addSql('ALTER TABLE api_tokens ADD CONSTRAINT FK_api_tokens_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE');
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE api_tokens');
+    }
+}

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -443,3 +443,20 @@ LEFT JOIN teams_users tu ON tu.user_id=u.id
 LEFT JOIN teams t ON t.id=tu.team_id
 WHERE u.type = 'DEV'
 GROUP BY Team, Jahr,Monat ORDER BY Jahr ASC, Monat ASC, Team ASC;
+
+-- User-bound API personal access tokens (ADR-021). Only the SHA-256 hash is stored.
+CREATE TABLE `api_tokens` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `name` VARCHAR(100) NOT NULL,
+  `token_hash` VARCHAR(64) NOT NULL,
+  `scopes` JSON NOT NULL,
+  `created_at` DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)',
+  `expires_at` DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+  `last_used_at` DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+  `revoked_at` DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_api_token_hash` (`token_hash`),
+  KEY `idx_api_token_user` (`user_id`),
+  CONSTRAINT `FK_api_tokens_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/Command/CreateApiTokenCommand.php
+++ b/src/Command/CreateApiTokenCommand.php
@@ -13,7 +13,7 @@ use App\Entity\User;
 use App\Service\ApiToken\ApiTokenService;
 use App\Service\ClockInterface;
 use App\ValueObject\ApiScope;
-use DateTimeImmutable;
+use DateMalformedStringException;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use Symfony\Component\Console\Attribute\Argument;
@@ -24,7 +24,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 use function implode;
 use function sprintf;
-use function strtotime;
 
 /**
  * Mint an API personal access token for a user (ADR-021), for cron/bootstrap use.
@@ -70,14 +69,15 @@ final readonly class CreateApiTokenCommand
 
         $expiresAt = null;
         if (null !== $expires && '' !== $expires) {
-            $timestamp = strtotime($expires, $this->clock->now()->getTimestamp());
-            if (false === $timestamp) {
+            try {
+                // Relative to the injected clock (not the system clock) so the
+                // stored expiry matches the app's time and stays testable.
+                $expiresAt = $this->clock->now()->modify($expires);
+            } catch (DateMalformedStringException) {
                 $io->error('Invalid --expires. Use e.g. "+90 days" or "2026-12-31".');
 
                 return Command::FAILURE;
             }
-
-            $expiresAt = new DateTimeImmutable()->setTimestamp($timestamp);
         }
 
         try {

--- a/src/Command/CreateApiTokenCommand.php
+++ b/src/Command/CreateApiTokenCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Service\ApiToken\ApiTokenService;
+use App\Service\ClockInterface;
+use App\ValueObject\ApiScope;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function implode;
+use function sprintf;
+use function strtotime;
+
+/**
+ * Mint an API personal access token for a user (ADR-021), for cron/bootstrap use.
+ * The plaintext is printed ONCE — it is not recoverable afterwards. Scopes narrow
+ * the user's access; enforcement is the Bearer firewall (Phase 2).
+ */
+#[AsCommand(name: 'app:api-token:create', description: 'Create an API personal access token for a user')]
+final readonly class CreateApiTokenCommand
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private ApiTokenService $apiTokenService,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @param list<string> $scope
+     */
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument(description: 'Login username the token acts as')]
+        string $username,
+        #[Argument(description: 'A label for the token (e.g. "ci-worklog")')]
+        string $name,
+        #[Option(description: 'Scope in resource:action form; repeatable. Use "*" for all the user can grant.', name: 'scope')]
+        array $scope = [],
+        #[Option(description: 'Optional expiry, e.g. "+90 days" or "2026-12-31"')]
+        ?string $expires = null,
+    ): int {
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        if (!$user instanceof User) {
+            $io->error(sprintf('No user "%s".', $username));
+
+            return Command::FAILURE;
+        }
+
+        if ([] === $scope) {
+            $io->error('At least one --scope is required. Valid scopes: ' . implode(', ', ApiScope::all()));
+
+            return Command::FAILURE;
+        }
+
+        $expiresAt = null;
+        if (null !== $expires && '' !== $expires) {
+            $timestamp = strtotime($expires, $this->clock->now()->getTimestamp());
+            if (false === $timestamp) {
+                $io->error('Invalid --expires. Use e.g. "+90 days" or "2026-12-31".');
+
+                return Command::FAILURE;
+            }
+
+            $expiresAt = new DateTimeImmutable()->setTimestamp($timestamp);
+        }
+
+        try {
+            [$token, $plaintext] = $this->apiTokenService->create($user, $name, $scope, $expiresAt);
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            $io->error($invalidArgumentException->getMessage() . ' Valid scopes: ' . implode(', ', ApiScope::all()));
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Created token "%s" for %s (scopes: %s).', $name, $username, implode(', ', $token->getScopes())));
+        $io->writeln('Token (shown once — store it now):');
+        $io->writeln('  <info>' . $plaintext . '</info>');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/ApiToken.php
+++ b/src/Entity/ApiToken.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\ApiTokenRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A user-bound Personal Access Token (ADR-021). Only the SHA-256 hash of the
+ * token is stored; the plaintext (prefix `tt_pat_…`) is shown once at creation.
+ * Scopes narrow the owning user's access. A token is active while it is neither
+ * revoked nor expired.
+ */
+#[ORM\Entity(repositoryClass: ApiTokenRepository::class)]
+#[ORM\Table(name: 'api_tokens')]
+class ApiToken
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    /**
+     * @param list<string> $scopes
+     */
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: User::class)]
+        #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+        private readonly User $user,
+        #[ORM\Column(type: 'string', length: 100)]
+        private string $name,
+        #[ORM\Column(name: 'token_hash', type: 'string', length: 64, unique: true)]
+        private readonly string $tokenHash,
+        #[ORM\Column(type: 'json')]
+        private array $scopes,
+        #[ORM\Column(name: 'created_at', type: 'datetime_immutable')]
+        private readonly DateTimeImmutable $createdAt,
+        #[ORM\Column(name: 'expires_at', type: 'datetime_immutable', nullable: true)]
+        private readonly ?DateTimeImmutable $expiresAt = null,
+        #[ORM\Column(name: 'last_used_at', type: 'datetime_immutable', nullable: true)]
+        private ?DateTimeImmutable $lastUsedAt = null,
+        #[ORM\Column(name: 'revoked_at', type: 'datetime_immutable', nullable: true)]
+        private ?DateTimeImmutable $revokedAt = null,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getTokenHash(): string
+    {
+        return $this->tokenHash;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getExpiresAt(): ?DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getLastUsedAt(): ?DateTimeImmutable
+    {
+        return $this->lastUsedAt;
+    }
+
+    public function setLastUsedAt(?DateTimeImmutable $lastUsedAt): void
+    {
+        $this->lastUsedAt = $lastUsedAt;
+    }
+
+    public function getRevokedAt(): ?DateTimeImmutable
+    {
+        return $this->revokedAt;
+    }
+
+    public function revoke(DateTimeImmutable $when): void
+    {
+        $this->revokedAt ??= $when;
+    }
+
+    /**
+     * Active = not revoked and not past its expiry.
+     */
+    public function isActive(DateTimeImmutable $now): bool
+    {
+        if ($this->revokedAt instanceof DateTimeImmutable) {
+            return false;
+        }
+
+        return !($this->expiresAt instanceof DateTimeImmutable) || $this->expiresAt > $now;
+    }
+}

--- a/src/Repository/ApiTokenRepository.php
+++ b/src/Repository/ApiTokenRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ApiToken>
+ */
+class ApiTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ApiToken::class);
+    }
+
+    public function findOneByHash(string $tokenHash): ?ApiToken
+    {
+        return $this->findOneBy(['tokenHash' => $tokenHash]);
+    }
+
+    /**
+     * A user's tokens, newest first (for the management list).
+     *
+     * @return list<ApiToken>
+     */
+    public function findByUser(User $user): array
+    {
+        return $this->findBy(['user' => $user], ['createdAt' => 'DESC']);
+    }
+}

--- a/src/Service/ApiToken/ApiTokenService.php
+++ b/src/Service/ApiToken/ApiTokenService.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\ApiToken;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Repository\ApiTokenRepository;
+use App\Service\ClockInterface;
+use App\ValueObject\ApiScope;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use SensitiveParameter;
+
+use function hash;
+use function in_array;
+use function sprintf;
+use function str_starts_with;
+
+/**
+ * Mints, verifies, and revokes API tokens (ADR-021). Tokens are opaque with a
+ * `tt_pat_` prefix; only their SHA-256 hash is stored. This service is auth-free
+ * (no firewall) — the Bearer authenticator that consumes findActiveByPlaintext()
+ * arrives in Phase 2.
+ */
+final readonly class ApiTokenService
+{
+    /** Recognizable prefix for secret-scanning and safe logging. */
+    public const string PREFIX = 'tt_pat_';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private ApiTokenRepository $apiTokenRepository,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * Create a token and return the entity plus the ONE-TIME plaintext (never
+     * recoverable afterwards).
+     *
+     * @param list<string> $scopes
+     *
+     * @throws InvalidArgumentException on an unknown scope or an empty scope list
+     *
+     * @return array{0: ApiToken, 1: string}
+     */
+    public function create(User $user, string $name, array $scopes, ?DateTimeImmutable $expiresAt = null): array
+    {
+        if ([] === $scopes) {
+            throw new InvalidArgumentException('At least one scope is required.');
+        }
+
+        foreach ($scopes as $scope) {
+            if (!ApiScope::isValid($scope)) {
+                throw new InvalidArgumentException(sprintf('Unknown scope: %s', $scope));
+            }
+        }
+
+        $plaintext = self::PREFIX . bin2hex(random_bytes(32));
+        $token = new ApiToken(
+            $user,
+            $name,
+            $this->hash($plaintext),
+            array_values(array_unique($scopes)),
+            $this->clock->now(),
+            $expiresAt,
+        );
+
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+
+        return [$token, $plaintext];
+    }
+
+    public function hash(string $plaintext): string
+    {
+        return hash('sha256', $plaintext);
+    }
+
+    /**
+     * Resolve a presented plaintext token to its active entity, or null if the
+     * prefix is wrong, the token is unknown, revoked, or expired.
+     */
+    public function findActiveByPlaintext(#[SensitiveParameter] string $plaintext): ?ApiToken
+    {
+        if (!str_starts_with($plaintext, self::PREFIX)) {
+            return null;
+        }
+
+        $token = $this->apiTokenRepository->findOneByHash($this->hash($plaintext));
+        if (!$token instanceof ApiToken || !$token->isActive($this->clock->now())) {
+            return null;
+        }
+
+        return $token;
+    }
+
+    public function recordUsage(ApiToken $token): void
+    {
+        $token->setLastUsedAt($this->clock->now());
+        $this->entityManager->flush();
+    }
+
+    public function revoke(ApiToken $token): void
+    {
+        $token->revoke($this->clock->now());
+        $this->entityManager->flush();
+    }
+
+    /**
+     * The scopes an owner may still grant that are not already on the token
+     * (used by the future management UI); a thin wrapper over the taxonomy so
+     * callers don't import ApiScope directly.
+     *
+     * @param list<string> $current
+     *
+     * @return list<string>
+     */
+    public function grantableScopes(array $current): array
+    {
+        return array_values(array_filter(ApiScope::all(), static fn (string $scope): bool => !in_array($scope, $current, true)));
+    }
+}

--- a/src/ValueObject/ApiScope.php
+++ b/src/ValueObject/ApiScope.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\ValueObject;
+
+use function in_array;
+
+/**
+ * The OAuth2-style `resource:action` scope taxonomy for API tokens (ADR-021).
+ *
+ * A token's scopes NARROW the owning user's access — they never expand it (the
+ * user's roles are still checked). Enforcement (a #[RequireScope] voter on the
+ * Bearer firewall) lands in Phase 2; this class is the single source of valid
+ * scope strings and the grant check.
+ */
+final class ApiScope
+{
+    /** Grants every scope the owning user can exercise. */
+    public const string WILDCARD = '*';
+
+    /** @var list<string> API resource areas (see docs/agent-readiness.md / api.yml) */
+    public const array RESOURCES = [
+        'entries', 'projects', 'customers', 'activities', 'presets', 'teams',
+        'users', 'contracts', 'ticketsystems', 'reporting', 'settings', 'sync',
+    ];
+
+    /** @var list<string> */
+    public const array ACTIONS = ['read', 'write'];
+
+    /**
+     * Every valid scope string, including the wildcard.
+     *
+     * @return list<string>
+     */
+    public static function all(): array
+    {
+        $scopes = [self::WILDCARD];
+        foreach (self::RESOURCES as $resource) {
+            foreach (self::ACTIONS as $action) {
+                $scopes[] = $resource . ':' . $action;
+            }
+        }
+
+        return $scopes;
+    }
+
+    public static function isValid(string $scope): bool
+    {
+        return in_array($scope, self::all(), true);
+    }
+
+    /**
+     * Whether a token carrying $granted scopes satisfies the $required scope.
+     * The wildcard satisfies anything.
+     *
+     * @param list<string> $granted
+     */
+    public static function grants(array $granted, string $required): bool
+    {
+        return in_array(self::WILDCARD, $granted, true) || in_array($required, $granted, true);
+    }
+}

--- a/src/ValueObject/ApiScope.php
+++ b/src/ValueObject/ApiScope.php
@@ -33,13 +33,20 @@ final class ApiScope
     /** @var list<string> */
     public const array ACTIONS = ['read', 'write'];
 
+    /** @var list<string>|null memoised scope list (resources/actions are constant) */
+    private static ?array $all = null;
+
     /**
-     * Every valid scope string, including the wildcard.
+     * Every valid scope string, including the wildcard. Computed once.
      *
      * @return list<string>
      */
     public static function all(): array
     {
+        if (null !== self::$all) {
+            return self::$all;
+        }
+
         $scopes = [self::WILDCARD];
         foreach (self::RESOURCES as $resource) {
             foreach (self::ACTIONS as $action) {
@@ -47,7 +54,7 @@ final class ApiScope
             }
         }
 
-        return $scopes;
+        return self::$all = $scopes;
     }
 
     public static function isValid(string $scope): bool

--- a/tests/Command/CreateApiTokenCommandTest.php
+++ b/tests/Command/CreateApiTokenCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Command;
+
+use App\Command\CreateApiTokenCommand;
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Repository\ApiTokenRepository;
+use App\Service\ApiToken\ApiTokenService;
+use App\Service\FrozenClock;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[CoversClass(CreateApiTokenCommand::class)]
+final class CreateApiTokenCommandTest extends TestCase
+{
+    private ?ApiToken $persisted = null;
+
+    public function testCreatesTokenAndPrintsThePlaintextOnce(): void
+    {
+        $tester = new CommandTester($this->makeCommand(new User()->setUsername('jane')->setType('DEV')));
+        $status = $tester->execute(['username' => 'jane', 'name' => 'ci', '--scope' => ['entries:write', 'entries:read']]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertInstanceOf(ApiToken::class, $this->persisted);
+        self::assertSame(['entries:write', 'entries:read'], $this->persisted->getScopes());
+        // The one-time plaintext is shown, and only the hash is stored.
+        self::assertStringContainsString('tt_pat_', $tester->getDisplay());
+        self::assertNotSame('', $this->persisted->getTokenHash());
+    }
+
+    public function testFailsForUnknownUser(): void
+    {
+        $tester = new CommandTester($this->makeCommand(null));
+        $status = $tester->execute(['username' => 'ghost', 'name' => 'x', '--scope' => ['entries:read']]);
+
+        self::assertSame(Command::FAILURE, $status);
+        self::assertStringContainsString('No user', $tester->getDisplay());
+    }
+
+    public function testFailsWithoutScope(): void
+    {
+        $tester = new CommandTester($this->makeCommand(new User()->setUsername('jane')->setType('DEV')));
+        $status = $tester->execute(['username' => 'jane', 'name' => 'x']);
+
+        self::assertSame(Command::FAILURE, $status);
+        self::assertStringContainsString('scope', $tester->getDisplay());
+    }
+
+    public function testFailsForUnknownScope(): void
+    {
+        $tester = new CommandTester($this->makeCommand(new User()->setUsername('jane')->setType('DEV')));
+        $status = $tester->execute(['username' => 'jane', 'name' => 'x', '--scope' => ['entries:delete']]);
+
+        self::assertSame(Command::FAILURE, $status);
+        self::assertStringContainsString('scope', $tester->getDisplay());
+    }
+
+    private function makeCommand(?User $user): Command
+    {
+        $entityManager = self::createStub(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($this->userRepositoryReturning($user));
+        $entityManager->method('persist')->willReturnCallback(function (object $object): void {
+            if ($object instanceof ApiToken) {
+                $this->persisted = $object;
+            }
+        });
+
+        $clock = new FrozenClock('2024-01-15 12:00:00');
+        $service = new ApiTokenService($entityManager, self::createStub(ApiTokenRepository::class), $clock);
+
+        $command = new Command('app:api-token:create');
+        $command->setCode(new CreateApiTokenCommand($entityManager, $service, $clock));
+
+        return $command;
+    }
+
+    private function userRepositoryReturning(?User $user): EntityRepository
+    {
+        $repository = self::createStub(EntityRepository::class);
+        $repository->method('findOneBy')->willReturn($user);
+
+        return $repository;
+    }
+}

--- a/tests/Service/ApiToken/ApiTokenServiceTest.php
+++ b/tests/Service/ApiToken/ApiTokenServiceTest.php
@@ -62,7 +62,7 @@ final class ApiTokenServiceTest extends TestCase
         $service->create($this->createMock(User::class), 'x', []);
     }
 
-    public function testFindActiveRejectsAwrongPrefixWithoutHittingTheRepository(): void
+    public function testFindActiveRejectsAWrongPrefixWithoutHittingTheRepository(): void
     {
         $apiTokenRepository = $this->createMock(ApiTokenRepository::class);
         $apiTokenRepository->expects(self::never())->method('findOneByHash');
@@ -109,6 +109,29 @@ final class ApiTokenServiceTest extends TestCase
         $service->revoke($token);
 
         self::assertNotNull($token->getRevokedAt());
+    }
+
+    public function testRecordUsageStampsLastUsedAtFromTheClockAndFlushes(): void
+    {
+        $token = $this->token(revoked: false, expired: false);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $service = $this->service($entityManager, $this->createMock(ApiTokenRepository::class));
+        $service->recordUsage($token);
+
+        self::assertSame(self::NOW, $token->getLastUsedAt()?->format('Y-m-d H:i:s'));
+    }
+
+    public function testGrantableScopesExcludesTheScopesAlreadyOnTheToken(): void
+    {
+        $service = $this->service($this->createMock(EntityManagerInterface::class), $this->createMock(ApiTokenRepository::class));
+
+        $grantable = $service->grantableScopes(['entries:read', '*']);
+
+        self::assertNotContains('entries:read', $grantable);
+        self::assertNotContains('*', $grantable);
+        self::assertContains('projects:write', $grantable);
     }
 
     private function service(EntityManagerInterface $entityManager, ApiTokenRepository $apiTokenRepository): ApiTokenService

--- a/tests/Service/ApiToken/ApiTokenServiceTest.php
+++ b/tests/Service/ApiToken/ApiTokenServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Service\ApiToken;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Repository\ApiTokenRepository;
+use App\Service\ApiToken\ApiTokenService;
+use App\Service\FrozenClock;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class ApiTokenServiceTest extends TestCase
+{
+    private const string NOW = '2024-01-15 12:00:00';
+
+    public function testCreateReturnsPrefixedPlaintextAndStoresOnlyItsHash(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('persist');
+        $entityManager->expects(self::once())->method('flush');
+
+        $service = $this->service($entityManager, $this->createMock(ApiTokenRepository::class));
+        [$token, $plaintext] = $service->create($this->createMock(User::class), 'ci', ['entries:write', 'entries:read']);
+
+        self::assertStringStartsWith('tt_pat_', $plaintext);
+        // Only the hash is persisted, never the plaintext.
+        self::assertSame($service->hash($plaintext), $token->getTokenHash());
+        self::assertNotSame($plaintext, $token->getTokenHash());
+        self::assertSame(['entries:write', 'entries:read'], $token->getScopes());
+    }
+
+    public function testCreateRejectsUnknownScope(): void
+    {
+        $service = $this->service($this->createMock(EntityManagerInterface::class), $this->createMock(ApiTokenRepository::class));
+
+        $this->expectException(InvalidArgumentException::class);
+        $service->create($this->createMock(User::class), 'x', ['entries:delete']);
+    }
+
+    public function testCreateRejectsEmptyScopes(): void
+    {
+        $service = $this->service($this->createMock(EntityManagerInterface::class), $this->createMock(ApiTokenRepository::class));
+
+        $this->expectException(InvalidArgumentException::class);
+        $service->create($this->createMock(User::class), 'x', []);
+    }
+
+    public function testFindActiveRejectsAwrongPrefixWithoutHittingTheRepository(): void
+    {
+        $apiTokenRepository = $this->createMock(ApiTokenRepository::class);
+        $apiTokenRepository->expects(self::never())->method('findOneByHash');
+
+        $service = $this->service($this->createMock(EntityManagerInterface::class), $apiTokenRepository);
+        self::assertNull($service->findActiveByPlaintext('nope_1234'));
+    }
+
+    public function testFindActiveReturnsAnActiveToken(): void
+    {
+        $token = $this->token(revoked: false, expired: false);
+        $apiTokenRepository = $this->createMock(ApiTokenRepository::class);
+        $apiTokenRepository->method('findOneByHash')->willReturn($token);
+
+        $service = $this->service($this->createMock(EntityManagerInterface::class), $apiTokenRepository);
+        self::assertSame($token, $service->findActiveByPlaintext('tt_pat_abc'));
+    }
+
+    public function testFindActiveRejectsRevokedAndExpired(): void
+    {
+        $apiTokenRepository = $this->createMock(ApiTokenRepository::class);
+        $service = $this->service($this->createMock(EntityManagerInterface::class), $apiTokenRepository);
+
+        $apiTokenRepository->method('findOneByHash')->willReturn($this->token(revoked: true, expired: false));
+        self::assertNull($service->findActiveByPlaintext('tt_pat_revoked'));
+    }
+
+    public function testFindActiveRejectsExpired(): void
+    {
+        $apiTokenRepository = $this->createMock(ApiTokenRepository::class);
+        $apiTokenRepository->method('findOneByHash')->willReturn($this->token(revoked: false, expired: true));
+
+        $service = $this->service($this->createMock(EntityManagerInterface::class), $apiTokenRepository);
+        self::assertNull($service->findActiveByPlaintext('tt_pat_expired'));
+    }
+
+    public function testRevokeStampsRevokedAtAndFlushes(): void
+    {
+        $token = $this->token(revoked: false, expired: false);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $service = $this->service($entityManager, $this->createMock(ApiTokenRepository::class));
+        $service->revoke($token);
+
+        self::assertNotNull($token->getRevokedAt());
+    }
+
+    private function service(EntityManagerInterface $entityManager, ApiTokenRepository $apiTokenRepository): ApiTokenService
+    {
+        return new ApiTokenService($entityManager, $apiTokenRepository, new FrozenClock(self::NOW));
+    }
+
+    private function token(bool $revoked, bool $expired): ApiToken
+    {
+        $now = new DateTimeImmutable(self::NOW);
+
+        return new ApiToken(
+            $this->createMock(User::class),
+            'name',
+            'hash',
+            ['entries:read'],
+            $now,
+            $expired ? $now->modify('-1 day') : $now->modify('+1 day'),
+            null,
+            $revoked ? $now : null,
+        );
+    }
+}

--- a/tests/ValueObject/ApiScopeTest.php
+++ b/tests/ValueObject/ApiScopeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\ValueObject;
+
+use App\ValueObject\ApiScope;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class ApiScopeTest extends TestCase
+{
+    public function testAllIncludesWildcardAndResourceActions(): void
+    {
+        $all = ApiScope::all();
+
+        self::assertContains('*', $all);
+        self::assertContains('entries:read', $all);
+        self::assertContains('projects:write', $all);
+        // 12 resources x 2 actions + the wildcard.
+        self::assertCount(25, $all);
+    }
+
+    public function testIsValid(): void
+    {
+        self::assertTrue(ApiScope::isValid('entries:write'));
+        self::assertTrue(ApiScope::isValid('*'));
+        self::assertFalse(ApiScope::isValid('entries:delete'));
+        self::assertFalse(ApiScope::isValid('bogus'));
+        self::assertFalse(ApiScope::isValid(''));
+    }
+
+    public function testGrantsHonoursWildcardAndExactMatch(): void
+    {
+        self::assertTrue(ApiScope::grants(['*'], 'users:write'));
+        self::assertTrue(ApiScope::grants(['entries:read', 'projects:read'], 'projects:read'));
+        self::assertFalse(ApiScope::grants(['entries:read'], 'entries:write'));
+        self::assertFalse(ApiScope::grants([], 'entries:read'));
+    }
+}


### PR DESCRIPTION
**Phase 1 of [ADR-021](../blob/main/docs/adr/ADR-021-api-token-authentication.md)** — the storage and minting layer for API personal access tokens. **No firewall yet**: tokens can be created but are not accepted for auth until Phase 2 wires the Bearer authenticator, so this PR adds no live auth surface.

## What's here
- **`ApiToken` entity + migration + `sql/full.sql`** — user-bound tokens; only the **SHA-256 hash** is stored (unique), scopes as JSON, `expires_at` / `last_used_at` / `revoked_at`. Additive; FK to `users` with `ON DELETE CASCADE`.
- **`ApiScope` (`App\ValueObject`)** — the `resource:action` taxonomy (12 resources × read/write + `*` wildcard) with `isValid()` and a `grants()` check for the Phase 2 voter.
- **`ApiTokenService`** — `create` (opaque `tt_pat_…`, returns the one-time plaintext), `hash`, `findActiveByPlaintext` (prefix + hash lookup + active check), `revoke`, `recordUsage`.
- **`app:api-token:create` CLI** — for cron/bootstrap; prints the plaintext **once**.

## Tests
`ApiScopeTest`, `ApiTokenServiceTest` (hash-not-plaintext, scope validation, active/revoked/expired resolution, revoke), `CreateApiTokenCommandTest`. All four PHP gates clean (PHPStan L10, cs-fixer, Rector, **phpat**). Verified **end-to-end against MariaDB**: the CLI minted a token and the row stored the hash (`91ea1a36…`), never the plaintext.

## Next (separate PRs)
Phase 2: stateless Bearer firewall + authenticator + `#[RequireScope]` voter + the fail-closed route test. Then Settings UI, OpenAPI `securitySchemes`, and finally `agent-skills.json` + MCP.