### PR TITLE
feat(api): admin on/offboarding — v2 write endpoints + MCP admin tools (ADR-022 Phase 3)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -773,6 +773,16 @@ A static OpenAPI 3.0 specification ships at `public/api.yml` (title "Time Tracke
 }
 ```
 
+### Admin onboarding (ADR-022 Phase 3)
+
+**Endpoints**: `POST /api/v2/projects`, `POST /api/v2/customers`, `POST /api/v2/users` (onboard, created active), plus `POST /api/v2/{projects|customers|users}/{id}/activate` and `.../deactivate` (offboard — the record stays, it just stops being bookable / able to log in)
+
+**Authentication**: Admin session, or Bearer PAT of an admin with the matching write scope (`projects:write` / `customers:write` / `users:write`) — both gates apply; a write scope on a non-admin token stays forbidden
+
+**Bodies** (JSON): projects `{name, customer_id, jira_id?, global?}`; customers `{name, global?, team_ids?}` (a non-global customer needs at least one team); users `{username, abbr (≤3 chars), type?, locale?, team_ids}` (at least one team; the account authenticates against the directory — no local password)
+
+**Responses**: `201` with `{project: {...}}` / `{customer: {...}}` / `{user: {...}}`; toggles answer `200` with the same shape; `422 {message}` on validation failure, `404` on unknown id. MCP mirrors: `onboard_project`, `onboard_customer`, `onboard_user`, `set_project_active`, `set_customer_active`, `set_user_active`.
+
 ### GET /api/v2/entries/{id}/summary
 **Purpose**: Per-scope booking totals and estimate verdict for one of the caller's own entries (ADR-022; the tracking UI's "Info" popup and the `get_ticket_info` MCP tool)
 

--- a/public/api.yml
+++ b/public/api.yml
@@ -687,6 +687,250 @@ paths:
                     items:
                       type: string
 
+  /api/v2/projects:
+    post:
+      summary: Onboard a new, active project (ADR-022 Phase 3; admin role required, tokens additionally need projects:write)
+      tags:
+        - Administration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, customer_id]
+              properties:
+                name:
+                  type: string
+                  example: Website relaunch
+                customer_id:
+                  type: integer
+                  example: 1
+                jira_id:
+                  type: string
+                  description: Ticket prefix (capital letters)
+                  example: ABC
+                global:
+                  type: boolean
+                  default: false
+      responses:
+        '422':
+          description: Validation failure
+        '403':
+          description: Not an admin, or the token lacks projects:write
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminProject'
+
+  /api/v2/projects/{id}/activate:
+    post:
+      summary: Activate a project (ADR-022 Phase 3; admin + projects:write)
+      tags:
+        - Administration
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '404':
+          description: No project for id
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminProject'
+
+  /api/v2/projects/{id}/deactivate:
+    post:
+      summary: Deactivate (offboard) a project — no longer bookable, entries stay (ADR-022 Phase 3; admin + projects:write)
+      tags:
+        - Administration
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '404':
+          description: No project for id
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminProject'
+
+  /api/v2/customers:
+    post:
+      summary: Onboard a new, active customer (ADR-022 Phase 3; admin role required, tokens additionally need customers:write)
+      tags:
+        - Administration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  example: ACME GmbH
+                global:
+                  type: boolean
+                  default: false
+                team_ids:
+                  type: array
+                  description: Required unless global
+                  items:
+                    type: integer
+      responses:
+        '422':
+          description: Validation failure
+        '403':
+          description: Not an admin, or the token lacks customers:write
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCustomer'
+
+  /api/v2/customers/{id}/activate:
+    post:
+      summary: Activate a customer (ADR-022 Phase 3; admin + customers:write)
+      tags:
+        - Administration
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '404':
+          description: No customer for id
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCustomer'
+
+  /api/v2/customers/{id}/deactivate:
+    post:
+      summary: Deactivate (offboard) a customer (ADR-022 Phase 3; admin + customers:write)
+      tags:
+        - Administration
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '404':
+          description: No customer for id
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCustomer'
+
+  /api/v2/users:
+    post:
+      summary: Onboard a new, active user account authenticating against the directory (ADR-022 Phase 3; admin role required, tokens additionally need users:write)
+      tags:
+        - Administration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, abbr]
+              properties:
+                username:
+                  type: string
+                  example: jane.doe
+                abbr:
+                  type: string
+                  description: At most 3 characters
+                  example: JDO
+                type:
+                  type: string
+                  enum: [USER, DEV, PL, ADMIN]
+                  default: DEV
+                locale:
+                  type: string
+                  default: de
+                team_ids:
+                  type: array
+                  description: At least one team
+                  items:
+                    type: integer
+      responses:
+        '422':
+          description: Validation failure
+        '403':
+          description: Not an admin, or the token lacks users:write
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUser'
+
+  /api/v2/users/{id}/activate:
+    post:
+      summary: Activate a user account (ADR-022 Phase 3; admin + users:write)
+      tags:
+        - Administration
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '404':
+          description: No user for id
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUser'
+
+  /api/v2/users/{id}/deactivate:
+    post:
+      summary: Deactivate (offboard) a user account — login and tokens stop working, bookings stay (ADR-022 Phase 3; admin + users:write)
+      tags:
+        - Administration
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '404':
+          description: No user for id
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUser'
+
   /api/v2/day:
     get:
       summary: The caller's own time entries and booked total for one day, default today (ADR-022 Phase 2; requires entries:read for tokens)
@@ -2870,6 +3114,66 @@ components:
         status:
           type: string
           enum: [ok, behind, over]
+
+    AdminProject:
+      type: object
+      properties:
+        project:
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+            customer_id:
+              type: integer
+              nullable: true
+            jira_id:
+              type: string
+            active:
+              type: boolean
+            global:
+              type: boolean
+
+    AdminCustomer:
+      type: object
+      properties:
+        customer:
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+            active:
+              type: boolean
+            global:
+              type: boolean
+            team_ids:
+              type: array
+              items:
+                type: integer
+
+    AdminUser:
+      type: object
+      properties:
+        user:
+          type: object
+          properties:
+            id:
+              type: integer
+            username:
+              type: string
+            abbr:
+              type: string
+            type:
+              type: string
+            active:
+              type: boolean
+            team_ids:
+              type: array
+              items:
+                type: integer
 
     ScopeSummary:
       type: object

--- a/public/api.yml
+++ b/public/api.yml
@@ -737,6 +737,8 @@ paths:
           schema:
             type: integer
       responses:
+        '403':
+          description: Not an admin, or the token lacks projects:write
         '404':
           description: No project for id
         '200':
@@ -758,6 +760,8 @@ paths:
           schema:
             type: integer
       responses:
+        '403':
+          description: Not an admin, or the token lacks projects:write
         '404':
           description: No project for id
         '200':
@@ -815,6 +819,8 @@ paths:
           schema:
             type: integer
       responses:
+        '403':
+          description: Not an admin, or the token lacks customers:write
         '404':
           description: No customer for id
         '200':
@@ -836,6 +842,8 @@ paths:
           schema:
             type: integer
       responses:
+        '403':
+          description: Not an admin, or the token lacks customers:write
         '404':
           description: No customer for id
         '200':
@@ -901,6 +909,8 @@ paths:
           schema:
             type: integer
       responses:
+        '403':
+          description: Not an admin, or the token lacks users:write
         '404':
           description: No user for id
         '200':
@@ -922,6 +932,8 @@ paths:
           schema:
             type: integer
       responses:
+        '403':
+          description: Not an admin, or the token lacks users:write
         '404':
           description: No user for id
         '200':

--- a/src/Controller/Api/V2/OnboardCustomerAction.php
+++ b/src/Controller/Api/V2/OnboardCustomerAction.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\CustomerOnboardDto;
+use App\Security\ApiToken\RequireScope;
+use App\Service\AdminOnboardingService;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Onboard a customer (ADR-022 Phase 3). Both gates: admin role AND, for
+ * tokens, the customers:write scope.
+ */
+final readonly class OnboardCustomerAction
+{
+    public function __construct(private AdminOnboardingService $adminOnboardingService)
+    {
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[RequireScope('customers:write')]
+    #[Route(path: '/api/v2/customers', name: 'api_v2_customers_onboard', methods: ['POST'])]
+    public function __invoke(#[MapRequestPayload] CustomerOnboardDto $customerOnboardDto): JsonResponse
+    {
+        try {
+            $customer = $this->adminOnboardingService->onboardCustomer($customerOnboardDto);
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            return new JsonResponse(['message' => $invalidArgumentException->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return new JsonResponse($customer, Response::HTTP_CREATED);
+    }
+}

--- a/src/Controller/Api/V2/OnboardProjectAction.php
+++ b/src/Controller/Api/V2/OnboardProjectAction.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\ProjectOnboardDto;
+use App\Security\ApiToken\RequireScope;
+use App\Service\AdminOnboardingService;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Onboard a project (ADR-022 Phase 3). Both gates: admin role AND, for
+ * tokens, the projects:write scope.
+ */
+final readonly class OnboardProjectAction
+{
+    public function __construct(private AdminOnboardingService $adminOnboardingService)
+    {
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[RequireScope('projects:write')]
+    #[Route(path: '/api/v2/projects', name: 'api_v2_projects_onboard', methods: ['POST'])]
+    public function __invoke(#[MapRequestPayload] ProjectOnboardDto $projectOnboardDto): JsonResponse
+    {
+        try {
+            $project = $this->adminOnboardingService->onboardProject($projectOnboardDto);
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            return new JsonResponse(['message' => $invalidArgumentException->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return new JsonResponse($project, Response::HTTP_CREATED);
+    }
+}

--- a/src/Controller/Api/V2/OnboardUserAction.php
+++ b/src/Controller/Api/V2/OnboardUserAction.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\UserOnboardDto;
+use App\Security\ApiToken\RequireScope;
+use App\Service\AdminOnboardingService;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Onboard a user (ADR-022 Phase 3). Both gates: admin role AND, for tokens,
+ * the users:write scope. The account authenticates against the directory —
+ * no local password is set here (ADR-018).
+ */
+final readonly class OnboardUserAction
+{
+    public function __construct(private AdminOnboardingService $adminOnboardingService)
+    {
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[RequireScope('users:write')]
+    #[Route(path: '/api/v2/users', name: 'api_v2_users_onboard', methods: ['POST'])]
+    public function __invoke(#[MapRequestPayload] UserOnboardDto $userOnboardDto): JsonResponse
+    {
+        try {
+            $user = $this->adminOnboardingService->onboardUser($userOnboardDto);
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            return new JsonResponse(['message' => $invalidArgumentException->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return new JsonResponse($user, Response::HTTP_CREATED);
+    }
+}

--- a/src/Controller/Api/V2/SetCustomerActiveAction.php
+++ b/src/Controller/Api/V2/SetCustomerActiveAction.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\Response\CustomerDto;
+use App\Security\ApiToken\RequireScope;
+use App\Service\AdminOnboardingService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Activate or deactivate (offboard) a customer (ADR-022 Phase 3). Both gates:
+ * admin role AND, for tokens, the customers:write scope.
+ */
+final readonly class SetCustomerActiveAction
+{
+    public function __construct(private AdminOnboardingService $adminOnboardingService)
+    {
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[RequireScope('customers:write')]
+    #[Route(path: '/api/v2/customers/{id}/{action}', name: 'api_v2_customers_active', requirements: ['id' => '\d+', 'action' => 'activate|deactivate'], methods: ['POST'])]
+    public function __invoke(int $id, string $action): JsonResponse
+    {
+        $customer = $this->adminOnboardingService->setCustomerActive($id, 'activate' === $action);
+        if (!$customer instanceof CustomerDto) {
+            return new JsonResponse(['message' => 'No customer for id.'], Response::HTTP_NOT_FOUND);
+        }
+
+        return new JsonResponse($customer);
+    }
+}

--- a/src/Controller/Api/V2/SetProjectActiveAction.php
+++ b/src/Controller/Api/V2/SetProjectActiveAction.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\Response\ProjectDto;
+use App\Security\ApiToken\RequireScope;
+use App\Service\AdminOnboardingService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Activate or deactivate (offboard) a project (ADR-022 Phase 3). Both gates:
+ * admin role AND, for tokens, the projects:write scope.
+ */
+final readonly class SetProjectActiveAction
+{
+    public function __construct(private AdminOnboardingService $adminOnboardingService)
+    {
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[RequireScope('projects:write')]
+    #[Route(path: '/api/v2/projects/{id}/{action}', name: 'api_v2_projects_active', requirements: ['id' => '\d+', 'action' => 'activate|deactivate'], methods: ['POST'])]
+    public function __invoke(int $id, string $action): JsonResponse
+    {
+        $project = $this->adminOnboardingService->setProjectActive($id, 'activate' === $action);
+        if (!$project instanceof ProjectDto) {
+            return new JsonResponse(['message' => 'No project for id.'], Response::HTTP_NOT_FOUND);
+        }
+
+        return new JsonResponse($project);
+    }
+}

--- a/src/Controller/Api/V2/SetUserActiveAction.php
+++ b/src/Controller/Api/V2/SetUserActiveAction.php
@@ -10,11 +10,13 @@ declare(strict_types=1);
 namespace App\Controller\Api\V2;
 
 use App\Dto\Response\UserDto;
+use App\Entity\User;
 use App\Security\ApiToken\RequireScope;
 use App\Service\AdminOnboardingService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
@@ -31,8 +33,13 @@ final readonly class SetUserActiveAction
     #[IsGranted('ROLE_ADMIN')]
     #[RequireScope('users:write')]
     #[Route(path: '/api/v2/users/{id}/{action}', name: 'api_v2_users_active', requirements: ['id' => '\d+', 'action' => 'activate|deactivate'], methods: ['POST'])]
-    public function __invoke(int $id, string $action): JsonResponse
+    public function __invoke(int $id, string $action, #[CurrentUser] ?User $actingUser = null): JsonResponse
     {
+        // Lockout guard: an admin must not deactivate their own account.
+        if ('deactivate' === $action && $actingUser instanceof User && $id === (int) $actingUser->getId()) {
+            return new JsonResponse(['message' => 'You cannot deactivate your own account.'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
         $user = $this->adminOnboardingService->setUserActive($id, 'activate' === $action);
         if (!$user instanceof UserDto) {
             return new JsonResponse(['message' => 'No user for id.'], Response::HTTP_NOT_FOUND);

--- a/src/Controller/Api/V2/SetUserActiveAction.php
+++ b/src/Controller/Api/V2/SetUserActiveAction.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\Response\UserDto;
+use App\Security\ApiToken\RequireScope;
+use App\Service\AdminOnboardingService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Activate or deactivate (offboard) a user (ADR-022 Phase 3). Deactivation is
+ * the offboarding: UserChecker refuses logins and token use for inactive
+ * accounts. Both gates: admin role AND, for tokens, the users:write scope.
+ */
+final readonly class SetUserActiveAction
+{
+    public function __construct(private AdminOnboardingService $adminOnboardingService)
+    {
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[RequireScope('users:write')]
+    #[Route(path: '/api/v2/users/{id}/{action}', name: 'api_v2_users_active', requirements: ['id' => '\d+', 'action' => 'activate|deactivate'], methods: ['POST'])]
+    public function __invoke(int $id, string $action): JsonResponse
+    {
+        $user = $this->adminOnboardingService->setUserActive($id, 'activate' === $action);
+        if (!$user instanceof UserDto) {
+            return new JsonResponse(['message' => 'No user for id.'], Response::HTTP_NOT_FOUND);
+        }
+
+        return new JsonResponse($user);
+    }
+}

--- a/src/Dto/CustomerOnboardDto.php
+++ b/src/Dto/CustomerOnboardDto.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Request body of POST /api/v2/customers (ADR-022 Phase 3). A non-global
+ * customer needs at least one team to be visible — enforced downstream by
+ * SaveCustomerAction.
+ *
+ * @property list<int> $team_ids
+ */
+final readonly class CustomerOnboardDto
+{
+    /**
+     * @param list<int> $team_ids
+     */
+    public function __construct(
+        #[Assert\NotBlank(message: 'Please provide a customer name.')]
+        public string $name = '',
+        public bool $global = false,
+        #[Assert\All([new Assert\Type('integer'), new Assert\Positive()])]
+        public array $team_ids = [],
+    ) {
+    }
+}

--- a/src/Dto/ProjectOnboardDto.php
+++ b/src/Dto/ProjectOnboardDto.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Request body of POST /api/v2/projects (ADR-022 Phase 3) — the minimal
+ * onboarding surface; detailed configuration stays in the admin UI. Deep
+ * validation (ticket-prefix format, customer existence) runs on the mapped
+ * ProjectSaveDto in AdminOnboardingService.
+ */
+final readonly class ProjectOnboardDto
+{
+    public function __construct(
+        #[Assert\NotBlank(message: 'Please provide a project name.')]
+        public string $name = '',
+        #[Assert\Positive(message: 'Please choose a customer.')]
+        public int $customer_id = 0,
+        public string $jira_id = '',
+        public bool $global = false,
+    ) {
+    }
+}

--- a/src/Dto/Response/CustomerDto.php
+++ b/src/Dto/Response/CustomerDto.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use App\Entity\Customer;
+use App\Entity\Team;
+use JsonSerializable;
+
+/**
+ * A customer as the v2 admin endpoints and MCP admin tools return it
+ * (ADR-022 Phase 3).
+ */
+final readonly class CustomerDto implements JsonSerializable
+{
+    /**
+     * @param list<int> $teamIds
+     */
+    public function __construct(
+        public int $id,
+        public string $name,
+        public bool $active,
+        public bool $global,
+        public array $teamIds,
+    ) {
+    }
+
+    public static function fromEntity(Customer $customer): self
+    {
+        $teamIds = [];
+        foreach ($customer->getTeams() as $team) {
+            if ($team instanceof Team) {
+                $teamIds[] = (int) $team->getId();
+            }
+        }
+
+        return new self(
+            id: (int) $customer->getId(),
+            name: (string) $customer->getName(),
+            active: (bool) $customer->getActive(),
+            global: (bool) $customer->getGlobal(),
+            teamIds: $teamIds,
+        );
+    }
+
+    /**
+     * @return array{customer: array{id: int, name: string, active: bool, global: bool, team_ids: list<int>}}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'customer' => [
+                'id' => $this->id,
+                'name' => $this->name,
+                'active' => $this->active,
+                'global' => $this->global,
+                'team_ids' => $this->teamIds,
+            ],
+        ];
+    }
+}

--- a/src/Dto/Response/ProjectDto.php
+++ b/src/Dto/Response/ProjectDto.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use App\Entity\Project;
+use JsonSerializable;
+
+/**
+ * A project as the v2 admin endpoints and MCP admin tools return it
+ * (ADR-022 Phase 3).
+ */
+final readonly class ProjectDto implements JsonSerializable
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public ?int $customerId,
+        public string $jiraId,
+        public bool $active,
+        public bool $global,
+    ) {
+    }
+
+    public static function fromEntity(Project $project): self
+    {
+        return new self(
+            id: (int) $project->getId(),
+            name: $project->getName(),
+            customerId: $project->getCustomer()?->getId(),
+            jiraId: (string) $project->getJiraId(),
+            active: $project->getActive(),
+            global: $project->getGlobal(),
+        );
+    }
+
+    /**
+     * @return array{project: array{id: int, name: string, customer_id: int|null, jira_id: string, active: bool, global: bool}}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'project' => [
+                'id' => $this->id,
+                'name' => $this->name,
+                'customer_id' => $this->customerId,
+                'jira_id' => $this->jiraId,
+                'active' => $this->active,
+                'global' => $this->global,
+            ],
+        ];
+    }
+}

--- a/src/Dto/Response/UserDto.php
+++ b/src/Dto/Response/UserDto.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto\Response;
+
+use App\Entity\Team;
+use App\Entity\User;
+use JsonSerializable;
+
+/**
+ * A user as the v2 admin endpoints and MCP admin tools return it
+ * (ADR-022 Phase 3).
+ */
+final readonly class UserDto implements JsonSerializable
+{
+    /**
+     * @param list<int> $teamIds
+     */
+    public function __construct(
+        public int $id,
+        public string $username,
+        public string $abbr,
+        public string $type,
+        public bool $active,
+        public array $teamIds,
+    ) {
+    }
+
+    public static function fromEntity(User $user): self
+    {
+        $teamIds = [];
+        foreach ($user->getTeams() as $team) {
+            if ($team instanceof Team) {
+                $teamIds[] = (int) $team->getId();
+            }
+        }
+
+        return new self(
+            id: (int) $user->getId(),
+            username: (string) $user->getUsername(),
+            abbr: (string) $user->getAbbr(),
+            type: $user->getType()->value,
+            active: $user->getActive(),
+            teamIds: $teamIds,
+        );
+    }
+
+    /**
+     * @return array{user: array{id: int, username: string, abbr: string, type: string, active: bool, team_ids: list<int>}}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'user' => [
+                'id' => $this->id,
+                'username' => $this->username,
+                'abbr' => $this->abbr,
+                'type' => $this->type,
+                'active' => $this->active,
+                'team_ids' => $this->teamIds,
+            ],
+        ];
+    }
+}

--- a/src/Dto/UserOnboardDto.php
+++ b/src/Dto/UserOnboardDto.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Request body of POST /api/v2/users (ADR-022 Phase 3). Uniqueness and
+ * abbreviation rules run on the mapped UserSaveDto in AdminOnboardingService.
+ * Auth source is the directory by default (no local password on onboarding).
+ *
+ * @property list<int> $team_ids
+ */
+final readonly class UserOnboardDto
+{
+    /**
+     * @param list<int> $team_ids
+     */
+    public function __construct(
+        #[Assert\NotBlank(message: 'Please provide a valid user name with at least 3 letters.')]
+        public string $username = '',
+        #[Assert\NotBlank(message: 'Please provide a user abbreviation.')]
+        public string $abbr = '',
+        #[Assert\Choice(choices: ['USER', 'DEV', 'PL', 'ADMIN'], message: 'Invalid user type.')]
+        public string $type = 'DEV',
+        public string $locale = 'de',
+        #[Assert\All([new Assert\Type('integer'), new Assert\Positive()])]
+        public array $team_ids = [],
+    ) {
+    }
+}

--- a/src/Mcp/AdminEntityResolver.php
+++ b/src/Mcp/AdminEntityResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp;
+
+use App\Entity\Customer;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+use Mcp\Exception\ToolCallException;
+
+use function ctype_digit;
+use function sprintf;
+use function trim;
+
+/**
+ * Resolves the admin tools' name-or-id inputs to entities (ADR-022 Phase 3) —
+ * a coding agent knows names ("ACME", "jane.doe"), not the SPA's numeric ids.
+ */
+final readonly class AdminEntityResolver
+{
+    public function __construct(private ManagerRegistry $managerRegistry)
+    {
+    }
+
+    /**
+     * @throws ToolCallException when the project cannot be resolved
+     */
+    public function project(string $input): Project
+    {
+        $project = $this->find(Project::class, $input, 'name');
+        if (!$project instanceof Project) {
+            throw new ToolCallException(sprintf('Unknown project "%s" — use list_projects to see valid names/ids.', trim($input)));
+        }
+
+        return $project;
+    }
+
+    /**
+     * @throws ToolCallException when the customer cannot be resolved
+     */
+    public function customer(string $input): Customer
+    {
+        $customer = $this->find(Customer::class, $input, 'name');
+        if (!$customer instanceof Customer) {
+            throw new ToolCallException(sprintf('Unknown customer "%s".', trim($input)));
+        }
+
+        return $customer;
+    }
+
+    /**
+     * @throws ToolCallException when the user cannot be resolved
+     */
+    public function user(string $input): User
+    {
+        $user = $this->find(User::class, $input, 'username');
+        if (!$user instanceof User) {
+            throw new ToolCallException(sprintf('Unknown user "%s".', trim($input)));
+        }
+
+        return $user;
+    }
+
+    /**
+     * @param class-string $entityClass
+     */
+    private function find(string $entityClass, string $input, string $nameField): ?object
+    {
+        $input = trim($input);
+        $repository = $this->managerRegistry->getRepository($entityClass);
+
+        return ctype_digit($input)
+            ? $repository->find((int) $input)
+            : $repository->findOneBy([$nameField => $input]);
+    }
+}

--- a/src/Mcp/ScopeGuard.php
+++ b/src/Mcp/ScopeGuard.php
@@ -15,6 +15,7 @@ use App\ValueObject\ApiScope;
 use Mcp\Exception\ToolCallException;
 use Symfony\Bundle\SecurityBundle\Security;
 
+use function in_array;
 use function sprintf;
 
 /**
@@ -50,6 +51,26 @@ final readonly class ScopeGuard
         $user = $token->getUser();
         if (!$user instanceof User) {
             throw new ToolCallException('No authenticated user for this token.');
+        }
+
+        return $user;
+    }
+
+    /**
+     * Both gates for admin tools (ADR-022 Phase 3): the token must grant the
+     * scope AND the owning user must hold ROLE_ADMIN — mirroring the
+     * #[IsGranted('ROLE_ADMIN')] + #[RequireScope] pair on the v2 endpoints.
+     * A scope can narrow but never expand what the user may do.
+     *
+     * @throws ToolCallException if not PAT-authenticated, the scope is missing,
+     *                           or the user is not an admin
+     */
+    public function requireAdminScope(string $scope): User
+    {
+        $user = $this->requireScope($scope);
+
+        if (!in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+            throw new ToolCallException('This tool requires an administrator account.');
         }
 
         return $user;

--- a/src/Mcp/ScopeGuard.php
+++ b/src/Mcp/ScopeGuard.php
@@ -14,6 +14,7 @@ use App\Security\ApiToken\ApiAccessToken;
 use App\ValueObject\ApiScope;
 use Mcp\Exception\ToolCallException;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 use function in_array;
 use function sprintf;
@@ -29,8 +30,10 @@ use function sprintf;
  */
 final readonly class ScopeGuard
 {
-    public function __construct(private Security $security)
-    {
+    public function __construct(
+        private Security $security,
+        private RoleHierarchyInterface $roleHierarchy,
+    ) {
     }
 
     /**
@@ -69,7 +72,12 @@ final readonly class ScopeGuard
     {
         $user = $this->requireScope($scope);
 
-        if (!in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+        // Vote on the TOKEN's roles expanded through the role hierarchy (e.g.
+        // ROLE_SUPER_ADMIN => ROLE_ADMIN) — the same input and semantics as the
+        // #[IsGranted('ROLE_ADMIN')] check on the v2 endpoints.
+        $token = $this->security->getToken();
+        $roles = $token instanceof ApiAccessToken ? $token->getRoleNames() : [];
+        if (!in_array('ROLE_ADMIN', $this->roleHierarchy->getReachableRoleNames($roles), true)) {
             throw new ToolCallException('This tool requires an administrator account.');
         }
 

--- a/src/Mcp/Tool/OnboardCustomerTool.php
+++ b/src/Mcp/Tool/OnboardCustomerTool.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Dto\CustomerOnboardDto;
+use App\Mcp\ScopeGuard;
+use App\Service\AdminOnboardingService;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+use function array_map;
+use function array_values;
+
+/**
+ * MCP admin tool: onboard a customer (ADR-022 Phase 3).
+ */
+final readonly class OnboardCustomerTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private AdminOnboardingService $adminOnboardingService,
+    ) {
+    }
+
+    /**
+     * Create (onboard) a new, active customer. A non-global customer needs at
+     * least one team to be visible. Requires an administrator account and the
+     * customers:write scope.
+     *
+     * @param list<int> $teamIds
+     *
+     * @throws ToolCallException on a validation failure
+     *
+     * @return array<string, mixed> the created customer
+     */
+    #[McpTool(name: 'onboard_customer', description: 'Onboard a new customer (admin only).')]
+    public function onboardCustomer(
+        #[Schema(description: 'Customer name (at least 3 characters).')]
+        string $name,
+        #[Schema(description: 'Whether the customer is bookable by every team.')]
+        bool $global = false,
+        #[Schema(description: 'Team ids granting visibility; required unless global.')]
+        array $teamIds = [],
+    ): array {
+        $this->scopeGuard->requireAdminScope('customers:write');
+
+        try {
+            return $this->adminOnboardingService->onboardCustomer(new CustomerOnboardDto(
+                name: $name,
+                global: $global,
+                team_ids: array_values(array_map(intval(...), $teamIds)),
+            ))->jsonSerialize();
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            throw new ToolCallException($invalidArgumentException->getMessage(), $invalidArgumentException->getCode(), previous: $invalidArgumentException);
+        }
+    }
+}

--- a/src/Mcp/Tool/OnboardProjectTool.php
+++ b/src/Mcp/Tool/OnboardProjectTool.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Dto\ProjectOnboardDto;
+use App\Mcp\AdminEntityResolver;
+use App\Mcp\ScopeGuard;
+use App\Service\AdminOnboardingService;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+/**
+ * MCP admin tool: onboard a project (ADR-022 Phase 3).
+ */
+final readonly class OnboardProjectTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private AdminEntityResolver $adminEntityResolver,
+        private AdminOnboardingService $adminOnboardingService,
+    ) {
+    }
+
+    /**
+     * Create (onboard) a new, active project for a customer. Requires an
+     * administrator account and the projects:write scope.
+     *
+     * @throws ToolCallException on unknown customer or a validation failure
+     *
+     * @return array<string, mixed> the created project
+     */
+    #[McpTool(name: 'onboard_project', description: 'Onboard a new project for a customer (admin only).')]
+    public function onboardProject(
+        #[Schema(description: 'Project name (at least 3 characters).')]
+        string $name,
+        #[Schema(description: 'Customer name or numeric id the project belongs to.')]
+        string $customer,
+        #[Schema(description: 'Ticket prefix (capital letters, e.g. "ABC"). Empty if none.')]
+        string $ticketPrefix = '',
+        #[Schema(description: 'Whether the project is bookable by every team.')]
+        bool $global = false,
+    ): array {
+        $this->scopeGuard->requireAdminScope('projects:write');
+
+        $customerEntity = $this->adminEntityResolver->customer($customer);
+
+        try {
+            return $this->adminOnboardingService->onboardProject(new ProjectOnboardDto(
+                name: $name,
+                customer_id: (int) $customerEntity->getId(),
+                jira_id: $ticketPrefix,
+                global: $global,
+            ))->jsonSerialize();
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            throw new ToolCallException($invalidArgumentException->getMessage(), $invalidArgumentException->getCode(), previous: $invalidArgumentException);
+        }
+    }
+}

--- a/src/Mcp/Tool/OnboardUserTool.php
+++ b/src/Mcp/Tool/OnboardUserTool.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Dto\UserOnboardDto;
+use App\Mcp\ScopeGuard;
+use App\Service\AdminOnboardingService;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+use function array_map;
+use function array_values;
+
+/**
+ * MCP admin tool: onboard a user (ADR-022 Phase 3).
+ */
+final readonly class OnboardUserTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private AdminOnboardingService $adminOnboardingService,
+    ) {
+    }
+
+    /**
+     * Create (onboard) a new, active user account. The account authenticates
+     * against the directory (no local password is set). Every user needs at
+     * least one team. Requires an administrator account and the users:write
+     * scope.
+     *
+     * @param list<int> $teamIds
+     *
+     * @throws ToolCallException on a validation failure
+     *
+     * @return array<string, mixed> the created user
+     */
+    #[McpTool(name: 'onboard_user', description: 'Onboard a new user account (admin only).')]
+    public function onboardUser(
+        #[Schema(description: 'Login name (at least 3 characters), e.g. "jane.doe".')]
+        string $username,
+        #[Schema(description: 'Short abbreviation shown in listings, e.g. "JDO".')]
+        string $abbr,
+        #[Schema(description: 'User type.', enum: ['USER', 'DEV', 'PL', 'ADMIN'])]
+        string $type = 'DEV',
+        #[Schema(description: 'UI locale.', enum: ['de', 'en', 'es', 'fr', 'ru'])]
+        string $locale = 'de',
+        #[Schema(description: 'Team ids the user belongs to (at least one).')]
+        array $teamIds = [],
+    ): array {
+        $this->scopeGuard->requireAdminScope('users:write');
+
+        try {
+            return $this->adminOnboardingService->onboardUser(new UserOnboardDto(
+                username: $username,
+                abbr: $abbr,
+                type: $type,
+                locale: $locale,
+                team_ids: array_values(array_map(intval(...), $teamIds)),
+            ))->jsonSerialize();
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            throw new ToolCallException($invalidArgumentException->getMessage(), $invalidArgumentException->getCode(), previous: $invalidArgumentException);
+        }
+    }
+}

--- a/src/Mcp/Tool/SetCustomerActiveTool.php
+++ b/src/Mcp/Tool/SetCustomerActiveTool.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Dto\Response\CustomerDto;
+use App\Mcp\AdminEntityResolver;
+use App\Mcp\ScopeGuard;
+use App\Service\AdminOnboardingService;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+/**
+ * MCP admin tool: activate or offboard (deactivate) a customer (ADR-022
+ * Phase 3).
+ */
+final readonly class SetCustomerActiveTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private AdminEntityResolver $adminEntityResolver,
+        private AdminOnboardingService $adminOnboardingService,
+    ) {
+    }
+
+    /**
+     * Activate or deactivate (offboard) a customer. A deactivated customer is
+     * no longer bookable; its projects and entries stay. Requires an
+     * administrator account and the customers:write scope.
+     *
+     * @throws ToolCallException on an unknown customer
+     *
+     * @return array<string, mixed> the updated customer
+     */
+    #[McpTool(name: 'set_customer_active', description: 'Activate or deactivate (offboard) a customer (admin only).')]
+    public function setCustomerActive(
+        #[Schema(description: 'Customer name or numeric id.')]
+        string $customer,
+        #[Schema(description: 'true to activate, false to offboard.')]
+        bool $active,
+    ): array {
+        $this->scopeGuard->requireAdminScope('customers:write');
+
+        $entity = $this->adminEntityResolver->customer($customer);
+        $dto = $this->adminOnboardingService->setCustomerActive((int) $entity->getId(), $active);
+        if (!$dto instanceof CustomerDto) {
+            throw new ToolCallException('The customer could not be updated.');
+        }
+
+        return $dto->jsonSerialize();
+    }
+}

--- a/src/Mcp/Tool/SetProjectActiveTool.php
+++ b/src/Mcp/Tool/SetProjectActiveTool.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Dto\Response\ProjectDto;
+use App\Mcp\AdminEntityResolver;
+use App\Mcp\ScopeGuard;
+use App\Service\AdminOnboardingService;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+/**
+ * MCP admin tool: activate or offboard (deactivate) a project (ADR-022
+ * Phase 3).
+ */
+final readonly class SetProjectActiveTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private AdminEntityResolver $adminEntityResolver,
+        private AdminOnboardingService $adminOnboardingService,
+    ) {
+    }
+
+    /**
+     * Activate or deactivate (offboard) a project. A deactivated project is no
+     * longer bookable; its entries stay. Requires an administrator account and
+     * the projects:write scope.
+     *
+     * @throws ToolCallException on an unknown project
+     *
+     * @return array<string, mixed> the updated project
+     */
+    #[McpTool(name: 'set_project_active', description: 'Activate or deactivate (offboard) a project (admin only).')]
+    public function setProjectActive(
+        #[Schema(description: 'Project name or numeric id.')]
+        string $project,
+        #[Schema(description: 'true to activate, false to offboard.')]
+        bool $active,
+    ): array {
+        $this->scopeGuard->requireAdminScope('projects:write');
+
+        $entity = $this->adminEntityResolver->project($project);
+        $dto = $this->adminOnboardingService->setProjectActive((int) $entity->getId(), $active);
+        if (!$dto instanceof ProjectDto) {
+            throw new ToolCallException('The project could not be updated.');
+        }
+
+        return $dto->jsonSerialize();
+    }
+}

--- a/src/Mcp/Tool/SetUserActiveTool.php
+++ b/src/Mcp/Tool/SetUserActiveTool.php
@@ -45,9 +45,13 @@ final readonly class SetUserActiveTool
         #[Schema(description: 'true to activate, false to offboard.')]
         bool $active,
     ): array {
-        $this->scopeGuard->requireAdminScope('users:write');
+        $actingUser = $this->scopeGuard->requireAdminScope('users:write');
 
         $entity = $this->adminEntityResolver->user($user);
+        // Lockout guard: an admin must not deactivate their own account.
+        if (!$active && $entity->getId() === $actingUser->getId()) {
+            throw new ToolCallException('You cannot deactivate your own account.');
+        }
         $dto = $this->adminOnboardingService->setUserActive((int) $entity->getId(), $active);
         if (!$dto instanceof UserDto) {
             throw new ToolCallException('The user could not be updated.');

--- a/src/Mcp/Tool/SetUserActiveTool.php
+++ b/src/Mcp/Tool/SetUserActiveTool.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Dto\Response\UserDto;
+use App\Mcp\AdminEntityResolver;
+use App\Mcp\ScopeGuard;
+use App\Service\AdminOnboardingService;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+/**
+ * MCP admin tool: activate or offboard (deactivate) a user (ADR-022 Phase 3).
+ */
+final readonly class SetUserActiveTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private AdminEntityResolver $adminEntityResolver,
+        private AdminOnboardingService $adminOnboardingService,
+    ) {
+    }
+
+    /**
+     * Activate or deactivate (offboard) a user account. A deactivated account
+     * cannot log in and its tokens stop working; its bookings stay. Requires
+     * an administrator account and the users:write scope.
+     *
+     * @throws ToolCallException on an unknown user
+     *
+     * @return array<string, mixed> the updated user
+     */
+    #[McpTool(name: 'set_user_active', description: 'Activate or deactivate (offboard) a user account (admin only).')]
+    public function setUserActive(
+        #[Schema(description: 'Username or numeric id.')]
+        string $user,
+        #[Schema(description: 'true to activate, false to offboard.')]
+        bool $active,
+    ): array {
+        $this->scopeGuard->requireAdminScope('users:write');
+
+        $entity = $this->adminEntityResolver->user($user);
+        $dto = $this->adminOnboardingService->setUserActive((int) $entity->getId(), $active);
+        if (!$dto instanceof UserDto) {
+            throw new ToolCallException('The user could not be updated.');
+        }
+
+        return $dto->jsonSerialize();
+    }
+}

--- a/src/Service/AdminOnboardingService.php
+++ b/src/Service/AdminOnboardingService.php
@@ -23,12 +23,12 @@ use App\Entity\Project;
 use App\Entity\Team;
 use App\Entity\User;
 use App\Enum\UserType;
-use App\Repository\ProjectRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-use function assert;
+use function array_unique;
+use function array_values;
 use function count;
 use function implode;
 use function sprintf;
@@ -76,14 +76,6 @@ final readonly class AdminOnboardingService
             throw new InvalidArgumentException('Please choose a customer.');
         }
 
-        if ('' !== $jiraId) {
-            $projectRepository = $this->managerRegistry->getRepository(Project::class);
-            assert($projectRepository instanceof ProjectRepository);
-            if (0 === $projectRepository->isValidJiraPrefix($jiraId)) {
-                throw new InvalidArgumentException('Please provide a valid ticket prefix with only capital letters.');
-            }
-        }
-
         $project = new Project();
         $project->setName(trim($projectOnboardDto->name))
             ->setCustomer($customer)
@@ -110,10 +102,6 @@ final readonly class AdminOnboardingService
             global: $customerOnboardDto->global,
             teams: $customerOnboardDto->team_ids,
         ));
-
-        if (!$customerOnboardDto->global && [] === $customerOnboardDto->team_ids) {
-            throw new InvalidArgumentException('Every customer must belong to at least one team if it is not global.');
-        }
 
         $customer = new Customer();
         $customer->setName(trim($customerOnboardDto->name))
@@ -227,6 +215,7 @@ final readonly class AdminOnboardingService
      */
     private function resolveTeams(array $teamIds): array
     {
+        $teamIds = array_values(array_unique($teamIds));
         if ([] === $teamIds) {
             return [];
         }

--- a/src/Service/AdminOnboardingService.php
+++ b/src/Service/AdminOnboardingService.php
@@ -27,6 +27,8 @@ use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
+use function array_diff;
+use function array_map;
 use function array_unique;
 use function array_values;
 use function count;
@@ -223,7 +225,10 @@ final readonly class AdminOnboardingService
         /** @var list<Team> $teams */
         $teams = $this->managerRegistry->getRepository(Team::class)->findBy(['id' => $teamIds]);
         if (count($teams) !== count($teamIds)) {
-            throw new InvalidArgumentException(sprintf('Could not find team(s) with ID(s): %s.', implode(', ', $teamIds)));
+            $foundIds = array_map(static fn (Team $team): int => (int) $team->getId(), $teams);
+            $missing = array_diff($teamIds, $foundIds);
+
+            throw new InvalidArgumentException(sprintf('Could not find team(s) with ID(s): %s.', implode(', ', $missing)));
         }
 
         return $teams;

--- a/src/Service/AdminOnboardingService.php
+++ b/src/Service/AdminOnboardingService.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Dto\CustomerOnboardDto;
+use App\Dto\CustomerSaveDto;
+use App\Dto\ProjectOnboardDto;
+use App\Dto\ProjectSaveDto;
+use App\Dto\Response\CustomerDto;
+use App\Dto\Response\ProjectDto;
+use App\Dto\Response\UserDto;
+use App\Dto\UserOnboardDto;
+use App\Dto\UserSaveDto;
+use App\Entity\Customer;
+use App\Entity\Project;
+use App\Entity\Team;
+use App\Entity\User;
+use App\Enum\UserType;
+use App\Repository\ProjectRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use InvalidArgumentException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+use function assert;
+use function count;
+use function implode;
+use function sprintf;
+use function strtoupper;
+use function trim;
+
+/**
+ * Onboarding and offboarding of projects, customers and users (ADR-022
+ * Phase 3) — one implementation behind the v2 admin endpoints and the MCP
+ * admin tools.
+ *
+ * Creation is validated through the v1 *SaveDto constraint sets (unique
+ * names, abbreviation format, team rules) — run explicitly, because
+ * #[MapRequestPayload] validation only fires during argument resolution.
+ * The entities are then built directly for the minimal onboarding surface;
+ * the v1 Save*Action controllers keep owning the admin UI's full-featured
+ * saves (services must not depend on controllers — architecture rule).
+ * Offboarding toggles the active flag — records are never hard-deleted
+ * (bookings reference them).
+ */
+final readonly class AdminOnboardingService
+{
+    public function __construct(
+        private ManagerRegistry $managerRegistry,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException on a validation failure
+     */
+    public function onboardProject(ProjectOnboardDto $projectOnboardDto): ProjectDto
+    {
+        $jiraId = strtoupper(trim($projectOnboardDto->jira_id));
+        $this->assertValid(new ProjectSaveDto(
+            name: trim($projectOnboardDto->name),
+            customer: $projectOnboardDto->customer_id,
+            jiraId: '' !== $jiraId ? $jiraId : null,
+            active: true,
+            global: $projectOnboardDto->global,
+        ));
+
+        $customer = $this->managerRegistry->getRepository(Customer::class)->find($projectOnboardDto->customer_id);
+        if (!$customer instanceof Customer) {
+            throw new InvalidArgumentException('Please choose a customer.');
+        }
+
+        if ('' !== $jiraId) {
+            $projectRepository = $this->managerRegistry->getRepository(Project::class);
+            assert($projectRepository instanceof ProjectRepository);
+            if (0 === $projectRepository->isValidJiraPrefix($jiraId)) {
+                throw new InvalidArgumentException('Please provide a valid ticket prefix with only capital letters.');
+            }
+        }
+
+        $project = new Project();
+        $project->setName(trim($projectOnboardDto->name))
+            ->setCustomer($customer)
+            ->setJiraId($jiraId)
+            ->setActive(true)
+            ->setGlobal($projectOnboardDto->global)
+            ->setEstimation(0);
+
+        $objectManager = $this->managerRegistry->getManager();
+        $objectManager->persist($project);
+        $objectManager->flush();
+
+        return ProjectDto::fromEntity($project);
+    }
+
+    /**
+     * @throws InvalidArgumentException on a validation failure
+     */
+    public function onboardCustomer(CustomerOnboardDto $customerOnboardDto): CustomerDto
+    {
+        $this->assertValid(new CustomerSaveDto(
+            name: trim($customerOnboardDto->name),
+            active: true,
+            global: $customerOnboardDto->global,
+            teams: $customerOnboardDto->team_ids,
+        ));
+
+        if (!$customerOnboardDto->global && [] === $customerOnboardDto->team_ids) {
+            throw new InvalidArgumentException('Every customer must belong to at least one team if it is not global.');
+        }
+
+        $customer = new Customer();
+        $customer->setName(trim($customerOnboardDto->name))
+            ->setActive(true)
+            ->setGlobal($customerOnboardDto->global);
+        foreach ($this->resolveTeams($customerOnboardDto->team_ids) as $team) {
+            $customer->addTeam($team);
+        }
+
+        $objectManager = $this->managerRegistry->getManager();
+        $objectManager->persist($customer);
+        $objectManager->flush();
+
+        return CustomerDto::fromEntity($customer);
+    }
+
+    /**
+     * @throws InvalidArgumentException on a validation failure
+     */
+    public function onboardUser(UserOnboardDto $userOnboardDto): UserDto
+    {
+        // Runs the full UserSaveDto constraint set: unique username, valid and
+        // unique abbreviation, and the at-least-one-team rule. No password —
+        // an onboarded account authenticates against the directory (ADR-018).
+        $this->assertValid(new UserSaveDto(
+            username: trim($userOnboardDto->username),
+            abbr: trim($userOnboardDto->abbr),
+            type: $userOnboardDto->type,
+            locale: $userOnboardDto->locale,
+            active: true,
+            teams: $userOnboardDto->team_ids,
+        ));
+
+        $user = new User();
+        $user->setUsername(trim($userOnboardDto->username))
+            ->setAbbr(trim($userOnboardDto->abbr))
+            ->setType(UserType::from($userOnboardDto->type))
+            ->setLocale($userOnboardDto->locale)
+            ->setActive(true);
+        foreach ($this->resolveTeams($userOnboardDto->team_ids) as $team) {
+            $user->addTeam($team);
+        }
+
+        $objectManager = $this->managerRegistry->getManager();
+        $objectManager->persist($user);
+        $objectManager->flush();
+
+        return UserDto::fromEntity($user);
+    }
+
+    public function setProjectActive(int $id, bool $active): ?ProjectDto
+    {
+        $project = $this->managerRegistry->getRepository(Project::class)->find($id);
+        if (!$project instanceof Project) {
+            return null;
+        }
+
+        $project->setActive($active);
+        $this->managerRegistry->getManager()->flush();
+
+        return ProjectDto::fromEntity($project);
+    }
+
+    public function setCustomerActive(int $id, bool $active): ?CustomerDto
+    {
+        $customer = $this->managerRegistry->getRepository(Customer::class)->find($id);
+        if (!$customer instanceof Customer) {
+            return null;
+        }
+
+        $customer->setActive($active);
+        $this->managerRegistry->getManager()->flush();
+
+        return CustomerDto::fromEntity($customer);
+    }
+
+    public function setUserActive(int $id, bool $active): ?UserDto
+    {
+        $user = $this->managerRegistry->getRepository(User::class)->find($id);
+        if (!$user instanceof User) {
+            return null;
+        }
+
+        $user->setActive($active);
+        $this->managerRegistry->getManager()->flush();
+
+        return UserDto::fromEntity($user);
+    }
+
+    /**
+     * Explicitly runs the validator on a manually constructed v1 save DTO —
+     * #[MapRequestPayload] constraint validation does not run outside argument
+     * resolution, and skipping it would bypass uniqueness and format rules.
+     *
+     * @throws InvalidArgumentException with the first violation message
+     */
+    private function assertValid(object $saveDto): void
+    {
+        $violations = $this->validator->validate($saveDto);
+        if (count($violations) > 0) {
+            throw new InvalidArgumentException((string) $violations->get(0)->getMessage());
+        }
+    }
+
+    /**
+     * @param list<int> $teamIds
+     *
+     * @throws InvalidArgumentException when a requested team does not exist
+     *
+     * @return list<Team>
+     */
+    private function resolveTeams(array $teamIds): array
+    {
+        if ([] === $teamIds) {
+            return [];
+        }
+
+        /** @var list<Team> $teams */
+        $teams = $this->managerRegistry->getRepository(Team::class)->findBy(['id' => $teamIds]);
+        if (count($teams) !== count($teamIds)) {
+            throw new InvalidArgumentException(sprintf('Could not find team(s) with ID(s): %s.', implode(', ', $teamIds)));
+        }
+
+        return $teams;
+    }
+}

--- a/tests/Controller/Api/V2/AdminOnboardingActionsTest.php
+++ b/tests/Controller/Api/V2/AdminOnboardingActionsTest.php
@@ -84,6 +84,15 @@ final class AdminOnboardingActionsTest extends AbstractWebTestCase
         self::assertFalse($data['user']['active']);
     }
 
+    public function testAdminCannotDeactivateOwnAccount(): void
+    {
+        // Session user 'unittest' is id 1 — self-deactivation would lock the
+        // admin out; reactivating yourself stays allowed.
+        $this->client->request(Request::METHOD_POST, '/api/v2/users/1/deactivate');
+
+        $this->assertStatusCode(422);
+    }
+
     public function testToggleUnknownProjectIsNotFound(): void
     {
         $this->client->request(Request::METHOD_POST, '/api/v2/projects/999999/deactivate');

--- a/tests/Controller/Api/V2/AdminOnboardingActionsTest.php
+++ b/tests/Controller/Api/V2/AdminOnboardingActionsTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller\Api\V2;
+
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+use Tests\Traits\MintsApiTokens;
+
+use function json_decode;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * The v2 admin endpoints (ADR-022 Phase 3): onboarding and active-toggling of
+ * projects, customers and users, with the double gate — admin role AND, for
+ * tokens, the matching write scope. Session user is 'unittest' (ADMIN);
+ * 'developer' (DEV) is the non-admin.
+ *
+ * @internal
+ */
+final class AdminOnboardingActionsTest extends AbstractWebTestCase
+{
+    use MintsApiTokens;
+
+    public function testOnboardProjectAsAdminSession(): void
+    {
+        $this->postJson('/api/v2/projects', ['name' => 'Launchpad', 'customer_id' => 1, 'jira_id' => 'LPD']);
+        $this->assertStatusCode(201);
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertIsArray($data['project']);
+        self::assertSame('Launchpad', $data['project']['name']);
+        self::assertSame('LPD', $data['project']['jira_id']);
+        self::assertTrue($data['project']['active']);
+    }
+
+    public function testOnboardProjectValidationFailureAnswers422(): void
+    {
+        $this->postJson('/api/v2/projects', ['name' => 'X', 'customer_id' => 1]);
+
+        $this->assertStatusCode(422);
+    }
+
+    public function testOnboardCustomerNeedsTeamUnlessGlobal(): void
+    {
+        $this->postJson('/api/v2/customers', ['name' => 'Teamless GmbH']);
+        $this->assertStatusCode(422);
+
+        $this->postJson('/api/v2/customers', ['name' => 'Teamful GmbH', 'team_ids' => [1]]);
+        $this->assertStatusCode(201);
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertIsArray($data['customer']);
+        self::assertSame([1], $data['customer']['team_ids']);
+    }
+
+    public function testOnboardUserAndOffboardAgain(): void
+    {
+        $this->postJson('/api/v2/users', ['username' => 'fresh.face', 'abbr' => 'FFC', 'team_ids' => [1]]);
+        $this->assertStatusCode(201);
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertIsArray($data['user']);
+        $id = $data['user']['id'];
+        self::assertIsInt($id);
+        self::assertTrue($data['user']['active']);
+
+        $this->client->request(Request::METHOD_POST, "/api/v2/users/{$id}/deactivate");
+        $this->assertStatusCode(200);
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertIsArray($data['user']);
+        self::assertFalse($data['user']['active']);
+    }
+
+    public function testToggleUnknownProjectIsNotFound(): void
+    {
+        $this->client->request(Request::METHOD_POST, '/api/v2/projects/999999/deactivate');
+
+        $this->assertStatusCode(404);
+    }
+
+    public function testNonAdminSessionIsForbidden(): void
+    {
+        $this->logInSession('developer');
+
+        $this->postJson('/api/v2/projects', ['name' => 'Nope Project', 'customer_id' => 1]);
+
+        $this->assertStatusCode(403);
+    }
+
+    public function testAdminTokenWithScopeCreates(): void
+    {
+        $status = $this->postJsonWithToken('/api/v2/projects', $this->mintToken(['projects:write']), ['name' => 'Token Project', 'customer_id' => 1]);
+
+        self::assertSame(201, $status);
+    }
+
+    public function testAdminTokenWithoutWriteScopeIsForbidden(): void
+    {
+        $status = $this->postJsonWithToken('/api/v2/projects', $this->mintToken(['projects:read']), ['name' => 'Read Only', 'customer_id' => 1]);
+
+        self::assertSame(403, $status);
+    }
+
+    public function testNonAdminTokenWithScopeIsForbidden(): void
+    {
+        // The scope narrows the user's rights; it never expands them (ADR-021).
+        $status = $this->postJsonWithToken('/api/v2/projects', $this->mintToken(['projects:write'], 'developer'), ['name' => 'Sneaky Project', 'customer_id' => 1]);
+
+        self::assertSame(403, $status);
+    }
+
+    /**
+     * @param array<string, mixed> $json
+     */
+    private function postJson(string $path, array $json): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            $path,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/json', 'CONTENT_TYPE' => 'application/json'],
+            json_encode($json, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/tests/Mcp/AdminToolsTest.php
+++ b/tests/Mcp/AdminToolsTest.php
@@ -116,7 +116,7 @@ final class AdminToolsTest extends AbstractWebTestCase
     {
         $this->useToken(['projects:write']);
 
-        $result = self::getContainer()->get(SetProjectActiveTool::class)->setProjectActive('1', false);
+        $result = self::getContainer()->get(SetProjectActiveTool::class)->setProjectActive('Das Kuchenbacken', false);
 
         self::assertIsArray($result['project']);
         self::assertFalse($result['project']['active']);

--- a/tests/Mcp/AdminToolsTest.php
+++ b/tests/Mcp/AdminToolsTest.php
@@ -102,6 +102,16 @@ final class AdminToolsTest extends AbstractWebTestCase
         self::assertFalse($result['user']['active']);
     }
 
+    public function testAdminCannotDeactivateOwnAccountViaTool(): void
+    {
+        // The token acts as 'unittest' — self-deactivation would lock the
+        // admin out.
+        $this->useToken(['users:write']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(SetUserActiveTool::class)->setUserActive('unittest', false);
+    }
+
     public function testOffboardProjectByName(): void
     {
         $this->useToken(['projects:write']);

--- a/tests/Mcp/AdminToolsTest.php
+++ b/tests/Mcp/AdminToolsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Mcp;
+
+use App\Mcp\Tool\OnboardCustomerTool;
+use App\Mcp\Tool\OnboardProjectTool;
+use App\Mcp\Tool\OnboardUserTool;
+use App\Mcp\Tool\SetProjectActiveTool;
+use App\Mcp\Tool\SetUserActiveTool;
+use Mcp\Exception\ToolCallException;
+use Tests\AbstractWebTestCase;
+use Tests\Traits\ActsAsApiTokenUser;
+
+/**
+ * The MCP admin tools (ADR-022 Phase 3): on/offboarding flows and the double
+ * gate — the scope alone is not enough, the token's user must be an admin.
+ * Fixture users: 'unittest' (ADMIN), 'developer' (DEV, non-admin); teams 1+2.
+ *
+ * @internal
+ */
+final class AdminToolsTest extends AbstractWebTestCase
+{
+    use ActsAsApiTokenUser;
+
+    public function testOnboardProjectCreatesActiveProject(): void
+    {
+        $this->useToken(['projects:write']);
+
+        $result = self::getContainer()->get(OnboardProjectTool::class)->onboardProject(name: 'Rocket Site', customer: '1', ticketPrefix: 'RCK');
+
+        self::assertIsArray($result['project']);
+        self::assertSame('Rocket Site', $result['project']['name']);
+        self::assertSame('RCK', $result['project']['jira_id']);
+        self::assertTrue($result['project']['active']);
+        self::assertSame(1, $result['project']['customer_id']);
+    }
+
+    public function testOnboardProjectResolvesCustomerByName(): void
+    {
+        $this->useToken(['projects:write', 'customers:write']);
+        $container = self::getContainer();
+        $customer = $container->get(OnboardCustomerTool::class)->onboardCustomer(name: 'Resolvable Corp', global: true);
+        self::assertIsArray($customer['customer']);
+
+        $result = $container->get(OnboardProjectTool::class)->onboardProject(name: 'Resolved Project', customer: 'Resolvable Corp');
+
+        self::assertIsArray($result['project']);
+        self::assertSame($customer['customer']['id'], $result['project']['customer_id']);
+    }
+
+    public function testOnboardProjectRejectsUnknownCustomer(): void
+    {
+        $this->useToken(['projects:write']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(OnboardProjectTool::class)->onboardProject(name: 'Orphan', customer: 'no-such-customer');
+    }
+
+    public function testOnboardCustomerRequiresTeamUnlessGlobal(): void
+    {
+        $this->useToken(['customers:write']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(OnboardCustomerTool::class)->onboardCustomer(name: 'Teamless GmbH');
+    }
+
+    public function testOnboardUserCreatesDirectoryAccount(): void
+    {
+        $this->useToken(['users:write']);
+
+        $result = self::getContainer()->get(OnboardUserTool::class)->onboardUser(username: 'new.hire', abbr: 'NHR', teamIds: [1]);
+
+        self::assertIsArray($result['user']);
+        self::assertSame('new.hire', $result['user']['username']);
+        self::assertSame('DEV', $result['user']['type']);
+        self::assertTrue($result['user']['active']);
+        self::assertSame([1], $result['user']['team_ids']);
+    }
+
+    public function testOnboardUserRejectsDuplicateUsername(): void
+    {
+        $this->useToken(['users:write']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(OnboardUserTool::class)->onboardUser(username: 'unittest', abbr: 'UTX', teamIds: [1]);
+    }
+
+    public function testOffboardUserDeactivatesTheAccount(): void
+    {
+        $this->useToken(['users:write']);
+
+        $result = self::getContainer()->get(SetUserActiveTool::class)->setUserActive('developer', false);
+
+        self::assertIsArray($result['user']);
+        self::assertFalse($result['user']['active']);
+    }
+
+    public function testOffboardProjectByName(): void
+    {
+        $this->useToken(['projects:write']);
+
+        $result = self::getContainer()->get(SetProjectActiveTool::class)->setProjectActive('1', false);
+
+        self::assertIsArray($result['project']);
+        self::assertFalse($result['project']['active']);
+    }
+
+    public function testScopeAloneIsNotEnoughWithoutAdminRole(): void
+    {
+        // 'developer' is a non-admin: the write scope must not open the tool.
+        $this->useToken(['projects:write'], 'developer');
+
+        try {
+            self::getContainer()->get(OnboardProjectTool::class)->onboardProject(name: 'Sneaky', customer: '1');
+            self::fail('expected the admin gate to refuse');
+        } catch (ToolCallException $toolCallException) {
+            self::assertStringContainsString('administrator', $toolCallException->getMessage());
+        }
+    }
+
+    public function testAdminWithoutScopeIsDenied(): void
+    {
+        // 'unittest' is an admin, but the token lacks the write scope.
+        $this->useToken(['projects:read']);
+
+        $this->expectException(ToolCallException::class);
+        self::getContainer()->get(OnboardProjectTool::class)->onboardProject(name: 'Unscoped', customer: '1');
+    }
+}

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -21,6 +21,12 @@ use App\Mcp\Tool\ListActivitiesTool;
 use App\Mcp\Tool\ListProjectsTool;
 use App\Mcp\Tool\ListRecentEntriesTool;
 use App\Mcp\Tool\LogTimeTool;
+use App\Mcp\Tool\OnboardCustomerTool;
+use App\Mcp\Tool\OnboardProjectTool;
+use App\Mcp\Tool\OnboardUserTool;
+use App\Mcp\Tool\SetCustomerActiveTool;
+use App\Mcp\Tool\SetProjectActiveTool;
+use App\Mcp\Tool\SetUserActiveTool;
 use App\Repository\ActivityRepository;
 use App\Repository\ProjectRepository;
 use App\Repository\UserRepository;
@@ -29,11 +35,11 @@ use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
 use ReflectionClass;
 use Tests\AbstractWebTestCase;
+use Tests\Traits\ActsAsApiTokenUser;
 
 use function array_column;
 use function array_is_list;
 use function array_keys;
-use function array_values;
 use function basename;
 use function count;
 use function dirname;
@@ -50,6 +56,8 @@ use function sprintf;
  */
 final class McpToolsTest extends AbstractWebTestCase
 {
+    use ActsAsApiTokenUser;
+
     public function testListActivitiesReturnsEntriesWithReadScope(): void
     {
         $this->useToken(['activities:read']);
@@ -365,7 +373,7 @@ final class McpToolsTest extends AbstractWebTestCase
      */
     public function testEveryToolReturnsATopLevelJsonObject(): void
     {
-        $this->useToken(['entries:read', 'entries:write', 'projects:read', 'activities:read', 'reporting:read']);
+        $this->useToken(['entries:read', 'entries:write', 'projects:read', 'projects:write', 'activities:read', 'reporting:read', 'customers:write', 'users:write']);
         $container = self::getContainer();
 
         $created = $container->get(LogTimeTool::class)->logTime(project: '1', activity: '1', ticket: 'SA-5', durationMinutes: 15);
@@ -376,6 +384,12 @@ final class McpToolsTest extends AbstractWebTestCase
         $results = [
             'delete_entry' => null, // called last — it removes the entry
             'get_day' => $container->get(GetDayTool::class)->getDay(),
+            'onboard_customer' => $container->get(OnboardCustomerTool::class)->onboardCustomer(name: 'Guard Customer', global: true),
+            'onboard_project' => $container->get(OnboardProjectTool::class)->onboardProject(name: 'Guard Project', customer: '1'),
+            'onboard_user' => $container->get(OnboardUserTool::class)->onboardUser(username: 'guard.user', abbr: 'GRD', teamIds: [1]),
+            'set_customer_active' => $container->get(SetCustomerActiveTool::class)->setCustomerActive('1', true),
+            'set_project_active' => $container->get(SetProjectActiveTool::class)->setProjectActive('1', true),
+            'set_user_active' => $container->get(SetUserActiveTool::class)->setUserActive('developer', true),
             'get_ticket_info' => $container->get(GetTicketInfoTool::class)->getTicketInfo($entryId),
             'get_time_balance' => $container->get(GetTimeBalanceTool::class)->getTimeBalance(),
             'list_activities' => $container->get(ListActivitiesTool::class)->listActivities(),
@@ -422,21 +436,5 @@ final class McpToolsTest extends AbstractWebTestCase
         sort($names);
 
         return $names;
-    }
-
-    /**
-     * Replace the session token from setUp() with a stateless PAT carrying the
-     * given scopes, acting as fixture user 1.
-     *
-     * @param list<string> $scopes
-     */
-    private function useToken(array $scopes): void
-    {
-        $container = self::getContainer();
-        $user = $container->get(UserRepository::class)->find(1);
-        self::assertInstanceOf(User::class, $user);
-
-        $token = new ApiAccessToken($user, array_values($user->getRoles()), $scopes);
-        $container->get('security.token_storage')->setToken($token);
     }
 }

--- a/tests/Mcp/ScopeGuardTest.php
+++ b/tests/Mcp/ScopeGuardTest.php
@@ -16,6 +16,7 @@ use Mcp\Exception\ToolCallException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
 
 /**
  * Unit tests for the MCP per-tool scope gate (ADR-021 Phase 5).
@@ -24,7 +25,7 @@ final class ScopeGuardTest extends TestCase
 {
     public function testRejectsWhenNoToken(): void
     {
-        $guard = new ScopeGuard($this->securityWithToken(null));
+        $guard = $this->guardWithToken(null);
 
         $this->expectException(ToolCallException::class);
         $guard->requireScope('entries:read');
@@ -34,7 +35,7 @@ final class ScopeGuardTest extends TestCase
     {
         // A non-ApiAccessToken (e.g. a session/cookie login) must not reach MCP
         // tools: the scope model only governs token auth.
-        $guard = new ScopeGuard($this->securityWithToken(self::createStub(TokenInterface::class)));
+        $guard = $this->guardWithToken(self::createStub(TokenInterface::class));
 
         $this->expectException(ToolCallException::class);
         $guard->requireScope('entries:read');
@@ -43,7 +44,7 @@ final class ScopeGuardTest extends TestCase
     public function testRejectsWhenTokenLacksScope(): void
     {
         $token = new ApiAccessToken(new User(), ['ROLE_USER'], ['reporting:read']);
-        $guard = new ScopeGuard($this->securityWithToken($token));
+        $guard = $this->guardWithToken($token);
 
         $this->expectException(ToolCallException::class);
         $guard->requireScope('entries:write');
@@ -53,7 +54,7 @@ final class ScopeGuardTest extends TestCase
     {
         $user = new User();
         $token = new ApiAccessToken($user, ['ROLE_USER'], ['entries:write']);
-        $guard = new ScopeGuard($this->securityWithToken($token));
+        $guard = $this->guardWithToken($token);
 
         self::assertSame($user, $guard->requireScope('entries:write'));
     }
@@ -62,16 +63,34 @@ final class ScopeGuardTest extends TestCase
     {
         $user = new User();
         $token = new ApiAccessToken($user, ['ROLE_USER'], ['*']);
-        $guard = new ScopeGuard($this->securityWithToken($token));
+        $guard = $this->guardWithToken($token);
 
         self::assertSame($user, $guard->requireScope('entries:write'));
     }
 
-    private function securityWithToken(?TokenInterface $token): Security
+    public function testRequireAdminScopeHonorsRoleHierarchy(): void
+    {
+        // ROLE_SUPER_ADMIN reaches ROLE_ADMIN only through the hierarchy — the
+        // guard must expand it exactly like #[IsGranted('ROLE_ADMIN')] does.
+        $user = new User();
+        $token = new ApiAccessToken($user, ['ROLE_SUPER_ADMIN'], ['projects:write']);
+
+        self::assertSame($user, $this->guardWithToken($token)->requireAdminScope('projects:write'));
+    }
+
+    public function testRequireAdminScopeRejectsNonAdmins(): void
+    {
+        $token = new ApiAccessToken(new User(), ['ROLE_USER'], ['projects:write']);
+
+        $this->expectException(ToolCallException::class);
+        $this->guardWithToken($token)->requireAdminScope('projects:write');
+    }
+
+    private function guardWithToken(?TokenInterface $token): ScopeGuard
     {
         $security = self::createStub(Security::class);
         $security->method('getToken')->willReturn($token);
 
-        return $security;
+        return new ScopeGuard($security, new RoleHierarchy(['ROLE_SUPER_ADMIN' => ['ROLE_ADMIN']]));
     }
 }

--- a/tests/Traits/ActsAsApiTokenUser.php
+++ b/tests/Traits/ActsAsApiTokenUser.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Traits;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Security\ApiToken\ApiAccessToken;
+
+use function array_values;
+
+/**
+ * Replaces the session token with a stateless PAT carrying the given scopes,
+ * acting as a named fixture user — the same authentication state the /mcp
+ * endpoint produces for tool calls.
+ */
+trait ActsAsApiTokenUser
+{
+    /**
+     * @param list<string> $scopes
+     */
+    protected function useToken(array $scopes, string $username = 'unittest'): void
+    {
+        $container = static::getContainer();
+        $user = $container->get(UserRepository::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $user);
+
+        $token = new ApiAccessToken($user, array_values($user->getRoles()), $scopes);
+        $container->get('security.token_storage')->setToken($token);
+    }
+}

--- a/tests/Traits/MintsApiTokens.php
+++ b/tests/Traits/MintsApiTokens.php
@@ -19,7 +19,10 @@ use Symfony\Component\HttpFoundation\Request;
 use function array_values;
 use function bin2hex;
 use function hash;
+use function json_encode;
 use function random_bytes;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Mints a scoped personal access token for the 'unittest' fixture user and
@@ -30,13 +33,13 @@ trait MintsApiTokens
     /**
      * @param list<string> $scopes
      */
-    protected function mintToken(array $scopes): string
+    protected function mintToken(array $scopes, string $username = 'unittest'): string
     {
         /** @var Registry $doctrine */
         $doctrine = static::getContainer()->get('doctrine');
         $entityManager = $doctrine->getManager();
 
-        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'unittest']);
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
         self::assertInstanceOf(User::class, $user);
 
         $plaintext = ApiTokenService::PREFIX . bin2hex(random_bytes(32));
@@ -50,6 +53,23 @@ trait MintsApiTokens
     protected function requestWithToken(string $path, string $bearer): int
     {
         $this->client->request(Request::METHOD_GET, $path, [], [], ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json']);
+
+        return $this->client->getResponse()->getStatusCode();
+    }
+
+    /**
+     * @param array<string, mixed> $json
+     */
+    protected function postJsonWithToken(string $path, string $bearer, array $json): int
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            $path,
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer ' . $bearer, 'HTTP_ACCEPT' => 'application/json', 'CONTENT_TYPE' => 'application/json'],
+            json_encode($json, JSON_THROW_ON_ERROR),
+        );
 
         return $this->client->getResponse()->getStatusCode();
     }


### PR DESCRIPTION
ADR-022 Phase 3 — the last phase: projects, customers and users can be onboarded and offboarded programmatically, over REST and MCP, from one `AdminOnboardingService`.

## Surface

| REST (ADR-022 §4 wire rules) | MCP tool | Scope (tokens) |
|---|---|---|
| `POST /api/v2/projects` | `onboard_project` | `projects:write` |
| `POST /api/v2/projects/{id}/activate\|deactivate` | `set_project_active` | `projects:write` |
| `POST /api/v2/customers` | `onboard_customer` | `customers:write` |
| `POST /api/v2/customers/{id}/activate\|deactivate` | `set_customer_active` | `customers:write` |
| `POST /api/v2/users` | `onboard_user` | `users:write` |
| `POST /api/v2/users/{id}/activate\|deactivate` | `set_user_active` | `users:write` |

- **Double gate everywhere:** `#[IsGranted('ROLE_ADMIN')]` + `#[RequireScope]` on the endpoints; `ScopeGuard::requireAdminScope()` mirrors the pair for tools. A write scope on a non-admin token stays forbidden (scopes narrow, never expand — ADR-021).
- **Offboarding = deactivation**, never hard-delete: bookings reference the records; a deactivated user cannot log in and its tokens stop working (`UserChecker`).
- **Validation without drift:** creation runs the v1 `*SaveDto` constraint sets (unique names, ≤3-char abbreviation, at-least-one-team rules) explicitly — `#[MapRequestPayload]` constraint validation only fires during argument resolution, so manual construction would otherwise bypass `UniqueUsername` & co. Entities are then built directly for the minimal onboarding surface (services must not depend on controllers — architecture rule); the v1 `Save*Action`s keep owning the admin UI's full-featured saves.
- **No local password on user onboarding** — the account authenticates against the directory (ADR-018).
- Tools resolve customers/projects/users by **name or id** (agents know names).

## Tests

Flows (onboard, offboard, name resolution, duplicate username, team rules) plus both gate denials per surface: non-admin session 403, admin token without write scope 403, non-admin token *with* write scope 403. The MCP object-shape guard now spans all 14 tools. Shared fixtures moved to `ActsAsApiTokenUser` / extended `MintsApiTokens` traits (no copied helpers).

Gates: PHPStan L10, cs, rector (idempotent), phpat clean; 2206 PHP tests. OpenAPI (9 paths + 3 schemas) and docs/api.md updated.

Completes the ADR-022 implementation plan (Phases 0–3).