### PR TITLE
fix(jira): stop orphaning worklogs on entry delete

### DIFF
--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -164,21 +164,13 @@ class Project extends Base
     #[ORM\Column(name: 'additional_information_from_external', type: 'boolean', options: ['default' => false])]
     protected bool $additionalInformationFromExternal = false;
 
-    /**
-     * the internal key of the project the current ticket should be booked to.
-     *
-     * @var string|null
-     */
+    /** the internal key of the project the current ticket should be booked to. */
     #[ORM\Column(name: 'internal_jira_project_key', type: 'string', length: 255, nullable: true)]
-    protected $internalJiraProjectKey;
+    protected ?string $internalJiraProjectKey = null;
 
-    /**
-     * the id of the internal jira ticket system.
-     *
-     * @var string|null
-     */
+    /** the id of the internal jira ticket system. */
     #[ORM\Column(name: 'internal_jira_ticket_system', type: 'string', length: 255, nullable: true)]
-    protected $internalJiraTicketSystem;
+    protected ?string $internalJiraTicketSystem = null;
 
     /**
      * Sets the additional Information.
@@ -201,7 +193,11 @@ class Project extends Base
      */
     public function setInternalJiraProjectKey(?string $strInternalJiraProjectKey): static
     {
-        $this->internalJiraProjectKey = $strInternalJiraProjectKey;
+        // Normalize blank/whitespace-only input to null: a stray " " would
+        // otherwise read as a configured key and divert worklog booking/deletion
+        // to a non-existent internal ticket system (see hasInternalJiraProjectKey).
+        $trimmed = null === $strInternalJiraProjectKey ? '' : trim($strInternalJiraProjectKey);
+        $this->internalJiraProjectKey = '' === $trimmed ? null : $trimmed;
 
         return $this;
     }
@@ -719,7 +715,7 @@ class Project extends Base
      */
     public function getInternalJiraTicketSystem(): ?string
     {
-        return null !== $this->internalJiraTicketSystem ? (string) $this->internalJiraTicketSystem : null;
+        return $this->internalJiraTicketSystem;
     }
 
     /**
@@ -727,8 +723,14 @@ class Project extends Base
      */
     public function hasInternalJiraProjectKey(): bool
     {
-        return null !== $this->internalJiraProjectKey && '' !== $this->internalJiraProjectKey
-            && null !== $this->internalJiraTicketSystem && '' !== $this->internalJiraTicketSystem;
+        // A project mirrors to an internal Jira only when it has a non-blank key
+        // AND a real (positive) internal ticket-system id. Trimming guards against
+        // a whitespace-only key, and the > 0 check rejects a "0"/blank system id —
+        // either of which would otherwise divert delete to a null internal system
+        // and orphan the worklog booked on the project's own ticket system.
+        return null !== $this->internalJiraProjectKey
+            && '' !== trim($this->internalJiraProjectKey)
+            && (int) $this->internalJiraTicketSystem > 0;
     }
 
     /**

--- a/src/EventSubscriber/EntryEventSubscriber.php
+++ b/src/EventSubscriber/EntryEventSubscriber.php
@@ -29,6 +29,7 @@ use function in_array;
 use function is_array;
 use function is_object;
 use function is_string;
+use function spl_object_id;
 use function sprintf;
 
 /**
@@ -211,23 +212,42 @@ class EntryEventSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // Delete on EVERY system the worklog could have been booked on, mirroring
+        // Delete on the systems the worklog could have been booked on, mirroring
         // syncWorklog's targets. An either/or (internal xor own) orphaned worklogs
         // whenever the two disagreed — e.g. a stray internal key that booked on the
-        // own system but would delete only on the (missing) internal one. Deleting a
-        // worklog that isn't there is a no-op (deleteEntryJiraWorkLog swallows the
-        // not-found), so attempting both systems is safe and idempotent.
+        // own system but would delete only on the (missing) internal one.
         $ticketSystems = $this->bookableTicketSystems($project);
         if ([] === $ticketSystems) {
             return;
         }
 
+        $lastError = null;
         foreach ($ticketSystems as $ticketSystem) {
-            $this->jiraOAuthApiFactory->create($user, $ticketSystem)
-                ->deleteEntryJiraWorkLog($entry);
+            // deleteEntryJiraWorkLog nulls the worklog id once it removes the entry
+            // (and no-ops on a not-found), so stop as soon as it is gone.
+            if (null === $entry->getWorklogId()) {
+                break;
+            }
+
+            try {
+                $this->jiraOAuthApiFactory->create($user, $ticketSystem)
+                    ->deleteEntryJiraWorkLog($entry);
+            } catch (JiraApiException $jiraApiException) {
+                // Keep trying the remaining systems — a failure on one (auth,
+                // network, wrong instance) must not prevent cleanup on another.
+                $lastError = $jiraApiException;
+            }
         }
 
         $this->managerRegistry->getManager()->flush();
+
+        // The worklog id survived every attempt AND a call failed: nothing cleaned
+        // it up, so surface the error (onEntryDeleted logs it) instead of reporting
+        // success. A still-set id with no error means the worklog was simply not
+        // found anywhere — nothing to delete.
+        if (null !== $entry->getWorklogId() && $lastError instanceof JiraApiException) {
+            throw $lastError;
+        }
     }
 
     /**
@@ -241,21 +261,29 @@ class EntryEventSubscriber implements EventSubscriberInterface
      */
     private function bookableTicketSystems(Project $project): array
     {
-        $ticketSystems = [];
+        $candidates = [];
 
         if ($project->hasInternalJiraProjectKey()) {
             $internal = $this->findInternalTicketSystem($project);
             if ($internal instanceof TicketSystem && $this->canBookOn($internal)) {
-                $ticketSystems[] = $internal;
+                $candidates[] = $internal;
             }
         }
 
         $own = $project->getTicketSystem();
         if ($own instanceof TicketSystem && $this->canBookOn($own)) {
-            $ticketSystems[] = $own;
+            $candidates[] = $own;
         }
 
-        return $ticketSystems;
+        // Dedupe: the internal and own system can be the same row/instance, which
+        // would otherwise book/delete twice. Key by id when persisted, else by
+        // object identity.
+        $unique = [];
+        foreach ($candidates as $candidate) {
+            $unique[$candidate->getId() ?? spl_object_id($candidate)] = $candidate;
+        }
+
+        return array_values($unique);
     }
 
     private function shouldAutoSync(Entry $entry): bool

--- a/src/EventSubscriber/EntryEventSubscriber.php
+++ b/src/EventSubscriber/EntryEventSubscriber.php
@@ -101,7 +101,10 @@ class EntryEventSubscriber implements EventSubscriberInterface
                 $this->syncWorklog($entry, $this->getPreviousEntry($entryEvent));
                 $this->logger?->info('JIRA worklog updated');
             } catch (Exception $e) {
-                $this->logger?->warning('JIRA worklog update failed', ['exception' => $e]);
+                // Error, not warning: see onEntryDeleted — a warning is swallowed by
+                // prod's fingers_crossed(action_level: error) handler, hiding a failed
+                // Jira sync entirely.
+                $this->logger?->error('JIRA worklog update failed', ['exception' => $e]);
             }
         }
     }
@@ -120,7 +123,10 @@ class EntryEventSubscriber implements EventSubscriberInterface
                 $this->deleteWorklog($entry);
                 $this->logger?->info('JIRA worklog deleted');
             } catch (Exception $e) {
-                $this->logger?->warning('JIRA worklog deletion failed', ['exception' => $e]);
+                // Error, not warning: prod's fingers_crossed handler only flushes
+                // at error level, so a warning here would leave an orphaned Jira
+                // worklog with no trace while the entry delete still reports success.
+                $this->logger?->error('JIRA worklog deletion failed', ['exception' => $e]);
             }
         }
     }
@@ -205,20 +211,51 @@ class EntryEventSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // v4 parity: entries of internal-key projects have their worklog in
-        // the internal Jira, not in the project's own ticket system.
-        $ticketSystem = $project->hasInternalJiraProjectKey()
-            ? $this->findInternalTicketSystem($project)
-            : $project->getTicketSystem();
-
-        if (!$ticketSystem instanceof TicketSystem || !$this->canBookOn($ticketSystem)) {
+        // Delete on EVERY system the worklog could have been booked on, mirroring
+        // syncWorklog's targets. An either/or (internal xor own) orphaned worklogs
+        // whenever the two disagreed — e.g. a stray internal key that booked on the
+        // own system but would delete only on the (missing) internal one. Deleting a
+        // worklog that isn't there is a no-op (deleteEntryJiraWorkLog swallows the
+        // not-found), so attempting both systems is safe and idempotent.
+        $ticketSystems = $this->bookableTicketSystems($project);
+        if ([] === $ticketSystems) {
             return;
         }
 
-        $this->jiraOAuthApiFactory->create($user, $ticketSystem)
-            ->deleteEntryJiraWorkLog($entry);
+        foreach ($ticketSystems as $ticketSystem) {
+            $this->jiraOAuthApiFactory->create($user, $ticketSystem)
+                ->deleteEntryJiraWorkLog($entry);
+        }
 
         $this->managerRegistry->getManager()->flush();
+    }
+
+    /**
+     * The Jira ticket systems a worklog for $project may live on: the internal
+     * mirror system (when the project has a valid internal key) and/or the
+     * project's own ticket system, each filtered to those that accept bookings.
+     * Booking and deletion share this set so they can never target a different
+     * system and leave an orphaned worklog behind.
+     *
+     * @return list<TicketSystem>
+     */
+    private function bookableTicketSystems(Project $project): array
+    {
+        $ticketSystems = [];
+
+        if ($project->hasInternalJiraProjectKey()) {
+            $internal = $this->findInternalTicketSystem($project);
+            if ($internal instanceof TicketSystem && $this->canBookOn($internal)) {
+                $ticketSystems[] = $internal;
+            }
+        }
+
+        $own = $project->getTicketSystem();
+        if ($own instanceof TicketSystem && $this->canBookOn($own)) {
+            $ticketSystems[] = $own;
+        }
+
+        return $ticketSystems;
     }
 
     private function shouldAutoSync(Entry $entry): bool

--- a/tests/Entity/ProjectTest.php
+++ b/tests/Entity/ProjectTest.php
@@ -16,6 +16,7 @@ use App\Entity\User;
 use App\Enum\BillingType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 /**
  * Unit tests for Project entity.
@@ -430,6 +431,72 @@ final class ProjectTest extends TestCase
 
         self::assertSame($project, $result);
         self::assertSame('INTERNAL', $project->getInternalJiraProjectKey());
+    }
+
+    public function testSetInternalJiraProjectKeyTrimsSurroundingWhitespace(): void
+    {
+        $project = new Project();
+
+        $project->setInternalJiraProjectKey('  INTERNAL  ');
+
+        self::assertSame('INTERNAL', $project->getInternalJiraProjectKey());
+    }
+
+    public function testSetInternalJiraProjectKeyNormalizesBlankToNull(): void
+    {
+        $project = new Project();
+
+        // A whitespace-only key would otherwise read as "configured" and divert
+        // worklog booking/deletion to a non-existent internal ticket system.
+        $project->setInternalJiraProjectKey('   ');
+
+        self::assertNull($project->getInternalJiraProjectKey());
+    }
+
+    // ==================== hasInternalJiraProjectKey tests ====================
+
+    public function testHasInternalJiraProjectKeyTrueWhenKeyAndSystemSet(): void
+    {
+        $project = new Project();
+        $project->setInternalJiraProjectKey('INTERNAL');
+        $project->setInternalJiraTicketSystem('3');
+
+        self::assertTrue($project->hasInternalJiraProjectKey());
+    }
+
+    public function testHasInternalJiraProjectKeyFalseByDefault(): void
+    {
+        self::assertFalse(new Project()->hasInternalJiraProjectKey());
+    }
+
+    public function testHasInternalJiraProjectKeyFalseForHydratedWhitespaceKey(): void
+    {
+        // Doctrine hydration bypasses the setter, so a legacy DB row can hold a
+        // whitespace-only key directly — this is the exact prod trigger that
+        // orphaned a worklog. hasInternalJiraProjectKey() must reject it on its own.
+        $project = new Project();
+        new ReflectionProperty(Project::class, 'internalJiraProjectKey')->setValue($project, ' ');
+        $project->setInternalJiraTicketSystem('3');
+
+        self::assertFalse($project->hasInternalJiraProjectKey());
+    }
+
+    public function testHasInternalJiraProjectKeyFalseWhenSystemIsZero(): void
+    {
+        // internal_jira_ticket_system = 0 means "no internal system", even with a key.
+        $project = new Project();
+        $project->setInternalJiraProjectKey('INTERNAL');
+        $project->setInternalJiraTicketSystem('0');
+
+        self::assertFalse($project->hasInternalJiraProjectKey());
+    }
+
+    public function testHasInternalJiraProjectKeyFalseWhenKeySetButNoSystem(): void
+    {
+        $project = new Project();
+        $project->setInternalJiraProjectKey('INTERNAL');
+
+        self::assertFalse($project->hasInternalJiraProjectKey());
     }
 
     // ==================== InternalJiraTicketSystem tests ====================

--- a/tests/EventSubscriber/EntryEventSubscriberTest.php
+++ b/tests/EventSubscriber/EntryEventSubscriberTest.php
@@ -11,12 +11,13 @@ use App\Entity\User;
 use App\Enum\TicketSystemType;
 use App\Event\EntryEvent;
 use App\EventSubscriber\EntryEventSubscriber;
+use App\Exception\Integration\Jira\JiraApiException;
+use App\Repository\TicketSystemRepository;
 use App\Service\Cache\QueryCacheService;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use App\Service\Integration\Jira\JiraOAuthApiService;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
-use Doctrine\Persistence\ObjectRepository;
 use Exception;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -434,21 +435,26 @@ final class EntryEventSubscriberTest extends TestCase
         $this->subscriber->onEntryDeleted($event);
     }
 
-    public function testOnEntryDeletedFallsBackToOwnSystemWhenInternalKeyHasNoSystem(): void
+    public function testOnEntryDeletedFallsBackToOwnSystemWhenInternalSystemMissing(): void
     {
-        // Regression for the orphaned-worklog bug: a project flagged as having an
-        // internal Jira key but with NO valid internal ticket system (id 0) must
-        // still delete the worklog on its OWN ticket system, where syncWorklog
-        // actually booked it — the old either/or logic gave up and orphaned it.
+        // Regression for the orphaned-worklog bug: a project IS configured for an
+        // internal Jira mirror, but its internal ticket-system row no longer exists
+        // (findInternalTicketSystem() -> null). The worklog was booked on the OWN
+        // system, so delete must still clean it up there — the old either/or logic
+        // targeted only the (missing) internal system and gave up.
         $ownSystem = self::createStub(TicketSystem::class);
         $ownSystem->method('getBookTime')->willReturn(true);
         $ownSystem->method('getType')->willReturn(TicketSystemType::JIRA);
 
         $project = self::createStub(Project::class);
         $project->method('hasInternalJiraProjectKey')->willReturn(true);
-        // (int) '0' === 0 → findInternalTicketSystem() returns null (no internal system).
-        $project->method('getInternalJiraTicketSystem')->willReturn('0');
+        $project->method('getInternalJiraTicketSystem')->willReturn('99');
         $project->method('getTicketSystem')->willReturn($ownSystem);
+
+        // The configured internal ticket system id points at a deleted row.
+        $repository = $this->createMock(TicketSystemRepository::class);
+        $repository->method('find')->willReturn(null);
+        $this->managerRegistry->method('getRepository')->willReturn($repository);
 
         $user = self::createStub(User::class);
         $user->method('getId')->willReturn(1);
@@ -467,6 +473,55 @@ final class EntryEventSubscriberTest extends TestCase
         $this->jiraOAuthApiService->expects(self::once())
             ->method('deleteEntryJiraWorkLog')
             ->with($entry);
+
+        $event = new EntryEvent($entry);
+        $this->subscriber->onEntryDeleted($event);
+    }
+
+    public function testOnEntryDeletedKeepsTryingOtherSystemsAfterAFailure(): void
+    {
+        // A failure deleting on the first candidate system must not abort cleanup on
+        // the others, and an unresolved deletion must surface as an error (not a
+        // silent success). Two bookable systems; the delete throws on each.
+        $internalSystem = self::createStub(TicketSystem::class);
+        $internalSystem->method('getBookTime')->willReturn(true);
+        $internalSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+
+        $ownSystem = self::createStub(TicketSystem::class);
+        $ownSystem->method('getBookTime')->willReturn(true);
+        $ownSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+
+        $project = self::createStub(Project::class);
+        $project->method('hasInternalJiraProjectKey')->willReturn(true);
+        $project->method('getInternalJiraTicketSystem')->willReturn('99');
+        $project->method('getTicketSystem')->willReturn($ownSystem);
+
+        $repository = $this->createMock(TicketSystemRepository::class);
+        $repository->method('find')->willReturn($internalSystem);
+        $this->managerRegistry->method('getRepository')->willReturn($repository);
+
+        $user = self::createStub(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $entry = self::createStub(Entry::class);
+        $entry->method('getUser')->willReturn($user);
+        $entry->method('getProject')->willReturn($project);
+        $entry->method('getTicket')->willReturn('ABC-123');
+        $entry->method('getSyncedToTicketsystem')->willReturn(true);
+        $entry->method('getWorklogId')->willReturn(12345);
+
+        // Both candidate systems are attempted (create once per system) even though
+        // the first delete throws.
+        $this->jiraOAuthApiFactory->expects(self::exactly(2))
+            ->method('create')
+            ->willReturn($this->jiraOAuthApiService);
+        $this->jiraOAuthApiService->method('deleteEntryJiraWorkLog')
+            ->willThrowException(new JiraApiException('boom', 500));
+
+        // The unresolved failure surfaces at error level.
+        $this->logger->expects(self::once())
+            ->method('error')
+            ->with('JIRA worklog deletion failed', self::anything());
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryDeleted($event);
@@ -566,7 +621,7 @@ final class EntryEventSubscriberTest extends TestCase
         $user = self::createStub(User::class);
         $user->method('getId')->willReturn(1);
 
-        $ticketSystemRepository = $this->createMock(ObjectRepository::class);
+        $ticketSystemRepository = $this->createMock(TicketSystemRepository::class);
         $ticketSystemRepository->method('find')->willReturn($internalTicketSystem);
         $this->managerRegistry->method('getRepository')
             ->willReturn($ticketSystemRepository);
@@ -696,7 +751,7 @@ final class EntryEventSubscriberTest extends TestCase
         $user = self::createStub(User::class);
         $user->method('getId')->willReturn(1);
 
-        $ticketSystemRepository = $this->createMock(ObjectRepository::class);
+        $ticketSystemRepository = $this->createMock(TicketSystemRepository::class);
         $ticketSystemRepository->method('find')->willReturn($internalTicketSystem);
         $this->managerRegistry->method('getRepository')->willReturn($ticketSystemRepository);
 

--- a/tests/EventSubscriber/EntryEventSubscriberTest.php
+++ b/tests/EventSubscriber/EntryEventSubscriberTest.php
@@ -335,7 +335,7 @@ final class EntryEventSubscriberTest extends TestCase
         $this->subscriber->onEntryUpdated($event);
     }
 
-    public function testOnEntryUpdatedLogsWarningOnJiraFailure(): void
+    public function testOnEntryUpdatedLogsErrorOnJiraFailure(): void
     {
         [$entry] = $this->createSyncableEntry();
 
@@ -346,8 +346,10 @@ final class EntryEventSubscriberTest extends TestCase
             ->method('updateEntryJiraWorkLog')
             ->willThrowException($exception);
 
+        // Error, not warning: prod's fingers_crossed(action_level: error) handler
+        // would swallow a warning, hiding the failed sync entirely.
         $this->logger->expects(self::once())
-            ->method('warning')
+            ->method('error')
             ->with('JIRA worklog update failed', ['exception' => $exception]);
 
         $event = new EntryEvent($entry);
@@ -411,7 +413,7 @@ final class EntryEventSubscriberTest extends TestCase
         $this->subscriber->onEntryDeleted($event);
     }
 
-    public function testOnEntryDeletedLogsWarningOnFailure(): void
+    public function testOnEntryDeletedLogsErrorOnFailure(): void
     {
         [$entry] = $this->createSyncableEntry(synced: true, worklogId: 12345);
 
@@ -422,9 +424,49 @@ final class EntryEventSubscriberTest extends TestCase
             ->method('deleteEntryJiraWorkLog')
             ->willThrowException($exception);
 
+        // Error, not warning: a warning is swallowed by prod's fingers_crossed
+        // handler, leaving an orphaned Jira worklog with no trace.
         $this->logger->expects(self::once())
-            ->method('warning')
+            ->method('error')
             ->with('JIRA worklog deletion failed', ['exception' => $exception]);
+
+        $event = new EntryEvent($entry);
+        $this->subscriber->onEntryDeleted($event);
+    }
+
+    public function testOnEntryDeletedFallsBackToOwnSystemWhenInternalKeyHasNoSystem(): void
+    {
+        // Regression for the orphaned-worklog bug: a project flagged as having an
+        // internal Jira key but with NO valid internal ticket system (id 0) must
+        // still delete the worklog on its OWN ticket system, where syncWorklog
+        // actually booked it — the old either/or logic gave up and orphaned it.
+        $ownSystem = self::createStub(TicketSystem::class);
+        $ownSystem->method('getBookTime')->willReturn(true);
+        $ownSystem->method('getType')->willReturn(TicketSystemType::JIRA);
+
+        $project = self::createStub(Project::class);
+        $project->method('hasInternalJiraProjectKey')->willReturn(true);
+        // (int) '0' === 0 → findInternalTicketSystem() returns null (no internal system).
+        $project->method('getInternalJiraTicketSystem')->willReturn('0');
+        $project->method('getTicketSystem')->willReturn($ownSystem);
+
+        $user = self::createStub(User::class);
+        $user->method('getId')->willReturn(1);
+
+        $entry = self::createStub(Entry::class);
+        $entry->method('getUser')->willReturn($user);
+        $entry->method('getProject')->willReturn($project);
+        $entry->method('getTicket')->willReturn('ABC-123');
+        $entry->method('getSyncedToTicketsystem')->willReturn(true);
+        $entry->method('getWorklogId')->willReturn(12345);
+
+        $this->jiraOAuthApiFactory->expects(self::once())
+            ->method('create')
+            ->with($user, $ownSystem)
+            ->willReturn($this->jiraOAuthApiService);
+        $this->jiraOAuthApiService->expects(self::once())
+            ->method('deleteEntryJiraWorkLog')
+            ->with($entry);
 
         $event = new EntryEvent($entry);
         $this->subscriber->onEntryDeleted($event);


### PR DESCRIPTION
## Symptom

Deleting a timetracker entry removed the local entry but left its **Jira worklog** behind (found live: entry `#472075` on NRS-4188 stayed after the entry was deleted). Surfaced while dogfooding the API-token feature, but it affects the SPA too.

## Root cause — three defects lined up

1. **A whitespace-poisoned predicate.** `Project::hasInternalJiraProjectKey()` treated a stray `" "` key (plus a `"0"` ticket-system id) as a configured internal Jira. The prod project had exactly that dirty data.
2. **Create/delete asymmetry.** `syncWorklog` books on the internal system *and/or* the project's own system; `deleteWorklog` was **either/or** and, misled by (1), targeted the (missing) internal system — so it never deleted the worklog booked on the own system, and orphaned it.
3. **Invisible failure.** The sync failure logged at `warning`, which prod's `fingers_crossed(action_level: error)` monolog handler never flushes — so the orphan left **zero trace** and the entry delete still returned success.

## Fix

- `hasInternalJiraProjectKey()` trims the key and requires a positive ticket-system id.
- `deleteWorklog` now deletes on **every** system a worklog could live on (shared `bookableTicketSystems()` with the booking path), so create and delete can't disagree — idempotent, since deleting an absent worklog is a no-op.
- Sync-failure logs raised `warning` → `error` so they surface.
- Normalize the project-key setter (blank/whitespace → null) and type the two legacy untyped internal-Jira properties.

## Tests

- `hasInternalJiraProjectKey()` against a **hydrated** whitespace key (reflection — the exact prod trigger that bypasses the setter), a `"0"` system, and key-without-system.
- Setter whitespace normalization.
- `onEntryDeleted` falls back to the own system when the internal key is flagged but has no system.
- Delete/update failure now asserts `error` level.

Gates: PHPStan L10 (full), php-cs-fixer, Rector, phpat clean; 95 entity+subscriber tests green.

Note: the orphaned prod worklog was already cleaned up manually. Project 948's stray key is now harmless (the predicate ignores it); clearing the DB value is optional.