### PR TITLE
feat(api): day summary — GET /api/v2/day, get_day tool, log_time day context (ADR-022 Phase 2)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -756,6 +756,23 @@ A static OpenAPI 3.0 specification ships at `public/api.yml` (title "Time Tracke
 
 `status` per period: `behind` (IST below the SOLL accrued so far), `over` (IST above the whole period's SOLL), else `ok`.
 
+### GET /api/v2/day
+**Purpose**: The caller's own time entries and booked total for one day (default: today) — the tracking grid's day view as data (ADR-022 Phase 2; also returned by `log_time` as `day` and by the `get_day` MCP tool)
+
+**Authentication**: Session, or Bearer PAT with `entries:read`
+
+**Parameters**: `date` (query, optional): `YYYY-MM-DD`; invalid dates answer `422`
+
+**Response (200 OK)**:
+```json
+{
+  "date": "2026-07-06",
+  "entries": [ { "id": 4711, "date": "06/07/2026", "start": "09:00", "end": "10:00", "duration": 60, "ticket": "SA-11", "...": "..." } ],
+  "count": 1,
+  "total_minutes": 60
+}
+```
+
 ### GET /api/v2/entries/{id}/summary
 **Purpose**: Per-scope booking totals and estimate verdict for one of the caller's own entries (ADR-022; the tracking UI's "Info" popup and the `get_ticket_info` MCP tool)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -767,7 +767,7 @@ A static OpenAPI 3.0 specification ships at `public/api.yml` (title "Time Tracke
 ```json
 {
   "date": "2026-07-06",
-  "entries": [ { "id": 4711, "date": "06/07/2026", "start": "09:00", "end": "10:00", "duration": 60, "ticket": "SA-11", "...": "..." } ],
+  "entries": [ { "id": 4711, "date": "06/07/2026", "start": "09:00", "end": "10:00", "duration": "01:00", "durationMinutes": 60, "ticket": "SA-11", "...": "..." } ],
   "count": 1,
   "total_minutes": 60
 }

--- a/public/api.yml
+++ b/public/api.yml
@@ -687,6 +687,42 @@ paths:
                     items:
                       type: string
 
+  /api/v2/day:
+    get:
+      summary: The caller's own time entries and booked total for one day, default today (ADR-022 Phase 2; requires entries:read for tokens)
+      tags:
+        - Summary
+      parameters:
+        - in: query
+          name: date
+          required: false
+          schema:
+            type: string
+            format: date
+            example: "2026-07-06"
+      responses:
+        '422':
+          description: Invalid date
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  date:
+                    type: string
+                    format: date
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      description: One time entry (same row shape as the tracking grid)
+                  count:
+                    type: integer
+                  total_minutes:
+                    type: integer
+
   /api/v2/entries/{id}/summary:
     get:
       summary: Per-scope booking totals and estimate verdict for one of the caller's own entries (ADR-022; requires reporting:read for tokens). Foreign entries read as 404.

--- a/src/Controller/Api/V2/GetDayAction.php
+++ b/src/Controller/Api/V2/GetDayAction.php
@@ -37,10 +37,10 @@ final readonly class GetDayAction
             return new JsonResponse(['message' => 'Authentication required'], Response::HTTP_UNAUTHORIZED);
         }
 
-        $date = $request->query->get('date');
+        $date = $request->query->getString('date');
 
         try {
-            $summary = $this->daySummaryService->forUser($user, null !== $date ? (string) $date : null);
+            $summary = $this->daySummaryService->forUser($user, '' !== $date ? $date : null);
         } catch (InvalidArgumentException $invalidArgumentException) {
             return new JsonResponse(['message' => $invalidArgumentException->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
         }

--- a/src/Controller/Api/V2/GetDayAction.php
+++ b/src/Controller/Api/V2/GetDayAction.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Entity\User;
+use App\Security\ApiToken\RequireScope;
+use App\Service\DaySummaryService;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * The caller's own bookings for one day (default: today) plus the booked
+ * total — the tracking grid's day view as data (ADR-022 Phase 2).
+ */
+final readonly class GetDayAction
+{
+    public function __construct(private DaySummaryService $daySummaryService)
+    {
+    }
+
+    #[RequireScope('entries:read')]
+    #[Route(path: '/api/v2/day', name: 'api_v2_day', methods: ['GET'])]
+    public function __invoke(Request $request, #[CurrentUser] ?User $user = null): JsonResponse
+    {
+        if (!$user instanceof User) {
+            return new JsonResponse(['message' => 'Authentication required'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $date = $request->query->get('date');
+
+        try {
+            $summary = $this->daySummaryService->forUser($user, null !== $date ? (string) $date : null);
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            return new JsonResponse(['message' => $invalidArgumentException->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return new JsonResponse($summary);
+    }
+}

--- a/src/Dto/Response/DaySummaryDto.php
+++ b/src/Dto/Response/DaySummaryDto.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use JsonSerializable;
+
+use function count;
+
+/**
+ * One day of the caller's own bookings — what the tracking grid shows for the
+ * day (ADR-022 Phase 2): the entries in start order plus the booked total, so
+ * an agent can spot out-of-band bookings without a second call.
+ */
+final readonly class DaySummaryDto implements JsonSerializable
+{
+    /**
+     * @param list<array<string, mixed>> $entries
+     */
+    public function __construct(
+        public string $date,
+        public array $entries,
+        public int $totalMinutes,
+    ) {
+    }
+
+    /**
+     * @return array{date: string, entries: list<array<string, mixed>>, count: int, total_minutes: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'date' => $this->date,
+            'entries' => $this->entries,
+            'count' => count($this->entries),
+            'total_minutes' => $this->totalMinutes,
+        ];
+    }
+}

--- a/src/Mcp/Tool/GetDayTool.php
+++ b/src/Mcp/Tool/GetDayTool.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\ScopeGuard;
+use App\Service\DaySummaryService;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+/**
+ * MCP tool: the caller's own bookings for one day (ADR-022 Phase 2).
+ */
+final readonly class GetDayTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private DaySummaryService $daySummaryService,
+    ) {
+    }
+
+    /**
+     * The authenticated user's own time entries for one day (default: today),
+     * in start order, plus the booked total — the same day list the tracking
+     * UI shows. Use it to check what is already booked before logging time.
+     *
+     * @throws ToolCallException on an invalid date
+     *
+     * @return array<string, mixed>
+     */
+    #[McpTool(name: 'get_day', description: "The authenticated user's own time entries and booked total for one day (default: today).")]
+    public function getDay(
+        #[Schema(description: 'The day as YYYY-MM-DD. Defaults to today.')]
+        ?string $date = null,
+    ): array {
+        $user = $this->scopeGuard->requireScope('entries:read');
+
+        try {
+            return $this->daySummaryService->forUser($user, $date)->jsonSerialize();
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            throw new ToolCallException($invalidArgumentException->getMessage(), $invalidArgumentException->getCode(), previous: $invalidArgumentException);
+        }
+    }
+}

--- a/src/Mcp/Tool/LogTimeTool.php
+++ b/src/Mcp/Tool/LogTimeTool.php
@@ -18,6 +18,7 @@ use App\Mcp\ScopeGuard;
 use App\Repository\ActivityRepository;
 use App\Repository\ProjectRepository;
 use App\Service\ClockInterface;
+use App\Service\DaySummaryService;
 use App\Service\EntrySummaryService;
 use App\Service\TimeBalanceService;
 use Mcp\Capability\Attribute\McpTool;
@@ -58,6 +59,7 @@ final readonly class LogTimeTool
         private ClockInterface $clock,
         private EntrySummaryService $entrySummaryService,
         private TimeBalanceService $timeBalanceService,
+        private DaySummaryService $daySummaryService,
     ) {
     }
 
@@ -120,12 +122,14 @@ final readonly class LogTimeTool
         $result = [] === $body ? ['success' => true] : $body;
 
         // Return the same context the user sees in the UI after a booking: the
-        // ticket's per-scope totals ("Info" popup) and the running time balance,
-        // both carrying any warnings the agent should surface.
+        // ticket's per-scope totals ("Info" popup), the booked day so far (so
+        // out-of-band bookings are visible without a second call), and the
+        // running time balance with any warnings the agent should surface.
         $entryId = $this->createdEntryId($body);
         if (null !== $entryId) {
             $result['ticket_info'] = $this->entrySummaryService->forEntry($entryId, (int) $user->getId())?->jsonSerialize();
         }
+        $result['day'] = $this->daySummaryService->forUser($user, $dto->date)->jsonSerialize();
         $result['balance'] = $this->timeBalanceService->forUser($user)->jsonSerialize();
 
         return $result;

--- a/src/Service/DaySummaryService.php
+++ b/src/Service/DaySummaryService.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Dto\Response\DaySummaryDto;
+use App\Entity\User;
+use App\Repository\EntryRepository;
+use InvalidArgumentException;
+
+use function checkdate;
+use function preg_match;
+use function sprintf;
+
+/**
+ * The caller's own bookings for one day (default: today) — the day list the
+ * tracking UI shows, exposed to GET /api/v2/day, the get_day MCP tool and the
+ * log_time enrichment (ADR-022 Phase 2).
+ */
+final readonly class DaySummaryService
+{
+    public function __construct(
+        private EntryRepository $entryRepository,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @param string|null $date 'Y-m-d'; null for today
+     *
+     * @throws InvalidArgumentException when $date is not a valid Y-m-d date
+     */
+    public function forUser(User $user, ?string $date = null): DaySummaryDto
+    {
+        $day = $date ?? $this->clock->today()->format('Y-m-d');
+        if (1 !== preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $day, $m) || !checkdate((int) $m[2], (int) $m[3], (int) $m[1])) {
+            throw new InvalidArgumentException(sprintf('Invalid date "%s"; use YYYY-MM-DD.', $day));
+        }
+
+        $entries = [];
+        $totalMinutes = 0;
+        foreach ($this->entryRepository->findByDay((int) $user->getId(), $day) as $entry) {
+            $entries[] = $entry->toArray();
+            $totalMinutes += $entry->getDuration();
+        }
+
+        return new DaySummaryDto(date: $day, entries: $entries, totalMinutes: $totalMinutes);
+    }
+}

--- a/tests/Controller/Api/V2/GetDayActionTest.php
+++ b/tests/Controller/Api/V2/GetDayActionTest.php
@@ -9,20 +9,12 @@ declare(strict_types=1);
 
 namespace Tests\Controller\Api\V2;
 
-use App\Entity\ApiToken;
-use App\Entity\User;
-use App\Service\ApiToken\ApiTokenService;
-use DateTimeImmutable;
-use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\AbstractWebTestCase;
 use Tests\Traits\CreatesTestEntries;
+use Tests\Traits\MintsApiTokens;
 
-use function array_values;
-use function bin2hex;
-use function hash;
 use function json_decode;
-use function random_bytes;
 
 /**
  * GET /api/v2/day (ADR-022 Phase 2): the caller's own bookings for one day.
@@ -32,6 +24,7 @@ use function random_bytes;
 final class GetDayActionTest extends AbstractWebTestCase
 {
     use CreatesTestEntries;
+    use MintsApiTokens;
 
     public function testSessionRequestReturnsTheRequestedDay(): void
     {
@@ -82,32 +75,5 @@ final class GetDayActionTest extends AbstractWebTestCase
         $status = $this->requestWithToken('/api/v2/day', $this->mintToken(['reporting:read']));
 
         self::assertSame(403, $status);
-    }
-
-    /**
-     * @param list<string> $scopes
-     */
-    private function mintToken(array $scopes): string
-    {
-        /** @var Registry $doctrine */
-        $doctrine = self::getContainer()->get('doctrine');
-        $entityManager = $doctrine->getManager();
-
-        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'unittest']);
-        self::assertInstanceOf(User::class, $user);
-
-        $plaintext = ApiTokenService::PREFIX . bin2hex(random_bytes(32));
-        $token = new ApiToken($user, 'test', hash('sha256', $plaintext), array_values($scopes), new DateTimeImmutable(), null, null, null);
-        $entityManager->persist($token);
-        $entityManager->flush();
-
-        return $plaintext;
-    }
-
-    private function requestWithToken(string $path, string $bearer): int
-    {
-        $this->client->request(Request::METHOD_GET, $path, [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json']);
-
-        return $this->client->getResponse()->getStatusCode();
     }
 }

--- a/tests/Controller/Api/V2/GetDayActionTest.php
+++ b/tests/Controller/Api/V2/GetDayActionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller\Api\V2;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Service\ApiToken\ApiTokenService;
+use DateTimeImmutable;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+use Tests\Traits\CreatesTestEntries;
+
+use function array_values;
+use function bin2hex;
+use function hash;
+use function json_decode;
+use function random_bytes;
+
+/**
+ * GET /api/v2/day (ADR-022 Phase 2): the caller's own bookings for one day.
+ *
+ * @internal
+ */
+final class GetDayActionTest extends AbstractWebTestCase
+{
+    use CreatesTestEntries;
+
+    public function testSessionRequestReturnsTheRequestedDay(): void
+    {
+        // The trait books 2026-07-06 for the session user.
+        $this->createEntryFor('unittest', ticket: 'SA-11', description: 'day summary entry');
+
+        $this->client->request(Request::METHOD_GET, '/api/v2/day?date=2026-07-06');
+        $this->assertStatusCode(200);
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertSame('2026-07-06', $data['date']);
+        self::assertIsList($data['entries']);
+        self::assertNotEmpty($data['entries']);
+        self::assertSame(60, $data['total_minutes']);
+        self::assertSame(1, $data['count']);
+    }
+
+    public function testForeignEntriesAreNotIncluded(): void
+    {
+        // Another user's booking on the same day must not appear for the caller.
+        $this->createEntryFor('developer', ticket: 'SA-12', description: 'foreign day entry');
+
+        $this->client->request(Request::METHOD_GET, '/api/v2/day?date=2026-07-06');
+        $this->assertStatusCode(200);
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertSame(0, $data['count']);
+    }
+
+    public function testInvalidDateIsRejected(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/api/v2/day?date=not-a-date');
+
+        $this->assertStatusCode(422);
+    }
+
+    public function testTokenWithEntriesReadIsAuthorized(): void
+    {
+        $status = $this->requestWithToken('/api/v2/day', $this->mintToken(['entries:read']));
+
+        self::assertSame(200, $status);
+    }
+
+    public function testTokenWithoutEntriesReadIsForbidden(): void
+    {
+        $status = $this->requestWithToken('/api/v2/day', $this->mintToken(['reporting:read']));
+
+        self::assertSame(403, $status);
+    }
+
+    /**
+     * @param list<string> $scopes
+     */
+    private function mintToken(array $scopes): string
+    {
+        /** @var Registry $doctrine */
+        $doctrine = self::getContainer()->get('doctrine');
+        $entityManager = $doctrine->getManager();
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'unittest']);
+        self::assertInstanceOf(User::class, $user);
+
+        $plaintext = ApiTokenService::PREFIX . bin2hex(random_bytes(32));
+        $token = new ApiToken($user, 'test', hash('sha256', $plaintext), array_values($scopes), new DateTimeImmutable(), null, null, null);
+        $entityManager->persist($token);
+        $entityManager->flush();
+
+        return $plaintext;
+    }
+
+    private function requestWithToken(string $path, string $bearer): int
+    {
+        $this->client->request(Request::METHOD_GET, $path, [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json']);
+
+        return $this->client->getResponse()->getStatusCode();
+    }
+}

--- a/tests/Controller/Api/V2/GetTimeBalanceActionTest.php
+++ b/tests/Controller/Api/V2/GetTimeBalanceActionTest.php
@@ -9,21 +9,13 @@ declare(strict_types=1);
 
 namespace Tests\Controller\Api\V2;
 
-use App\Entity\ApiToken;
-use App\Entity\User;
-use App\Service\ApiToken\ApiTokenService;
-use DateTimeImmutable;
-use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\AbstractWebTestCase;
+use Tests\Traits\MintsApiTokens;
 
-use function array_values;
 use function assert;
-use function bin2hex;
-use function hash;
 use function is_array;
 use function json_decode;
-use function random_bytes;
 
 /**
  * GET /api/v2/time-balance (ADR-022): session and PAT access, scope gate,
@@ -33,6 +25,8 @@ use function random_bytes;
  */
 final class GetTimeBalanceActionTest extends AbstractWebTestCase
 {
+    use MintsApiTokens;
+
     public function testSessionRequestReturnsBalance(): void
     {
         $this->client->request(Request::METHOD_GET, '/api/v2/time-balance');
@@ -62,32 +56,5 @@ final class GetTimeBalanceActionTest extends AbstractWebTestCase
         $status = $this->requestWithToken('/api/v2/time-balance', $this->mintToken(['entries:read']));
 
         self::assertSame(403, $status);
-    }
-
-    /**
-     * @param list<string> $scopes
-     */
-    private function mintToken(array $scopes): string
-    {
-        /** @var Registry $doctrine */
-        $doctrine = self::getContainer()->get('doctrine');
-        $entityManager = $doctrine->getManager();
-
-        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'unittest']);
-        self::assertInstanceOf(User::class, $user);
-
-        $plaintext = ApiTokenService::PREFIX . bin2hex(random_bytes(32));
-        $token = new ApiToken($user, 'test', hash('sha256', $plaintext), array_values($scopes), new DateTimeImmutable(), null, null, null);
-        $entityManager->persist($token);
-        $entityManager->flush();
-
-        return $plaintext;
-    }
-
-    private function requestWithToken(string $path, string $bearer): int
-    {
-        $this->client->request(Request::METHOD_GET, $path, [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json']);
-
-        return $this->client->getResponse()->getStatusCode();
     }
 }

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -14,6 +14,7 @@ use App\Entity\Customer;
 use App\Entity\Entry;
 use App\Entity\User;
 use App\Mcp\Tool\DeleteEntryTool;
+use App\Mcp\Tool\GetDayTool;
 use App\Mcp\Tool\GetTicketInfoTool;
 use App\Mcp\Tool\GetTimeBalanceTool;
 use App\Mcp\Tool\ListActivitiesTool;
@@ -34,6 +35,7 @@ use function array_is_list;
 use function array_keys;
 use function array_values;
 use function basename;
+use function count;
 use function dirname;
 use function glob;
 use function is_string;
@@ -307,7 +309,7 @@ final class McpToolsTest extends AbstractWebTestCase
         self::getContainer()->get(GetTicketInfoTool::class)->getTicketInfo(1);
     }
 
-    public function testLogTimeReturnsTicketInfoAndBalance(): void
+    public function testLogTimeReturnsTicketInfoDayAndBalance(): void
     {
         $this->useToken(['entries:write']);
 
@@ -317,6 +319,41 @@ final class McpToolsTest extends AbstractWebTestCase
         self::assertArrayHasKey('balance', $result);
         self::assertIsArray($result['balance']);
         self::assertArrayHasKey('today', $result['balance']);
+        // The booked day so far — the created entry must be in it.
+        self::assertIsArray($result['day']);
+        self::assertIsList($result['day']['entries']);
+        self::assertGreaterThanOrEqual(45, $result['day']['total_minutes']);
+    }
+
+    public function testGetDayReturnsTheBookedDay(): void
+    {
+        $this->useToken(['entries:read', 'entries:write']);
+        $created = self::getContainer()->get(LogTimeTool::class)->logTime(project: '1', activity: '1', ticket: 'SA-7', durationMinutes: 30);
+        self::assertIsArray($created['result'] ?? null);
+
+        $day = self::getContainer()->get(GetDayTool::class)->getDay();
+
+        self::assertArrayHasKey('date', $day);
+        self::assertIsList($day['entries']);
+        self::assertNotEmpty($day['entries']);
+        self::assertGreaterThanOrEqual(30, $day['total_minutes']);
+        self::assertSame(count($day['entries']), $day['count']);
+    }
+
+    public function testGetDayRejectsAnInvalidDate(): void
+    {
+        $this->useToken(['entries:read']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(GetDayTool::class)->getDay('2026-13-99');
+    }
+
+    public function testGetDayIsDeniedWithoutScope(): void
+    {
+        $this->useToken(['reporting:read']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(GetDayTool::class)->getDay();
     }
 
     /**
@@ -337,6 +374,7 @@ final class McpToolsTest extends AbstractWebTestCase
 
         $results = [
             'delete_entry' => null, // called last — it removes the entry
+            'get_day' => $container->get(GetDayTool::class)->getDay(),
             'get_ticket_info' => $container->get(GetTicketInfoTool::class)->getTicketInfo($entryId),
             'get_time_balance' => $container->get(GetTimeBalanceTool::class)->getTimeBalance(),
             'list_activities' => $container->get(ListActivitiesTool::class)->listActivities(),

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -320,6 +320,7 @@ final class McpToolsTest extends AbstractWebTestCase
         self::assertIsArray($result['balance']);
         self::assertArrayHasKey('today', $result['balance']);
         // The booked day so far — the created entry must be in it.
+        self::assertArrayHasKey('day', $result);
         self::assertIsArray($result['day']);
         self::assertIsList($result['day']['entries']);
         self::assertGreaterThanOrEqual(45, $result['day']['total_minutes']);

--- a/tests/Traits/MintsApiTokens.php
+++ b/tests/Traits/MintsApiTokens.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Traits;
+
+use App\Entity\ApiToken;
+use App\Entity\User;
+use App\Service\ApiToken\ApiTokenService;
+use DateTimeImmutable;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Symfony\Component\HttpFoundation\Request;
+
+use function array_values;
+use function bin2hex;
+use function hash;
+use function random_bytes;
+
+/**
+ * Mints a scoped personal access token for the 'unittest' fixture user and
+ * fires Bearer-authenticated GETs with it — for endpoint scope-gate tests.
+ */
+trait MintsApiTokens
+{
+    /**
+     * @param list<string> $scopes
+     */
+    protected function mintToken(array $scopes): string
+    {
+        /** @var Registry $doctrine */
+        $doctrine = static::getContainer()->get('doctrine');
+        $entityManager = $doctrine->getManager();
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'unittest']);
+        self::assertInstanceOf(User::class, $user);
+
+        $plaintext = ApiTokenService::PREFIX . bin2hex(random_bytes(32));
+        $token = new ApiToken($user, 'test', hash('sha256', $plaintext), array_values($scopes), new DateTimeImmutable(), null, null, null);
+        $entityManager->persist($token);
+        $entityManager->flush();
+
+        return $plaintext;
+    }
+
+    protected function requestWithToken(string $path, string $bearer): int
+    {
+        $this->client->request(Request::METHOD_GET, $path, [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json']);
+
+        return $this->client->getResponse()->getStatusCode();
+    }
+}


### PR DESCRIPTION
ADR-022 Phase 2: the caller's own bookings for one day (default: today) in start order plus the booked total, exposed three ways off one `DaySummaryService`/`DaySummaryDto`:

- **`GET /api/v2/day[?date=YYYY-MM-DD]`** — session or PAT with `entries:read`; invalid dates answer `422 {message}`; response `{date, entries, count, total_minutes}` (entry rows reuse the `list_recent_entries` shape).
- **`get_day` MCP tool** — same shape; lets an agent check what is already booked before logging time.
- **`log_time` enrichment** — the result now also carries `day` (for the booked date), so an agent sees bookings made through the web UI or another client without a second call, alongside the existing `ticket_info` and `balance`.

Backed by the existing `EntryRepository::findByDay` — no query logic reimplemented. Wire format per ADR-022 §4 (top-level object, snake_case).

## Tests

- MCP: day content after a booking, invalid date, scope denial, `log_time` `day` assertion; the every-tool object-shape guard now covers `get_day` (the reflection sweep forced it).
- Controller: session day content, foreign entries excluded, invalid date 422, PAT scope allow/deny.

OpenAPI + docs/api.md updated. Follow-up (ADR-022 Phase 3): admin on/offboarding endpoints + tools.