### PR TITLE
fix(mcp): wrap list-tool results in objects (structuredContent must be an object)

### DIFF
--- a/src/Mcp/Tool/ListActivitiesTool.php
+++ b/src/Mcp/Tool/ListActivitiesTool.php
@@ -31,20 +31,23 @@ final readonly class ListActivitiesTool
      * List the activities available for time entries (id, name, whether a ticket
      * is required). Use an activity's name or id with `log_time`.
      *
-     * @return list<array{id: int, name: string, needs_ticket: bool}>
+     * The list is wrapped in an object — MCP structuredContent must be a JSON
+     * object at the top level, never a bare array (#573, ADR-022 §4).
+     *
+     * @return array{activities: list<array{id: int, name: string, needs_ticket: bool}>}
      */
     #[McpTool(name: 'list_activities', description: 'List the activities a time entry can be booked against.')]
     public function listActivities(): array
     {
         $this->scopeGuard->requireScope('activities:read');
 
-        return array_values(array_map(
+        return ['activities' => array_values(array_map(
             static fn (array $row): array => [
                 'id' => $row['activity']['id'],
                 'name' => $row['activity']['name'],
                 'needs_ticket' => $row['activity']['needsTicket'],
             ],
             $this->activityRepository->getActivities(),
-        ));
+        ))];
     }
 }

--- a/src/Mcp/Tool/ListProjectsTool.php
+++ b/src/Mcp/Tool/ListProjectsTool.php
@@ -31,7 +31,10 @@ final readonly class ListProjectsTool
      * customer. Returns id, name, customer, and the ticket prefixes the project
      * accepts. Use a project's name or id with `log_time`.
      *
-     * @return list<array{id: int|null, name: string, customer: string|null, customer_id: int|null, ticket_prefixes: string|null}>
+     * The list is wrapped in an object — MCP structuredContent must be a JSON
+     * object at the top level, never a bare array (#573, ADR-022 §4).
+     *
+     * @return array{projects: list<array{id: int|null, name: string, customer: string|null, customer_id: int|null, ticket_prefixes: string|null}>}
      */
     #[McpTool(name: 'list_projects', description: 'List bookable projects (active or global) to log time against.')]
     public function listProjects(
@@ -62,6 +65,6 @@ final readonly class ListProjectsTool
             ];
         }
 
-        return $result;
+        return ['projects' => $result];
     }
 }

--- a/src/Mcp/Tool/ListRecentEntriesTool.php
+++ b/src/Mcp/Tool/ListRecentEntriesTool.php
@@ -35,7 +35,10 @@ final readonly class ListRecentEntriesTool
      * (default 7, capped at 90), oldest first. Each entry includes its id, date,
      * start/end, duration, ticket, project/activity ids and description.
      *
-     * @return list<array<string, mixed>>
+     * The list is wrapped in an object — MCP structuredContent must be a JSON
+     * object at the top level, never a bare array (#573, ADR-022 §4).
+     *
+     * @return array{entries: list<array<string, mixed>>}
      */
     #[McpTool(name: 'list_recent_entries', description: "List the authenticated user's own recent time entries.")]
     public function listRecentEntries(
@@ -46,9 +49,9 @@ final readonly class ListRecentEntriesTool
 
         $days = max(1, min(90, $days));
 
-        return array_map(
+        return ['entries' => array_map(
             static fn (Entry $entry): array => $entry->toArray(),
             $this->entryRepository->getEntriesByUser($user, $days, false),
-        );
+        )];
     }
 }

--- a/src/Mcp/Tool/ListRecentEntriesTool.php
+++ b/src/Mcp/Tool/ListRecentEntriesTool.php
@@ -16,6 +16,7 @@ use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
 
 use function array_map;
+use function array_values;
 use function max;
 use function min;
 
@@ -49,9 +50,9 @@ final readonly class ListRecentEntriesTool
 
         $days = max(1, min(90, $days));
 
-        return ['entries' => array_map(
+        return ['entries' => array_values(array_map(
             static fn (Entry $entry): array => $entry->toArray(),
             $this->entryRepository->getEntriesByUser($user, $days, false),
-        )];
+        ))];
     }
 }

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -24,11 +24,21 @@ use App\Repository\ActivityRepository;
 use App\Repository\ProjectRepository;
 use App\Repository\UserRepository;
 use App\Security\ApiToken\ApiAccessToken;
+use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
+use ReflectionClass;
 use Tests\AbstractWebTestCase;
 
 use function array_column;
+use function array_is_list;
+use function array_keys;
 use function array_values;
+use function basename;
+use function dirname;
+use function glob;
+use function is_string;
+use function sort;
+use function sprintf;
 
 /**
  * Integration tests for the MCP tools (ADR-021 Phase 5), exercised through the
@@ -44,10 +54,10 @@ final class McpToolsTest extends AbstractWebTestCase
 
         $result = self::getContainer()->get(ListActivitiesTool::class)->listActivities();
 
-        self::assertNotEmpty($result);
-        self::assertArrayHasKey('id', $result[0]);
-        self::assertArrayHasKey('name', $result[0]);
-        self::assertArrayHasKey('needs_ticket', $result[0]);
+        self::assertNotEmpty($result['activities']);
+        self::assertArrayHasKey('id', $result['activities'][0]);
+        self::assertArrayHasKey('name', $result['activities'][0]);
+        self::assertArrayHasKey('needs_ticket', $result['activities'][0]);
     }
 
     public function testListActivitiesIsDeniedWithoutScope(): void
@@ -71,8 +81,8 @@ final class McpToolsTest extends AbstractWebTestCase
 
         $result = self::getContainer()->get(ListProjectsTool::class)->listProjects();
 
-        self::assertNotEmpty($result);
-        self::assertContains(1, array_column($result, 'id'));
+        self::assertNotEmpty($result['projects']);
+        self::assertContains(1, array_column($result['projects'], 'id'));
     }
 
     public function testListProjectsIsDeniedWithoutScope(): void
@@ -89,7 +99,8 @@ final class McpToolsTest extends AbstractWebTestCase
 
         $result = self::getContainer()->get(ListRecentEntriesTool::class)->listRecentEntries(30);
 
-        self::assertIsList($result);
+        self::assertArrayHasKey('entries', $result);
+        self::assertIsList($result['entries']);
     }
 
     public function testListRecentEntriesIsDeniedWithoutScope(): void
@@ -306,6 +317,72 @@ final class McpToolsTest extends AbstractWebTestCase
         self::assertArrayHasKey('balance', $result);
         self::assertIsArray($result['balance']);
         self::assertArrayHasKey('today', $result['balance']);
+    }
+
+    /**
+     * MCP structuredContent must be a JSON object at the top level — a bare
+     * array is rejected by strict clients (#573). Calls every registered tool
+     * and asserts an object-shaped (string-keyed) result; the reflection sweep
+     * below forces any future tool to join this guard.
+     */
+    public function testEveryToolReturnsATopLevelJsonObject(): void
+    {
+        $this->useToken(['entries:read', 'entries:write', 'projects:read', 'activities:read', 'reporting:read']);
+        $container = self::getContainer();
+
+        $created = $container->get(LogTimeTool::class)->logTime(project: '1', activity: '1', ticket: 'SA-5', durationMinutes: 15);
+        self::assertIsArray($created['result'] ?? null);
+        $entryId = $created['result']['id'];
+        self::assertIsInt($entryId);
+
+        $results = [
+            'delete_entry' => null, // called last — it removes the entry
+            'get_ticket_info' => $container->get(GetTicketInfoTool::class)->getTicketInfo($entryId),
+            'get_time_balance' => $container->get(GetTimeBalanceTool::class)->getTimeBalance(),
+            'list_activities' => $container->get(ListActivitiesTool::class)->listActivities(),
+            'list_projects' => $container->get(ListProjectsTool::class)->listProjects(),
+            'list_recent_entries' => $container->get(ListRecentEntriesTool::class)->listRecentEntries(),
+            'log_time' => $created,
+        ];
+        $results['delete_entry'] = $container->get(DeleteEntryTool::class)->deleteEntry($entryId);
+
+        foreach ($results as $tool => $result) {
+            self::assertIsArray($result, sprintf('%s: expected an array result', $tool));
+            self::assertNotSame([], $result, sprintf('%s: an empty result cannot prove object shape', $tool));
+            self::assertFalse(array_is_list($result), sprintf('%s must return a top-level JSON object, never a bare array (#573)', $tool));
+        }
+
+        $covered = array_keys($results);
+        sort($covered);
+        self::assertSame($this->declaredToolNames(), $covered, 'every #[McpTool] must be covered by this object-shape guard — add new tools here');
+    }
+
+    /**
+     * All tool names declared via #[McpTool] under src/Mcp/Tool, sorted.
+     *
+     * @return list<string>
+     */
+    private function declaredToolNames(): array
+    {
+        $names = [];
+        $files = glob(dirname(__DIR__, 2) . '/src/Mcp/Tool/*.php');
+        self::assertNotFalse($files);
+        foreach ($files as $file) {
+            /** @var class-string $class */
+            $class = 'App\\Mcp\\Tool\\' . basename($file, '.php');
+            foreach (new ReflectionClass($class)->getMethods() as $method) {
+                foreach ($method->getAttributes(McpTool::class) as $attribute) {
+                    $name = $attribute->newInstance()->name;
+                    if (is_string($name)) {
+                        $names[] = $name;
+                    }
+                }
+            }
+        }
+
+        sort($names);
+
+        return $names;
     }
 
     /**


### PR DESCRIPTION
MCP requires `structuredContent` to be a JSON **object** at the top level; `list_projects`, `list_activities` and `list_recent_entries` returned bare arrays, so strict clients rejected every call — the tools were unusable for their whole purpose, discovering valid ids for `log_time`.

The lists are now wrapped per ADR-022 §4 ("every response body is a top-level JSON object, never a bare array"):

- `list_projects` → `{"projects": […]}`
- `list_activities` → `{"activities": […]}`
- `list_recent_entries` → `{"entries": […]}`

## Regression guard

`testEveryToolReturnsATopLevelJsonObject` calls every registered tool and asserts an object-shaped (string-keyed, non-empty) result. A reflection sweep over `src/Mcp/Tool` compares the covered set against all `#[McpTool]` declarations, so a future tool cannot ship without joining the guard.

Fixes #573