### PR TITLE
fix(tracking): harden entry deletion (payload, no-op, ownership)

### DIFF
--- a/src/Controller/Tracking/DeleteEntryAction.php
+++ b/src/Controller/Tracking/DeleteEntryAction.php
@@ -46,30 +46,53 @@ final class DeleteEntryAction extends BaseTrackingController
         #[CurrentUser]
         User $currentUser,
     ): Response|JsonResponse|Error {
-        $entryId = RequestEntityHelper::id($request, 'id');
-        if ($entryId > 0) {
-            $doctrine = $this->managerRegistry;
-            $entry = RequestEntityHelper::findById($doctrine, Entry::class, $entryId);
-
-            if (!$entry instanceof Entry) {
-                $message = $this->translator->trans('No entry for id.');
-
-                return new Error($message, \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
-            }
-
-            $day = $entry->getDay()->format('Y-m-d');
-
-            // Dispatch event before removal (subscriber handles Jira worklog deletion)
-            if ($this->eventDispatcher instanceof EventDispatcherInterface) {
-                $this->eventDispatcher->dispatch(new EntryEvent($entry), EntryEvent::DELETED);
-            }
-
-            $manager = $doctrine->getManager();
-            $manager->remove($entry);
-            $manager->flush();
-
-            $this->calculateClasses($currentUser->getId() ?? 0, $day);
+        // Read from the merged payload so form (SPA) and JSON (API/token) clients
+        // behave identically. A missing/invalid id is a client error, not a silent
+        // success — the old code returned {"success":true} without deleting anything
+        // when the id could not be read (e.g. a JSON body).
+        $entryId = (int) $request->getPayload()->get('id', 0);
+        if ($entryId <= 0) {
+            return new Error(
+                $this->translator->trans('No entry id provided.'),
+                \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST,
+            );
         }
+
+        $doctrine = $this->managerRegistry;
+        $entry = RequestEntityHelper::findById($doctrine, Entry::class, (string) $entryId);
+        if (!$entry instanceof Entry) {
+            return new Error(
+                $this->translator->trans('No entry for id.'),
+                \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
+            );
+        }
+
+        // Ownership (mirrors GetEntryAction): a developer may only delete their own
+        // entries; admins and project leads (ROLE_ADMIN — PL carries it) may delete
+        // any. Without this, any authenticated principal — including an
+        // entries:write API token — could delete another user's entry by id.
+        if ($entry->getUserId() !== $currentUser->getId()
+            && !$this->isGranted('ROLE_ADMIN')
+            && !$currentUser->getType()->isPl()
+        ) {
+            return new Error(
+                $this->translator->trans('You are not allowed to delete this entry.'),
+                \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN,
+            );
+        }
+
+        $day = $entry->getDay()->format('Y-m-d');
+
+        // Dispatch event before removal (subscriber handles Jira worklog deletion)
+        if ($this->eventDispatcher instanceof EventDispatcherInterface) {
+            $this->eventDispatcher->dispatch(new EntryEvent($entry), EntryEvent::DELETED);
+        }
+
+        $manager = $doctrine->getManager();
+        $manager->remove($entry);
+        $manager->flush();
+
+        $this->calculateClasses($currentUser->getId() ?? 0, $day);
 
         return new JsonResponse(['success' => true]);
     }

--- a/src/Controller/Tracking/DeleteEntryAction.php
+++ b/src/Controller/Tracking/DeleteEntryAction.php
@@ -46,10 +46,46 @@ final class DeleteEntryAction extends BaseTrackingController
         #[CurrentUser]
         User $currentUser,
     ): Response|JsonResponse|Error {
-        // Read from the merged payload so form (SPA) and JSON (API/token) clients
-        // behave identically. A missing/invalid id is a client error, not a silent
-        // success — the old code returned {"success":true} without deleting anything
-        // when the id could not be read (e.g. a JSON body).
+        $entry = $this->resolveEntry($request);
+        if ($entry instanceof Error) {
+            return $entry;
+        }
+
+        if (!$this->mayDelete($entry, $currentUser)) {
+            return new Error(
+                $this->translator->trans('You are not allowed to delete this entry.'),
+                \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN,
+            );
+        }
+
+        // The owner's day is what changed — recalculate their classes, not the
+        // deleter's (an admin/PL may be removing someone else's entry).
+        $ownerId = $entry->getUserId() ?? 0;
+        $day = $entry->getDay()->format('Y-m-d');
+
+        // Dispatch event before removal (subscriber handles Jira worklog deletion)
+        if ($this->eventDispatcher instanceof EventDispatcherInterface) {
+            $this->eventDispatcher->dispatch(new EntryEvent($entry), EntryEvent::DELETED);
+        }
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->remove($entry);
+        $manager->flush();
+
+        $this->calculateClasses($ownerId, $day);
+
+        return new JsonResponse(['success' => true]);
+    }
+
+    /**
+     * Resolve the entry to delete from the request, reading the id from the merged
+     * payload so form (SPA) and JSON (API/token) clients behave identically. A
+     * missing/invalid id is a client error, not a silent success — the old code
+     * returned {"success":true} without deleting anything when the id could not be
+     * read (e.g. from a JSON body).
+     */
+    private function resolveEntry(Request $request): Entry|Error
+    {
         $entryId = (int) $request->getPayload()->get('id', 0);
         if ($entryId <= 0) {
             return new Error(
@@ -58,42 +94,29 @@ final class DeleteEntryAction extends BaseTrackingController
             );
         }
 
-        $doctrine = $this->managerRegistry;
-        $entry = RequestEntityHelper::findById($doctrine, Entry::class, (string) $entryId);
-        if (!$entry instanceof Entry) {
-            return new Error(
-                $this->translator->trans('No entry for id.'),
-                \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
-            );
+        $entry = RequestEntityHelper::findById($this->managerRegistry, Entry::class, (string) $entryId);
+
+        return $entry instanceof Entry ? $entry : new Error(
+            $this->translator->trans('No entry for id.'),
+            \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
+        );
+    }
+
+    /**
+     * Ownership (mirrors GetEntryAction): a developer may only delete their own
+     * entries; admins and project leads (ROLE_ADMIN — PL carries it) may delete any.
+     * Without this, any authenticated principal — including an entries:write API
+     * token — could delete another user's entry by id.
+     */
+    private function mayDelete(Entry $entry, User $currentUser): bool
+    {
+        if ($entry->getUserId() === $currentUser->getId()) {
+            return true;
+        }
+        if ($this->isGranted('ROLE_ADMIN')) {
+            return true;
         }
 
-        // Ownership (mirrors GetEntryAction): a developer may only delete their own
-        // entries; admins and project leads (ROLE_ADMIN — PL carries it) may delete
-        // any. Without this, any authenticated principal — including an
-        // entries:write API token — could delete another user's entry by id.
-        if ($entry->getUserId() !== $currentUser->getId()
-            && !$this->isGranted('ROLE_ADMIN')
-            && !$currentUser->getType()->isPl()
-        ) {
-            return new Error(
-                $this->translator->trans('You are not allowed to delete this entry.'),
-                \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN,
-            );
-        }
-
-        $day = $entry->getDay()->format('Y-m-d');
-
-        // Dispatch event before removal (subscriber handles Jira worklog deletion)
-        if ($this->eventDispatcher instanceof EventDispatcherInterface) {
-            $this->eventDispatcher->dispatch(new EntryEvent($entry), EntryEvent::DELETED);
-        }
-
-        $manager = $doctrine->getManager();
-        $manager->remove($entry);
-        $manager->flush();
-
-        $this->calculateClasses($currentUser->getId() ?? 0, $day);
-
-        return new JsonResponse(['success' => true]);
+        return $currentUser->getType()->isPl();
     }
 }

--- a/tests/Controller/DeleteEntryActionTest.php
+++ b/tests/Controller/DeleteEntryActionTest.php
@@ -13,12 +13,10 @@ use App\Entity\Activity;
 use App\Entity\Customer;
 use App\Entity\Entry;
 use App\Entity\Project;
-use App\Entity\User;
-use Doctrine\Bundle\DoctrineBundle\Registry;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AbstractWebTestCase;
+use Tests\Traits\EntityManagerTestTrait;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -33,25 +31,9 @@ use const JSON_THROW_ON_ERROR;
  */
 final class DeleteEntryActionTest extends AbstractWebTestCase
 {
+    use EntityManagerTestTrait;
+
     private const string JSON_MIME = 'application/json';
-
-    private function entityManager(): EntityManagerInterface
-    {
-        $doctrine = self::getContainer()->get('doctrine');
-        self::assertInstanceOf(Registry::class, $doctrine);
-        $manager = $doctrine->getManager();
-        self::assertInstanceOf(EntityManagerInterface::class, $manager);
-
-        return $manager;
-    }
-
-    private function user(string $username): User
-    {
-        $user = $this->entityManager()->getRepository(User::class)->findOneBy(['username' => $username]);
-        self::assertInstanceOf(User::class, $user);
-
-        return $user;
-    }
 
     /** Persist a minimal entry owned by $username and return it. */
     private function makeEntry(string $username): Entry

--- a/tests/Controller/DeleteEntryActionTest.php
+++ b/tests/Controller/DeleteEntryActionTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Entry;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\AbstractWebTestCase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Covers the DeleteEntryAction fixes: it reads the id from a JSON body (not only
+ * form params), rejects a missing id instead of silently succeeding, and enforces
+ * entry ownership (a developer cannot delete another user's entry).
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class DeleteEntryActionTest extends AbstractWebTestCase
+{
+    private function entityManager(): EntityManagerInterface
+    {
+        $doctrine = self::getContainer()->get('doctrine');
+        self::assertInstanceOf(Registry::class, $doctrine);
+        $manager = $doctrine->getManager();
+        self::assertInstanceOf(EntityManagerInterface::class, $manager);
+
+        return $manager;
+    }
+
+    private function user(string $username): User
+    {
+        $user = $this->entityManager()->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+
+    /** Persist a minimal entry owned by $username and return it. */
+    private function makeEntry(string $username): Entry
+    {
+        $entityManager = $this->entityManager();
+        $customer = $entityManager->getRepository(Customer::class)->findOneBy([]);
+        $project = $entityManager->getRepository(Project::class)->findOneBy([]);
+        $activity = $entityManager->getRepository(Activity::class)->findOneBy([]);
+        self::assertInstanceOf(Customer::class, $customer);
+        self::assertInstanceOf(Project::class, $project);
+        self::assertInstanceOf(Activity::class, $activity);
+
+        $entry = new Entry();
+        $entry->setUser($this->user($username))
+            ->setCustomer($customer)
+            ->setProject($project)
+            ->setActivity($activity)
+            ->setTicket('')
+            ->setDescription('delete-test')
+            ->setDay('2024-01-15')
+            ->setStart('09:00:00')
+            ->setEnd('10:00:00')
+            ->setDuration(60);
+        $entityManager->persist($entry);
+        $entityManager->flush();
+
+        return $entry;
+    }
+
+    private function deleteJson(int $id): Response
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/tracking/delete',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            json_encode(['id' => $id], JSON_THROW_ON_ERROR),
+        );
+
+        return $this->client->getResponse();
+    }
+
+    private function entryExists(int $id): bool
+    {
+        return null !== $this->entityManager()->getRepository(Entry::class)->find($id);
+    }
+
+    public function testDeletesOwnEntryFromJsonBody(): void
+    {
+        // unittest is the default logged-in user; delete via a JSON body (the old
+        // code read form params only, so a JSON id was silently ignored).
+        $this->logInSession('unittest');
+        $entry = $this->makeEntry('unittest');
+        $id = $entry->getId();
+        self::assertIsInt($id);
+
+        $status = $this->deleteJson($id)->getStatusCode();
+
+        self::assertSame(Response::HTTP_OK, $status);
+        self::assertFalse($this->entryExists($id));
+    }
+
+    public function testMissingIdReturnsBadRequestNotSilentSuccess(): void
+    {
+        $this->logInSession('unittest');
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/tracking/delete',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            json_encode([], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testNonexistentIdReturnsNotFound(): void
+    {
+        $this->logInSession('unittest');
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->deleteJson(999999999)->getStatusCode());
+    }
+
+    public function testCannotDeleteAnotherUsersEntry(): void
+    {
+        // Entry owned by i.myself; developer (type DEV, not admin/PL) must not be
+        // able to delete it — the ownership guard against IDOR.
+        $entry = $this->makeEntry('i.myself');
+        $id = $entry->getId();
+        self::assertIsInt($id);
+
+        $this->logInSession('developer');
+        $status = $this->deleteJson($id)->getStatusCode();
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $status);
+        self::assertTrue($this->entryExists($id));
+    }
+
+    public function testAdminCanDeleteAnotherUsersEntry(): void
+    {
+        // unittest is an admin, so it may delete an entry owned by another user.
+        $entry = $this->makeEntry('developer');
+        $id = $entry->getId();
+        self::assertIsInt($id);
+
+        $this->logInSession('unittest');
+        $status = $this->deleteJson($id)->getStatusCode();
+
+        self::assertSame(Response::HTTP_OK, $status);
+        self::assertFalse($this->entryExists($id));
+    }
+}

--- a/tests/Controller/DeleteEntryActionTest.php
+++ b/tests/Controller/DeleteEntryActionTest.php
@@ -33,6 +33,8 @@ use const JSON_THROW_ON_ERROR;
  */
 final class DeleteEntryActionTest extends AbstractWebTestCase
 {
+    private const string JSON_MIME = 'application/json';
+
     private function entityManager(): EntityManagerInterface
     {
         $doctrine = self::getContainer()->get('doctrine');
@@ -86,7 +88,7 @@ final class DeleteEntryActionTest extends AbstractWebTestCase
             '/tracking/delete',
             [],
             [],
-            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            ['CONTENT_TYPE' => self::JSON_MIME, 'HTTP_ACCEPT' => self::JSON_MIME],
             json_encode(['id' => $id], JSON_THROW_ON_ERROR),
         );
 
@@ -122,7 +124,7 @@ final class DeleteEntryActionTest extends AbstractWebTestCase
             '/tracking/delete',
             [],
             [],
-            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            ['CONTENT_TYPE' => self::JSON_MIME, 'HTTP_ACCEPT' => self::JSON_MIME],
             json_encode([], JSON_THROW_ON_ERROR),
         );
 

--- a/tests/Controller/Settings/ApiTokenManagementTest.php
+++ b/tests/Controller/Settings/ApiTokenManagementTest.php
@@ -10,14 +10,12 @@ declare(strict_types=1);
 namespace Tests\Controller\Settings;
 
 use App\Entity\ApiToken;
-use App\Entity\User;
 use App\Service\ApiToken\ApiTokenService;
 use DateTimeImmutable;
-use Doctrine\Bundle\DoctrineBundle\Registry;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AbstractWebTestCase;
+use Tests\Traits\EntityManagerTestTrait;
 
 /**
  * The Settings API-token management endpoints (ADR-021 Phase 3): list, create
@@ -30,25 +28,9 @@ use Tests\AbstractWebTestCase;
  */
 final class ApiTokenManagementTest extends AbstractWebTestCase
 {
+    use EntityManagerTestTrait;
+
     private const string JSON_MIME = 'application/json';
-
-    private function entityManager(): EntityManagerInterface
-    {
-        $doctrine = self::getContainer()->get('doctrine');
-        self::assertInstanceOf(Registry::class, $doctrine);
-        $manager = $doctrine->getManager();
-        self::assertInstanceOf(EntityManagerInterface::class, $manager);
-
-        return $manager;
-    }
-
-    private function user(string $username): User
-    {
-        $user = $this->entityManager()->getRepository(User::class)->findOneBy(['username' => $username]);
-        self::assertInstanceOf(User::class, $user);
-
-        return $user;
-    }
 
     /**
      * Persist a token fixture for $username directly (hash mirrors ApiTokenService)

--- a/tests/Traits/EntityManagerTestTrait.php
+++ b/tests/Traits/EntityManagerTestTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Traits;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Shared Doctrine helpers for functional tests: a typed EntityManager accessor
+ * (via the public `doctrine` service, so it stays env-independent) and a
+ * user-by-username lookup. Requires the using class to be a KernelTestCase (for
+ * self::getContainer()).
+ */
+trait EntityManagerTestTrait
+{
+    protected function entityManager(): EntityManagerInterface
+    {
+        $doctrine = self::getContainer()->get('doctrine');
+        self::assertInstanceOf(Registry::class, $doctrine);
+        $manager = $doctrine->getManager();
+        self::assertInstanceOf(EntityManagerInterface::class, $manager);
+
+        return $manager;
+    }
+
+    protected function user(string $username): User
+    {
+        $user = $this->entityManager()->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Three defects in `DeleteEntryAction`, all reachable via an `entries:write` API token

Surfaced while dogfooding the token feature (the delete "succeeded" but nothing happened).

1. **JSON body ignored.** The id was read via `RequestEntityHelper::id` → `$request->request` (form params only), so a JSON `{"id":…}` was dropped. `SaveEntryAction` uses `#[MapRequestPayload]` (JSON) — the two disagreed. Now reads `$request->getPayload()`, which parses **both** form (the SPA) and JSON (API/token).
2. **Silent success on a no-op.** When no id parsed, the handler skipped its body and still returned `{"success":true}` / 200. A caller believing it deleted a row it didn't is the worst outcome for automation. Now returns **400**.
3. **IDOR — no ownership check.** Any authenticated principal (incl. an `entries:write` token) could delete **another user's** entry by id. Now enforces the same policy as `GetEntryAction`: owner only, unless `ROLE_ADMIN` or a project lead (`PL`). → **403** otherwise.

## Tests

`DeleteEntryActionTest`: JSON-body delete works, missing id → 400, foreign entry → 403 (and left intact), admin can delete any, unknown id → 404. The existing form-encoded `CrudControllerTest` delete still passes (backward compatible).

## Note

`RequestEntityHelper::id` is retained — it's still used internally by the helper's `user()`/`ticketSystem()` methods and has its own tests; it just no longer backs this action. (Those two helpers share the same form-only blindness, but they're out of scope here.)

Gates: PHPStan L10 (full), php-cs-fixer, Rector, phpat clean; 20 controller tests (5 new + Crud) green.