### PR TITLE
chore(v4): pin CI actions to SHAs + announce end-of-life

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           # list of Docker images to use as base name for tags
           images: ghcr.io/${{ github.repository }}
@@ -33,20 +33,20 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,17 @@ Netresearch TimeTracker
 
 Project and customer based time tracking for company employees.
 
+.. warning::
+
+   **End of life — this v4 line is no longer maintained.**
+
+   All further fixes, updates, and improvements go to the current stable line
+   (``main`` / v6) only. The final v4 release is a good-will **security patch**
+   for an entry-deletion authorization issue (any authenticated user could delete
+   another user's entry by id — an IDOR); it receives no further changes.
+
+   Please **upgrade to v6**.
+
 Features:
 
 - Time tracking with autocompletion


### PR DESCRIPTION
Two housekeeping changes for the EOL v4 line.

## Fix v4 CI

`docker-publish.yml` used unpinned action versions (`docker/*@v5`/`@v3`/`@v6`), which the org ruleset rejects ("all actions must be pinned to a full-length commit SHA") — the reason the docker check was failing on v4 PRs. Pinned all five to their current commit SHA with a version comment:

- `docker/metadata-action` → v5.10.0
- `docker/login-action` → v3.7.0
- `docker/setup-qemu-action` → v3.7.0
- `docker/setup-buildx-action` → v3.12.0
- `docker/build-push-action` → v6.19.2

## End-of-life announcement

`README.rst` gains a prominent EOL notice: v4 is no longer maintained; all further fixes/updates/improvements go to the current stable line (`main` / v6). The final v4 release is the good-will security patch for the entry-deletion IDOR (#560). Users are pointed to v6.

Note: v4 is Symfony 2/3 and can't run in a modern PHP env; there's no test-CI on the branch. This change is YAML/RST only.