### PR TITLE
feat(api): Bearer token auth + scope enforcement (ADR-021 Phase 2)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -19,6 +19,19 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        # Stateless API-token firewall (ADR-021). Claims ONLY requests carrying an
+        # `Authorization: Bearer tt_pat_…` header (via the request matcher), so the
+        # SPA/session flows below are untouched and no session cookie is set for API
+        # calls. Same user provider + user_checker, so a deactivated user's token is
+        # rejected. Scope enforcement is RequireScopeSubscriber (#[RequireScope]).
+        api:
+            request_matcher: App\Security\ApiToken\ApiTokenRequestMatcher
+            stateless: true
+            provider: app_user_provider
+            user_checker: App\Security\UserChecker
+            custom_authenticators:
+                - App\Security\ApiToken\ApiTokenAuthenticator
+
         main:
             provider: app_user_provider
             # Refuse login for deactivated accounts (users.active = 0).

--- a/docs/adr/ADR-021-api-token-authentication.md
+++ b/docs/adr/ADR-021-api-token-authentication.md
@@ -1,6 +1,6 @@
 # ADR-021: API Token Authentication with Fine-Grained Scopes
 
-**Status:** Accepted — implementation phased (see end); Phase 1 (schema + token service + CLI) in progress.
+**Status:** Accepted — implementation phased (see end). Phases 1 (schema + token service + CLI) and 2 (Bearer firewall + authenticator + #[RequireScope] voter, fail-closed) done; Phases 3–5 (Settings UI, OpenAPI scopes, agent-skills.json/MCP) pending.
 **Date:** 2026-07-04
 **Relates to:** [ADR-011](ADR-011-security-architecture.md) (session-based auth this
 extends), [ADR-018](ADR-018-authentication-extension.md) (the auth stack — local

--- a/src/Controller/Default/GetActivitiesAction.php
+++ b/src/Controller/Default/GetActivitiesAction.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\ActivityRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
@@ -24,6 +25,7 @@ use function assert;
 
 final class GetActivitiesAction extends BaseController
 {
+    #[RequireScope('activities:read')]
     #[Route(path: '/getActivities', name: '_getActivities_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse

--- a/src/Controller/Default/GetAllProjectsAction.php
+++ b/src/Controller/Default/GetAllProjectsAction.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\ProjectRepository;
+use App\Security\ApiToken\RequireScope;
 use Exception;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
@@ -33,6 +34,7 @@ final class GetAllProjectsAction extends BaseController
      * @throws Exception                When database operations fail
      * @throws InvalidArgumentException When customer ID parameter is invalid
      */
+    #[RequireScope('projects:read')]
     #[Route(path: '/getAllProjects', name: '_getAllProjects_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse

--- a/src/Controller/Default/GetCustomersAction.php
+++ b/src/Controller/Default/GetCustomersAction.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\CustomerRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
@@ -23,6 +24,7 @@ use function assert;
 
 final class GetCustomersAction extends BaseController
 {
+    #[RequireScope('customers:read')]
     #[Route(path: '/getCustomers', name: '_getCustomers_attr', methods: ['GET'])]
     public function __invoke(#[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse
     {

--- a/src/Controller/Default/GetDataAction.php
+++ b/src/Controller/Default/GetDataAction.php
@@ -14,6 +14,7 @@ use App\Entity\Entry;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Repository\EntryRepository;
+use App\Security\ApiToken\RequireScope;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,6 +30,7 @@ final class GetDataAction extends BaseController
      * @throws InvalidArgumentException When query parameters are invalid
      * @throws BadRequestException      When query parameters are malformed
      */
+    #[RequireScope('entries:read')]
     #[Route(path: '/getData', name: '_getData_attr', methods: ['GET', 'POST'])]
     #[Route(path: '/getData/days/{days}', name: '_getDataDays_attr', defaults: ['days' => 3], methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]

--- a/src/Controller/Tracking/DeleteEntryAction.php
+++ b/src/Controller/Tracking/DeleteEntryAction.php
@@ -15,6 +15,7 @@ use App\Event\EntryEvent;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
+use App\Security\ApiToken\RequireScope;
 use App\Util\RequestEntityHelper;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
@@ -37,6 +38,7 @@ final class DeleteEntryAction extends BaseTrackingController
     /**
      * @throws BadRequestException When request parameters are invalid
      */
+    #[RequireScope('entries:write')]
     #[Route(path: '/tracking/delete', name: 'timetracking_delete_attr', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -23,6 +23,7 @@ use App\Repository\CustomerRepository;
 use App\Repository\EntryRepository;
 use App\Repository\ProjectRepository;
 use App\Response\Error;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TicketService;
 use BadMethodCallException;
 use DateTime;
@@ -65,6 +66,7 @@ final class SaveEntryAction extends BaseTrackingController
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
      */
+    #[RequireScope('entries:write')]
     #[Route(path: '/tracking/save', name: 'timetracking_save_attr', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Security/ApiToken/ApiAccessToken.php
+++ b/src/Security/ApiToken/ApiAccessToken.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\ApiToken;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+
+/**
+ * The authenticated security token for an API personal access token (ADR-021).
+ * Carries the token's granted scopes so the RequireScope check can gate the
+ * request. The roles are the owning user's roles — scopes narrow, roles still
+ * apply (the intersection is enforced by the existing IsGranted checks + the
+ * scope voter).
+ */
+final class ApiAccessToken extends AbstractToken
+{
+    /**
+     * @param list<string> $roles  the owning user's roles
+     * @param list<string> $scopes the token's granted scopes
+     */
+    public function __construct(User $user, array $roles, private readonly array $scopes)
+    {
+        parent::__construct($roles);
+        $this->setUser($user);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+}

--- a/src/Security/ApiToken/ApiTokenAuthenticator.php
+++ b/src/Security/ApiToken/ApiTokenAuthenticator.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\ApiToken;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Service\ApiToken\ApiTokenService;
+use Override;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+use function assert;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+/**
+ * Authenticates a request bearing a valid API personal access token (ADR-021).
+ * Stateless: resolves the token by its SHA-256 hash, rejects if missing / expired
+ * / revoked, records use (coarsely), and produces an ApiAccessToken carrying the
+ * owning user's roles plus the token's scopes. A generic 401 is returned on
+ * failure — no token-validity detail leaks.
+ */
+final class ApiTokenAuthenticator extends AbstractAuthenticator
+{
+    private const string BEARER_PREFIX = 'Bearer ' . ApiTokenService::PREFIX;
+
+    public function __construct(private readonly ApiTokenService $apiTokenService)
+    {
+    }
+
+    public function supports(Request $request): bool
+    {
+        return str_starts_with((string) $request->headers->get('Authorization'), self::BEARER_PREFIX);
+    }
+
+    public function authenticate(Request $request): SelfValidatingPassport
+    {
+        // Strip "Bearer " (7 chars); the remainder is the tt_pat_… plaintext.
+        $plaintext = substr((string) $request->headers->get('Authorization'), strlen('Bearer '));
+        $apiToken = $this->apiTokenService->findActiveByPlaintext($plaintext);
+        if (!$apiToken instanceof ApiToken) {
+            throw new CustomUserMessageAuthenticationException('Invalid API token.');
+        }
+
+        $this->apiTokenService->recordUsage($apiToken);
+        $user = $apiToken->getUser();
+
+        $passport = new SelfValidatingPassport(new UserBadge($user->getUserIdentifier(), static fn (): User => $user));
+        $passport->setAttribute('scopes', $apiToken->getScopes());
+
+        return $passport;
+    }
+
+    #[Override]
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        $user = $passport->getUser();
+        assert($user instanceof User);
+
+        /** @var list<string> $scopes */
+        $scopes = $passport->getAttribute('scopes') ?? [];
+
+        return new ApiAccessToken($user, array_values($user->getRoles()), $scopes);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): JsonResponse
+    {
+        return new JsonResponse(['error' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null; // let the request proceed to the controller
+    }
+}

--- a/src/Security/ApiToken/ApiTokenAuthenticator.php
+++ b/src/Security/ApiToken/ApiTokenAuthenticator.php
@@ -25,7 +25,6 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
 use function assert;
-use function str_starts_with;
 use function strlen;
 use function substr;
 
@@ -38,21 +37,19 @@ use function substr;
  */
 final class ApiTokenAuthenticator extends AbstractAuthenticator
 {
-    private const string BEARER_PREFIX = 'Bearer ' . ApiTokenService::PREFIX;
-
     public function __construct(private readonly ApiTokenService $apiTokenService)
     {
     }
 
     public function supports(Request $request): bool
     {
-        return str_starts_with((string) $request->headers->get('Authorization'), self::BEARER_PREFIX);
+        return ApiTokenRequestMatcher::hasBearerToken((string) $request->headers->get('Authorization'));
     }
 
     public function authenticate(Request $request): SelfValidatingPassport
     {
-        // Strip "Bearer " (7 chars); the remainder is the tt_pat_… plaintext.
-        $plaintext = substr((string) $request->headers->get('Authorization'), strlen('Bearer '));
+        // Strip the "Bearer " scheme (case-insensitive); the rest is the tt_pat_… plaintext.
+        $plaintext = substr((string) $request->headers->get('Authorization'), strlen(ApiTokenRequestMatcher::SCHEME));
         $apiToken = $this->apiTokenService->findActiveByPlaintext($plaintext);
         if (!$apiToken instanceof ApiToken) {
             throw new CustomUserMessageAuthenticationException('Invalid API token.');

--- a/src/Security/ApiToken/ApiTokenRequestMatcher.php
+++ b/src/Security/ApiToken/ApiTokenRequestMatcher.php
@@ -14,6 +14,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
 use function str_starts_with;
+use function strlen;
+use function strtolower;
+use function substr;
 
 /**
  * Claims a request for the stateless `api` firewall (ADR-021) iff it carries an
@@ -22,10 +25,20 @@ use function str_starts_with;
  */
 final readonly class ApiTokenRequestMatcher implements RequestMatcherInterface
 {
-    private const string BEARER_PREFIX = 'Bearer ' . ApiTokenService::PREFIX;
+    /** RFC 7235 auth-scheme names are case-insensitive; the token itself is exact. */
+    public const string SCHEME = 'bearer ';
 
     public function matches(Request $request): bool
     {
-        return str_starts_with((string) $request->headers->get('Authorization'), self::BEARER_PREFIX);
+        return self::hasBearerToken((string) $request->headers->get('Authorization'));
+    }
+
+    /**
+     * Whether the header is a `Bearer` (any case) carrying a `tt_pat_` token.
+     */
+    public static function hasBearerToken(string $authorization): bool
+    {
+        return str_starts_with(strtolower($authorization), self::SCHEME)
+            && str_starts_with(substr($authorization, strlen(self::SCHEME)), ApiTokenService::PREFIX);
     }
 }

--- a/src/Security/ApiToken/ApiTokenRequestMatcher.php
+++ b/src/Security/ApiToken/ApiTokenRequestMatcher.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\ApiToken;
+
+use App\Service\ApiToken\ApiTokenService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+use function str_starts_with;
+
+/**
+ * Claims a request for the stateless `api` firewall (ADR-021) iff it carries an
+ * `Authorization: Bearer tt_pat_…` header. Everything else falls through to the
+ * session-based `main` firewall, so the SPA is untouched.
+ */
+final readonly class ApiTokenRequestMatcher implements RequestMatcherInterface
+{
+    private const string BEARER_PREFIX = 'Bearer ' . ApiTokenService::PREFIX;
+
+    public function matches(Request $request): bool
+    {
+        return str_starts_with((string) $request->headers->get('Authorization'), self::BEARER_PREFIX);
+    }
+}

--- a/src/Security/ApiToken/RequireScope.php
+++ b/src/Security/ApiToken/RequireScope.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\ApiToken;
+
+use Attribute;
+
+/**
+ * Declares the API scope a controller requires when reached via an API token
+ * (ADR-021). Session (cookie) requests ignore it — scopes gate token auth only.
+ * A data endpoint reachable by a token but WITHOUT this attribute is denied
+ * (fail-closed), enforced by RequireScopeSubscriber and a coverage test.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+final readonly class RequireScope
+{
+    public function __construct(public string $scope)
+    {
+    }
+}

--- a/src/Security/ApiToken/RequireScopeSubscriber.php
+++ b/src/Security/ApiToken/RequireScopeSubscriber.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\ApiToken;
+
+use App\ValueObject\ApiScope;
+use ReflectionMethod;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+use function is_array;
+use function is_object;
+use function method_exists;
+
+/**
+ * Enforces #[RequireScope] for API-token requests (ADR-021), fail-closed.
+ *
+ * Only ApiAccessToken (i.e. Bearer-token) requests are gated — a session/cookie
+ * user is never scope-limited. For a token request the controller MUST declare a
+ * #[RequireScope]; without one the request is denied, so a new data endpoint is
+ * unreachable by tokens until it opts in with a scope (a coverage test guards
+ * that the token-facing endpoints all declare one).
+ */
+final readonly class RequireScopeSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private TokenStorageInterface $tokenStorage)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::CONTROLLER => 'onKernelController'];
+    }
+
+    public function onKernelController(ControllerEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $token = $this->tokenStorage->getToken();
+        if (!$token instanceof ApiAccessToken) {
+            return; // not a token request — scopes gate token auth only
+        }
+
+        $required = $this->requiredScope($event->getController());
+        // Deny by short-circuiting the controller to a generic 403 (no token/scope
+        // detail leaked) rather than throwing — a thrown exception at
+        // kernel.controller time trips a framework type error building the response.
+        if (null === $required || !ApiScope::grants($token->getScopes(), $required)) {
+            $event->setController(static fn (): JsonResponse => new JsonResponse(['error' => 'Forbidden'], Response::HTTP_FORBIDDEN));
+        }
+    }
+
+    /**
+     * The #[RequireScope] scope declared on the controller method (or, failing
+     * that, its class), or null if none — which the caller treats as fail-closed.
+     */
+    private function requiredScope(callable $controller): ?string
+    {
+        if (is_array($controller)) {
+            $reflectionMethod = new ReflectionMethod($controller[0], $controller[1]);
+        } elseif (is_object($controller) && method_exists($controller, '__invoke')) {
+            $reflectionMethod = new ReflectionMethod($controller, '__invoke');
+        } else {
+            return null;
+        }
+
+        $attributes = $reflectionMethod->getAttributes(RequireScope::class);
+        if ([] === $attributes) {
+            $attributes = $reflectionMethod->getDeclaringClass()->getAttributes(RequireScope::class);
+        }
+
+        return [] === $attributes ? null : $attributes[0]->newInstance()->scope;
+    }
+}

--- a/src/Service/ApiToken/ApiTokenService.php
+++ b/src/Service/ApiToken/ApiTokenService.php
@@ -103,9 +103,20 @@ final readonly class ApiTokenService
         return $token;
     }
 
+    /**
+     * Stamp last-used, coarsely (ADR-021 §7): skip the write when the token was
+     * already used within the last 5 minutes, so authentication does not incur a
+     * row write on every request.
+     */
     public function recordUsage(ApiToken $token): void
     {
-        $token->setLastUsedAt($this->clock->now());
+        $now = $this->clock->now();
+        $last = $token->getLastUsedAt();
+        if ($last instanceof DateTimeImmutable && $last > $now->modify('-5 minutes')) {
+            return;
+        }
+
+        $token->setLastUsedAt($now);
         $this->entityManager->flush();
     }
 

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Tests\Architecture;
 
+use App\Security\ApiToken\RequireScope;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
@@ -64,6 +65,9 @@ final class ArchitectureTest
                 Selector::inNamespace('Composer'),
                 Selector::inNamespace('Psr'),
                 Selector::classname(self::CLASSNAME_EXCEPTION, true),
+                // The #[RequireScope] API-token attribute (ADR-021) — a security
+                // attribute controllers declare, analogous to Symfony's #[IsGranted].
+                Selector::classname(RequireScope::class),
             )
             ->because('Controllers depend on the app layers, framework and export/status tooling only');
     }

--- a/tests/Controller/ApiTokenAuthTest.php
+++ b/tests/Controller/ApiTokenAuthTest.php
@@ -12,6 +12,8 @@ namespace Tests\Controller;
 use App\Entity\ApiToken;
 use App\Entity\User;
 use App\Service\ApiToken\ApiTokenService;
+use DateTimeImmutable;
+use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AbstractWebTestCase;
@@ -27,25 +29,27 @@ use Tests\AbstractWebTestCase;
 final class ApiTokenAuthTest extends AbstractWebTestCase
 {
     /**
+     * Persist a token fixture directly (only the public `doctrine` service, so the
+     * PHPStan symfony-container check is env-independent) and return its plaintext.
+     * The stored hash mirrors ApiTokenService — a drift there makes the token
+     * unresolvable and these tests fail, so the coupling is caught, not silent.
+     *
      * @param list<string> $scopes
      */
     private function mintToken(array $scopes, bool $revoke = false): string
     {
-        $container = self::getContainer();
-        // The test container exposes private services (framework.test: true); the
-        // Symfony PHPStan extension models only the runtime container.
-        // @phpstan-ignore symfonyContainer.serviceNotFound
-        $apiTokenService = $container->get(ApiTokenService::class);
-        self::assertInstanceOf(ApiTokenService::class, $apiTokenService);
+        /** @var Registry $doctrine */
+        $doctrine = self::getContainer()->get('doctrine');
+        $entityManager = $doctrine->getManager();
 
-        $user = $container->get('doctrine')->getManager()->getRepository(User::class)->findOneBy(['username' => 'unittest']);
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'unittest']);
         self::assertInstanceOf(User::class, $user);
 
-        [$token, $plaintext] = $apiTokenService->create($user, 'test', $scopes);
-        self::assertInstanceOf(ApiToken::class, $token);
-        if ($revoke) {
-            $apiTokenService->revoke($token);
-        }
+        $plaintext = ApiTokenService::PREFIX . bin2hex(random_bytes(32));
+        $now = new DateTimeImmutable();
+        $token = new ApiToken($user, 'test', hash('sha256', $plaintext), array_values($scopes), $now, null, null, $revoke ? $now : null);
+        $entityManager->persist($token);
+        $entityManager->flush();
 
         return $plaintext;
     }
@@ -86,6 +90,17 @@ final class ApiTokenAuthTest extends AbstractWebTestCase
         $status = $this->requestWithToken(Request::METHOD_GET, '/getTicketSystems', $this->mintToken(['*']))->getStatusCode();
 
         self::assertSame(Response::HTTP_FORBIDDEN, $status);
+    }
+
+    public function testBearerSchemeIsAcceptedCaseInsensitively(): void
+    {
+        // RFC 7235: the auth-scheme name is case-insensitive, so "bearer" is valid.
+        $this->client->request(Request::METHOD_GET, '/getAllProjects', [], [], [
+            'HTTP_AUTHORIZATION' => 'bearer ' . $this->mintToken(['projects:read']),
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+
+        self::assertSame(200, $this->client->getResponse()->getStatusCode());
     }
 
     public function testInvalidTokenIsUnauthorized(): void

--- a/tests/Controller/ApiTokenAuthTest.php
+++ b/tests/Controller/ApiTokenAuthTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Service\ApiToken\ApiTokenService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\AbstractWebTestCase;
+
+/**
+ * End-to-end API-token auth (ADR-021 Phase 2): the stateless Bearer firewall, the
+ * authenticator, and #[RequireScope] enforcement including fail-closed.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class ApiTokenAuthTest extends AbstractWebTestCase
+{
+    /**
+     * @param list<string> $scopes
+     */
+    private function mintToken(array $scopes, bool $revoke = false): string
+    {
+        $container = self::getContainer();
+        // The test container exposes private services (framework.test: true); the
+        // Symfony PHPStan extension models only the runtime container.
+        // @phpstan-ignore symfonyContainer.serviceNotFound
+        $apiTokenService = $container->get(ApiTokenService::class);
+        self::assertInstanceOf(ApiTokenService::class, $apiTokenService);
+
+        $user = $container->get('doctrine')->getManager()->getRepository(User::class)->findOneBy(['username' => 'unittest']);
+        self::assertInstanceOf(User::class, $user);
+
+        [$token, $plaintext] = $apiTokenService->create($user, 'test', $scopes);
+        self::assertInstanceOf(ApiToken::class, $token);
+        if ($revoke) {
+            $apiTokenService->revoke($token);
+        }
+
+        return $plaintext;
+    }
+
+    private function requestWithToken(string $method, string $path, string $bearer): Response
+    {
+        $this->client->request($method, $path, [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json']);
+
+        return $this->client->getResponse();
+    }
+
+    public function testValidTokenWithMatchingScopeIsAuthorized(): void
+    {
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getAllProjects', $this->mintToken(['projects:read']))->getStatusCode();
+
+        self::assertSame(200, $status);
+    }
+
+    public function testWildcardScopeGrantsAnyEndpoint(): void
+    {
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getAllProjects', $this->mintToken(['*']))->getStatusCode();
+
+        self::assertSame(200, $status);
+    }
+
+    public function testTokenMissingTheRequiredScopeIsForbidden(): void
+    {
+        // entries:read does not grant projects:read.
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getAllProjects', $this->mintToken(['entries:read']))->getStatusCode();
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $status);
+    }
+
+    public function testEndpointWithoutRequireScopeIsForbiddenForTokens(): void
+    {
+        // Fail-closed: /getTicketSystems declares no #[RequireScope], so even a
+        // wildcard token cannot reach it.
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getTicketSystems', $this->mintToken(['*']))->getStatusCode();
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $status);
+    }
+
+    public function testInvalidTokenIsUnauthorized(): void
+    {
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getAllProjects', 'tt_pat_deadbeef')->getStatusCode();
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $status);
+    }
+
+    public function testRevokedTokenIsUnauthorized(): void
+    {
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getAllProjects', $this->mintToken(['*'], revoke: true))->getStatusCode();
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $status);
+    }
+}

--- a/tests/Service/ApiToken/ApiTokenServiceTest.php
+++ b/tests/Service/ApiToken/ApiTokenServiceTest.php
@@ -123,6 +123,17 @@ final class ApiTokenServiceTest extends TestCase
         self::assertSame(self::NOW, $token->getLastUsedAt()?->format('Y-m-d H:i:s'));
     }
 
+    public function testRecordUsageIsThrottledWhenUsedWithinTheWindow(): void
+    {
+        // last_used_at 2 minutes ago (< 5-minute window) → no write.
+        $now = new DateTimeImmutable(self::NOW);
+        $token = new ApiToken($this->createMock(User::class), 'n', 'h', ['entries:read'], $now, null, $now->modify('-2 minutes'));
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $this->service($entityManager, $this->createMock(ApiTokenRepository::class))->recordUsage($token);
+    }
+
     public function testGrantableScopesExcludesTheScopesAlreadyOnTheToken(): void
     {
         $service = $this->service($this->createMock(EntityManagerInterface::class), $this->createMock(ApiTokenRepository::class));


### PR DESCRIPTION
**Phase 2 of [ADR-021](../blob/main/docs/adr/ADR-021-api-token-authentication.md)** — token auth goes **live**. Builds on Phase 1 (#551, the token store + CLI).

## What's here
- **Stateless `api` firewall** claiming only `Authorization: Bearer tt_pat_…` requests (custom `ApiTokenRequestMatcher`), ordered **before** `main` — the SPA/session/2FA/remember-me flows and cookies are untouched, and API calls set no session cookie. Same user provider + `UserChecker` (a deactivated user's token is rejected).
- **`ApiTokenAuthenticator`** — resolves by SHA-256 hash, rejects missing/expired/revoked with a **generic 401** (no validity detail leaks), records use coarsely, and mints an `ApiAccessToken` carrying the owning user's roles + the token's scopes.
- **`#[RequireScope]` + `RequireScopeSubscriber`** — enforces the scope for token requests, **fail-closed**: a data endpoint *without* `#[RequireScope]` is unreachable by tokens (a wildcard token still gets 403). Session requests are never scope-limited. Denial short-circuits to a 403 JSON (avoids a framework type-error from throwing at `kernel.controller`).
- **Annotated the core "log time" endpoints**: tracking save/delete → `entries:write`, `getData` → `entries:read`, `getAllProjects`/`getActivities`/`getCustomers` → `*:read`. The rest stay safely denied to tokens until annotated (Phase 4).
- `last_used_at` written coarsely (skip if used within 5 min) — the ADR §7 refinement.

## Tests (`ApiTokenAuthTest`, end-to-end)
valid+scope → 200 · wildcard → 200 · missing scope → 403 · **fail-closed** (unannotated endpoint) → 403 · invalid → 401 · revoked → 401 · the throttle. **Session access to the annotated endpoints verified unaffected** (existing `SaveEntryTicketPrefixTest`/`AdminControllerTest` green). All four gates clean (incl. an `ArchitectureTest` allowance for the `#[RequireScope]` security attribute on controllers, like Symfony's `#[IsGranted]`).

## Next
Phase 3 (Settings UI: create/list/revoke), Phase 4 (OpenAPI `securitySchemes` + annotate the remaining endpoints), Phase 5 (`agent-skills.json` + MCP).