### PR TITLE
fix(mcp): make /mcp reachable for remote clients + admin-status card

### DIFF
--- a/.env
+++ b/.env
@@ -67,3 +67,10 @@ REQUIRE_TWO_FACTOR=false
 WEBAUTHN_RP_ID=localhost
 WEBAUTHN_ALLOWED_ORIGINS=http://localhost
 ###< web-auth/webauthn-symfony-bundle ###
+
+###> app/mcp ###
+# MCP server (ADR-021 Phase 5): comma-separated hostnames (no port; IPv6 bracketed)
+# the /mcp DNS-rebinding guard accepts. Override per deployment with the public
+# domain, e.g. MCP_ALLOWED_HOSTS=tt.netresearch.de,localhost
+MCP_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
+###< app/mcp ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,6 +24,10 @@ parameters:
     ldap_usernamefield: '%env(LDAP_USERNAMEFIELD)%'
     ldap_usessl: '%env(bool:LDAP_USESSL)%'
     ldap_create_user: '%env(bool:LDAP_CREATE_USER)%'
+    # MCP server (ADR-021 Phase 5): hostnames the /mcp Streamable-HTTP transport's
+    # DNS-rebinding guard accepts in the Host/Origin header. Must include the public
+    # domain (the SDK default is localhost-only, which 403s a real host).
+    app.mcp_allowed_hosts: '%env(csv:MCP_ALLOWED_HOSTS)%'
 
 imports:
     - { resource: services/object_mapper.yaml }
@@ -52,11 +56,30 @@ services:
             - '../src/Service/Integration/Jira/JiraTicketService.php'
             - '../src/Service/Integration/Jira/JiraAuthenticationService.php'
             - '../src/Service/Integration/Jira/JiraIntegrationService.php'
+            # Wired explicitly below (overrides the bundle's mcp.server.controller).
+            - '../src/Mcp/McpEndpointController.php'
 
     # Controllers are tagged automatically
     App\Controller\:
         resource: '../src/Controller/'
         tags: ['controller.service_arguments']
+
+    # ADR-021 Phase 5: override the bundle's mcp.server.controller (final, hardcodes
+    # localhost-only DNS-rebinding hosts) with ours, host-allowlisted. Same args as
+    # Symfony\AI\McpBundle McpBundle::loadExtension registers, plus the allowed hosts.
+    mcp.server.controller:
+        class: App\Mcp\McpEndpointController
+        public: true
+        arguments:
+            - '@mcp.server'
+            - '@mcp.psr_http_factory'
+            - '@mcp.http_foundation_factory'
+            - '@mcp.psr17_factory'
+            - '@mcp.psr17_factory'
+            - '%app.mcp_allowed_hosts%'
+            - '@logger'
+        tags:
+            - 'controller.service_arguments'
 
     # Add this if you use repositories
     App\Repository\:

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -562,6 +562,8 @@
   "status_subsystem_authentication_desc": "Login-Backends und Verzeichnisdienst.",
   "status_subsystem_api": "API",
   "status_subsystem_api_desc": "REST-API-Schnittstelle und Authentifizierung.",
+  "status_subsystem_mcp": "MCP-Server",
+  "status_subsystem_mcp_desc": "Model-Context-Protocol-Endpunkt für Coding-Agents (Streamable HTTP).",
   "status_subsystem_jira": "Jira-Integration",
   "status_subsystem_jira_desc": "Worklog-Synchronisation mit Jira."
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -562,6 +562,8 @@
   "status_subsystem_authentication_desc": "Login backends and directory.",
   "status_subsystem_api": "API",
   "status_subsystem_api_desc": "REST API surface and authentication.",
+  "status_subsystem_mcp": "MCP server",
+  "status_subsystem_mcp_desc": "Model Context Protocol endpoint for coding agents (Streamable HTTP).",
   "status_subsystem_jira": "Jira integration",
   "status_subsystem_jira_desc": "Worklog synchronization with Jira."
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -562,6 +562,8 @@
   "status_subsystem_authentication_desc": "Backends de inicio de sesión y directorio.",
   "status_subsystem_api": "API",
   "status_subsystem_api_desc": "Superficie de la API REST y autenticación.",
+  "status_subsystem_mcp": "Servidor MCP",
+  "status_subsystem_mcp_desc": "Punto de conexión Model Context Protocol para agentes de código (Streamable HTTP).",
   "status_subsystem_jira": "Integración con Jira",
   "status_subsystem_jira_desc": "Sincronización de worklogs con Jira."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -562,6 +562,8 @@
   "status_subsystem_authentication_desc": "Backends de connexion et annuaire.",
   "status_subsystem_api": "API",
   "status_subsystem_api_desc": "Surface de l'API REST et authentification.",
+  "status_subsystem_mcp": "Serveur MCP",
+  "status_subsystem_mcp_desc": "Point de terminaison Model Context Protocol pour les agents de code (Streamable HTTP).",
   "status_subsystem_jira": "Intégration Jira",
   "status_subsystem_jira_desc": "Synchronisation des worklogs avec Jira."
 }

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -562,6 +562,8 @@
   "status_subsystem_authentication_desc": "Механизмы входа и каталог.",
   "status_subsystem_api": "API",
   "status_subsystem_api_desc": "REST API и аутентификация.",
+  "status_subsystem_mcp": "MCP-сервер",
+  "status_subsystem_mcp_desc": "Конечная точка Model Context Protocol для агентов по коду (Streamable HTTP).",
   "status_subsystem_jira": "Интеграция с Jira",
   "status_subsystem_jira_desc": "Синхронизация worklog с Jira."
 }

--- a/frontend/src/pages/AdminStatus.tsx
+++ b/frontend/src/pages/AdminStatus.tsx
@@ -67,6 +67,7 @@ const SUBSYSTEM_LABELS: Record<string, () => string> = {
   passkeys_mfa: () => m.status_subsystem_passkeys_mfa(),
   authentication: () => m.status_subsystem_authentication(),
   api: () => m.status_subsystem_api(),
+  mcp: () => m.status_subsystem_mcp(),
   jira: () => m.status_subsystem_jira(),
 }
 const SUBSYSTEM_DESCS: Record<string, () => string> = {
@@ -77,6 +78,7 @@ const SUBSYSTEM_DESCS: Record<string, () => string> = {
   passkeys_mfa: () => m.status_subsystem_passkeys_mfa_desc(),
   authentication: () => m.status_subsystem_authentication_desc(),
   api: () => m.status_subsystem_api_desc(),
+  mcp: () => m.status_subsystem_mcp_desc(),
   jira: () => m.status_subsystem_jira_desc(),
 }
 const subsystemLabel = (id: string): string => SUBSYSTEM_LABELS[id]?.() ?? id

--- a/src/Controller/Admin/GetStatusAction.php
+++ b/src/Controller/Admin/GetStatusAction.php
@@ -15,6 +15,8 @@ use App\Service\ApiToken\ApiTokenService;
 use Composer\InstalledVersions;
 use Doctrine\DBAL\Connection;
 use ReflectionClass;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -59,6 +61,8 @@ final class GetStatusAction extends BaseController
     public function __construct(
         private readonly Connection $connection,
         private readonly ApiTokenService $apiTokenService,
+        #[AutowireLocator('mcp.tool')]
+        private readonly ServiceLocator $mcpTools,
     ) {
     }
 
@@ -315,6 +319,18 @@ final class GetStatusAction extends BaseController
                     'auth' => 'Bearer ' . ApiTokenService::PREFIX . '…',
                     'scopes' => $scopeCount,
                     'openapi' => '/api.yml',
+                ],
+                'adr' => 'ADR-021',
+            ],
+            [
+                'id' => 'mcp',
+                'backend' => 'Native MCP server (Streamable HTTP)',
+                'status' => 'ok',
+                'config' => [
+                    'endpoint' => '/mcp',
+                    'transport' => 'streamable-http',
+                    'tools' => count($this->mcpTools->getProvidedServices()),
+                    'auth' => 'scoped ' . ApiTokenService::PREFIX . '… (per-tool)',
                 ],
                 'adr' => 'ADR-021',
             ],

--- a/src/Mcp/McpEndpointController.php
+++ b/src/Mcp/McpEndpointController.php
@@ -23,6 +23,7 @@ use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+use function str_starts_with;
 use function strtolower;
 
 /**
@@ -67,7 +68,8 @@ final readonly class McpEndpointController implements SelfEnforcesScope
         );
 
         $psrResponse = $this->server->run($transport);
-        $streamed = 'text/event-stream' === strtolower($psrResponse->getHeaderLine('Content-Type'));
+        // Match the media type tolerant of parameters (e.g. "text/event-stream; charset=utf-8").
+        $streamed = str_starts_with(strtolower($psrResponse->getHeaderLine('Content-Type')), 'text/event-stream');
 
         return $this->httpFoundationFactory->createResponse($psrResponse, $streamed);
     }

--- a/src/Mcp/McpEndpointController.php
+++ b/src/Mcp/McpEndpointController.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp;
+
+use App\Security\ApiToken\SelfEnforcesScope;
+use Mcp\Server;
+use Mcp\Server\Transport\Http\Middleware\CorsMiddleware;
+use Mcp\Server\Transport\Http\Middleware\DnsRebindingProtectionMiddleware;
+use Mcp\Server\Transport\Http\Middleware\ProtocolVersionMiddleware;
+use Mcp\Server\Transport\StreamableHttpTransport;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use function strtolower;
+
+/**
+ * MCP HTTP endpoint (ADR-021 Phase 5), replacing the bundle's McpController
+ * (which is final and hardcodes the transport's default middleware).
+ *
+ * The SDK's StreamableHttpTransport defaults its DnsRebindingProtectionMiddleware
+ * to `allowedHosts = [localhost, 127.0.0.1, [::1]]`, so behind a real domain the
+ * `Host` header is rejected with 403 "Invalid Host header". We rebuild the same
+ * secure stack (CORS + DNS-rebinding + protocol-version) but with the deployment's
+ * host(s) allowlisted (see `app.mcp_allowed_hosts` / MCP_ALLOWED_HOSTS).
+ */
+final readonly class McpEndpointController implements SelfEnforcesScope
+{
+    /**
+     * @param list<string> $allowedHosts hostnames (no port) permitted by the
+     *                                   DNS-rebinding check; IPv6 must be bracketed
+     */
+    public function __construct(
+        private Server $server,
+        private HttpMessageFactoryInterface $httpMessageFactory,
+        private HttpFoundationFactoryInterface $httpFoundationFactory,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+        private array $allowedHosts,
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function handle(Request $request): Response
+    {
+        $transport = new StreamableHttpTransport(
+            $this->httpMessageFactory->createRequest($request),
+            $this->responseFactory,
+            $this->streamFactory,
+            logger: $this->logger,
+            middleware: [
+                new CorsMiddleware(),
+                new DnsRebindingProtectionMiddleware(allowedHosts: $this->allowedHosts),
+                new ProtocolVersionMiddleware(),
+            ],
+        );
+
+        $psrResponse = $this->server->run($transport);
+        $streamed = 'text/event-stream' === strtolower($psrResponse->getHeaderLine('Content-Type'));
+
+        return $this->httpFoundationFactory->createResponse($psrResponse, $streamed);
+    }
+}

--- a/src/Security/ApiToken/RequireScopeSubscriber.php
+++ b/src/Security/ApiToken/RequireScopeSubscriber.php
@@ -53,7 +53,13 @@ final readonly class RequireScopeSubscriber implements EventSubscriberInterface
             return; // not a token request — scopes gate token auth only
         }
 
-        $required = $this->requiredScope($event->getController());
+        $controller = $event->getController();
+        $controllerObject = is_array($controller) ? $controller[0] : (is_object($controller) ? $controller : null);
+        if ($controllerObject instanceof SelfEnforcesScope) {
+            return; // controller enforces scopes per call (e.g. the MCP endpoint)
+        }
+
+        $required = $this->requiredScope($controller);
         // Deny by short-circuiting the controller to a generic 403 (no token/scope
         // detail leaked) rather than throwing — a thrown exception at
         // kernel.controller time trips a framework type error building the response.

--- a/src/Security/ApiToken/SelfEnforcesScope.php
+++ b/src/Security/ApiToken/SelfEnforcesScope.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\ApiToken;
+
+/**
+ * Opt-out of the RequireScopeSubscriber fail-closed gate for a controller that
+ * enforces scopes itself, per call, rather than via a single #[RequireScope]
+ * attribute (ADR-021 Phase 5).
+ *
+ * The MCP endpoint multiplexes many tools, each requiring a different scope
+ * checked in its handler (App\Mcp\ScopeGuard), so a single controller-level scope
+ * cannot express its requirement. A controller implementing this interface takes
+ * responsibility for enforcing scopes on every path — the fail-closed default
+ * (deny token requests to controllers with no declared scope) is bypassed only
+ * for these explicitly-marked controllers.
+ */
+interface SelfEnforcesScope
+{
+}

--- a/tests/Controller/GetStatusActionTest.php
+++ b/tests/Controller/GetStatusActionTest.php
@@ -74,7 +74,7 @@ final class GetStatusActionTest extends AbstractWebTestCase
         }
 
         // Every storage/subsystem the page promises is present.
-        foreach (['database', 'sessions', 'cache', 'api_tokens', 'passkeys_mfa', 'authentication', 'api', 'jira'] as $id) {
+        foreach (['database', 'sessions', 'cache', 'api_tokens', 'passkeys_mfa', 'authentication', 'api', 'mcp', 'jira'] as $id) {
             self::assertArrayHasKey($id, $byId, sprintf('missing subsystem card: %s', $id));
         }
 

--- a/tests/Mcp/McpHttpEndpointTest.php
+++ b/tests/Mcp/McpHttpEndpointTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Mcp;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\ApiToken\ApiTokenService;
+use Tests\AbstractWebTestCase;
+
+/**
+ * Functional tests for the /mcp HTTP endpoint (ADR-021 Phase 5), driving the full
+ * stack — the Bearer-PAT firewall, our McpEndpointController, and the SDK's
+ * Streamable-HTTP transport middleware (incl. the DNS-rebinding Host guard the
+ * direct tool tests bypass). Regression cover for the localhost-only default that
+ * 403'd a real domain until McpEndpointController allowlisted the host.
+ */
+final class McpHttpEndpointTest extends AbstractWebTestCase
+{
+    private const string INITIALIZE = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"phpunit","version":"1"}}}';
+
+    public function testInitializeSucceedsForAnAllowedHost(): void
+    {
+        // MCP_ALLOWED_HOSTS in the test env includes localhost (the test client's
+        // host), so the DNS-rebinding guard must let the handshake through.
+        $this->client->request('POST', '/mcp', server: $this->mcpServer('localhost'), content: self::INITIALIZE);
+
+        $status = $this->client->getResponse()->getStatusCode();
+        self::assertNotSame(403, $status, 'the request was rejected before reaching the MCP transport');
+        self::assertSame(200, $status);
+    }
+
+    public function testDisallowedHostIsForbidden(): void
+    {
+        // A host not in MCP_ALLOWED_HOSTS must still be rejected — the guard stays active.
+        $this->client->request('POST', '/mcp', server: $this->mcpServer('evil.example.com'), content: self::INITIALIZE);
+
+        self::assertSame(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testBogusTokenIsUnauthorized(): void
+    {
+        // A tt_pat_ Bearer is claimed by the stateless api firewall; an invalid one
+        // is rejected before the request reaches the MCP transport.
+        $server = $this->mcpServer('localhost');
+        $server['HTTP_AUTHORIZATION'] = 'Bearer tt_pat_bogus';
+        $this->client->request('POST', '/mcp', server: $server, content: self::INITIALIZE);
+
+        self::assertSame(401, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function mcpServer(string $host): array
+    {
+        return [
+            'HTTP_HOST' => $host,
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $this->readToken(),
+            'HTTP_ACCEPT' => 'application/json, text/event-stream',
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_MCP_PROTOCOL_VERSION' => '2025-06-18',
+        ];
+    }
+
+    private function readToken(): string
+    {
+        $container = self::getContainer();
+        $user = $container->get(UserRepository::class)->find(1);
+        self::assertInstanceOf(User::class, $user);
+
+        [, $plaintext] = $container->get(ApiTokenService::class)->create($user, 'mcp-http-test', ['entries:read'], null);
+
+        return $plaintext;
+    }
+}


### PR DESCRIPTION
End-to-end testing of the deployed Phase 5 MCP server (#567) revealed the `/mcp` endpoint 403s every remote client — the direct tool tests bypass the HTTP layer, so they missed it. Two distinct causes, plus the missing admin-status card.

## `/mcp` was 403 for valid tokens

1. **Fail-closed subscriber.** `RequireScopeSubscriber` denies a token request to any controller without `#[RequireScope]`. MCP multiplexes many per-tool scopes (enforced in each tool by `ScopeGuard`), so a single controller-level scope can't express it. Added a `SelfEnforcesScope` marker the subscriber honours to skip the gate for controllers that enforce scopes per call.
2. **DNS-rebinding host guard.** The SDK's `StreamableHttpTransport` hardcodes `allowedHosts=[localhost]`, 403ing a real domain; the bundle's `McpController` is `final` with no config. Override `mcp.server.controller` with `McpEndpointController` that rebuilds the secure middleware stack (CORS + DNS-rebinding + protocol-version) with the deployment's host(s) allowlisted via `MCP_ALLOWED_HOSTS`.

New functional test drives the full HTTP stack (firewall → controller → transport): initialize succeeds for an allowed host, disallowed host → 403, bogus token → 401.

## Admin status

Added the missing **MCP** subsystem card to `/ui/admin/status` (endpoint, transport, live tool count via a tagged locator, per-tool auth) + i18n across all five locales.

## Deploy note

Prod must set `MCP_ALLOWED_HOSTS=tt.netresearch.de` (the mounted env shadows `.env`).

All four PHP gates green; 27 backend + 418 frontend tests pass.