### PR TITLE
chore(v4): bump CI actions to latest majors + louder EOL notice

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           # list of Docker images to use as base name for tags
           images: ghcr.io/${{ github.repository }}
@@ -33,20 +33,20 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.rst
+++ b/README.rst
@@ -3,22 +3,30 @@
       :height: 25px
       :align: left
 
-=======================
-Netresearch TimeTracker
-=======================
+.. danger::
+
+   **⚠  DEPRECATED — v4 IS END-OF-LIFE.  DO NOT DEPLOY v4.  ⚠**
+
+   **This v4 line is no longer maintained.** It receives **no further fixes,
+   features, or support** — only one final good-will security patch. It is kept
+   for historical reference only.
+
+   ➡️  **Use the current stable line — ``main`` / v6 — for everything.**
+   New installations must start on v6; existing v4 installs should **upgrade to
+   v6 now.**
+
+   The last v4 change is a **security patch** for an entry-deletion authorization
+   flaw: any authenticated user could delete another user's time entry by id (an
+   IDOR). Nothing else will be fixed on this branch.
+
+==========================================
+Netresearch TimeTracker — v4 (END-OF-LIFE)
+==========================================
 
 Project and customer based time tracking for company employees.
 
-.. warning::
-
-   **End of life — this v4 line is no longer maintained.**
-
-   All further fixes, updates, and improvements go to the current stable line
-   (``main`` / v6) only. The final v4 release is a good-will **security patch**
-   for an entry-deletion authorization issue (any authenticated user could delete
-   another user's entry by id — an IDOR); it receives no further changes.
-
-   Please **upgrade to v6**.
+    ⚠ **v4 is end-of-life and unmaintained — see the deprecation notice above.
+    Use / upgrade to v6 (``main``).**
 
 Features:
 


### PR DESCRIPTION
Follow-up cleanup on the EOL v4 branch — "leave it cleaner than we found it."

## CI actions → latest majors (still SHA-pinned)

The earlier pass pinned to the latest release *within the existing major*; this bumps to the latest **major**, keeping the SHA pin + version comment:

| Action | was | now |
|--------|-----|-----|
| docker/metadata-action | v5.10.0 | **v6.2.0** |
| docker/login-action | v3.7.0 | **v4.4.0** |
| docker/setup-qemu-action | v3.7.0 | **v4.2.0** |
| docker/setup-buildx-action | v3.12.0 | **v4.2.0** |
| docker/build-push-action | v6.19.2 | **v7.3.0** |

## Louder EOL notice

The prior deprecation read too quietly. `README.rst` now leads with a red `danger` banner **above the title** ("DEPRECATED — v4 IS END-OF-LIFE. DO NOT DEPLOY v4."), marks the title `(END-OF-LIFE)`, and restates the upgrade-to-v6 pointer. Validated with docutils (0 issues).

The docker check will confirm the bumped actions still build.