### PR TITLE
feat(api-token): scope-annotate read endpoints + OpenAPI security (ADR-021 Phase 4)

### DIFF
--- a/docs/adr/ADR-021-api-token-authentication.md
+++ b/docs/adr/ADR-021-api-token-authentication.md
@@ -1,6 +1,6 @@
 # ADR-021: API Token Authentication with Fine-Grained Scopes
 
-**Status:** Accepted — implementation phased (see end). Phases 1 (schema + token service + CLI), 2 (Bearer firewall + authenticator + #[RequireScope] voter, fail-closed), and 3 (Settings token-management UI + i18n) done; Phases 4–5 (OpenAPI scopes, agent-skills.json/MCP) pending.
+**Status:** Accepted — implementation phased (see end). Phases 1 (schema + token service + CLI), 2 (Bearer firewall + authenticator + #[RequireScope] voter, fail-closed), 3 (Settings token-management UI + i18n), and 4 (read endpoints annotated with #[RequireScope]; OpenAPI bearer securityScheme + scope model; coverage test) done; Phase 5 (agent-skills.json/MCP) pending.
 **Date:** 2026-07-04
 **Relates to:** [ADR-011](ADR-011-security-architecture.md) (session-based auth this
 extends), [ADR-018](ADR-018-authentication-extension.md) (the auth stack — local
@@ -128,4 +128,11 @@ passkeys) — those stay session+re-auth only, out of the token firewall.
 3. Settings UI (create/list/revoke) + i18n. **Done** — session-only endpoints
    under `/settings/api-tokens` (fail-closed against Bearer) + the SPA section.
 4. OpenAPI `securitySchemes` + per-endpoint scopes; docs/agent-readiness.md update.
+   **Done** — read endpoints (customers/projects/users/teams/presets/contracts/
+   ticketsystems/reporting/entry) annotated `#[RequireScope('resource:read')]`;
+   OpenAPI gained the `bearerAuth` scheme + scope model in the description; a
+   coverage test validates every declared scope and guards the count. Per-operation
+   scope tags are intentionally NOT duplicated into the static YAML — the code's
+   `#[RequireScope]` is the single source of truth. Holidays/admin-status/jira-sync
+   left fail-closed (not token-facing).
 5. (Then, separately) agent-skills.json with real skills; optional MCP wrapper.

--- a/public/api.yml
+++ b/public/api.yml
@@ -1289,6 +1289,7 @@ paths:
 
   /login:
      post:
+      security: []   # public: this is where a session is established
       summary: login
       tags:
         - User
@@ -1927,6 +1928,7 @@ paths:
 
   /status/check:
     get:
+      security: []   # public: reports auth state, callable unauthenticated
       summary: Check the login status
       tags:
       - Setting
@@ -1944,6 +1946,7 @@ paths:
 
   /status/page:
     get:
+      security: []   # public: reports auth state, callable unauthenticated
       summary: Display login status
       tags:
         - Setting

--- a/public/api.yml
+++ b/public/api.yml
@@ -1,7 +1,33 @@
 openapi: 3.0.0
 info:
   title: Time Tracker API
-  description: Track your time
+  description: |
+    Track your time.
+
+    ## Authentication (ADR-021)
+
+    Two mechanisms:
+    - **Session cookie** — the SolidJS SPA; unrestricted (a session carries the
+      user's full role-based access).
+    - **Personal access token (Bearer)** — for scripts, CI and agents. Send it as
+      `Authorization: Bearer tt_pat_…`. Tokens are user-bound and created in
+      Settings → Security → API tokens; only their SHA-256 hash is stored.
+
+    ### Scopes
+
+    A token carries `resource:action` scopes (e.g. `entries:read`, `projects:read`,
+    `entries:write`), or the `*` wildcard. A token's effective access is the
+    **intersection** of the owning user's roles and the token's scopes — scopes only
+    ever narrow access, never widen it.
+
+    Resources: `entries`, `projects`, `customers`, `activities`, `presets`, `teams`,
+    `users`, `contracts`, `ticketsystems`, `reporting`, `settings`, `sync`.
+    Actions: `read`, `write`.
+
+    Enforcement is **fail-closed**: an endpoint reachable by a token must declare its
+    required scope server-side (`#[RequireScope]`); one that declares none is denied
+    to tokens entirely (session access is unaffected). The required scope per
+    endpoint is authoritative in the code, not duplicated here.
   version: 0.1.9
 tags:
 - name: "Activity"
@@ -2263,7 +2289,24 @@ paths:
                 example: [16,"tinatest","TINA","DEV"]
 
 
+security:
+  - bearerAuth: []
+  - cookieAuth: []
+
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: >-
+        Personal access token (ADR-021). Send as `Authorization: Bearer tt_pat_…`.
+        The token's `resource:action` scopes (or `*`) are enforced per endpoint,
+        fail-closed, intersected with the owning user's roles.
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: PHPSESSID
+      description: Session cookie used by the SPA (full role-based access).
   schemas:
 
     ChartDataSuccessResponse:

--- a/src/Controller/Admin/GetContractsAction.php
+++ b/src/Controller/Admin/GetContractsAction.php
@@ -14,6 +14,7 @@ use App\Entity\Contract;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\ContractRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -21,6 +22,7 @@ use function assert;
 
 final class GetContractsAction extends BaseController
 {
+    #[RequireScope('contracts:read')]
     #[Route(path: '/getContracts', name: '_getContracts_attr', methods: ['GET'])]
     #[IsGranted('ROLE_ADMIN')]
     public function __invoke(): Response|JsonResponse

--- a/src/Controller/Admin/GetCustomersAction.php
+++ b/src/Controller/Admin/GetCustomersAction.php
@@ -14,6 +14,7 @@ use App\Entity\Customer;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\CustomerRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -21,6 +22,7 @@ use function assert;
 
 final class GetCustomersAction extends BaseController
 {
+    #[RequireScope('customers:read')]
     #[Route(path: '/getAllCustomers', name: '_getAllCustomers_attr', methods: ['GET'])]
     #[IsGranted('ROLE_ADMIN')]
     public function __invoke(): Response|JsonResponse

--- a/src/Controller/Admin/GetPresetsAction.php
+++ b/src/Controller/Admin/GetPresetsAction.php
@@ -14,6 +14,7 @@ use App\Entity\Preset;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Repository\PresetRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
@@ -27,6 +28,7 @@ final class GetPresetsAction extends BaseController
     // authenticated user) needs — so reading the list is not admin-gated.
     // Creating/editing/deleting presets stays admin-only via the dedicated
     // Save/Delete actions.
+    #[RequireScope('presets:read')]
     #[Route(path: '/getAllPresets', name: '_getAllPresets_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse

--- a/src/Controller/Admin/GetTeamsAction.php
+++ b/src/Controller/Admin/GetTeamsAction.php
@@ -14,6 +14,7 @@ use App\Entity\Team;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\TeamRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -21,6 +22,7 @@ use function assert;
 
 final class GetTeamsAction extends BaseController
 {
+    #[RequireScope('teams:read')]
     #[Route(path: '/getAllTeams', name: '_getAllTeams_attr', methods: ['GET'])]
     #[IsGranted('ROLE_ADMIN')]
     public function __invoke(): Response|JsonResponse

--- a/src/Controller/Admin/GetTicketSystemsAction.php
+++ b/src/Controller/Admin/GetTicketSystemsAction.php
@@ -14,6 +14,7 @@ use App\Entity\TicketSystem;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\TicketSystemRepository;
+use App\Security\ApiToken\RequireScope;
 use Exception;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -27,6 +28,7 @@ final class GetTicketSystemsAction extends BaseController
     /**
      * @throws Exception
      */
+    #[RequireScope('ticketsystems:read')]
     #[Route(path: '/getTicketSystems', name: '_getTicketSystems_attr', methods: ['GET'])]
     #[IsGranted('ROLE_ADMIN')]
     public function __invoke(): Response|JsonResponse

--- a/src/Controller/Admin/GetUsersAction.php
+++ b/src/Controller/Admin/GetUsersAction.php
@@ -14,6 +14,7 @@ use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\UserRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -22,6 +23,7 @@ use function assert;
 
 final class GetUsersAction extends BaseController
 {
+    #[RequireScope('users:read')]
     #[Route(path: '/getAllUsers', name: '_getAllUsers_attr', methods: ['GET'])]
     #[IsGranted('ROLE_ADMIN')]
     public function __invoke(#[CurrentUser] ?User $user = null): Response|JsonResponse

--- a/src/Controller/Controlling/ExportAction.php
+++ b/src/Controller/Controlling/ExportAction.php
@@ -16,6 +16,7 @@ use App\Entity\Customer;
 use App\Entity\Entry;
 use App\Entity\Project;
 use App\Model\Response;
+use App\Security\ApiToken\RequireScope;
 use App\Service\ExportService as Export;
 use App\Util\PhpSpreadsheet\LOReadFilter;
 use DateTimeInterface;
@@ -54,6 +55,7 @@ final class ExportAction extends BaseController
     // canBill() gate (ROLE_PL || ROLE_ADMIN); enforcing it here closes the IDOR
     // a plain IS_AUTHENTICATED_FULLY left open.
     #[IsGranted('ROLE_ADMIN')]
+    #[RequireScope('reporting:read')]
     #[Route(path: '/controlling/export', name: '_controllingExport_attr_invokable', methods: ['GET'])]
     #[Route(path: '/controlling/export/{userid}/{year}/{month}/{project}/{customer}/{billable}', name: '_controllingExport_bc', requirements: ['year' => '\d+', 'userid' => '\d+'], defaults: ['userid' => 0, 'year' => 0, 'month' => 0, 'project' => 0, 'customer' => 0, 'billable' => 0], methods: ['GET'])]
     public function __invoke(Request $request): Response

--- a/src/Controller/Default/ExportCsvAction.php
+++ b/src/Controller/Default/ExportCsvAction.php
@@ -14,6 +14,7 @@ use App\Entity\Entry;
 use App\Entity\User;
 use App\Model\Response;
 use App\Repository\EntryRepository;
+use App\Security\ApiToken\RequireScope;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -28,6 +29,7 @@ final class ExportCsvAction extends BaseController
     /**
      * @throws Exception
      */
+    #[RequireScope('reporting:read')]
     #[Route(path: '/export/{days}', name: '_export_attr', defaults: ['days' => 10000], methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): Response

--- a/src/Controller/Default/GetContractHoursAction.php
+++ b/src/Controller/Default/GetContractHoursAction.php
@@ -14,6 +14,7 @@ use App\Entity\Contract;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Repository\ContractRepository;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\ContractHoursResolver;
 use DateTime;
 use Exception;
@@ -48,6 +49,7 @@ final class GetContractHoursAction extends BaseController
     /**
      * @throws Exception When date construction fails
      */
+    #[RequireScope('contracts:read')]
     #[Route(path: '/getContractHours', name: '_getContractHours_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse

--- a/src/Controller/Default/GetProjectsAction.php
+++ b/src/Controller/Default/GetProjectsAction.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\ProjectRepository;
+use App\Security\ApiToken\RequireScope;
 use Exception;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -33,6 +34,7 @@ final class GetProjectsAction extends BaseController
      * @throws BadRequestException   When request is malformed
      * @throws AccessDeniedException When user lacks required permissions
      */
+    #[RequireScope('projects:read')]
     #[Route(path: '/getProjects', name: '_getProjects_attr', methods: ['GET'])]
     #[IsGranted('ROLE_USER')]
     public function __invoke(#[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse

--- a/src/Controller/Default/GetTicketTimeSummaryAction.php
+++ b/src/Controller/Default/GetTicketTimeSummaryAction.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\EntryRepository;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TimeCalculationService;
 use Exception;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
@@ -44,6 +45,7 @@ final class GetTicketTimeSummaryAction extends BaseController
      * @throws BadRequestException When route parameters are invalid
      * @throws Exception           When time calculation operations fail
      */
+    #[RequireScope('reporting:read')]
     #[Route(path: '/getTicketTimeSummary/{ticket}', name: '_getTicketTimeSummary_attr', defaults: ['ticket' => null], methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): Response|RedirectResponse

--- a/src/Controller/Default/GetTimeSummaryAction.php
+++ b/src/Controller/Default/GetTimeSummaryAction.php
@@ -17,6 +17,7 @@ use App\Enum\Period;
 use App\Model\JsonResponse;
 use App\Repository\ContractRepository;
 use App\Repository\EntryRepository;
+use App\Security\ApiToken\RequireScope;
 use App\Service\ClockInterface;
 use App\Service\Util\ExpectedWorkTimeCalculator;
 use DateTimeImmutable;
@@ -63,6 +64,7 @@ final class GetTimeSummaryAction extends BaseController
      * @throws Exception When database operations fail
      * @throws Exception When user ID retrieval or time calculation fails
      */
+    #[RequireScope('reporting:read')]
     #[Route(path: '/getTimeSummary', name: 'time_summary_attr', methods: ['GET'])]
     public function __invoke(#[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse
     {

--- a/src/Controller/Default/GetUsersAction.php
+++ b/src/Controller/Default/GetUsersAction.php
@@ -15,6 +15,7 @@ use App\Enum\UserType;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Repository\UserRepository;
+use App\Security\ApiToken\RequireScope;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
@@ -24,6 +25,7 @@ use function assert;
 
 final class GetUsersAction extends BaseController
 {
+    #[RequireScope('users:read')]
     #[Route(path: '/getUsers', name: '_getUsers_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse

--- a/src/Controller/Interpretation/GetLastEntriesAction.php
+++ b/src/Controller/Interpretation/GetLastEntriesAction.php
@@ -12,6 +12,7 @@ namespace App\Controller\Interpretation;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TimeCalculationService;
 use Exception;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
@@ -36,6 +37,7 @@ final class GetLastEntriesAction extends BaseInterpretationController
      * @throws Exception           When database operations fail
      * @throws Exception           When entry retrieval or time calculation fails
      */
+    #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/entries', name: 'interpretation_entries_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Interpretation/GroupByActivityAction.php
+++ b/src/Controller/Interpretation/GroupByActivityAction.php
@@ -13,6 +13,7 @@ use App\Entity\Activity;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TimeCalculationService;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,6 +32,7 @@ final class GroupByActivityAction extends BaseInterpretationController
         $this->timeCalculationService = $timeCalculationService;
     }
 
+    #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/activity', name: 'interpretation_activity_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Interpretation/GroupByCustomerAction.php
+++ b/src/Controller/Interpretation/GroupByCustomerAction.php
@@ -12,6 +12,7 @@ namespace App\Controller\Interpretation;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TimeCalculationService;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,6 +31,7 @@ final class GroupByCustomerAction extends BaseInterpretationController
         $this->timeCalculationService = $timeCalculationService;
     }
 
+    #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/customer', name: 'interpretation_customer_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Interpretation/GroupByProjectAction.php
+++ b/src/Controller/Interpretation/GroupByProjectAction.php
@@ -12,6 +12,7 @@ namespace App\Controller\Interpretation;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TimeCalculationService;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,6 +31,7 @@ final class GroupByProjectAction extends BaseInterpretationController
         $this->timeCalculationService = $timeCalculationService;
     }
 
+    #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/project', name: 'interpretation_project_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Interpretation/GroupByTicketAction.php
+++ b/src/Controller/Interpretation/GroupByTicketAction.php
@@ -12,6 +12,7 @@ namespace App\Controller\Interpretation;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TimeCalculationService;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,6 +31,7 @@ final class GroupByTicketAction extends BaseInterpretationController
         $this->timeCalculationService = $timeCalculationService;
     }
 
+    #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/ticket', name: 'interpretation_ticket_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Interpretation/GroupByUserAction.php
+++ b/src/Controller/Interpretation/GroupByUserAction.php
@@ -12,6 +12,7 @@ namespace App\Controller\Interpretation;
 use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\TimeCalculationService;
 use Exception;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,6 +31,7 @@ final class GroupByUserAction extends BaseInterpretationController
         $this->timeCalculationService = $timeCalculationService;
     }
 
+    #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/user', name: 'interpretation_user_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Interpretation/GroupByWorktimeAction.php
+++ b/src/Controller/Interpretation/GroupByWorktimeAction.php
@@ -15,6 +15,7 @@ use App\Enum\UserType;
 use App\Model\JsonResponse;
 use App\Model\Response as ModelResponse;
 use App\Repository\ContractRepository;
+use App\Security\ApiToken\RequireScope;
 use App\Service\Util\ContractHoursResolver;
 use App\Service\Util\TimeCalculationService;
 use DateTimeInterface;
@@ -47,6 +48,7 @@ final class GroupByWorktimeAction extends BaseInterpretationController
         $this->contractHoursResolver = $contractHoursResolver;
     }
 
+    #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/time', name: 'interpretation_time_attr', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/src/Controller/Tracking/GetEntryAction.php
+++ b/src/Controller/Tracking/GetEntryAction.php
@@ -14,6 +14,7 @@ use App\Entity\User;
 use App\Model\JsonResponse;
 use App\Model\Response;
 use App\Response\Error;
+use App\Security\ApiToken\RequireScope;
 use App\Util\RequestEntityHelper;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
@@ -21,6 +22,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 final class GetEntryAction extends BaseTrackingController
 {
+    #[RequireScope('entries:read')]
     #[Route(path: '/tracking/entry/{id}', name: 'timetracking_get_attr', requirements: ['id' => '\d+'], methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(

--- a/tests/Controller/ApiTokenAuthTest.php
+++ b/tests/Controller/ApiTokenAuthTest.php
@@ -85,11 +85,34 @@ final class ApiTokenAuthTest extends AbstractWebTestCase
 
     public function testEndpointWithoutRequireScopeIsForbiddenForTokens(): void
     {
-        // Fail-closed: /getTicketSystems declares no #[RequireScope], so even a
-        // wildcard token cannot reach it.
-        $status = $this->requestWithToken(Request::METHOD_GET, '/getTicketSystems', $this->mintToken(['*']))->getStatusCode();
+        // Fail-closed: /getAllHolidays declares no #[RequireScope] (deliberately not
+        // opened to tokens), so even a wildcard token cannot reach it.
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getAllHolidays', $this->mintToken(['*']))->getStatusCode();
 
         self::assertSame(Response::HTTP_FORBIDDEN, $status);
+    }
+
+    public function testPhase4ReadEndpointReachableWithItsScope(): void
+    {
+        // /getTicketSystems opted in with ticketsystems:read (Phase 4).
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getTicketSystems', $this->mintToken(['ticketsystems:read']))->getStatusCode();
+
+        self::assertSame(200, $status);
+    }
+
+    public function testPhase4ReadEndpointDeniedWithWrongScope(): void
+    {
+        // A reporting endpoint needs reporting:read; entries:read does not satisfy it.
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getTimeSummary', $this->mintToken(['entries:read']))->getStatusCode();
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $status);
+    }
+
+    public function testReportingEndpointReachableWithReportingScope(): void
+    {
+        $status = $this->requestWithToken(Request::METHOD_GET, '/getTimeSummary', $this->mintToken(['reporting:read']))->getStatusCode();
+
+        self::assertSame(200, $status);
     }
 
     public function testBearerSchemeIsAcceptedCaseInsensitively(): void

--- a/tests/Security/RequireScopeCoverageTest.php
+++ b/tests/Security/RequireScopeCoverageTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Security;
+
+use App\ValueObject\ApiScope;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function dirname;
+use function file_get_contents;
+use function preg_match_all;
+use function sprintf;
+
+/**
+ * ADR-021 Phase 4 coverage guard: every #[RequireScope('…')] declared on a
+ * controller must use a scope from the ApiScope taxonomy (catches typos like
+ * 'reporting:reed' that would silently make an endpoint unreachable), and the
+ * read/write endpoints must keep declaring their scopes (a floor count so the
+ * annotations can't quietly disappear).
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class RequireScopeCoverageTest extends TestCase
+{
+    public function testEveryRequireScopeUsesAValidScope(): void
+    {
+        $controllerDir = dirname(__DIR__, 2) . '/src/Controller';
+        $found = 0;
+
+        /** @var iterable<SplFileInfo> $files */
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($controllerDir));
+        foreach ($files as $file) {
+            if (!$file->isFile() || 'php' !== $file->getExtension()) {
+                continue;
+            }
+
+            $source = file_get_contents($file->getPathname());
+            if (false === $source) {
+                continue;
+            }
+
+            preg_match_all("/#\\[RequireScope\\('([^']+)'\\)\\]/", $source, $matches);
+            foreach ($matches[1] as $scope) {
+                ++$found;
+                self::assertTrue(
+                    ApiScope::isValid($scope),
+                    sprintf('Invalid API scope "%s" in %s', $scope, $file->getFilename()),
+                );
+            }
+        }
+
+        // Phase 2 (6) + Phase 4 (21) endpoints; a floor guards against accidental removal.
+        self::assertGreaterThanOrEqual(25, $found, 'expected the token-facing endpoints to declare #[RequireScope]');
+    }
+}

--- a/tests/Security/RequireScopeCoverageTest.php
+++ b/tests/Security/RequireScopeCoverageTest.php
@@ -9,23 +9,28 @@ declare(strict_types=1);
 
 namespace Tests\Security;
 
+use App\Security\ApiToken\RequireScope;
 use App\ValueObject\ApiScope;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use ReflectionClass;
 use SplFileInfo;
 
+use function class_exists;
 use function dirname;
-use function file_get_contents;
-use function preg_match_all;
 use function sprintf;
+use function str_replace;
+use function strlen;
+use function substr;
 
 /**
- * ADR-021 Phase 4 coverage guard: every #[RequireScope('…')] declared on a
- * controller must use a scope from the ApiScope taxonomy (catches typos like
- * 'reporting:reed' that would silently make an endpoint unreachable), and the
- * read/write endpoints must keep declaring their scopes (a floor count so the
- * annotations can't quietly disappear).
+ * ADR-021 Phase 4 coverage guard: every #[RequireScope(...)] declared on a
+ * controller must use a scope from the ApiScope taxonomy — a typo like
+ * 'reporting:reed' would otherwise silently make the endpoint unreachable by
+ * tokens. Read via reflection (not a regex) so quoting/grouping/formatting of the
+ * attribute cannot hide a declaration. A floor count guards against accidental
+ * removal of the annotations.
  *
  * @internal
  *
@@ -33,34 +38,59 @@ use function sprintf;
  */
 final class RequireScopeCoverageTest extends TestCase
 {
+    private const string CONTROLLER_NAMESPACE = 'App\\Controller\\';
+
     public function testEveryRequireScopeUsesAValidScope(): void
     {
-        $controllerDir = dirname(__DIR__, 2) . '/src/Controller';
         $found = 0;
+        foreach ($this->controllerClasses() as $class) {
+            $reflection = new ReflectionClass($class);
+            $attributes = $reflection->getAttributes(RequireScope::class);
+            foreach ($reflection->getMethods() as $method) {
+                foreach ($method->getAttributes(RequireScope::class) as $attribute) {
+                    $attributes[] = $attribute;
+                }
+            }
+
+            foreach ($attributes as $attribute) {
+                $scope = $attribute->newInstance()->scope;
+                ++$found;
+                self::assertTrue(
+                    ApiScope::isValid($scope),
+                    sprintf('Invalid API scope "%s" declared in %s', $scope, $class),
+                );
+            }
+        }
+
+        // Phase 2 (6) + Phase 4 (21) = 27; a floor guards against accidental removal
+        // while still allowing new scoped endpoints to be added.
+        self::assertGreaterThanOrEqual(27, $found, 'expected the token-facing endpoints to declare #[RequireScope]');
+    }
+
+    /**
+     * FQCNs of every controller class under src/Controller.
+     *
+     * @return list<class-string>
+     */
+    private function controllerClasses(): array
+    {
+        $baseDir = dirname(__DIR__, 2) . '/src/Controller';
+        $classes = [];
 
         /** @var iterable<SplFileInfo> $files */
-        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($controllerDir));
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($baseDir));
         foreach ($files as $file) {
             if (!$file->isFile() || 'php' !== $file->getExtension()) {
                 continue;
             }
 
-            $source = file_get_contents($file->getPathname());
-            if (false === $source) {
-                continue;
-            }
-
-            preg_match_all("/#\\[RequireScope\\('([^']+)'\\)\\]/", $source, $matches);
-            foreach ($matches[1] as $scope) {
-                ++$found;
-                self::assertTrue(
-                    ApiScope::isValid($scope),
-                    sprintf('Invalid API scope "%s" in %s', $scope, $file->getFilename()),
-                );
+            $relative = substr($file->getPathname(), strlen($baseDir) + 1, -strlen('.php'));
+            $class = self::CONTROLLER_NAMESPACE . str_replace('/', '\\', $relative);
+            if (class_exists($class)) {
+                $classes[] = $class;
             }
         }
 
-        // Phase 2 (6) + Phase 4 (21) endpoints; a floor guards against accidental removal.
-        self::assertGreaterThanOrEqual(25, $found, 'expected the token-facing endpoints to declare #[RequireScope]');
+        return $classes;
     }
 }


### PR DESCRIPTION
## What

Opens the read data API to personal access tokens, **fail-closed by default**.

**21 read endpoints** now declare `#[RequireScope('resource:read')]`:

| Scope | Endpoints |
|-------|-----------|
| `customers:read` | `/getAllCustomers` |
| `projects:read` | `/getProjects` |
| `users:read` | `/getUsers`, `/getAllUsers` |
| `teams:read` | `/getAllTeams` |
| `presets:read` | `/getAllPresets` |
| `contracts:read` | `/getContracts`, `/getContractHours` |
| `ticketsystems:read` | `/getTicketSystems` |
| `entries:read` | `/tracking/entry/{id}` |
| `reporting:read` | `/getTimeSummary`, `/getTicketTimeSummary/{ticket}`, the `/interpretation/*` group, `/controlling/export`, `/export/{days}` |

Admin (`ROLE_ADMIN`) endpoints keep their role gate — `#[RequireScope]` **composes** with it (a token needs both an admin user *and* the scope). Holidays, `/admin/status`, and the jira-sync trigger are left **unannotated on purpose** (not token-facing → unreachable by tokens).

## OpenAPI (`public/api.yml`)

Added the `bearerAuth` (+ `cookieAuth`) `securityScheme`, a top-level `security`, and the token/scope model in the description. **Per-operation scope tags are intentionally not duplicated** into the static YAML — the code's `#[RequireScope]` is the single source of truth, so spec and enforcement can't drift.

## Coverage

- `RequireScopeCoverageTest` — every declared `#[RequireScope]` uses a valid `ApiScope` (catches typos that would silently break an endpoint) + a floor count so annotations can't vanish.
- `ApiTokenAuthTest` — a Phase-4 endpoint is reachable with its scope and denied with a wrong one; the fail-closed example moved to a still-unannotated endpoint.

Gates: PHPStan L10, php-cs-fixer, Rector, phpat clean; **full suite 2185 tests green** (session access unaffected — `RequireScopeSubscriber` only gates token requests).