### PR TITLE
feat(api): v2 read endpoints with typed response DTOs + SPA migration (ADR-022)

### DIFF
--- a/docs/adr/ADR-022-v2-api-layer-and-response-dtos.md
+++ b/docs/adr/ADR-022-v2-api-layer-and-response-dtos.md
@@ -1,0 +1,91 @@
+# ADR-022: v2 API layer with typed response DTOs
+
+**Status:** Accepted
+**Date:** 2026-07-06
+**Relates to:** [ADR-016](ADR-016-solidjs-frontend-rewrite.md) (the SolidJS SPA that consumes these endpoints and whose rewrite was done against a deliberately *stable* v1 API), [ADR-021](ADR-021-api-token-authentication.md) (scoped PATs + the MCP tools that now share logic with the UI), issue [#573](https://github.com/netresearch/timetracker/issues/573) (MCP list tools broken by top-level JSON arrays), and the agent-readiness work ([docs/agent-readiness.md](../agent-readiness.md)).
+
+## Context
+
+ADR-021 Phase 5 added two services — `TimeBalanceService` (today/week/month IST-vs-SOLL) and `EntrySummaryService` (an entry's per-scope "Info" totals) — extracted so the new MCP tools would not reimplement existing logic. That extraction surfaced a latent problem: the logic now lives in **two** places.
+
+- `TimeBalanceService` and `GetTimeSummaryAction::targetMinutes()` (`GET /getTimeSummary`) compute the same thing from the same sources (`EntryRepository::getWorkByUser`, `ExpectedWorkTimeCalculator::minutesForRange`, contracts minus holidays, SOLL "through today").
+- `EntrySummaryService` and `GetSummaryAction` (`POST /getSummary`) both build the 4-scope skeleton and call `EntryRepository::getEntrySummary`. `EntrySummaryService` additionally scopes the summary to the caller's own entry (an IDOR fix, #570); `GetSummaryAction` does **not** — the same cross-user disclosure is live on the web endpoint and reachable by any session user or PAT with `reporting:read`.
+
+Three further constraints shape the decision:
+
+1. **The v1 API is intentionally frozen.** ADR-016 rebuilt the frontend against a stable API surface; the existing endpoints return ad-hoc arrays serialized with `new JsonResponse($array)`, mixing camelCase (`durationMinutes`) and snake_case keys. There is **no response-DTO convention** — even `DatabaseResultDto` returns `array<string,mixed>`. Retrofitting DTOs onto v1 would break that stability contract.
+2. **The absence of wire-format rules already caused a production bug.** #573: three MCP tools return top-level JSON **arrays**; MCP requires `structuredContent` to be a JSON **object**, so strict clients reject every call — the tools are unusable. A stated "top-level object, always" rule would have prevented it.
+3. **New endpoints are coming anyway.** ADR-021 anticipated `/api/v2/*` endpoints "where BC blocks", and the pending admin on/offboarding tools need write endpoints. New endpoints are the place to fix the shape, not the frozen v1 surface.
+
+## Decision
+
+### 1. A versioned `/api/v2` layer for new and reworked endpoints
+
+New endpoints — and reworked equivalents of frozen v1 endpoints — live under an `/api/v2` route prefix (version in the path; resource names in kebab-case). v1 stays as-is for backward compatibility and is deprecated per §5. v2 is additive; it is not a big-bang rewrite of all ~54 endpoints, only of the surfaces we actively touch.
+
+No firewall or routing changes are needed: the ADR-021 token firewall is **header-based** (it claims any request carrying `Authorization: Bearer tt_pat_…`, regardless of path), sessions fall through to the `main` firewall, and the `access_control` catch-all (`^/` → `IS_AUTHENTICATED_FULLY`) already covers `/api/v2`.
+
+### 2. Services are the single source of truth; v2, MCP, and the UI all consume them
+
+Business logic lives in a service exactly once. A v2 controller is a thin adapter: authenticate/authorize, call the service, serialize the result. An MCP tool is another thin adapter over the same service. This removes the duplication rather than adding a third copy.
+
+The two existing services are **refactored to return typed DTOs** (see §3). Both consumers (v2 REST and MCP tools) serialize the same DTO, so REST and MCP cannot drift.
+
+### 3. Typed response DTOs for every v2 endpoint
+
+Every v2 response is a `final readonly` DTO in `src/Dto/Response/`, implementing `JsonSerializable` with an explicit `jsonSerialize()` (no serializer configuration, deterministic output, fully type-checked — this also removes the PHPStan sealed-array-shape juggling the array style forces). Request bodies continue to use the established `*SaveDto` request-DTO pattern.
+
+Arguments against (more classes, explicit serialization) are accepted: the v1 "arrays everywhere" style was a *frozen-API concession*, not a preference to preserve.
+
+### 4. v2 wire-format conventions
+
+- **JSON keys are `snake_case`.** The canonical field names are the ones the MCP tools already shipped (ADR-021 Phase 5) — the DTOs adopt them verbatim, so introducing DTOs changes **no** wire output on the MCP side:
+  - time balance: `today` / `week` / `month`, each `{ist, soll_total, soll_so_far, diff, status}`, plus `warnings`;
+  - entry summary: `customer` / `project` / `activity` / `ticket`, each `{scope, name, entries, total, own, estimation}`, plus `estimate {estimation, booked_total, percent, status}` and `warnings`.
+- **Every response body is a top-level JSON object — never a bare array** (the #573 rule; MCP `structuredContent` requires it, and it keeps every payload extensible). Lists are wrapped: `{"projects": […]}`, `{"entries": […]}`.
+- **Errors** are `{"message": string}` with a proper HTTP status (401/403/404/422/…), matching the existing `App\Response\Error` shape the SPA client already understands.
+- **Not-owned resources read as not-found (404), not forbidden (403)** — no existence disclosure through status differences.
+- Aggregates within an owned entry's summary intentionally span all users (`total` vs the caller's `own`) — that is the feature, scoped to entries the caller owns.
+
+### 5. Deprecate superseded v1 endpoints
+
+When a v2 endpoint fully supersedes a v1 one, the v1 controller gets an `@deprecated` docblock pointing to the v2 route, `deprecated: true` in `public/api.yml`, and a `Deprecation: true` response header (RFC 9745 style) so API consumers see it at call time. Superseded v1 endpoints are **removed in the next major release (v7.0)**. The SPA is migrated to v2 in the same change that introduces the superseding endpoint, so no endpoint is deprecated while still in use by our own frontend.
+
+**Security exception to the v1 freeze:** the v1 freeze protects consumers from *shape* changes; it does not protect vulnerabilities. The `/getSummary` ownership check (IDOR) is backported to v1 in Phase 1 — a foreign entry id answers 404 exactly like v2. This is a deliberate behavior change on a deprecated endpoint.
+
+### 6. Scope + role enforcement unchanged
+
+v2 endpoints carry `#[RequireScope('resource:action')]` (ADR-021) and, for admin resources, `#[IsGranted('ROLE_ADMIN')]` — both gates, exactly as v1. `RequireScopeCoverageTest` scans all of `src/Controller` recursively, so v2 controllers are covered automatically; the fail-closed subscriber denies tokens on any unannotated controller.
+
+## Initial v2 surface (implemented incrementally)
+
+| v2 endpoint | Backed by | Supersedes |
+|---|---|---|
+| `GET /api/v2/time-balance` | `TimeBalanceService` | `GET /getTimeSummary` |
+| `GET /api/v2/entries/{id}/summary` | `EntrySummaryService` (owner-scoped) | `POST /getSummary` |
+| `GET /api/v2/day` | new day-summary service | — (new: today's entries + budgets) |
+| `POST /api/v2/projects`, `/customers`, `/users` + activate/deactivate | admin services | new (on/offboarding) |
+
+## Alternatives considered
+
+- **Retrofit DTOs onto v1 in place.** Rejected: breaks the ADR-016 stable-API contract the SPA was built against, and mixes a shape change into endpoints that don't otherwise need to change.
+- **Keep services array-based; wrap in DTOs only at the v2 controller.** Rejected: leaves two shapes (array from the service, DTO from the controller) and lets the MCP path diverge from REST. Refactoring the service to return the DTO gives one contract.
+- **Invent new v2 field names and re-key the MCP tools to match.** Rejected: the MCP wire surface shipped days ago; re-keying it is a gratuitous break. The DTOs adopt the existing MCP keys instead (§4).
+- **No versioning — just add new unprefixed endpoints.** Rejected: no clean deprecation story and no signal to consumers about the shape/coverage difference.
+- **GraphQL / a full API redesign.** Out of scope; this is an incremental, per-endpoint migration, not a platform change.
+
+## Consequences
+
+- **Duplication removed:** the balance and entry-summary logic exists once, in the services.
+- **IDOR closed everywhere:** v2 `GET /api/v2/entries/{id}/summary` is owner-scoped, and the check is backported to v1 `/getSummary` (§5) — the disclosure does not survive Phase 1 on either surface.
+- **Two response conventions coexist during migration:** v1 arrays (frozen, deprecated) and v2 DTOs. Intentional and bounded to the endpoints we migrate.
+- **MCP wire output is unchanged** by the DTO refactor (§4); the #573 fix (wrapping list-tool results in objects) is the only MCP-visible change, and it is a bug fix strict clients require.
+- **Known consumers to migrate/update in Phase 1** (verified by repo sweep): `frontend/src/header.ts`, `frontend/src/pages/Tracking.tsx` (+ `Tracking.test.tsx`), `e2e/helpers/api.ts`, `e2e/interpretation.spec.ts`, `tests/Controller/DefaultControllerSummaryTest.php` (uses `findOneBy([])` — must pin entry ownership once v1 is owner-scoped), `tests/Api/Functional/EndpointAvailabilityTest.php`, `tests/Api/Functional/ResponseFormatTest.php`, `tests/Controller/ApiTokenAuthTest.php` (keep probing v1 while it exists), `public/api.yml`, `docs/api.md`.
+- **Each v2 endpoint owns a response DTO** and an OpenAPI entry; the frozen v1 spec stays accurate for un-migrated endpoints.
+
+## Implementation phases
+
+0. **#573 hotfix** (standalone PR, precedes the rest): wrap the three MCP list-tool results in objects (`{"projects": […]}`, `{"activities": […]}`, `{"entries": […]}`) + a regression test that every registered MCP tool returns a top-level object.
+1. **v2 read endpoints + DTO refactor + UI migration** (one PR, per the sequencing decision): `GET /api/v2/time-balance` and `GET /api/v2/entries/{id}/summary` with response DTOs (wire keys per §4); refactor `TimeBalanceService`/`EntrySummaryService` to return those DTOs; MCP tools serialize the DTOs (output unchanged); backport the ownership check to v1 `/getSummary`; migrate the SPA and the consumers listed above; deprecate `/getTimeSummary` + `/getSummary` per §5.
+2. **Day-so-far**: `GET /api/v2/day` + a `get_day` MCP tool + `log_time` returning the day's entries and budgets after a booking (all top-level objects per §4).
+3. **Admin on/offboarding**: v2 write endpoints for project/customer/user create + activate/deactivate, with request/response DTOs, `ROLE_ADMIN` + scope (both gates), and MCP admin tools.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,7 @@ ADRs are historical records: bodies are not rewritten when reality moves on. Whe
 | [ADR-019](ADR-019-session-storage-and-lock-contention.md) | Session Storage and Lock-Contention Strategy | Accepted (files + early lock-release; Valkey deferred) | 2026-07-04 |
 | [ADR-020](ADR-020-subticket-ticket-resolution.md) | Jira Subticket Sync and Ticket→Project Resolution | Accepted | 2026-07-04 |
 | [ADR-021](ADR-021-api-token-authentication.md) | API Token Authentication with Fine-Grained Scopes | Accepted | 2026-07-04 |
+| [ADR-022](ADR-022-v2-api-layer-and-response-dtos.md) | v2 API layer with typed response DTOs | Proposed | 2026-07-06 |
 
 ## ADR Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,7 +29,7 @@ ADRs are historical records: bodies are not rewritten when reality moves on. Whe
 | [ADR-019](ADR-019-session-storage-and-lock-contention.md) | Session Storage and Lock-Contention Strategy | Accepted (files + early lock-release; Valkey deferred) | 2026-07-04 |
 | [ADR-020](ADR-020-subticket-ticket-resolution.md) | Jira Subticket Sync and Ticket→Project Resolution | Accepted | 2026-07-04 |
 | [ADR-021](ADR-021-api-token-authentication.md) | API Token Authentication with Fine-Grained Scopes | Accepted | 2026-07-04 |
-| [ADR-022](ADR-022-v2-api-layer-and-response-dtos.md) | v2 API layer with typed response DTOs | Proposed | 2026-07-06 |
+| [ADR-022](ADR-022-v2-api-layer-and-response-dtos.md) | v2 API layer with typed response DTOs | Accepted | 2026-07-06 |
 
 ## ADR Format
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -714,53 +714,66 @@ A static OpenAPI 3.0 specification ships at `public/api.yml` (title "Time Tracke
 
 **Authentication**: Required (`IS_AUTHENTICATED_FULLY`)
 
-### POST /getSummary
-**Purpose**: Generate time summary report
+### POST /getSummary — deprecated
+**Deprecated** (ADR-022): superseded by [`GET /api/v2/entries/{id}/summary`](#get-apiv2entriesidsummary); removal in v7. Responses carry a `Deprecation: true` header.
 
-**Method**: `POST` only (route `_getSummary_attr`, `methods: ['POST']`)
+**Purpose**: Per-scope booking totals (customer/project/activity/ticket) for one of the caller's own time entries — the tracking UI's "Info" popup
 
-**Authentication**: Required (`IS_AUTHENTICATED_FULLY`)
+**Method**: `POST` only (route `_getSummary_attr`, `methods: ['POST']`), form-encoded `id`
 
-**Response (200 OK)**:
-```json
-{
-  "summary": {
-    "totalHours": 160.5,
-    "totalMinutes": 9630,
-    "averageDaily": 8.0,
-    "workingDays": 20
-  },
-  "breakdown": [
-    {
-      "customer": "Customer Name",
-      "project": "Project Name",
-      "hours": 40.0,
-      "percentage": 25.0
-    }
-  ]
-}
-```
+**Authentication**: Required (`IS_AUTHENTICATED_FULLY`); scoped to the caller's own entries — a foreign or unknown entry id answers `404`
 
-### GET /getTimeSummary
-**Purpose**: Get time summary for current user
+**Response (200 OK)**: `customer` / `project` / `activity` / `ticket` objects, each `{scope, name, entries, total, own, estimation}` (minutes); `project.quota` is a formatted percentage string when the project has an estimate
+
+### GET /getTimeSummary — deprecated
+**Deprecated** (ADR-022): superseded by [`GET /api/v2/time-balance`](#get-apiv2time-balance); removal in v7. Responses carry a `Deprecation: true` header.
+
+**Purpose**: Get worked minutes and target for today/week/month
 
 **Response (200 OK)**:
 ```json
 {
-  "today": {
-    "hours": 8.5,
-    "minutes": 510
-  },
-  "week": {
-    "hours": 42.0,
-    "minutes": 2520
-  },
-  "month": {
-    "hours": 168.0,
-    "minutes": 10080
-  }
+  "today": { "duration": 450, "count": 3, "target": 480 },
+  "week": { "duration": 1935, "count": 12, "target": 2400 },
+  "month": { "duration": 5760, "count": 40, "target": 9600 }
 }
 ```
+
+### GET /api/v2/time-balance
+**Purpose**: The authenticated user's worked-vs-target balance for today, this week and this month (ADR-022; same numbers as the header display and the `get_time_balance` MCP tool)
+
+**Authentication**: Session, or Bearer PAT with `reporting:read`
+
+**Response (200 OK)**:
+```json
+{
+  "today": { "ist": 450, "soll_total": 480, "soll_so_far": 480, "diff": -30, "status": "behind" },
+  "week": { "ist": 1935, "soll_total": 2400, "soll_so_far": 960, "diff": 975, "status": "ok" },
+  "month": { "ist": 5760, "soll_total": 9600, "soll_so_far": 1440, "diff": 4320, "status": "ok" },
+  "warnings": ["today: behind target by 0h 30m (worked 7h 30m, expected 8h 00m so far)."]
+}
+```
+
+`status` per period: `behind` (IST below the SOLL accrued so far), `over` (IST above the whole period's SOLL), else `ok`.
+
+### GET /api/v2/entries/{id}/summary
+**Purpose**: Per-scope booking totals and estimate verdict for one of the caller's own entries (ADR-022; the tracking UI's "Info" popup and the `get_ticket_info` MCP tool)
+
+**Authentication**: Session, or Bearer PAT with `reporting:read`. Owner-scoped: a foreign or unknown entry id answers `404` (no existence disclosure).
+
+**Response (200 OK)**:
+```json
+{
+  "customer": { "scope": "customer", "name": "ACME", "entries": 5, "total": 300, "own": 120, "estimation": 0 },
+  "project": { "scope": "project", "name": "Site", "entries": 3, "total": 180, "own": 90, "estimation": 600 },
+  "activity": { "scope": "activity", "name": "Dev", "entries": 2, "total": 120, "own": 60, "estimation": 0 },
+  "ticket": { "scope": "ticket", "name": "ABC-1", "entries": 1, "total": 60, "own": 60, "estimation": 0 },
+  "estimate": { "estimation": 600, "booked_total": 180, "percent": 30, "status": "ok" },
+  "warnings": []
+}
+```
+
+`estimate.status`: `none` (no estimate), `ok`, `near` (≥ 90 %), `over` (at/above the estimate). `total` spans all users; `own` is the caller's share.
 
 ### GET /getTicketTimeSummary/{ticket}
 **Purpose**: Get time summary for specific ticket

--- a/e2e/interpretation.spec.ts
+++ b/e2e/interpretation.spec.ts
@@ -169,6 +169,8 @@ test.describe('Time Summary', () => {
   test('/getTimeSummary should return correct format', async ({ page }) => {
     const response = await page.request.get('/getTimeSummary');
     expect(response.ok()).toBe(true);
+    // Deprecated v1 endpoint (ADR-022) — signalled per response until removal in v7.
+    expect(response.headers()['deprecation']).toBe('true');
 
     const data = await response.json();
 
@@ -187,6 +189,21 @@ test.describe('Time Summary', () => {
       week: data.week.duration,
       month: data.month.duration,
     });
+  });
+
+  test('/api/v2/time-balance should return the v2 balance shape', async ({ page }) => {
+    const response = await page.request.get('/api/v2/time-balance');
+    expect(response.ok()).toBe(true);
+
+    const data = await response.json();
+
+    expect(data).toHaveProperty('warnings');
+    for (const period of ['today', 'week', 'month'] as const) {
+      expect(data).toHaveProperty(period);
+      for (const key of ['ist', 'soll_total', 'soll_so_far', 'diff', 'status'] as const) {
+        expect(data[period]).toHaveProperty(key);
+      }
+    }
   });
 
   test('/getTicketTimeSummary should return ticket times', async ({ page }) => {

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -324,7 +324,7 @@ export function trackingTicketSystemsQuery() {
   }
 }
 
-/** Summary scope row from POST /getSummary (minutes for total/own/estimation). */
+/** Summary scope row from GET /api/v2/entries/{id}/summary (minutes for total/own/estimation). */
 export interface SummaryScope {
   scope: string
   name: string

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -334,6 +334,21 @@ export interface SummaryScope {
   estimation: number
 }
 
+/** Full response of GET /api/v2/entries/{id}/summary (ADR-022). */
+export interface EntrySummaryResponse {
+  customer: SummaryScope
+  project: SummaryScope
+  activity: SummaryScope
+  ticket: SummaryScope
+  estimate: {
+    estimation: number
+    booked_total: number
+    percent: number | null
+    status: 'none' | 'ok' | 'near' | 'over'
+  }
+  warnings: string[]
+}
+
 /** Shared filter shape for every interpretation view. */
 export interface InterpretationFilters {
   datestart: string

--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -91,9 +91,10 @@ describe('updateWorktime', () => {
   it('tints each total by IST vs SOLL and fills the detail popover', async () => {
     renderWorktime()
     vi.mocked(getJson).mockResolvedValue({
-      today: { duration: 450, target: 420 },
-      week: { duration: 1935, target: 2400 },
-      month: { duration: 5760, target: 9600 },
+      today: { ist: 450, soll_total: 420, soll_so_far: 420, diff: 30, status: 'over' },
+      week: { ist: 1935, soll_total: 2400, soll_so_far: 2400, diff: -465, status: 'behind' },
+      month: { ist: 5760, soll_total: 9600, soll_so_far: 9600, diff: -3840, status: 'behind' },
+      warnings: [],
     })
 
     await updateWorktime()
@@ -110,12 +111,13 @@ describe('updateWorktime', () => {
     expect(row.querySelector('[data-wd="delta"]')?.textContent).toBe('+0:30')
   })
 
-  it('leaves a period neutral when the backend omits its target', async () => {
+  it('leaves a period neutral when its SOLL so far is zero (weekend/holiday)', async () => {
     renderWorktime()
     vi.mocked(getJson).mockResolvedValue({
-      today: { duration: 450 },
-      week: { duration: 1935 },
-      month: { duration: 5760 },
+      today: { ist: 450, soll_total: 0, soll_so_far: 0, diff: 450, status: 'over' },
+      week: { ist: 1935, soll_total: 0, soll_so_far: 0, diff: 1935, status: 'over' },
+      month: { ist: 5760, soll_total: 0, soll_so_far: 0, diff: 5760, status: 'over' },
+      warnings: [],
     })
 
     await updateWorktime()

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -6,16 +6,24 @@ import type { AppConfig } from './config'
 import { setPaletteOpen } from './lib/commandPalette'
 import { setShortcutsHelpOpen } from './lib/shortcutsHelp'
 
-interface SummaryPeriod {
-  duration: number
-  /** Expected ("Soll") minutes through today; absent on older backends. */
-  target?: number
+/** One period from GET /api/v2/time-balance (ADR-022). */
+interface BalancePeriod {
+  /** Worked minutes (IST). */
+  ist: number
+  /** Expected minutes for the whole period. */
+  soll_total: number
+  /** Expected ("Soll") minutes accrued through today. */
+  soll_so_far: number
+  /** ist − soll_so_far, server-computed. */
+  diff: number
+  status: 'ok' | 'behind' | 'over'
 }
 
-interface TimeSummary {
-  today: SummaryPeriod
-  week: SummaryPeriod
-  month: SummaryPeriod
+interface TimeBalance {
+  today: BalancePeriod
+  week: BalancePeriod
+  month: BalancePeriod
+  warnings: string[]
 }
 
 type WorktimeStatus = 'ok' | 'under' | 'neutral'
@@ -102,9 +110,11 @@ function setBadge(loggedIn: boolean, userName: string): void {
 /**
  * Paint one worktime total from IST vs SOLL: tint the sidebar badge (is-ok /
  * is-under) and fill its row in the detail popover (IST / SOLL / signed Δ).
+ * SOLL is the "through today" figure (soll_so_far), so mid-week or mid-month
+ * the comparison stays like-with-like.
  */
-function applyWorktimeStatus(period: string, data: SummaryPeriod): void {
-  const status = worktimeStatus(data.duration, data.target)
+function applyWorktimeStatus(period: string, data: BalancePeriod): void {
+  const status = worktimeStatus(data.ist, data.soll_so_far)
   const item = document.querySelector(`.worktime-item[data-period="${period}"]`)
   const row = document.querySelector(`.worktime-detail-row[data-period="${period}"]`)
   for (const element of [item, row]) {
@@ -122,17 +132,9 @@ function applyWorktimeStatus(period: string, data: SummaryPeriod): void {
       cell.textContent = text
     }
   }
-  set('[data-wd="ist"]', formatDuration(data.duration))
-  // No target (weekend/holiday, or an older backend that omits it): show the
-  // actual, but leave SOLL/Δ as placeholders rather than implying a 0:00 target.
-  if (data.target === undefined) {
-    set('[data-wd="soll"]', '–')
-    set('[data-wd="delta"]', '–')
-
-    return
-  }
-  set('[data-wd="soll"]', `/ ${formatDuration(data.target)}`)
-  set('[data-wd="delta"]', formatSignedDuration(data.duration - data.target))
+  set('[data-wd="ist"]', formatDuration(data.ist))
+  set('[data-wd="soll"]', `/ ${formatDuration(data.soll_so_far)}`)
+  set('[data-wd="delta"]', formatSignedDuration(data.diff))
 }
 
 /**
@@ -228,14 +230,14 @@ export function wireWorktimeDetail(): void {
 // sums (loaded once on init) go stale until a full page reload (#446).
 export async function updateWorktime(): Promise<void> {
   try {
-    const summary = await getJson<TimeSummary>('/getTimeSummary')
-    setText('worktime-day', formatDuration(summary.today.duration))
-    setText('worktime-week', formatDuration(summary.week.duration))
+    const summary = await getJson<TimeBalance>('/api/v2/time-balance')
+    setText('worktime-day', formatDuration(summary.today.ist))
+    setText('worktime-week', formatDuration(summary.week.ist))
     // Month shows person-days only; the hours stay in the title for reference.
-    setText('worktime-month', formatDays(summary.month.duration))
+    setText('worktime-month', formatDays(summary.month.ist))
     const month = document.getElementById('worktime-month')
     if (month !== null) {
-      month.title = formatDuration(summary.month.duration)
+      month.title = formatDuration(summary.month.ist)
     }
     // Tint each total by IST vs SOLL and fill the detail popover (sidebar only;
     // the elements are absent/plain in the top bar, so this is a harmless no-op).

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -28,12 +28,16 @@ interface MockData {
   projects?: unknown[]
   activities?: unknown[]
   ticketSystems?: unknown[]
+  summary?: unknown
 }
 
 function mockTracking(data: MockData): void {
   getJson.mockImplementation((path: string) => {
     if (path.startsWith('/getData/days/')) {
       return Promise.resolve(data.entries ?? [])
+    }
+    if (/^\/api\/v2\/entries\/\d+\/summary$/.test(path)) {
+      return Promise.resolve(data.summary ?? {})
     }
     switch (path) {
       case '/getCustomers':
@@ -377,7 +381,7 @@ describe('Tracking (Worklog grid)', () => {
 
     await waitFor(() => expect(postJson).toHaveBeenCalledWith('/tracking/save', expect.anything()))
     // The save also re-pulls the server header's totals (otherwise stale until F5).
-    await waitFor(() => expect(getJson).toHaveBeenCalledWith('/getTimeSummary'))
+    await waitFor(() => expect(getJson).toHaveBeenCalledWith('/api/v2/time-balance'))
 
     unmount()
   })
@@ -642,23 +646,27 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
-  it('Alt+I requests the summary as form-encoded (legacy $request->request) and shows it', async () => {
-    mockApi()
-    // /getSummary reads form params, so the client uses postForm and returns the
-    // JSON *text*; a JSON body would leave the server's id null → all-zero totals.
-    postForm.mockResolvedValue(JSON.stringify({
-      customer: { scope: 'customer', name: 'ACME', entries: 5, total: 300, own: 120, estimation: 0 },
-      project: { scope: 'project', name: 'Site', entries: 3, total: 180, own: 90, estimation: 600 },
-      activity: { scope: 'activity', name: 'Dev', entries: 2, total: 120, own: 60, estimation: 0 },
-      ticket: { scope: 'ticket', name: 'ABC-1', entries: 1, total: 60, own: 60, estimation: 0 },
-    }))
+  it('Alt+I fetches the v2 entry summary and shows it', async () => {
+    mockTracking({
+      entries: [{ entry: DEFAULT_ENTRY }],
+      customers: [{ customer: { id: 1, name: 'ACME' } }],
+      projects: [{ project: { id: 4, name: 'Site' } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }],
+      summary: {
+        customer: { scope: 'customer', name: 'ACME', entries: 5, total: 300, own: 120, estimation: 0 },
+        project: { scope: 'project', name: 'Site', entries: 3, total: 180, own: 90, estimation: 600 },
+        activity: { scope: 'activity', name: 'Dev', entries: 2, total: 120, own: 60, estimation: 0 },
+        ticket: { scope: 'ticket', name: 'ABC-1', entries: 1, total: 60, own: 60, estimation: 0 },
+        estimate: { estimation: 600, booked_total: 180, percent: 30, status: 'ok' },
+        warnings: [],
+      },
+    })
     const { getByRole, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'Work' })).toBeInTheDocument())
 
     fireEvent.keyDown(document, { key: 'i', altKey: true })
 
-    expect(postForm).toHaveBeenCalledWith('/getSummary', { id: 1 })
-    expect(postJson).not.toHaveBeenCalledWith('/getSummary', expect.anything())
+    await waitFor(() => expect(getJson).toHaveBeenCalledWith('/api/v2/entries/1/summary'))
     // The summary dialog is portalled to document.body → query via screen.
     const dialog = await screen.findByRole('dialog')
     expect(within(dialog).getByText('ACME')).toBeInTheDocument()
@@ -771,16 +779,13 @@ describe('Tracking (Worklog grid)', () => {
       projects: [{ project: { id: 4, name: 'Site' } }],
       activities: [{ activity: { id: 5, name: 'Dev' } }],
     })
-    postForm.mockResolvedValue(JSON.stringify({
-      customer: { scope: 'customer', name: 'ACME', entries: 1, total: 60, own: 60, estimation: 0 },
-    }))
     const { container, getByRole, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'Second' })).toBeInTheDocument())
 
     focusBodyRow(container, 1) // cursor on the 2nd row (id 2)
     fireEvent.keyDown(document, { key: 'i', altKey: true })
 
-    expect(postForm).toHaveBeenCalledWith('/getSummary', { id: 2 })
+    await waitFor(() => expect(getJson).toHaveBeenCalledWith('/api/v2/entries/2/summary'))
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage, getJson, postForm, postJson, ValidationError } from '../api/client'
-import { activitiesQuery, ENTRIES_KEY, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, upsertSavedEntry, type NamedOption, type SavedEntryResult, type SummaryScope, type TrackingEntry } from '../api/queries'
+import { activitiesQuery, ENTRIES_KEY, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, upsertSavedEntry, type EntrySummaryResponse, type NamedOption, type SavedEntryResult, type SummaryScope, type TrackingEntry } from '../api/queries'
 import { appConfig, canBulkEnter } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
 import { num, str } from '../lib/coerce'
@@ -908,8 +908,8 @@ export default function Tracking() {
     }
     setPageError('')
     try {
-      const result = await getJson<Record<string, SummaryScope>>(`/api/v2/entries/${num(target.id)}/summary`)
-      setSummary([result.customer, result.project, result.activity, result.ticket].filter((scope): scope is SummaryScope => scope != null))
+      const result = await getJson<EntrySummaryResponse>(`/api/v2/entries/${num(target.id)}/summary`)
+      setSummary([result.customer, result.project, result.activity, result.ticket])
     } catch (caught) {
       setPageError(apiErrorMessage(caught, m.app_load_error()))
     }

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show, type JSX } from 'solid-js'
 
-import { apiErrorMessage, postForm, postJson, ValidationError } from '../api/client'
+import { apiErrorMessage, getJson, postForm, postJson, ValidationError } from '../api/client'
 import { activitiesQuery, ENTRIES_KEY, trackingCustomersQuery, trackingEntriesQuery, trackingProjectsQuery, trackingTicketSystemsQuery, upsertSavedEntry, type NamedOption, type SavedEntryResult, type SummaryScope, type TrackingEntry } from '../api/queries'
 import { appConfig, canBulkEnter } from '../config'
 import type { FieldDef, OptionLookup, OptionSource } from '../admin/types'
@@ -899,9 +899,8 @@ export default function Tracking() {
   }
 
   // Alt+I: per-customer/project/activity/ticket totals for the cursor row (or
-  // the latest entry). /getSummary is a legacy endpoint that reads form params
-  // ($request->request->get('id')), so it must be POSTed as form-encoded — a
-  // JSON body leaves `id` null and the server answers all-zero totals.
+  // the latest entry), from GET /api/v2/entries/{id}/summary (ADR-022; also
+  // carries `estimate` and `warnings` beyond the four scopes shown here).
   async function showInfo(entry?: TrackingEntry): Promise<void> {
     const target = entry ?? activeOrLatestEntry()
     if (target === undefined) {
@@ -909,7 +908,7 @@ export default function Tracking() {
     }
     setPageError('')
     try {
-      const result = JSON.parse(await postForm('/getSummary', { id: num(target.id) })) as Record<string, SummaryScope>
+      const result = await getJson<Record<string, SummaryScope>>(`/api/v2/entries/${num(target.id)}/summary`)
       setSummary([result.customer, result.project, result.activity, result.ticket].filter((scope): scope is SummaryScope => scope != null))
     } catch (caught) {
       setPageError(apiErrorMessage(caught, m.app_load_error()))

--- a/public/api.yml
+++ b/public/api.yml
@@ -663,9 +663,86 @@ paths:
                     project:
                       $ref: '#/components/schemas/ProjectInfo'
 
+  /api/v2/time-balance:
+    get:
+      summary: The authenticated user's worked-vs-target balance for today, this week and this month (ADR-022; requires reporting:read for tokens)
+      tags:
+        - Summary
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  today:
+                    $ref: '#/components/schemas/PeriodBalance'
+                  week:
+                    $ref: '#/components/schemas/PeriodBalance'
+                  month:
+                    $ref: '#/components/schemas/PeriodBalance'
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+
+  /api/v2/entries/{id}/summary:
+    get:
+      summary: Per-scope booking totals and estimate verdict for one of the caller's own entries (ADR-022; requires reporting:read for tokens). Foreign entries read as 404.
+      tags:
+        - Summary
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        '404':
+          description: No entry for id (unknown or not owned by the caller)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoEntryForId'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  customer:
+                    $ref: '#/components/schemas/ScopeSummary'
+                  project:
+                    $ref: '#/components/schemas/ScopeSummary'
+                  activity:
+                    $ref: '#/components/schemas/ScopeSummary'
+                  ticket:
+                    $ref: '#/components/schemas/ScopeSummary'
+                  estimate:
+                    type: object
+                    properties:
+                      estimation:
+                        type: integer
+                      booked_total:
+                        type: integer
+                      percent:
+                        type: integer
+                        nullable: true
+                      status:
+                        type: string
+                        enum: [none, ok, near, over]
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+
   /getSummary:
     post:
-      summary: Returns a summary about the customer, project,activity and ticket
+      deprecated: true
+      summary: Returns a summary about the customer, project, activity and ticket. Deprecated (ADR-022) — superseded by GET /api/v2/entries/{id}/summary; removal in v7. Scoped to the caller's own entries.
       tags:
         - Summary
       requestBody:
@@ -732,7 +809,8 @@ paths:
 
   /getTimeSummary:
     get:
-      summary: Return a time summary for an entry
+      deprecated: true
+      summary: Return a time summary for an entry. Deprecated (ADR-022) — superseded by GET /api/v2/time-balance; removal in v7.
       tags:
         - Summary
       responses:
@@ -2732,6 +2810,56 @@ components:
         count:
           type: boolean
           example: true
+
+    PeriodBalance:
+      type: object
+      description: One balance period (ADR-022) — worked minutes vs the expected minutes for the whole period and accrued through today
+      properties:
+        ist:
+          type: integer
+          description: Worked minutes
+          example: 420
+        soll_total:
+          type: integer
+          description: Expected minutes for the whole period
+          example: 2400
+        soll_so_far:
+          type: integer
+          description: Expected minutes accrued through today
+          example: 480
+        diff:
+          type: integer
+          description: ist minus soll_so_far
+          example: -60
+        status:
+          type: string
+          enum: [ok, behind, over]
+
+    ScopeSummary:
+      type: object
+      description: One aggregation scope of an entry summary (ADR-022) — the caller's own minutes vs everyone's total
+      properties:
+        scope:
+          type: string
+          enum: [customer, project, activity, ticket]
+        name:
+          type: string
+          example: Website relaunch
+        entries:
+          type: integer
+          example: 12
+        total:
+          type: integer
+          description: Booked minutes across all users
+          example: 5400
+        own:
+          type: integer
+          description: The caller's own booked minutes
+          example: 1200
+        estimation:
+          type: integer
+          description: Estimated minutes (project scope only, 0 elsewhere)
+          example: 12000
 
     UnauthorizedResponse:
       type: object

--- a/src/Controller/Api/V2/GetEntrySummaryAction.php
+++ b/src/Controller/Api/V2/GetEntrySummaryAction.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\Response\EntrySummaryDto;
+use App\Entity\User;
+use App\Security\ApiToken\RequireScope;
+use App\Service\EntrySummaryService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * Per-scope booking totals (customer/project/activity/ticket) plus estimate
+ * verdict for one of the caller's own entries — the tracking UI's "Info" (I)
+ * popup (ADR-022). Supersedes POST /getSummary. Owner-scoped: an entry the
+ * caller does not own reads as not found (404, no existence disclosure).
+ */
+final readonly class GetEntrySummaryAction
+{
+    public function __construct(private EntrySummaryService $entrySummaryService)
+    {
+    }
+
+    #[RequireScope('reporting:read')]
+    #[Route(path: '/api/v2/entries/{id}/summary', name: 'api_v2_entry_summary', requirements: ['id' => '\d+'], methods: ['GET'])]
+    public function __invoke(int $id, #[CurrentUser] ?User $user = null): JsonResponse
+    {
+        if (!$user instanceof User) {
+            return new JsonResponse(['message' => 'Authentication required'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $summary = $this->entrySummaryService->forEntry($id, (int) $user->getId());
+        if (!$summary instanceof EntrySummaryDto) {
+            return new JsonResponse(['message' => 'No entry for id.'], Response::HTTP_NOT_FOUND);
+        }
+
+        return new JsonResponse($summary);
+    }
+}

--- a/src/Controller/Api/V2/GetTimeBalanceAction.php
+++ b/src/Controller/Api/V2/GetTimeBalanceAction.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Entity\User;
+use App\Security\ApiToken\RequireScope;
+use App\Service\TimeBalanceService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * The authenticated user's today/week/month worked-vs-target balance
+ * (ADR-022). Supersedes GET /getTimeSummary; same numbers as the header
+ * display and the get_time_balance MCP tool — all three consume
+ * TimeBalanceService.
+ */
+final readonly class GetTimeBalanceAction
+{
+    public function __construct(private TimeBalanceService $timeBalanceService)
+    {
+    }
+
+    #[RequireScope('reporting:read')]
+    #[Route(path: '/api/v2/time-balance', name: 'api_v2_time_balance', methods: ['GET'])]
+    public function __invoke(#[CurrentUser] ?User $user = null): JsonResponse
+    {
+        if (!$user instanceof User) {
+            return new JsonResponse(['message' => 'Authentication required'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return new JsonResponse($this->timeBalanceService->forUser($user));
+    }
+}

--- a/src/Controller/Default/GetSummaryAction.php
+++ b/src/Controller/Default/GetSummaryAction.php
@@ -17,6 +17,7 @@ use App\Model\Response;
 use App\Repository\EntryRepository;
 use App\Response\Error;
 use App\Service\Util\TimeCalculationService;
+use Deprecated;
 use Exception;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
@@ -48,6 +49,7 @@ final class GetSummaryAction extends BaseController
      */
     #[Route(path: '/getSummary', name: '_getSummary_attr', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[Deprecated(message: 'superseded by GET /api/v2/entries/{id}/summary (ADR-022); removal in v7')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse|Error
     {
         if (!$user instanceof User) {
@@ -65,15 +67,20 @@ final class GetSummaryAction extends BaseController
 
         $entryId = $request->request->get('id');
         if (null === $entryId || '' === $entryId || false === $entryId) {
-            return new JsonResponse($data);
+            return $this->deprecated(new JsonResponse($data));
         }
 
         $objectRepository = $this->managerRegistry->getRepository(Entry::class);
         assert($objectRepository instanceof EntryRepository);
-        if (null === $objectRepository->find($entryId)) {
+        $entry = $objectRepository->find($entryId);
+        // Owner-scoped like the v2 successor (ADR-022 §5 security exception to
+        // the v1 freeze): the aggregation spans all users, so a foreign entry id
+        // would disclose other users' scope names and totals (IDOR). "Not owned"
+        // reads as "not found".
+        if (!$entry instanceof Entry || $entry->getUser()?->getId() !== $userId) {
             $message = $this->translator->trans('No entry for id.');
 
-            return new Error($message, \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
+            return $this->deprecated(new Error($message, \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND));
         }
 
         $data = $objectRepository->getEntrySummary((int) $entryId, $userId, $data);
@@ -98,6 +105,24 @@ final class GetSummaryAction extends BaseController
             }
         }
 
-        return new JsonResponse($data);
+        return $this->deprecated(new JsonResponse($data));
+    }
+
+    /**
+     * Marks the response as coming from a deprecated endpoint (ADR-022 §5) so
+     * API consumers see it at call time.
+     *
+     * @template T of \Symfony\Component\HttpFoundation\Response
+     *
+     * @param T $response
+     *
+     * @return T
+     */
+    private function deprecated(\Symfony\Component\HttpFoundation\Response $response): \Symfony\Component\HttpFoundation\Response
+    {
+        $response->headers->set('Deprecation', 'true');
+        $response->headers->set('Link', '</api/v2/entries/{id}/summary>; rel="successor-version"');
+
+        return $response;
     }
 }

--- a/src/Controller/Default/GetSummaryAction.php
+++ b/src/Controller/Default/GetSummaryAction.php
@@ -30,6 +30,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 use function assert;
 use function is_array;
+use function sprintf;
 
 final class GetSummaryAction extends BaseController
 {
@@ -67,7 +68,7 @@ final class GetSummaryAction extends BaseController
 
         $entryId = $request->request->get('id');
         if (null === $entryId || '' === $entryId || false === $entryId) {
-            return $this->deprecated(new JsonResponse($data));
+            return $this->deprecated(new JsonResponse($data), null);
         }
 
         $objectRepository = $this->managerRegistry->getRepository(Entry::class);
@@ -80,7 +81,7 @@ final class GetSummaryAction extends BaseController
         if (!$entry instanceof Entry || $entry->getUser()?->getId() !== $userId) {
             $message = $this->translator->trans('No entry for id.');
 
-            return $this->deprecated(new Error($message, \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND));
+            return $this->deprecated(new Error($message, \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND), (int) $entryId);
         }
 
         $data = $objectRepository->getEntrySummary((int) $entryId, $userId, $data);
@@ -105,7 +106,7 @@ final class GetSummaryAction extends BaseController
             }
         }
 
-        return $this->deprecated(new JsonResponse($data));
+        return $this->deprecated(new JsonResponse($data), (int) $entryId);
     }
 
     /**
@@ -118,10 +119,14 @@ final class GetSummaryAction extends BaseController
      *
      * @return T
      */
-    private function deprecated(\Symfony\Component\HttpFoundation\Response $response): \Symfony\Component\HttpFoundation\Response
+    private function deprecated(\Symfony\Component\HttpFoundation\Response $response, ?int $entryId): \Symfony\Component\HttpFoundation\Response
     {
         $response->headers->set('Deprecation', 'true');
-        $response->headers->set('Link', '</api/v2/entries/{id}/summary>; rel="successor-version"');
+        // A concrete URI only — '{id}' URI templates are not valid in a Link
+        // target, so without an entry id the header carries no Link.
+        if (null !== $entryId) {
+            $response->headers->set('Link', sprintf('</api/v2/entries/%d/summary>; rel="successor-version"', $entryId));
+        }
 
         return $response;
     }

--- a/src/Controller/Default/GetTimeSummaryAction.php
+++ b/src/Controller/Default/GetTimeSummaryAction.php
@@ -22,6 +22,7 @@ use App\Service\ClockInterface;
 use App\Service\Util\ExpectedWorkTimeCalculator;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Deprecated;
 use Doctrine\DBAL\Connection;
 use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -66,6 +67,7 @@ final class GetTimeSummaryAction extends BaseController
      */
     #[RequireScope('reporting:read')]
     #[Route(path: '/getTimeSummary', name: 'time_summary_attr', methods: ['GET'])]
+    #[Deprecated(message: 'superseded by GET /api/v2/time-balance (ADR-022); removal in v7')]
     public function __invoke(#[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse
     {
         if (!$user instanceof User) {
@@ -87,7 +89,12 @@ final class GetTimeSummaryAction extends BaseController
             'month' => $month + ['target' => $target['month']],
         ];
 
-        return new JsonResponse($data);
+        $response = new JsonResponse($data);
+        // Deprecated endpoint (ADR-022 §5) — signal at call time.
+        $response->headers->set('Deprecation', 'true');
+        $response->headers->set('Link', '</api/v2/time-balance>; rel="successor-version"');
+
+        return $response;
     }
 
     /**

--- a/src/Dto/Response/EntrySummaryDto.php
+++ b/src/Dto/Response/EntrySummaryDto.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use JsonSerializable;
+
+/**
+ * The per-scope booking aggregation the tracking UI shows in an entry's
+ * "Info" (I) popup — customer / project / activity / ticket — plus the
+ * project-estimate verdict and agent-facing warnings (ADR-022). Serialized
+ * identically by GET /api/v2/entries/{id}/summary and the get_ticket_info
+ * MCP tool.
+ */
+final readonly class EntrySummaryDto implements JsonSerializable
+{
+    /**
+     * @param list<string> $warnings
+     */
+    public function __construct(
+        public ScopeSummaryDto $customer,
+        public ScopeSummaryDto $project,
+        public ScopeSummaryDto $activity,
+        public ScopeSummaryDto $ticket,
+        public EstimateDto $estimate,
+        public array $warnings,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     customer: array{scope: string, name: string, entries: int, total: int, own: int, estimation: int},
+     *     project: array{scope: string, name: string, entries: int, total: int, own: int, estimation: int},
+     *     activity: array{scope: string, name: string, entries: int, total: int, own: int, estimation: int},
+     *     ticket: array{scope: string, name: string, entries: int, total: int, own: int, estimation: int},
+     *     estimate: array{estimation: int, booked_total: int, percent: int|null, status: string},
+     *     warnings: list<string>
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'customer' => $this->customer->jsonSerialize(),
+            'project' => $this->project->jsonSerialize(),
+            'activity' => $this->activity->jsonSerialize(),
+            'ticket' => $this->ticket->jsonSerialize(),
+            'estimate' => $this->estimate->jsonSerialize(),
+            'warnings' => $this->warnings,
+        ];
+    }
+}

--- a/src/Dto/Response/EstimateDto.php
+++ b/src/Dto/Response/EstimateDto.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use App\Enum\EstimateStatus;
+use JsonSerializable;
+
+/**
+ * Project-estimate summary for an entry: how much of the project's estimate is
+ * booked (all users), as absolute minutes and percent, with a verdict the
+ * consumer can act on (ADR-022). `percent` is null when there is no estimate.
+ */
+final readonly class EstimateDto implements JsonSerializable
+{
+    public function __construct(
+        public int $estimation,
+        public int $bookedTotal,
+        public ?int $percent,
+        public EstimateStatus $status,
+    ) {
+    }
+
+    /**
+     * @return array{estimation: int, booked_total: int, percent: int|null, status: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'estimation' => $this->estimation,
+            'booked_total' => $this->bookedTotal,
+            'percent' => $this->percent,
+            'status' => $this->status->value,
+        ];
+    }
+}

--- a/src/Dto/Response/PeriodBalanceDto.php
+++ b/src/Dto/Response/PeriodBalanceDto.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use App\Enum\BalanceStatus;
+use JsonSerializable;
+
+/**
+ * One balance period (today / week / month): worked minutes (IST) against the
+ * expected minutes (SOLL) for the whole period and accrued through today.
+ * Wire keys per ADR-022 §4 (the keys the MCP tools shipped with).
+ */
+final readonly class PeriodBalanceDto implements JsonSerializable
+{
+    public function __construct(
+        public int $ist,
+        public int $sollTotal,
+        public int $sollSoFar,
+        public int $diff,
+        public BalanceStatus $status,
+    ) {
+    }
+
+    /**
+     * @return array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'ist' => $this->ist,
+            'soll_total' => $this->sollTotal,
+            'soll_so_far' => $this->sollSoFar,
+            'diff' => $this->diff,
+            'status' => $this->status->value,
+        ];
+    }
+}

--- a/src/Dto/Response/ScopeSummaryDto.php
+++ b/src/Dto/Response/ScopeSummaryDto.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use JsonSerializable;
+
+use function is_numeric;
+use function is_string;
+
+/**
+ * One aggregation scope of an entry summary (customer / project / activity /
+ * ticket): the caller's own booked minutes, everyone's total, and the estimate
+ * (project scope only). Wire keys per ADR-022 §4.
+ */
+final readonly class ScopeSummaryDto implements JsonSerializable
+{
+    public function __construct(
+        public string $scope,
+        public string $name,
+        public int $entries,
+        public int $total,
+        public int $own,
+        public int $estimation,
+    ) {
+    }
+
+    /**
+     * Normalizes a raw EntryRepository::getEntrySummary row (DBAL values may
+     * arrive as numeric strings) into the typed DTO.
+     *
+     * @param array<string, mixed> $row
+     */
+    public static function fromRow(string $scope, array $row): self
+    {
+        return new self(
+            scope: $scope,
+            name: is_string($row['name'] ?? null) ? $row['name'] : '',
+            entries: self::int($row['entries'] ?? null),
+            total: self::int($row['total'] ?? null),
+            own: self::int($row['own'] ?? null),
+            estimation: self::int($row['estimation'] ?? null),
+        );
+    }
+
+    /**
+     * @return array{scope: string, name: string, entries: int, total: int, own: int, estimation: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'scope' => $this->scope,
+            'name' => $this->name,
+            'entries' => $this->entries,
+            'total' => $this->total,
+            'own' => $this->own,
+            'estimation' => $this->estimation,
+        ];
+    }
+
+    private static function int(mixed $value): int
+    {
+        return is_numeric($value) ? (int) $value : 0;
+    }
+}

--- a/src/Dto/Response/TimeBalanceDto.php
+++ b/src/Dto/Response/TimeBalanceDto.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use JsonSerializable;
+
+/**
+ * The authenticated user's today/week/month worked-vs-target balance, with
+ * agent-facing warnings when a target is missed or exceeded (ADR-022).
+ * Serialized identically by GET /api/v2/time-balance and the get_time_balance
+ * MCP tool — single contract, no drift.
+ */
+final readonly class TimeBalanceDto implements JsonSerializable
+{
+    /**
+     * @param list<string> $warnings
+     */
+    public function __construct(
+        public PeriodBalanceDto $today,
+        public PeriodBalanceDto $week,
+        public PeriodBalanceDto $month,
+        public array $warnings,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     today: array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
+     *     week: array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
+     *     month: array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
+     *     warnings: list<string>
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'today' => $this->today->jsonSerialize(),
+            'week' => $this->week->jsonSerialize(),
+            'month' => $this->month->jsonSerialize(),
+            'warnings' => $this->warnings,
+        ];
+    }
+}

--- a/src/Enum/BalanceStatus.php
+++ b/src/Enum/BalanceStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Worked-vs-target verdict for a balance period (ADR-022): `behind` when IST
+ * is under the SOLL accrued so far, `over` when IST exceeds the period's whole
+ * SOLL, else `ok`.
+ */
+enum BalanceStatus: string
+{
+    case Ok = 'ok';
+    case Behind = 'behind';
+    case Over = 'over';
+}

--- a/src/Enum/EstimateStatus.php
+++ b/src/Enum/EstimateStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Project-estimate verdict for an entry summary (ADR-022): `none` when the
+ * project has no estimate, `over` at/above it, `near` from 90 %, else `ok`.
+ */
+enum EstimateStatus: string
+{
+    case None = 'none';
+    case Ok = 'ok';
+    case Near = 'near';
+    case Over = 'over';
+}

--- a/src/Mcp/Tool/GetTicketInfoTool.php
+++ b/src/Mcp/Tool/GetTicketInfoTool.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace App\Mcp\Tool;
 
+use App\Dto\Response\EntrySummaryDto;
 use App\Mcp\ScopeGuard;
 use App\Service\EntrySummaryService;
 use Mcp\Capability\Attribute\McpTool;
@@ -47,10 +48,10 @@ final readonly class GetTicketInfoTool
         $user = $this->scopeGuard->requireScope('reporting:read');
 
         $info = $this->entrySummaryService->forEntry($entryId, (int) $user->getId());
-        if (null === $info) {
+        if (!$info instanceof EntrySummaryDto) {
             throw new ToolCallException(sprintf('No entry with id %d.', $entryId));
         }
 
-        return $info;
+        return $info->jsonSerialize();
     }
 }

--- a/src/Mcp/Tool/GetTimeBalanceTool.php
+++ b/src/Mcp/Tool/GetTimeBalanceTool.php
@@ -36,6 +36,6 @@ final readonly class GetTimeBalanceTool
     {
         $user = $this->scopeGuard->requireScope('reporting:read');
 
-        return $this->timeBalanceService->forUser($user);
+        return $this->timeBalanceService->forUser($user)->jsonSerialize();
     }
 }

--- a/src/Mcp/Tool/LogTimeTool.php
+++ b/src/Mcp/Tool/LogTimeTool.php
@@ -124,9 +124,9 @@ final readonly class LogTimeTool
         // both carrying any warnings the agent should surface.
         $entryId = $this->createdEntryId($body);
         if (null !== $entryId) {
-            $result['ticket_info'] = $this->entrySummaryService->forEntry($entryId, (int) $user->getId());
+            $result['ticket_info'] = $this->entrySummaryService->forEntry($entryId, (int) $user->getId())?->jsonSerialize();
         }
-        $result['balance'] = $this->timeBalanceService->forUser($user);
+        $result['balance'] = $this->timeBalanceService->forUser($user)->jsonSerialize();
 
         return $result;
     }

--- a/src/Service/EntrySummaryService.php
+++ b/src/Service/EntrySummaryService.php
@@ -9,21 +9,25 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Dto\Response\EntrySummaryDto;
+use App\Dto\Response\EstimateDto;
+use App\Dto\Response\ScopeSummaryDto;
 use App\Entity\Entry;
+use App\Enum\EstimateStatus;
 use App\Repository\EntryRepository;
 
-use function is_int;
-use function is_string;
+use function round;
 use function sprintf;
 
 /**
  * The per-scope booking aggregation shown in the tracking UI's "Info" (I) popup
  * for an entry — Customer / Project / Activity / Ticket, each with the user's own
  * booked minutes, everyone's total, and (project only) the estimate (ADR-021
- * Phase 5, the get_ticket_info MCP tool + log_time enrichment).
+ * Phase 5 / ADR-022 — the get_ticket_info MCP tool, the
+ * GET /api/v2/entries/{id}/summary endpoint, and the log_time enrichment).
  *
  * Wraps EntryRepository::getEntrySummary and adds a project-estimate status the
- * agent can act on: `over` at/above the estimate, `near` from 90 %, else `ok`
+ * consumer can act on: `over` at/above the estimate, `near` from 90 %, else `ok`
  * (or `none` when the project has no estimate).
  */
 final readonly class EntrySummaryService
@@ -35,22 +39,14 @@ final readonly class EntrySummaryService
     }
 
     /**
-     * @return array{
-     *     customer: array<string, mixed>,
-     *     project: array<string, mixed>,
-     *     activity: array<string, mixed>,
-     *     ticket: array<string, mixed>,
-     *     estimate: array{estimation: int, booked_total: int, percent: int|null, status: string},
-     *     warnings: list<string>
-     * }|null null when the entry does not exist
+     * Scoped to the caller's own entries: getEntrySummary aggregates the
+     * customer/project/activity/ticket totals across all users, so returning a
+     * summary for an entry the caller does not own would leak other users'
+     * scope names and totals (IDOR). "Not owned" reads as "not found" (null).
      */
-    public function forEntry(int $entryId, int $userId): ?array
+    public function forEntry(int $entryId, int $userId): ?EntrySummaryDto
     {
         $entry = $this->entryRepository->find($entryId);
-        // Scope to the caller's own entries: getEntrySummary aggregates the
-        // customer/project/activity/ticket totals across all users, so returning
-        // a summary for an entry the caller does not own would leak other users'
-        // scope names and totals (IDOR). Treat "not owned" as "not found".
         if (!$entry instanceof Entry || $entry->getUser()?->getId() !== $userId) {
             return null;
         }
@@ -63,57 +59,46 @@ final readonly class EntrySummaryService
         ];
 
         $summary = $this->entryRepository->getEntrySummary($entryId, $userId, $seed);
-        $project = $summary['project'] ?? [];
+        $project = ScopeSummaryDto::fromRow('project', $summary['project'] ?? []);
         $estimate = $this->estimate($project);
 
-        return [
-            'customer' => $summary['customer'] ?? [],
-            'project' => $project,
-            'activity' => $summary['activity'] ?? [],
-            'ticket' => $summary['ticket'] ?? [],
-            'estimate' => $estimate,
-            'warnings' => $this->warnings($project, $estimate),
-        ];
+        return new EntrySummaryDto(
+            customer: ScopeSummaryDto::fromRow('customer', $summary['customer'] ?? []),
+            project: $project,
+            activity: ScopeSummaryDto::fromRow('activity', $summary['activity'] ?? []),
+            ticket: ScopeSummaryDto::fromRow('ticket', $summary['ticket'] ?? []),
+            estimate: $estimate,
+            warnings: $this->warnings($project->name, $estimate),
+        );
     }
 
     /**
-     * @param array<string, mixed>                                                         $project
-     * @param array{estimation: int, booked_total: int, percent: int|null, status: string} $estimate
-     *
      * @return list<string>
      */
-    private function warnings(array $project, array $estimate): array
+    private function warnings(string $projectName, EstimateDto $estimate): array
     {
-        $name = is_string($project['name'] ?? null) ? $project['name'] : 'project';
+        $name = '' !== $projectName ? $projectName : 'project';
 
-        return match ($estimate['status']) {
-            'over' => [sprintf('Project "%s" is over its estimate (%d%% — %d of %d min booked).', $name, (int) $estimate['percent'], $estimate['booked_total'], $estimate['estimation'])],
-            'near' => [sprintf('Project "%s" is near its estimate (%d%%).', $name, (int) $estimate['percent'])],
+        return match ($estimate->status) {
+            EstimateStatus::Over => [sprintf('Project "%s" is over its estimate (%d%% — %d of %d min booked).', $name, (int) $estimate->percent, $estimate->bookedTotal, $estimate->estimation)],
+            EstimateStatus::Near => [sprintf('Project "%s" is near its estimate (%d%%).', $name, (int) $estimate->percent)],
             default => [],
         };
     }
 
-    /**
-     * @param array<string, mixed> $project
-     *
-     * @return array{estimation: int, booked_total: int, percent: int|null, status: string}
-     */
-    private function estimate(array $project): array
+    private function estimate(ScopeSummaryDto $project): EstimateDto
     {
-        $estimation = is_int($project['estimation'] ?? null) ? $project['estimation'] : 0;
-        $total = is_int($project['total'] ?? null) ? $project['total'] : 0;
-
-        if ($estimation <= 0) {
-            return ['estimation' => 0, 'booked_total' => $total, 'percent' => null, 'status' => 'none'];
+        if ($project->estimation <= 0) {
+            return new EstimateDto(estimation: 0, bookedTotal: $project->total, percent: null, status: EstimateStatus::None);
         }
 
-        $percent = (int) round($total / $estimation * 100);
+        $percent = (int) round($project->total / $project->estimation * 100);
         $status = match (true) {
-            $total >= $estimation => 'over',
-            $percent >= self::NEAR_THRESHOLD_PERCENT => 'near',
-            default => 'ok',
+            $project->total >= $project->estimation => EstimateStatus::Over,
+            $percent >= self::NEAR_THRESHOLD_PERCENT => EstimateStatus::Near,
+            default => EstimateStatus::Ok,
         };
 
-        return ['estimation' => $estimation, 'booked_total' => $total, 'percent' => $percent, 'status' => $status];
+        return new EstimateDto(estimation: $project->estimation, bookedTotal: $project->total, percent: $percent, status: $status);
     }
 }

--- a/src/Service/TimeBalanceService.php
+++ b/src/Service/TimeBalanceService.php
@@ -9,8 +9,11 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Dto\Response\PeriodBalanceDto;
+use App\Dto\Response\TimeBalanceDto;
 use App\Entity\Contract;
 use App\Entity\User;
+use App\Enum\BalanceStatus;
 use App\Enum\Period;
 use App\Repository\ContractRepository;
 use App\Repository\EntryRepository;
@@ -20,7 +23,9 @@ use DateTimeInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
 
+use function abs;
 use function assert;
+use function intdiv;
 use function is_string;
 use function max;
 use function min;
@@ -29,13 +34,14 @@ use function substr;
 
 /**
  * The authenticated user's worked-vs-target balance for today/week/month
- * (ADR-021 Phase 5, the get_time_balance MCP tool + log_time enrichment).
+ * (ADR-021 Phase 5 / ADR-022 — the get_time_balance MCP tool, the
+ * GET /api/v2/time-balance endpoint, and the log_time enrichment).
  *
  * For each period it reports IST (worked minutes), SOLL for the whole period and
- * SOLL through today ("so far"), the difference, and a status the agent can act
- * on: `behind` when IST < SOLL-so-far, `over` when IST > SOLL-total, else `ok`.
- * SOLL comes from the user's contracts minus public holidays, the same source as
- * /getTimeSummary and the /ui/month balance.
+ * SOLL through today ("so far"), the difference, and a status the consumer can
+ * act on: `behind` when IST < SOLL-so-far, `over` when IST > SOLL-total, else
+ * `ok`. SOLL comes from the user's contracts minus public holidays, the same
+ * source as /getTimeSummary and the /ui/month balance.
  */
 final readonly class TimeBalanceService
 {
@@ -47,15 +53,7 @@ final readonly class TimeBalanceService
     ) {
     }
 
-    /**
-     * @return array{
-     *     today: array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
-     *     week:  array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
-     *     month: array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string},
-     *     warnings: list<string>
-     * }
-     */
-    public function forUser(User $user): array
+    public function forUser(User $user): TimeBalanceDto
     {
         $userId = (int) $user->getId();
         $today = $this->clock->today();
@@ -75,15 +73,15 @@ final readonly class TimeBalanceService
         ];
 
         $warnings = [];
-        foreach ($periods as $label => $p) {
-            if ('behind' === $p['status']) {
-                $warnings[] = sprintf('%s: behind target by %s (worked %s, expected %s so far).', $label, $this->hm(-$p['diff']), $this->hm($p['ist']), $this->hm($p['soll_so_far']));
-            } elseif ('over' === $p['status']) {
-                $warnings[] = sprintf('%s: over target (worked %s, target %s).', $label, $this->hm($p['ist']), $this->hm($p['soll_total']));
+        foreach ($periods as $label => $period) {
+            if (BalanceStatus::Behind === $period->status) {
+                $warnings[] = sprintf('%s: behind target by %s (worked %s, expected %s so far).', $label, $this->hm(-$period->diff), $this->hm($period->ist), $this->hm($period->sollSoFar));
+            } elseif (BalanceStatus::Over === $period->status) {
+                $warnings[] = sprintf('%s: over target (worked %s, target %s).', $label, $this->hm($period->ist), $this->hm($period->sollTotal));
             }
         }
 
-        return $periods + ['warnings' => $warnings];
+        return new TimeBalanceDto($periods['today'], $periods['week'], $periods['month'], $warnings);
     }
 
     /** Minutes as "Hh Mm" (e.g. 95 → "1h 35m"). */
@@ -98,29 +96,27 @@ final readonly class TimeBalanceService
      * @param array{duration: int, count: int} $work
      * @param Contract[]                       $contracts
      * @param array<string, true>              $holidays
-     *
-     * @return array{ist: int, soll_total: int, soll_so_far: int, diff: int, status: string}
      */
-    private function period(array $work, array $contracts, array $holidays, DateTimeImmutable $start, DateTimeImmutable $end, DateTimeImmutable $today): array
+    private function period(array $work, array $contracts, array $holidays, DateTimeImmutable $start, DateTimeImmutable $end, DateTimeImmutable $today): PeriodBalanceDto
     {
         $ist = $work['duration'];
         $sollTotal = $this->expectedWorkTimeCalculator->minutesForRange($contracts, $holidays, $start, $end);
         $sollSoFar = $this->expectedWorkTimeCalculator->minutesForRange($contracts, $holidays, $start, min($today, $end));
 
-        $status = 'ok';
+        $status = BalanceStatus::Ok;
         if ($ist > $sollTotal && $sollTotal > 0) {
-            $status = 'over';
+            $status = BalanceStatus::Over;
         } elseif ($ist < $sollSoFar) {
-            $status = 'behind';
+            $status = BalanceStatus::Behind;
         }
 
-        return [
-            'ist' => $ist,
-            'soll_total' => $sollTotal,
-            'soll_so_far' => $sollSoFar,
-            'diff' => $ist - $sollSoFar,
-            'status' => $status,
-        ];
+        return new PeriodBalanceDto(
+            ist: $ist,
+            sollTotal: $sollTotal,
+            sollSoFar: $sollSoFar,
+            diff: $ist - $sollSoFar,
+            status: $status,
+        );
     }
 
     /**

--- a/tests/Controller/Api/V2/GetEntrySummaryActionTest.php
+++ b/tests/Controller/Api/V2/GetEntrySummaryActionTest.php
@@ -9,15 +9,9 @@ declare(strict_types=1);
 
 namespace Tests\Controller\Api\V2;
 
-use App\Entity\Activity;
-use App\Entity\Customer;
-use App\Entity\Entry;
-use App\Entity\Project;
-use App\Entity\User;
-use Doctrine\Bundle\DoctrineBundle\Registry;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\AbstractWebTestCase;
+use Tests\Traits\CreatesTestEntries;
 
 use function assert;
 use function is_array;
@@ -32,9 +26,11 @@ use function sprintf;
  */
 final class GetEntrySummaryActionTest extends AbstractWebTestCase
 {
+    use CreatesTestEntries;
+
     public function testOwnEntryReturnsScopesAndEstimate(): void
     {
-        $entryId = $this->createEntryFor('unittest');
+        $entryId = (int) $this->createEntryFor('unittest', description: 'summary test entry')->getId();
 
         $this->client->request(Request::METHOD_GET, sprintf('/api/v2/entries/%d/summary', $entryId));
         $this->assertStatusCode(200);
@@ -58,7 +54,7 @@ final class GetEntrySummaryActionTest extends AbstractWebTestCase
     {
         // Owned by user 'developer' (id 2), requested by the session user
         // 'unittest' (id 1) — must be 404, not a cross-user disclosure (IDOR).
-        $entryId = $this->createEntryFor('developer');
+        $entryId = (int) $this->createEntryFor('developer', description: 'foreign entry')->getId();
 
         $this->client->request(Request::METHOD_GET, sprintf('/api/v2/entries/%d/summary', $entryId));
 
@@ -70,38 +66,5 @@ final class GetEntrySummaryActionTest extends AbstractWebTestCase
         $this->client->request(Request::METHOD_GET, '/api/v2/entries/999999/summary');
 
         $this->assertStatusCode(404);
-    }
-
-    private function createEntryFor(string $username): int
-    {
-        /** @var Registry $doctrine */
-        $doctrine = self::getContainer()->get('doctrine');
-        $entityManager = $doctrine->getManager();
-        assert($entityManager instanceof EntityManagerInterface);
-
-        $owner = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
-        self::assertInstanceOf(User::class, $owner);
-        $project = $entityManager->getRepository(Project::class)->find(1);
-        self::assertInstanceOf(Project::class, $project);
-        $customer = $project->getCustomer();
-        self::assertInstanceOf(Customer::class, $customer);
-        $activity = $entityManager->getRepository(Activity::class)->find(1);
-        self::assertInstanceOf(Activity::class, $activity);
-
-        $entry = new Entry();
-        $entry->setUser($owner)
-            ->setCustomer($customer)
-            ->setProject($project)
-            ->setActivity($activity)
-            ->setTicket('SA-42')
-            ->setDescription('summary test entry')
-            ->setDay('2026-07-06')
-            ->setStart('09:00:00')
-            ->setEnd('10:00:00')
-            ->setDuration(60);
-        $entityManager->persist($entry);
-        $entityManager->flush();
-
-        return (int) $entry->getId();
     }
 }

--- a/tests/Controller/Api/V2/GetEntrySummaryActionTest.php
+++ b/tests/Controller/Api/V2/GetEntrySummaryActionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller\Api\V2;
+
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Entry;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+use function assert;
+use function is_array;
+use function json_decode;
+use function sprintf;
+
+/**
+ * GET /api/v2/entries/{id}/summary (ADR-022): the "Info" popup aggregation,
+ * owner-scoped — a foreign or unknown entry id reads as 404.
+ *
+ * @internal
+ */
+final class GetEntrySummaryActionTest extends AbstractWebTestCase
+{
+    public function testOwnEntryReturnsScopesAndEstimate(): void
+    {
+        $entryId = $this->createEntryFor('unittest');
+
+        $this->client->request(Request::METHOD_GET, sprintf('/api/v2/entries/%d/summary', $entryId));
+        $this->assertStatusCode(200);
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        foreach (['customer', 'project', 'activity', 'ticket'] as $scope) {
+            self::assertArrayHasKey($scope, $data);
+            assert(is_array($data[$scope]));
+            foreach (['scope', 'name', 'entries', 'total', 'own', 'estimation'] as $key) {
+                self::assertArrayHasKey($key, $data[$scope], $scope);
+            }
+        }
+        self::assertArrayHasKey('estimate', $data);
+        assert(is_array($data['estimate']));
+        self::assertArrayHasKey('status', $data['estimate']);
+        self::assertArrayHasKey('warnings', $data);
+    }
+
+    public function testForeignEntryReadsAsNotFound(): void
+    {
+        // Owned by user 'developer' (id 2), requested by the session user
+        // 'unittest' (id 1) — must be 404, not a cross-user disclosure (IDOR).
+        $entryId = $this->createEntryFor('developer');
+
+        $this->client->request(Request::METHOD_GET, sprintf('/api/v2/entries/%d/summary', $entryId));
+
+        $this->assertStatusCode(404);
+    }
+
+    public function testUnknownEntryIsNotFound(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/api/v2/entries/999999/summary');
+
+        $this->assertStatusCode(404);
+    }
+
+    private function createEntryFor(string $username): int
+    {
+        /** @var Registry $doctrine */
+        $doctrine = self::getContainer()->get('doctrine');
+        $entityManager = $doctrine->getManager();
+        assert($entityManager instanceof EntityManagerInterface);
+
+        $owner = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $owner);
+        $project = $entityManager->getRepository(Project::class)->find(1);
+        self::assertInstanceOf(Project::class, $project);
+        $customer = $project->getCustomer();
+        self::assertInstanceOf(Customer::class, $customer);
+        $activity = $entityManager->getRepository(Activity::class)->find(1);
+        self::assertInstanceOf(Activity::class, $activity);
+
+        $entry = new Entry();
+        $entry->setUser($owner)
+            ->setCustomer($customer)
+            ->setProject($project)
+            ->setActivity($activity)
+            ->setTicket('SA-42')
+            ->setDescription('summary test entry')
+            ->setDay('2026-07-06')
+            ->setStart('09:00:00')
+            ->setEnd('10:00:00')
+            ->setDuration(60);
+        $entityManager->persist($entry);
+        $entityManager->flush();
+
+        return (int) $entry->getId();
+    }
+}

--- a/tests/Controller/Api/V2/GetTimeBalanceActionTest.php
+++ b/tests/Controller/Api/V2/GetTimeBalanceActionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller\Api\V2;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Service\ApiToken\ApiTokenService;
+use DateTimeImmutable;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+use function array_values;
+use function assert;
+use function bin2hex;
+use function hash;
+use function is_array;
+use function json_decode;
+use function random_bytes;
+
+/**
+ * GET /api/v2/time-balance (ADR-022): session and PAT access, scope gate,
+ * and the DTO wire shape.
+ *
+ * @internal
+ */
+final class GetTimeBalanceActionTest extends AbstractWebTestCase
+{
+    public function testSessionRequestReturnsBalance(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/api/v2/time-balance');
+        $this->assertStatusCode(200);
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('warnings', $data);
+        foreach (['today', 'week', 'month'] as $period) {
+            self::assertArrayHasKey($period, $data);
+            assert(is_array($data[$period]));
+            foreach (['ist', 'soll_total', 'soll_so_far', 'diff', 'status'] as $key) {
+                self::assertArrayHasKey($key, $data[$period], $period);
+            }
+        }
+    }
+
+    public function testTokenWithReportingReadIsAuthorized(): void
+    {
+        $status = $this->requestWithToken('/api/v2/time-balance', $this->mintToken(['reporting:read']));
+
+        self::assertSame(200, $status);
+    }
+
+    public function testTokenWithoutReportingReadIsForbidden(): void
+    {
+        $status = $this->requestWithToken('/api/v2/time-balance', $this->mintToken(['entries:read']));
+
+        self::assertSame(403, $status);
+    }
+
+    /**
+     * @param list<string> $scopes
+     */
+    private function mintToken(array $scopes): string
+    {
+        /** @var Registry $doctrine */
+        $doctrine = self::getContainer()->get('doctrine');
+        $entityManager = $doctrine->getManager();
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'unittest']);
+        self::assertInstanceOf(User::class, $user);
+
+        $plaintext = ApiTokenService::PREFIX . bin2hex(random_bytes(32));
+        $token = new ApiToken($user, 'test', hash('sha256', $plaintext), array_values($scopes), new DateTimeImmutable(), null, null, null);
+        $entityManager->persist($token);
+        $entityManager->flush();
+
+        return $plaintext;
+    }
+
+    private function requestWithToken(string $path, string $bearer): int
+    {
+        $this->client->request(Request::METHOD_GET, $path, [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json']);
+
+        return $this->client->getResponse()->getStatusCode();
+    }
+}

--- a/tests/Controller/DefaultControllerSummaryTest.php
+++ b/tests/Controller/DefaultControllerSummaryTest.php
@@ -9,13 +9,23 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
+use App\Entity\Activity;
+use App\Entity\Customer;
 use App\Entity\Entry;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Tests\AbstractWebTestCase;
 
 use function assert;
 use function is_array;
+use function json_decode;
 
 /**
+ * POST /getSummary — deprecated v1 endpoint (ADR-022): quota formatting and
+ * the backported owner scoping (a foreign entry id reads as 404).
+ *
  * @internal
  *
  * @coversNothing
@@ -24,24 +34,14 @@ final class DefaultControllerSummaryTest extends AbstractWebTestCase
 {
     public function testGetSummaryActionWithProjectEstimationComputesQuota(): void
     {
-        $container = $this->client->getContainer();
-        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
-        $doctrine = $container->get('doctrine');
-        $em = $doctrine->getManager();
-        $entry = $em->getRepository(Entry::class)->findOneBy([]);
-        if (null === $entry) {
-            self::markTestSkipped('No entries found in the database.');
-        }
-
+        $entry = $this->createEntryFor('unittest');
         $project = $entry->getProject();
         self::assertNotNull($project, 'Project should not be null');
         // Ensure estimation is set to a non-zero value
         $project->setEstimation(300);
+        $this->entityManager()->flush();
 
-        $em->persist($project);
-        $em->flush();
-
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
+        $this->client->request(Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
         $this->assertStatusCode(200);
 
         $response = json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -53,28 +53,20 @@ final class DefaultControllerSummaryTest extends AbstractWebTestCase
         // When estimation is set, quota should be a percentage string
         self::assertIsString($quota);
         self::assertStringEndsWith('%', $quota);
+        // Deprecated endpoint (ADR-022 §5) — consumers see it at call time.
+        self::assertSame('true', $this->client->getResponse()->headers->get('Deprecation'));
     }
 
     public function testGetSummaryActionWithoutEstimationLeavesZeroQuota(): void
     {
-        $container = $this->client->getContainer();
-        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
-        $doctrine = $container->get('doctrine');
-        $em = $doctrine->getManager();
-        $entry = $em->getRepository(Entry::class)->findOneBy([]);
-        if (null === $entry) {
-            self::markTestSkipped('No entries found in the database.');
-        }
-
+        $entry = $this->createEntryFor('unittest');
         $project = $entry->getProject();
         self::assertNotNull($project, 'Project should not be null');
         // Remove estimation (set to 0)
         $project->setEstimation(0);
+        $this->entityManager()->flush();
 
-        $em->persist($project);
-        $em->flush();
-
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
+        $this->client->request(Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
         $this->assertStatusCode(200);
 
         $response = json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -83,5 +75,56 @@ final class DefaultControllerSummaryTest extends AbstractWebTestCase
         assert(is_array($response['project']));
         // Without estimation set, quota remains numeric zero according to default data
         self::assertSame(0, $response['project']['quota'] ?? 0);
+    }
+
+    public function testGetSummaryActionForeignEntryReadsAsNotFound(): void
+    {
+        // Owned by 'developer' (id 2), requested by the session user 'unittest'
+        // (id 1): the ADR-022 §5 backport scopes v1 to the caller's own entries.
+        $entry = $this->createEntryFor('developer');
+
+        $this->client->request(Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
+
+        $this->assertStatusCode(404);
+    }
+
+    private function createEntryFor(string $username): Entry
+    {
+        $entityManager = $this->entityManager();
+
+        $owner = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $owner);
+        $project = $entityManager->getRepository(Project::class)->find(1);
+        self::assertInstanceOf(Project::class, $project);
+        $customer = $project->getCustomer();
+        self::assertInstanceOf(Customer::class, $customer);
+        $activity = $entityManager->getRepository(Activity::class)->find(1);
+        self::assertInstanceOf(Activity::class, $activity);
+
+        $entry = new Entry();
+        $entry->setUser($owner)
+            ->setCustomer($customer)
+            ->setProject($project)
+            ->setActivity($activity)
+            ->setTicket('SA-21')
+            ->setDescription('summary quota test entry')
+            ->setDay('2026-07-06')
+            ->setStart('09:00:00')
+            ->setEnd('10:00:00')
+            ->setDuration(60);
+        $entityManager->persist($entry);
+        $entityManager->flush();
+
+        return $entry;
+    }
+
+    private function entityManager(): EntityManagerInterface
+    {
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
+        $doctrine = $this->client->getContainer()->get('doctrine');
+        $entityManager = $doctrine->getManager();
+        assert($entityManager instanceof EntityManagerInterface);
+
+        return $entityManager;
     }
 }

--- a/tests/Controller/DefaultControllerSummaryTest.php
+++ b/tests/Controller/DefaultControllerSummaryTest.php
@@ -9,17 +9,10 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
-use App\Entity\Activity;
-use App\Entity\Customer;
-use App\Entity\Entry;
-use App\Entity\Project;
-use App\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\AbstractWebTestCase;
+use Tests\Traits\CreatesTestEntries;
 
-use function assert;
-use function is_array;
 use function json_decode;
 
 /**
@@ -32,24 +25,14 @@ use function json_decode;
  */
 final class DefaultControllerSummaryTest extends AbstractWebTestCase
 {
+    use CreatesTestEntries;
+
     public function testGetSummaryActionWithProjectEstimationComputesQuota(): void
     {
-        $entry = $this->createEntryFor('unittest');
-        $project = $entry->getProject();
-        self::assertNotNull($project, 'Project should not be null');
-        // Ensure estimation is set to a non-zero value
-        $project->setEstimation(300);
-        $this->entityManager()->flush();
+        $project = $this->requestOwnProjectSummary(estimation: 300);
 
-        $this->client->request(Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
-        $this->assertStatusCode(200);
-
-        $response = json_decode((string) $this->client->getResponse()->getContent(), true);
-        self::assertIsArray($response);
-        self::assertArrayHasKey('project', $response);
-        assert(is_array($response['project']));
-        self::assertArrayHasKey('quota', $response['project']);
-        $quota = $response['project']['quota'];
+        self::assertArrayHasKey('quota', $project);
+        $quota = $project['quota'];
         // When estimation is set, quota should be a percentage string
         self::assertIsString($quota);
         self::assertStringEndsWith('%', $quota);
@@ -59,22 +42,10 @@ final class DefaultControllerSummaryTest extends AbstractWebTestCase
 
     public function testGetSummaryActionWithoutEstimationLeavesZeroQuota(): void
     {
-        $entry = $this->createEntryFor('unittest');
-        $project = $entry->getProject();
-        self::assertNotNull($project, 'Project should not be null');
-        // Remove estimation (set to 0)
-        $project->setEstimation(0);
-        $this->entityManager()->flush();
+        $project = $this->requestOwnProjectSummary(estimation: 0);
 
-        $this->client->request(Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
-        $this->assertStatusCode(200);
-
-        $response = json_decode((string) $this->client->getResponse()->getContent(), true);
-        self::assertIsArray($response);
-        self::assertArrayHasKey('project', $response);
-        assert(is_array($response['project']));
         // Without estimation set, quota remains numeric zero according to default data
-        self::assertSame(0, $response['project']['quota'] ?? 0);
+        self::assertSame(0, $project['quota'] ?? 0);
     }
 
     public function testGetSummaryActionForeignEntryReadsAsNotFound(): void
@@ -88,43 +59,28 @@ final class DefaultControllerSummaryTest extends AbstractWebTestCase
         $this->assertStatusCode(404);
     }
 
-    private function createEntryFor(string $username): Entry
+    /**
+     * Creates an entry owned by the session user, pins its project estimation,
+     * POSTs /getSummary for it and returns the decoded `project` scope row.
+     *
+     * @return array<mixed>
+     */
+    private function requestOwnProjectSummary(int $estimation): array
     {
-        $entityManager = $this->entityManager();
+        $entry = $this->createEntryFor('unittest', ticket: 'SA-21', description: 'summary quota test entry');
+        $project = $entry->getProject();
+        self::assertNotNull($project, 'Project should not be null');
+        $project->setEstimation($estimation);
+        $this->testEntityManager()->flush();
 
-        $owner = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
-        self::assertInstanceOf(User::class, $owner);
-        $project = $entityManager->getRepository(Project::class)->find(1);
-        self::assertInstanceOf(Project::class, $project);
-        $customer = $project->getCustomer();
-        self::assertInstanceOf(Customer::class, $customer);
-        $activity = $entityManager->getRepository(Activity::class)->find(1);
-        self::assertInstanceOf(Activity::class, $activity);
+        $this->client->request(Request::METHOD_POST, '/getSummary', ['id' => $entry->getId()]);
+        $this->assertStatusCode(200);
 
-        $entry = new Entry();
-        $entry->setUser($owner)
-            ->setCustomer($customer)
-            ->setProject($project)
-            ->setActivity($activity)
-            ->setTicket('SA-21')
-            ->setDescription('summary quota test entry')
-            ->setDay('2026-07-06')
-            ->setStart('09:00:00')
-            ->setEnd('10:00:00')
-            ->setDuration(60);
-        $entityManager->persist($entry);
-        $entityManager->flush();
+        $response = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($response);
+        self::assertArrayHasKey('project', $response);
+        self::assertIsArray($response['project']);
 
-        return $entry;
-    }
-
-    private function entityManager(): EntityManagerInterface
-    {
-        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
-        $doctrine = $this->client->getContainer()->get('doctrine');
-        $entityManager = $doctrine->getManager();
-        assert($entityManager instanceof EntityManagerInterface);
-
-        return $entityManager;
+        return $response['project'];
     }
 }

--- a/tests/Traits/CreatesTestEntries.php
+++ b/tests/Traits/CreatesTestEntries.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Traits;
+
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Entry;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityManagerInterface;
+
+use function assert;
+
+/**
+ * Persists a minimal time entry owned by a named fixture user (project /
+ * customer / activity id 1), for tests that need an entry with a pinned
+ * owner — e.g. owner-scoping (IDOR) and summary assertions.
+ */
+trait CreatesTestEntries
+{
+    protected function createEntryFor(string $username, string $ticket = 'SA-42', string $description = 'test entry'): Entry
+    {
+        $entityManager = $this->testEntityManager();
+
+        $owner = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $owner);
+        $project = $entityManager->getRepository(Project::class)->find(1);
+        self::assertInstanceOf(Project::class, $project);
+        $customer = $project->getCustomer();
+        self::assertInstanceOf(Customer::class, $customer);
+        $activity = $entityManager->getRepository(Activity::class)->find(1);
+        self::assertInstanceOf(Activity::class, $activity);
+
+        $entry = new Entry();
+        $entry->setUser($owner)
+            ->setCustomer($customer)
+            ->setProject($project)
+            ->setActivity($activity)
+            ->setTicket($ticket)
+            ->setDescription($description)
+            ->setDay('2026-07-06')
+            ->setStart('09:00:00')
+            ->setEnd('10:00:00')
+            ->setDuration(60);
+        $entityManager->persist($entry);
+        $entityManager->flush();
+
+        return $entry;
+    }
+
+    protected function testEntityManager(): EntityManagerInterface
+    {
+        /** @var Registry $doctrine */
+        $doctrine = static::getContainer()->get('doctrine');
+        $entityManager = $doctrine->getManager();
+        assert($entityManager instanceof EntityManagerInterface);
+
+        return $entityManager;
+    }
+}


### PR DESCRIPTION
Implements ADR-022 Phase 1 (docs/adr/ADR-022-v2-api-layer-and-response-dtos.md, first commit): a versioned `/api/v2` layer whose responses are typed DTOs, with the SPA migrated onto it and the superseded v1 pair deprecated.

## What changed

**ADR-022** — records the v2 decisions: services as single source of truth; `final readonly` `JsonSerializable` response DTOs; snake_case wire keys adopted verbatim from the shipped MCP tools (so no MCP re-keying); every response a top-level JSON object (#573 rule); `{message}` error shape; 404 for not-owned; deprecation via `Deprecation` header + OpenAPI `deprecated: true`, removal in v7.

**DTO layer** — `TimeBalanceService` → `TimeBalanceDto`/`PeriodBalanceDto` (+ `BalanceStatus` enum), `EntrySummaryService` → `EntrySummaryDto`/`ScopeSummaryDto`/`EstimateDto` (+ `EstimateStatus` enum). The MCP tools serialize the DTOs — wire output byte-identical (existing MCP test assertions prove it).

**v2 endpoints** (session, or PAT with `reporting:read`):
- `GET /api/v2/time-balance` — supersedes `GET /getTimeSummary`
- `GET /api/v2/entries/{id}/summary` — supersedes `POST /getSummary`; owner-scoped, foreign/unknown ids answer 404

**v1 deprecation + security backport** — both v1 endpoints get `#[\Deprecated]`, a `Deprecation: true` + successor `Link` header, and `deprecated: true` in `public/api.yml`. Per ADR-022 §5 the `/getSummary` ownership check is backported: the aggregation spans all users, so a foreign entry id disclosed other users' scope names and totals (IDOR, same class as the MCP-side fix in #570). This is a deliberate behavior change on a deprecated endpoint.

**SPA migration** — `header.ts` consumes `/api/v2/time-balance` (delta now server-computed); Tracking's Alt+I dialog fetches the v2 entry summary as JSON, retiring the form-encoded POST workaround.

**Docs/tests** — OpenAPI v2 paths + `PeriodBalance`/`ScopeSummary` schemas; docs/api.md corrected (the old response examples described fields the endpoints never returned); e2e covers the v2 balance shape and asserts the v1 `Deprecation` header; `DefaultControllerSummaryTest` now creates owner-pinned entries (its `findOneBy([])` lookup made it skip on an empty DB, so the quota assertions never ran).

## Verification

- PHP: PHPStan level 10, cs-check, rector (idempotent), phpat — clean; 2192 tests pass (full suite incl. ldap-dev)
- Frontend: tsc, eslint clean; 418 vitest tests pass
- The 2 reported PHPUnit deprecations are the `#[\Deprecated]` v1 endpoints intentionally exercised by their own tests

Depends conceptually on #578 (the #573 hotfix, ADR-022 Phase 0) — no file conflicts; merge order #578 → this.

Follow-ups (ADR-022 phases 2–3): `GET /api/v2/day` + `get_day` tool + `log_time` day context; admin on/offboarding endpoints + tools.