### PR TITLE
docs(v4): fix the EOL banner rendering as literal "!DANGER!"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,21 +3,21 @@
       :height: 25px
       :align: left
 
-.. danger::
+⚠️  **DEPRECATED — v4 IS END-OF-LIFE. DO NOT DEPLOY v4.**  ⚠️
 
-   **⚠  DEPRECATED — v4 IS END-OF-LIFE.  DO NOT DEPLOY v4.  ⚠**
+**This v4 line is no longer maintained.** It receives **no further fixes,
+features, or support** — only one final good-will security patch. It is kept
+for historical reference only.
 
-   **This v4 line is no longer maintained.** It receives **no further fixes,
-   features, or support** — only one final good-will security patch. It is kept
-   for historical reference only.
+➡️  **Use the current stable line —** ``main`` **/ v6 — for everything.**
+New installations must start on v6; existing v4 installs should **upgrade to
+v6 now.**
 
-   ➡️  **Use the current stable line — ``main`` / v6 — for everything.**
-   New installations must start on v6; existing v4 installs should **upgrade to
-   v6 now.**
+The last v4 change is a **security patch** for an entry-deletion authorization
+flaw: any authenticated user could delete another user's time entry by id (an
+IDOR). Nothing else will be fixed on this branch.
 
-   The last v4 change is a **security patch** for an entry-deletion authorization
-   flaw: any authenticated user could delete another user's time entry by id (an
-   IDOR). Nothing else will be fixed on this branch.
+----
 
 ==========================================
 Netresearch TimeTracker — v4 (END-OF-LIFE)


### PR DESCRIPTION
## Problem

On GitHub, the v4 README's EOL notice rendered as a literal **`!DANGER!`** line with no box or colour.

GitHub renders `.rst` through a bare docutils HTML writer with no admonition CSS. The `.. danger::` directive therefore emits its title as a plain `<p>!DANGER!</p>` (docutils decorates `danger/warning/caution/…` titles with exclamation marks) and none of the coloured-box styling a Sphinx site would apply. So instead of a warning banner, readers saw the string "!DANGER!".

## Fix

Drop the directive; keep the content as top-level **bold paragraphs** between horizontal rules, which render verbatim on GitHub and read as a prominent banner. Removed the leading `----` because the `.. header::` directive already emits its own trailing rule (two stacked rules otherwise).

## Verified against GitHub's actual rendering

Fetched the rendered HTML for this branch (`GET /repos/.../readme` with `Accept: application/vnd.github.html`) and took a screenshot of the blob page:

- `!DANGER!` occurrences: **0**
- Banner renders as bold text + ⚠️ emoji, one rule under the logo, one before the title.

> Note: GitHub-rendered `.rst` cannot show a coloured alert box — that is a Sphinx-only feature. This is the most prominent form available in RST. A coloured box would require converting the README to Markdown (`> [!CAUTION]`).

v4 is end-of-life; docs-only change.