### PR TITLE
fix(a11y): fix the /ui/tracking contrast flake at its source (header worktime labels)

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -62,7 +62,7 @@
   --color-bg: light-dark(#f6f8f9, #15181c);
   --color-surface: light-dark(#ffffff, #1d2127);
   --color-text: light-dark(#1c1e21, #f1f2f4);
-  --color-text-muted: light-dark(#50555b, #b9bec4);
+  --color-text-muted: light-dark(#414650, #b9bec4);
   --color-border: light-dark(#dde5e8, #3c434b);
   --color-link: light-dark(#0a4f8f, #93c1f8);
   --color-focus: light-dark(#0a4f8f, #93c1f8);

--- a/frontend/src/styles/header.css
+++ b/frontend/src/styles/header.css
@@ -227,7 +227,10 @@
 }
 
 .worktime-item dt {
-    color: light-dark(#50555b,#b9bec4);
+    /* Use the shared muted token (not a hardcoded copy) so its AA-contrast value
+       applies here too — the old literal #50555b was ~4.49:1 on the header, a
+       near-threshold flake source in the a11y scan. */
+    color: var(--color-text-muted);
     font-size: 10px;
     letter-spacing: .5px;
     margin: 0;


### PR DESCRIPTION
## The flake
The `/ui/tracking` accessibility test (`accessibility.spec.ts`) has flaked across nearly every PR with a color-contrast violation. Prior commits (`7f2db795`, `a5a9e4c2`, `4bbebd83`) tried to *stabilise the scan* (blur, scroll-reset, rAF) — it kept flaking.

## Root cause (reproduced)
Running raw axe (no stabilisation) 12× against `/ui/tracking` reliably flags `.worktime-item > dt` — the header **"Heute / Woche / Monat"** labels — at **contrast 4.49** (`#50555b` on a composited `#c8c8c8`). It's a **near-threshold** value (4.49 vs 4.5), so sub-pixel rendering tips it below on some runs. The color was a **hardcoded `#50555b`** in `header.css` — a stale copy of the muted design token, so it never benefited from the token's contrast.

## Fix
- `.worktime-item dt` now uses the shared `var(--color-text-muted)` (no hardcoded copy).
- `--color-text-muted` (light) darkened `#50555b` → `#414650`: **~5.7:1** on the header composite and **~9:1** on white — comfortable margin, moving toward the app's stated 7:1 (AAA) target. Dark-mode value unchanged.

## Verification
- **0** color-contrast violations across **10 raw axe scans** (stabilisation removed, to prove the contrast itself is fixed).
- Full `accessibility.spec.ts` green (login / tracking / auswertung / admin).
- Earlier: the `/ui/tracking` test passed 8/8 consecutive runs.

The scan stabilisation is left in place as defence-in-depth for the separate sticky-header composite artifact, but the reliable flake source is now gone.