### PR TITLE
feat(mcp): expose entry info and time balance to agents (ADR-021 Phase 5)

### DIFF
--- a/docs/adr/ADR-021-api-token-authentication.md
+++ b/docs/adr/ADR-021-api-token-authentication.md
@@ -162,7 +162,14 @@ PHP 8.5 / Symfony 8.1.
   research shows per-endpoint auto-generation underperforms): `log_time`
   (`entries:write`, flagship), `list_recent_entries` (`entries:read`),
   `list_projects` (`projects:read`), `list_activities` (`activities:read`),
-  `delete_entry` (`entries:write`). Optional `get_summary` (`reporting:read`).
+  `delete_entry` (`entries:write`), `get_ticket_info` (`reporting:read`) and
+  `get_time_balance` (`reporting:read`).
+- **Info-on-write:** `log_time` returns the same context the tracking UI shows
+  after a booking — the entry's per-scope totals (the "Info"/`I` popup, via
+  `EntrySummaryService`) under `ticket_info`, and the user's today/week/month
+  IST-vs-SOLL balance (via `TimeBalanceService`) under `balance`. Both carry
+  `warnings` for the agent when an estimate or a time target is neared/exceeded/
+  underrun. The two info tools expose the same data on demand.
 - **New v2 endpoints where BC blocks:** if an existing endpoint's shape can't serve
   a clean tool without breaking the SPA, add a `/api/v2/*` endpoint for the tool to
   call rather than mutate the BC surface.

--- a/src/Mcp/Tool/GetTicketInfoTool.php
+++ b/src/Mcp/Tool/GetTicketInfoTool.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\ScopeGuard;
+use App\Service\EntrySummaryService;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+use function sprintf;
+
+/**
+ * MCP tool: the "Info" (I) aggregation for a booked entry (ADR-021 Phase 5).
+ */
+final readonly class GetTicketInfoTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private EntrySummaryService $entrySummaryService,
+    ) {
+    }
+
+    /**
+     * For a given entry, the per-scope booking totals shown in the tracking UI's
+     * "Info" popup: Customer / Project / Activity / Ticket, each with the user's
+     * own booked minutes (`own`), everyone's total (`total`) and the estimate
+     * (`estimation`, project only), plus an `estimate` summary and `warnings`.
+     * Get entry ids from `list_recent_entries` or `log_time`.
+     *
+     * @throws ToolCallException when the entry does not exist
+     *
+     * @return array<string, mixed>
+     */
+    #[McpTool(name: 'get_ticket_info', description: 'Per-scope booking totals (customer/project/activity/ticket) and estimate status for an entry.')]
+    public function getTicketInfo(
+        #[Schema(description: 'The id of a time entry to report on.', minimum: 1)]
+        int $entryId,
+    ): array {
+        $user = $this->scopeGuard->requireScope('reporting:read');
+
+        $info = $this->entrySummaryService->forEntry($entryId, (int) $user->getId());
+        if (null === $info) {
+            throw new ToolCallException(sprintf('No entry with id %d.', $entryId));
+        }
+
+        return $info;
+    }
+}

--- a/src/Mcp/Tool/GetTimeBalanceTool.php
+++ b/src/Mcp/Tool/GetTimeBalanceTool.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\ScopeGuard;
+use App\Service\TimeBalanceService;
+use Mcp\Capability\Attribute\McpTool;
+
+/**
+ * MCP tool: the authenticated user's worked-vs-target balance (ADR-021 Phase 5).
+ */
+final readonly class GetTimeBalanceTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private TimeBalanceService $timeBalanceService,
+    ) {
+    }
+
+    /**
+     * The user's time balance for today, this week and this month: IST (worked
+     * minutes), SOLL for the whole period and through today, the difference, a
+     * per-period status (`ok`/`behind`/`over`), and a `warnings` list to act on.
+     *
+     * @return array<string, mixed>
+     */
+    #[McpTool(name: 'get_time_balance', description: "The authenticated user's worked-vs-target time balance for today, this week and this month.")]
+    public function getTimeBalance(): array
+    {
+        $user = $this->scopeGuard->requireScope('reporting:read');
+
+        return $this->timeBalanceService->forUser($user);
+    }
+}

--- a/src/Mcp/Tool/LogTimeTool.php
+++ b/src/Mcp/Tool/LogTimeTool.php
@@ -18,6 +18,8 @@ use App\Mcp\ScopeGuard;
 use App\Repository\ActivityRepository;
 use App\Repository\ProjectRepository;
 use App\Service\ClockInterface;
+use App\Service\EntrySummaryService;
+use App\Service\TimeBalanceService;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
 use Mcp\Exception\ToolCallException;
@@ -25,6 +27,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 use function ctype_digit;
 use function intdiv;
+use function is_array;
+use function is_int;
 use function ltrim;
 use function preg_match;
 use function sprintf;
@@ -52,6 +56,8 @@ final readonly class LogTimeTool
         private ProjectRepository $projectRepository,
         private ActivityRepository $activityRepository,
         private ClockInterface $clock,
+        private EntrySummaryService $entrySummaryService,
+        private TimeBalanceService $timeBalanceService,
     ) {
     }
 
@@ -111,7 +117,31 @@ final readonly class LogTimeTool
             throw new ToolCallException($this->errorMessage($body, 'Failed to save the time entry.'));
         }
 
-        return [] === $body ? ['success' => true] : $body;
+        $result = [] === $body ? ['success' => true] : $body;
+
+        // Return the same context the user sees in the UI after a booking: the
+        // ticket's per-scope totals ("Info" popup) and the running time balance,
+        // both carrying any warnings the agent should surface.
+        $entryId = $this->createdEntryId($body);
+        if (null !== $entryId) {
+            $result['ticket_info'] = $this->entrySummaryService->forEntry($entryId, (int) $user->getId());
+        }
+        $result['balance'] = $this->timeBalanceService->forUser($user);
+
+        return $result;
+    }
+
+    /**
+     * @param array<array-key, mixed> $body the decoded SaveEntryAction response
+     */
+    private function createdEntryId(array $body): ?int
+    {
+        $result = $body['result'] ?? null;
+        if (!is_array($result)) {
+            return null;
+        }
+
+        return is_int($result['id'] ?? null) ? $result['id'] : null;
     }
 
     /**

--- a/src/Service/EntrySummaryService.php
+++ b/src/Service/EntrySummaryService.php
@@ -46,7 +46,12 @@ final readonly class EntrySummaryService
      */
     public function forEntry(int $entryId, int $userId): ?array
     {
-        if (!$this->entryRepository->find($entryId) instanceof Entry) {
+        $entry = $this->entryRepository->find($entryId);
+        // Scope to the caller's own entries: getEntrySummary aggregates the
+        // customer/project/activity/ticket totals across all users, so returning
+        // a summary for an entry the caller does not own would leak other users'
+        // scope names and totals (IDOR). Treat "not owned" as "not found".
+        if (!$entry instanceof Entry || $entry->getUser()?->getId() !== $userId) {
             return null;
         }
 

--- a/src/Service/EntrySummaryService.php
+++ b/src/Service/EntrySummaryService.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Entry;
+use App\Repository\EntryRepository;
+
+use function is_int;
+use function is_string;
+use function sprintf;
+
+/**
+ * The per-scope booking aggregation shown in the tracking UI's "Info" (I) popup
+ * for an entry — Customer / Project / Activity / Ticket, each with the user's own
+ * booked minutes, everyone's total, and (project only) the estimate (ADR-021
+ * Phase 5, the get_ticket_info MCP tool + log_time enrichment).
+ *
+ * Wraps EntryRepository::getEntrySummary and adds a project-estimate status the
+ * agent can act on: `over` at/above the estimate, `near` from 90 %, else `ok`
+ * (or `none` when the project has no estimate).
+ */
+final readonly class EntrySummaryService
+{
+    private const int NEAR_THRESHOLD_PERCENT = 90;
+
+    public function __construct(private EntryRepository $entryRepository)
+    {
+    }
+
+    /**
+     * @return array{
+     *     customer: array<string, mixed>,
+     *     project: array<string, mixed>,
+     *     activity: array<string, mixed>,
+     *     ticket: array<string, mixed>,
+     *     estimate: array{estimation: int, booked_total: int, percent: int|null, status: string},
+     *     warnings: list<string>
+     * }|null null when the entry does not exist
+     */
+    public function forEntry(int $entryId, int $userId): ?array
+    {
+        if (!$this->entryRepository->find($entryId) instanceof Entry) {
+            return null;
+        }
+
+        $seed = [
+            'customer' => ['scope' => 'customer', 'name' => '', 'entries' => 0, 'total' => 0, 'own' => 0, 'estimation' => 0],
+            'project' => ['scope' => 'project', 'name' => '', 'entries' => 0, 'total' => 0, 'own' => 0, 'estimation' => 0],
+            'activity' => ['scope' => 'activity', 'name' => '', 'entries' => 0, 'total' => 0, 'own' => 0, 'estimation' => 0],
+            'ticket' => ['scope' => 'ticket', 'name' => '', 'entries' => 0, 'total' => 0, 'own' => 0, 'estimation' => 0],
+        ];
+
+        $summary = $this->entryRepository->getEntrySummary($entryId, $userId, $seed);
+        $project = $summary['project'] ?? [];
+        $estimate = $this->estimate($project);
+
+        return [
+            'customer' => $summary['customer'] ?? [],
+            'project' => $project,
+            'activity' => $summary['activity'] ?? [],
+            'ticket' => $summary['ticket'] ?? [],
+            'estimate' => $estimate,
+            'warnings' => $this->warnings($project, $estimate),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>                                                         $project
+     * @param array{estimation: int, booked_total: int, percent: int|null, status: string} $estimate
+     *
+     * @return list<string>
+     */
+    private function warnings(array $project, array $estimate): array
+    {
+        $name = is_string($project['name'] ?? null) ? $project['name'] : 'project';
+
+        return match ($estimate['status']) {
+            'over' => [sprintf('Project "%s" is over its estimate (%d%% — %d of %d min booked).', $name, (int) $estimate['percent'], $estimate['booked_total'], $estimate['estimation'])],
+            'near' => [sprintf('Project "%s" is near its estimate (%d%%).', $name, (int) $estimate['percent'])],
+            default => [],
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $project
+     *
+     * @return array{estimation: int, booked_total: int, percent: int|null, status: string}
+     */
+    private function estimate(array $project): array
+    {
+        $estimation = is_int($project['estimation'] ?? null) ? $project['estimation'] : 0;
+        $total = is_int($project['total'] ?? null) ? $project['total'] : 0;
+
+        if ($estimation <= 0) {
+            return ['estimation' => 0, 'booked_total' => $total, 'percent' => null, 'status' => 'none'];
+        }
+
+        $percent = (int) round($total / $estimation * 100);
+        $status = match (true) {
+            $total >= $estimation => 'over',
+            $percent >= self::NEAR_THRESHOLD_PERCENT => 'near',
+            default => 'ok',
+        };
+
+        return ['estimation' => $estimation, 'booked_total' => $total, 'percent' => $percent, 'status' => $status];
+    }
+}

--- a/src/Service/TimeBalanceService.php
+++ b/src/Service/TimeBalanceService.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Contract;
+use App\Entity\User;
+use App\Enum\Period;
+use App\Repository\ContractRepository;
+use App\Repository\EntryRepository;
+use App\Service\Util\ExpectedWorkTimeCalculator;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
+
+use function assert;
+use function is_string;
+use function max;
+use function min;
+use function sprintf;
+use function substr;
+
+/**
+ * The authenticated user's worked-vs-target balance for today/week/month
+ * (ADR-021 Phase 5, the get_time_balance MCP tool + log_time enrichment).
+ *
+ * For each period it reports IST (worked minutes), SOLL for the whole period and
+ * SOLL through today ("so far"), the difference, and a status the agent can act
+ * on: `behind` when IST < SOLL-so-far, `over` when IST > SOLL-total, else `ok`.
+ * SOLL comes from the user's contracts minus public holidays, the same source as
+ * /getTimeSummary and the /ui/month balance.
+ */
+final readonly class TimeBalanceService
+{
+    public function __construct(
+        private ManagerRegistry $managerRegistry,
+        private EntryRepository $entryRepository,
+        private ExpectedWorkTimeCalculator $expectedWorkTimeCalculator,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     today: array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
+     *     week:  array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
+     *     month: array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
+     *     warnings: list<string>
+     * }
+     */
+    public function forUser(User $user): array
+    {
+        $userId = (int) $user->getId();
+        $today = $this->clock->today();
+
+        $weekStart = $this->modify($today, 'monday this week');
+        $weekEnd = $this->modify($today, 'sunday this week');
+        $monthStart = $this->modify($today, 'first day of this month');
+        $monthEnd = $this->modify($today, 'last day of this month');
+
+        $contracts = $this->contracts($user);
+        $holidays = $this->holidayDates(min($weekStart, $monthStart), max($weekEnd, $monthEnd));
+
+        $periods = [
+            'today' => $this->period($this->entryRepository->getWorkByUser($userId, Period::DAY), $contracts, $holidays, $today, $today, $today),
+            'week' => $this->period($this->entryRepository->getWorkByUser($userId, Period::WEEK), $contracts, $holidays, $weekStart, $weekEnd, $today),
+            'month' => $this->period($this->entryRepository->getWorkByUser($userId, Period::MONTH), $contracts, $holidays, $monthStart, $monthEnd, $today),
+        ];
+
+        $warnings = [];
+        foreach ($periods as $label => $p) {
+            if ('behind' === $p['status']) {
+                $warnings[] = sprintf('%s: behind target by %s (worked %s, expected %s so far).', $label, $this->hm(-$p['diff']), $this->hm($p['ist']), $this->hm($p['soll_so_far']));
+            } elseif ('over' === $p['status']) {
+                $warnings[] = sprintf('%s: over target (worked %s, target %s).', $label, $this->hm($p['ist']), $this->hm($p['soll_total']));
+            }
+        }
+
+        return $periods + ['warnings' => $warnings];
+    }
+
+    /** Minutes as "Hh Mm" (e.g. 95 → "1h 35m"). */
+    private function hm(int $minutes): string
+    {
+        $minutes = abs($minutes);
+
+        return sprintf('%dh %02dm', intdiv($minutes, 60), $minutes % 60);
+    }
+
+    /**
+     * @param array{duration: int, count: int} $work
+     * @param Contract[]                       $contracts
+     * @param array<string, true>              $holidays
+     *
+     * @return array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string}
+     */
+    private function period(array $work, array $contracts, array $holidays, DateTimeImmutable $start, DateTimeImmutable $end, DateTimeImmutable $today): array
+    {
+        $ist = $work['duration'];
+        $sollTotal = $this->expectedWorkTimeCalculator->minutesForRange($contracts, $holidays, $start, $end);
+        $sollSoFar = $this->expectedWorkTimeCalculator->minutesForRange($contracts, $holidays, $start, min($today, $end));
+
+        $status = 'ok';
+        if ($ist > $sollTotal && $sollTotal > 0) {
+            $status = 'over';
+        } elseif ($ist < $sollSoFar) {
+            $status = 'behind';
+        }
+
+        return [
+            'ist' => $ist,
+            'soll_total' => $sollTotal,
+            'soll_so_far' => $sollSoFar,
+            'diff' => $ist - $sollSoFar,
+            'status' => $status,
+        ];
+    }
+
+    /**
+     * @return Contract[]
+     */
+    private function contracts(User $user): array
+    {
+        $repository = $this->managerRegistry->getRepository(Contract::class);
+        assert($repository instanceof ContractRepository);
+
+        /** @var Contract[] $contracts */
+        $contracts = $repository->findBy(['user' => $user], ['start' => 'DESC']);
+
+        return $contracts;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function holidayDates(DateTimeInterface $from, DateTimeInterface $to): array
+    {
+        $connection = $this->managerRegistry->getConnection();
+        assert($connection instanceof Connection);
+
+        $rows = $connection->fetchFirstColumn(
+            'SELECT day FROM holidays WHERE day BETWEEN ? AND ?',
+            [$from->format('Y-m-d'), $to->format('Y-m-d')],
+        );
+
+        $holidays = [];
+        foreach ($rows as $row) {
+            if (is_string($row)) {
+                $holidays[substr($row, 0, 10)] = true;
+            }
+        }
+
+        return $holidays;
+    }
+
+    private function modify(DateTimeImmutable $date, string $modifier): DateTimeImmutable
+    {
+        $result = $date->modify($modifier);
+
+        // The modifiers used here are all well-defined; the guard only satisfies
+        // the analyser (DateTimeImmutable::modify is typed to allow false).
+        return false !== $result ? $result : $date;
+    }
+}

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Tests\Mcp;
 
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Entry;
 use App\Entity\User;
 use App\Mcp\Tool\DeleteEntryTool;
 use App\Mcp\Tool\GetTicketInfoTool;
@@ -17,6 +20,8 @@ use App\Mcp\Tool\ListActivitiesTool;
 use App\Mcp\Tool\ListProjectsTool;
 use App\Mcp\Tool\ListRecentEntriesTool;
 use App\Mcp\Tool\LogTimeTool;
+use App\Repository\ActivityRepository;
+use App\Repository\ProjectRepository;
 use App\Repository\UserRepository;
 use App\Security\ApiToken\ApiAccessToken;
 use Mcp\Exception\ToolCallException;
@@ -245,6 +250,42 @@ final class McpToolsTest extends AbstractWebTestCase
 
         $this->expectException(ToolCallException::class);
         self::getContainer()->get(GetTicketInfoTool::class)->getTicketInfo(999999);
+    }
+
+    public function testGetTicketInfoRejectsAnotherUsersEntry(): void
+    {
+        // An entry owned by user 2, requested by user 1 — must read as "not
+        // found" so cross-user scope totals are never disclosed (IDOR).
+        $container = self::getContainer();
+        $em = $container->get('doctrine')->getManager();
+        $owner = $container->get(UserRepository::class)->find(2);
+        self::assertInstanceOf(User::class, $owner);
+        $project = $container->get(ProjectRepository::class)->find(1);
+        self::assertNotNull($project);
+        $customer = $project->getCustomer();
+        self::assertInstanceOf(Customer::class, $customer);
+        $activity = $container->get(ActivityRepository::class)->find(1);
+        self::assertInstanceOf(Activity::class, $activity);
+
+        $entry = new Entry();
+        $entry->setUser($owner)
+            ->setCustomer($customer)
+            ->setProject($project)
+            ->setActivity($activity)
+            ->setTicket('SA-77')
+            ->setDescription('owned by user 2')
+            ->setDay('2026-07-06')
+            ->setStart('09:00:00')
+            ->setEnd('10:00:00')
+            ->setDuration(60);
+        $em->persist($entry);
+        $em->flush();
+        $foreignId = (int) $entry->getId();
+
+        $this->useToken(['reporting:read']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(GetTicketInfoTool::class)->getTicketInfo($foreignId);
     }
 
     public function testGetTicketInfoIsDeniedWithoutScope(): void

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -11,6 +11,8 @@ namespace Tests\Mcp;
 
 use App\Entity\User;
 use App\Mcp\Tool\DeleteEntryTool;
+use App\Mcp\Tool\GetTicketInfoTool;
+use App\Mcp\Tool\GetTimeBalanceTool;
 use App\Mcp\Tool\ListActivitiesTool;
 use App\Mcp\Tool\ListProjectsTool;
 use App\Mcp\Tool\ListRecentEntriesTool;
@@ -191,6 +193,78 @@ final class McpToolsTest extends AbstractWebTestCase
 
         $this->expectException(ToolCallException::class);
         self::getContainer()->get(DeleteEntryTool::class)->deleteEntry(1);
+    }
+
+    public function testGetTimeBalanceReturnsPeriods(): void
+    {
+        $this->useToken(['reporting:read']);
+
+        $result = self::getContainer()->get(GetTimeBalanceTool::class)->getTimeBalance();
+
+        self::assertArrayHasKey('warnings', $result);
+        self::assertIsList($result['warnings']);
+        foreach (['today', 'week', 'month'] as $period) {
+            self::assertArrayHasKey($period, $result);
+            self::assertIsArray($result[$period]);
+            foreach (['ist', 'soll_total', 'soll_so_far', 'diff', 'status'] as $key) {
+                self::assertArrayHasKey($key, $result[$period]);
+            }
+        }
+    }
+
+    public function testGetTimeBalanceIsDeniedWithoutScope(): void
+    {
+        $this->useToken(['entries:read']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(GetTimeBalanceTool::class)->getTimeBalance();
+    }
+
+    public function testGetTicketInfoReturnsScopes(): void
+    {
+        // Create an entry to report on.
+        $this->useToken(['entries:write']);
+        $created = self::getContainer()->get(LogTimeTool::class)->logTime(project: '1', activity: '1', ticket: 'SA-9', durationMinutes: 30);
+        self::assertIsArray($created['result'] ?? null);
+        $id = $created['result']['id'];
+        self::assertIsInt($id);
+
+        $this->useToken(['reporting:read']);
+        $info = self::getContainer()->get(GetTicketInfoTool::class)->getTicketInfo($id);
+
+        foreach (['customer', 'project', 'activity', 'ticket', 'estimate', 'warnings'] as $key) {
+            self::assertArrayHasKey($key, $info);
+        }
+        self::assertIsArray($info['estimate']);
+        self::assertArrayHasKey('status', $info['estimate']);
+    }
+
+    public function testGetTicketInfoRejectsUnknownEntry(): void
+    {
+        $this->useToken(['reporting:read']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(GetTicketInfoTool::class)->getTicketInfo(999999);
+    }
+
+    public function testGetTicketInfoIsDeniedWithoutScope(): void
+    {
+        $this->useToken(['entries:read']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(GetTicketInfoTool::class)->getTicketInfo(1);
+    }
+
+    public function testLogTimeReturnsTicketInfoAndBalance(): void
+    {
+        $this->useToken(['entries:write']);
+
+        $result = self::getContainer()->get(LogTimeTool::class)->logTime(project: '1', activity: '1', ticket: 'SA-8', durationMinutes: 45);
+
+        self::assertArrayHasKey('ticket_info', $result);
+        self::assertArrayHasKey('balance', $result);
+        self::assertIsArray($result['balance']);
+        self::assertArrayHasKey('today', $result['balance']);
     }
 
     /**


### PR DESCRIPTION
Gives MCP agents the same booking context a user sees in the tracking UI, both inline after a write and as dedicated read tools.

## Tools

- **get_ticket_info** (`reporting:read`) — the per-scope totals from an entry’s "Info" (I) popup: customer / project / activity / ticket, each with the user’s own booked minutes and everyone’s total, plus the project estimate. Adds a `near`/`over` status and `warnings`.
- **get_time_balance** (`reporting:read`) — today / week / month IST vs SOLL (both whole-period and "so far"), the diff, and a `behind`/`over` status with `warnings`.

## log_time enrichment

After a successful booking, `log_time` now returns:
- `ticket_info` — the same aggregation as `get_ticket_info` for the created entry
- `balance` — the same data as `get_time_balance`

so an agent sees an estimate or time target being neared / exceeded / underrun without a second round-trip.

Both tools are thin wrappers over two new services — `EntrySummaryService` (wraps `EntryRepository::getEntrySummary`) and `TimeBalanceService` (IST from `EntryRepository::getWorkByUser`, SOLL from `ExpectedWorkTimeCalculator` over the user’s contracts minus public holidays). No business logic is reimplemented.

## Tests

`tests/Mcp/McpToolsTest.php`: happy path + scope-denied for each new tool, an unknown-entry error path, and that `log_time` returns `ticket_info` + `balance`.

Docs: ADR-021 Phase 5 toolset section updated.