### PR TITLE
fix(security): enforce entry ownership on delete (IDOR) — v4 good-will fix

### DIFF
--- a/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
@@ -94,6 +94,17 @@ class CrudController extends BaseController
                 return new Error($message, 404);
             }
 
+            // Security fix: a user may only delete their own entries; project
+            // leads (PL) may delete any. Without this ownership check any
+            // logged-in user could delete another user's entry by guessing its
+            // id (IDOR). See v6 DeleteEntryAction for the same policy.
+            if ($entry->getUser()->getId() != $this->getUserId($request)
+                && !$this->isPl($request)
+            ) {
+                $message = $this->get('translator')->trans('You are not allowed to delete this entry.');
+                return new Error($message, 403);
+            }
+
             try {
                 $this->deleteJiraWorklog($entry);
 

--- a/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
@@ -98,7 +98,10 @@ class CrudController extends BaseController
             // leads (PL) may delete any. Without this ownership check any
             // logged-in user could delete another user's entry by guessing its
             // id (IDOR). See v6 DeleteEntryAction for the same policy.
-            if ($entry->getUser()->getId() != $this->getUserId($request)
+            // getUser() can be null (nullable relation, cf. getAction) — a
+            // null-owned entry is only deletable by a PL.
+            $owner = $entry->getUser();
+            if ((!is_object($owner) || $owner->getId() != $this->getUserId($request))
                 && !$this->isPl($request)
             ) {
                 $message = $this->get('translator')->trans('You are not allowed to delete this entry.');

--- a/tests/src/Netresearch/TimeTrackerBundle/Controller/CrudControllerTest.php
+++ b/tests/src/Netresearch/TimeTrackerBundle/Controller/CrudControllerTest.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\DB;
 
 class CrudControllerTest extends BaseTest
 {
+    private const DELETE_URL = '/tracking/delete';
+
     public function testGetAction()
     {
         $this->client->request('GET', '/tracking/entry/1');
@@ -108,11 +110,11 @@ class CrudControllerTest extends BaseTest
     {
         $parameter = ['id' => 1,];
 
-        $this->client->request('POST', '/tracking/delete', $parameter);
+        $this->client->request('POST', self::DELETE_URL, $parameter);
         $this->assertStatusCode(200, 'First delete did not return expected 200');
         $this->assertJsonStructure(['success' => true, 'alert' => null]);
         //  second delete
-        $this->client->request('POST', '/tracking/delete', $parameter);
+        $this->client->request('POST', self::DELETE_URL, $parameter);
         $this->assertStatusCode(404, 'Second delete did not return expected 404');
         $this->assertJsonStructure(['message' => 'Kein Eintrag für ID.']);
     }
@@ -122,7 +124,7 @@ class CrudControllerTest extends BaseTest
         // Security (IDOR fix): a plain developer must not delete another user's
         // entry. noContract -> loginId 4 (DEV); entry 2 is owned by user 1 (PL).
         $this->logInSession('noContract');
-        $this->client->request('POST', '/tracking/delete', ['id' => 2]);
+        $this->client->request('POST', self::DELETE_URL, ['id' => 2]);
         $this->assertStatusCode(403, 'A developer must not be able to delete a foreign entry');
     }
 

--- a/tests/src/Netresearch/TimeTrackerBundle/Controller/CrudControllerTest.php
+++ b/tests/src/Netresearch/TimeTrackerBundle/Controller/CrudControllerTest.php
@@ -117,6 +117,15 @@ class CrudControllerTest extends BaseTest
         $this->assertJsonStructure(['message' => 'Kein Eintrag für ID.']);
     }
 
+    public function testDeleteForeignEntryIsForbidden()
+    {
+        // Security (IDOR fix): a plain developer must not delete another user's
+        // entry. noContract -> loginId 4 (DEV); entry 2 is owned by user 1 (PL).
+        $this->logInSession('noContract');
+        $this->client->request('POST', '/tracking/delete', ['id' => 2]);
+        $this->assertStatusCode(403, 'A developer must not be able to delete a foreign entry');
+    }
+
     //-------------- Bulkentry routes ----------------------------------------
 
     public function testBulkentryActionNonExistendPreset()


### PR DESCRIPTION
## Security fix (IDOR) — final good-will patch for the EOL v4 line

`CrudController::deleteAction` only verified that a user was **logged in**, then deleted whatever entry id was posted:

```php
$entry = $repo->find($request->request->get('id'));
if (!$entry) { return new Error('No entry for id.', 404); }
// ...deletes it. No ownership check.
```

**Any authenticated user could delete another user's time entry** by guessing/enumerating ids (IDOR). Present in every shipped v4.x release (v4.0.0–v4.1.4). The same flaw was found and fixed on the v6 line (owner-only unless PL/admin).

### Fix

Add the ownership check, mirroring v6's policy in v4 idiom: a user may delete only their own entries; **project leads (PL) may delete any**. Returns `403` otherwise.

### Tests

- `testDeleteForeignEntryIsForbidden` (new): a developer deleting a foreign entry now gets `403`.
- `testDeleteAction` (existing) still passes — its login maps to a PL user, which is permitted.

⚠️ **Not runtime-verified here:** v4 is Symfony 2/3 and can't run in the current PHP 8.5 environment, and the v4 branch has no test-CI workflow (only docker-publish). The change is verified by `php -l` + static review against the confirmed-correct v6 fix. Please run the v4 suite in a legacy environment before release.

### Note

This is intended as the **last good-will security release** for v4. Only the stable **main / v6** line receives further fixes, updates, and improvements going forward — the release notes should carry that EOL announcement. Holding the tag/release for maintainer confirmation.