### PR TITLE
fix(import): author-scope the worklog import JQL + paginate the issue search

### DIFF
--- a/src/Service/Integration/Jira/JiraCloudApiService.php
+++ b/src/Service/Integration/Jira/JiraCloudApiService.php
@@ -160,20 +160,14 @@ class JiraCloudApiService extends JiraOAuthApiService
 
             $response = $this->post('search/jql', $body);
 
-            if (isset($response->issues) && is_array($response->issues)) {
-                foreach ($response->issues as $issue) {
-                    if (is_object($issue) && isset($issue->key) && is_string($issue->key)) {
-                        $keys[] = $issue->key;
-                    }
-                }
+            foreach ($this->extractIssueKeys($response) as $key) {
+                $keys[] = $key;
             }
 
-            $nextPageToken = isset($response->nextPageToken) && is_string($response->nextPageToken) && '' !== $response->nextPageToken
-                ? $response->nextPageToken
-                : null;
+            $nextPageToken = $this->extractNextPageToken($response);
 
             // Cursor exhausted: explicit isLast, or no continuation token.
-            if ((isset($response->isLast) && true === $response->isLast) || null === $nextPageToken) {
+            if ($this->isLastPage($response) || null === $nextPageToken) {
                 break;
             }
 
@@ -185,6 +179,24 @@ class JiraCloudApiService extends JiraOAuthApiService
         }
 
         return new JiraIssueKeySearchResult($keys, $truncated);
+    }
+
+    /**
+     * The cursor for the next `search/jql` page, or null when absent/empty.
+     */
+    private function extractNextPageToken(mixed $response): ?string
+    {
+        return is_object($response) && isset($response->nextPageToken) && is_string($response->nextPageToken) && '' !== $response->nextPageToken
+            ? $response->nextPageToken
+            : null;
+    }
+
+    /**
+     * Whether `search/jql` flagged this as the final page.
+     */
+    private function isLastPage(mixed $response): bool
+    {
+        return is_object($response) && isset($response->isLast) && true === $response->isLast;
     }
 
     /**

--- a/src/Service/Integration/Jira/JiraCloudApiService.php
+++ b/src/Service/Integration/Jira/JiraCloudApiService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace App\Service\Integration\Jira;
 
+use App\DTO\Jira\JiraIssueKeySearchResult;
 use App\Entity\TicketSystem;
 use App\Entity\User;
 use App\Entity\UserTicketsystem;
@@ -29,6 +30,7 @@ use Throwable;
 use function in_array;
 use function is_array;
 use function is_int;
+use function is_object;
 use function is_string;
 use function json_decode;
 use function parse_url;
@@ -117,7 +119,7 @@ class JiraCloudApiService extends JiraOAuthApiService
      * @param array<int, string> $fields
      */
     #[Override]
-    public function searchTicket(string $jql, array $fields, int $limit = 1): mixed
+    public function searchTicket(string $jql, array $fields, int $limit = 1, int $startAt = 0): mixed
     {
         return $this->post(
             'search/jql',
@@ -125,8 +127,64 @@ class JiraCloudApiService extends JiraOAuthApiService
                 'jql' => $jql,
                 'fields' => $fields,
                 'maxResults' => $limit,
+                'startAt' => $startAt,
             ],
         );
+    }
+
+    /**
+     * Cloud `search/jql` is cursor-based, not offset-based: it ignores
+     * `startAt`, never returns `total`, and paginates via
+     * `nextPageToken`/`isLast`. The `startAt` loop of the base class would
+     * re-fetch the first page forever here, so this override threads the page
+     * token instead. `truncated` is only set if the defensive page cap is hit.
+     *
+     * @throws JiraApiException
+     */
+    #[Override]
+    public function searchIssueKeysWithWorklogs(string $jql, int $limit = 500): JiraIssueKeySearchResult
+    {
+        $keys = [];
+        $nextPageToken = null;
+        $truncated = false;
+
+        for ($page = 0;; ++$page) {
+            $body = [
+                'jql' => $jql,
+                'fields' => ['key'],
+                'maxResults' => $limit,
+            ];
+            if (null !== $nextPageToken) {
+                $body['nextPageToken'] = $nextPageToken;
+            }
+
+            $response = $this->post('search/jql', $body);
+
+            if (isset($response->issues) && is_array($response->issues)) {
+                foreach ($response->issues as $issue) {
+                    if (is_object($issue) && isset($issue->key) && is_string($issue->key)) {
+                        $keys[] = $issue->key;
+                    }
+                }
+            }
+
+            $nextPageToken = isset($response->nextPageToken) && is_string($response->nextPageToken) && '' !== $response->nextPageToken
+                ? $response->nextPageToken
+                : null;
+
+            // Cursor exhausted: explicit isLast, or no continuation token.
+            if ((isset($response->isLast) && true === $response->isLast) || null === $nextPageToken) {
+                break;
+            }
+
+            // Defensive stop against a misbehaving API that never terminates.
+            if ($page + 1 >= self::MAX_SEARCH_PAGES) {
+                $truncated = true;
+                break;
+            }
+        }
+
+        return new JiraIssueKeySearchResult($keys, $truncated);
     }
 
     /**

--- a/src/Service/Integration/Jira/JiraCloudApiService.php
+++ b/src/Service/Integration/Jira/JiraCloudApiService.php
@@ -164,10 +164,9 @@ class JiraCloudApiService extends JiraOAuthApiService
                 $keys[] = $key;
             }
 
-            $nextPageToken = $this->extractNextPageToken($response);
-
             // Cursor exhausted: explicit isLast, or no continuation token.
-            if ($this->isLastPage($response) || null === $nextPageToken) {
+            $nextPageToken = $this->nextCursor($response);
+            if (null === $nextPageToken) {
                 break;
             }
 
@@ -182,21 +181,18 @@ class JiraCloudApiService extends JiraOAuthApiService
     }
 
     /**
-     * The cursor for the next `search/jql` page, or null when absent/empty.
+     * The cursor for the next `search/jql` page, or null when the page is flagged
+     * `isLast` or carries no (non-empty) continuation token.
      */
-    private function extractNextPageToken(mixed $response): ?string
+    private function nextCursor(mixed $response): ?string
     {
-        return is_object($response) && isset($response->nextPageToken) && is_string($response->nextPageToken) && '' !== $response->nextPageToken
+        if (!is_object($response) || (isset($response->isLast) && true === $response->isLast)) {
+            return null;
+        }
+
+        return isset($response->nextPageToken) && is_string($response->nextPageToken) && '' !== $response->nextPageToken
             ? $response->nextPageToken
             : null;
-    }
-
-    /**
-     * Whether `search/jql` flagged this as the final page.
-     */
-    private function isLastPage(mixed $response): bool
-    {
-        return is_object($response) && isset($response->isLast) && true === $response->isLast;
     }
 
     /**

--- a/src/Service/Integration/Jira/JiraOAuthApiService.php
+++ b/src/Service/Integration/Jira/JiraOAuthApiService.php
@@ -42,7 +42,6 @@ use Throwable;
 use UnexpectedValueException;
 
 use function assert;
-use function count;
 use function is_array;
 use function is_numeric;
 use function is_object;
@@ -56,6 +55,9 @@ use const JSON_THROW_ON_ERROR;
  */
 class JiraOAuthApiService
 {
+    /** Defensive cap on issue-search pagination (ADR-023 read path 2) — an API that never advances stops here. */
+    protected const int MAX_SEARCH_PAGES = 100;
+
     protected string $oAuthCallbackUrl;
 
     protected string $jiraApiUrl = '/rest/api/latest/';
@@ -446,7 +448,7 @@ class JiraOAuthApiService
      * @throws JiraApiException
      * @throws JiraApiInvalidResourceException
      */
-    public function searchTicket(string $jql, array $fields, int $limit = 1): mixed
+    public function searchTicket(string $jql, array $fields, int $limit = 1, int $startAt = 0): mixed
     {
         return $this->post(
             'search/',
@@ -454,6 +456,7 @@ class JiraOAuthApiService
                 'jql' => $jql,
                 'fields' => $fields,
                 'maxResults' => $limit,
+                'startAt' => $startAt,
             ],
         );
     }
@@ -532,25 +535,50 @@ class JiraOAuthApiService
     }
 
     /**
-     * JQL search returning issue keys only, with explicit truncation reporting (ADR-023 read path 2).
+     * JQL search returning issue keys only, paginated over `startAt` until exhausted
+     * (ADR-023 read path 2). `truncated` is only set if the defensive page cap is hit
+     * with results still pending — the normal path fetches every page.
      *
      * @throws JiraApiException
      */
     public function searchIssueKeysWithWorklogs(string $jql, int $limit = 500): JiraIssueKeySearchResult
     {
-        $response = $this->searchTicket($jql, ['key'], $limit);
-
         $keys = [];
-        if (is_object($response) && isset($response->issues) && is_array($response->issues)) {
-            foreach ($response->issues as $issue) {
-                if (is_object($issue) && isset($issue->key) && is_string($issue->key)) {
-                    $keys[] = $issue->key;
+        $startAt = 0;
+        $truncated = false;
+
+        for ($page = 0;; ++$page) {
+            $response = $this->searchTicket($jql, ['key'], $limit, $startAt);
+
+            $pageCount = 0;
+            if (is_object($response) && isset($response->issues) && is_array($response->issues)) {
+                foreach ($response->issues as $issue) {
+                    ++$pageCount;
+                    if (is_object($issue) && isset($issue->key) && is_string($issue->key)) {
+                        $keys[] = $issue->key;
+                    }
                 }
             }
-        }
 
-        $total = is_object($response) && isset($response->total) && is_numeric($response->total) ? (int) $response->total : null;
-        $truncated = count($keys) >= $limit || (null !== $total && $total > count($keys));
+            $total = is_object($response) && isset($response->total) && is_numeric($response->total) ? (int) $response->total : null;
+            $startAt += $pageCount;
+
+            // A short page is the last page (also covers a missing/absent total).
+            if ($pageCount < $limit) {
+                break;
+            }
+
+            // Reached the known total.
+            if (null !== $total && $startAt >= $total) {
+                break;
+            }
+
+            // Defensive stop against a misbehaving API that never advances/terminates.
+            if ($page + 1 >= self::MAX_SEARCH_PAGES) {
+                $truncated = true;
+                break;
+            }
+        }
 
         return new JiraIssueKeySearchResult($keys, $truncated);
     }

--- a/src/Service/Integration/Jira/JiraOAuthApiService.php
+++ b/src/Service/Integration/Jira/JiraOAuthApiService.php
@@ -42,6 +42,7 @@ use Throwable;
 use UnexpectedValueException;
 
 use function assert;
+use function count;
 use function is_array;
 use function is_numeric;
 use function is_object;
@@ -550,17 +551,11 @@ class JiraOAuthApiService
         for ($page = 0;; ++$page) {
             $response = $this->searchTicket($jql, ['key'], $limit, $startAt);
 
-            $pageCount = 0;
-            if (is_object($response) && isset($response->issues) && is_array($response->issues)) {
-                foreach ($response->issues as $issue) {
-                    ++$pageCount;
-                    if (is_object($issue) && isset($issue->key) && is_string($issue->key)) {
-                        $keys[] = $issue->key;
-                    }
-                }
+            $pageCount = $this->issueCount($response);
+            foreach ($this->extractIssueKeys($response) as $key) {
+                $keys[] = $key;
             }
-
-            $total = is_object($response) && isset($response->total) && is_numeric($response->total) ? (int) $response->total : null;
+            $total = $this->extractTotal($response);
             $startAt += $pageCount;
 
             // A short page is the last page (also covers a missing/absent total).
@@ -581,6 +576,45 @@ class JiraOAuthApiService
         }
 
         return new JiraIssueKeySearchResult($keys, $truncated);
+    }
+
+    /**
+     * Pull the string issue keys out of a JQL-search response, tolerating any shape.
+     *
+     * @return list<string>
+     */
+    protected function extractIssueKeys(mixed $response): array
+    {
+        $keys = [];
+        if (is_object($response) && isset($response->issues) && is_array($response->issues)) {
+            foreach ($response->issues as $issue) {
+                if (is_object($issue) && isset($issue->key) && is_string($issue->key)) {
+                    $keys[] = $issue->key;
+                }
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Number of issues on a search page (independent of key validity) — drives short-page detection.
+     */
+    protected function issueCount(mixed $response): int
+    {
+        return is_object($response) && isset($response->issues) && is_array($response->issues)
+            ? count($response->issues)
+            : 0;
+    }
+
+    /**
+     * The offset-search `total`, or null when the endpoint omits it (e.g. Cloud `search/jql`).
+     */
+    protected function extractTotal(mixed $response): ?int
+    {
+        return is_object($response) && isset($response->total) && is_numeric($response->total)
+            ? (int) $response->total
+            : null;
     }
 
     /**

--- a/src/Service/Sync/ImportWorklogsService.php
+++ b/src/Service/Sync/ImportWorklogsService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace App\Service\Sync;
 
+use App\DTO\Jira\JiraUserIdentity;
 use App\DTO\Jira\JiraWorkLog;
 use App\Entity\Activity;
 use App\Entity\Customer;
@@ -24,6 +25,7 @@ use App\Enum\SyncRunStatus;
 use App\Enum\SyncRunType;
 use App\Enum\WorklogSyncStatus;
 use App\Repository\EntryRepository;
+use App\Repository\UserRepository;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use App\Service\Tracking\DayClassService;
 use App\ValueObject\Sync\WorklogSnapshot;
@@ -35,10 +37,13 @@ use Psr\Clock\ClockInterface;
 use Throwable;
 
 use function array_key_exists;
+use function array_values;
+use function implode;
 use function in_array;
 use function mb_substr;
 use function spl_object_id;
 use function sprintf;
+use function str_replace;
 use function substr;
 
 /**
@@ -56,6 +61,7 @@ class ImportWorklogsService extends AbstractSyncRunService
         private readonly TicketProjectResolver $ticketProjectResolver,
         private readonly JiraAuthorMapper $jiraAuthorMapper,
         private readonly DayClassService $dayClassService,
+        private readonly UserRepository $userRepository,
         ClockInterface $clock,
     ) {
         parent::__construct($entityManager, $clock);
@@ -116,10 +122,10 @@ class ImportWorklogsService extends AbstractSyncRunService
 
         $api = $this->jiraOAuthApiFactory->create($triggeredBy, $ticketSystem);
 
-        $jql = sprintf('worklogDate >= "%s" AND worklogDate <= "%s"', $from->format('Y-m-d'), $to->format('Y-m-d'));
+        $jql = $this->buildAuthorScopedJql($targetUsernames, $triggeredBy, $ticketSystem, $from, $to);
         $searchResult = $api->searchIssueKeysWithWorklogs($jql);
         if ($searchResult->truncated) {
-            $this->addItem($syncRun, SyncItemKind::TRUNCATED, reason: 'issue search hit its result cap; import may be incomplete — narrow the date range and re-run');
+            $this->addItem($syncRun, SyncItemKind::TRUNCATED, reason: 'issue search hit the pagination safety cap; import may be incomplete — narrow the date range and re-run');
         }
 
         $importRunContext = new ImportRunContext(
@@ -152,6 +158,70 @@ class ImportWorklogsService extends AbstractSyncRunService
         foreach ($importRunContext->affectedDays as $affected) {
             $this->dayClassService->recalculate((int) $affected['user']->getId(), $affected['day']);
         }
+    }
+
+    /**
+     * Author-scope the search JQL when a target set is given, so Jira returns only the
+     * targets' worklogs instead of everyone's (mirrors SyncWorklogsService::buildRead).
+     * Empty target set = import-all: the search stays author-unrestricted so resolveAuthor
+     * can shadow-create unknown authors. If no target resolves to an identity the search
+     * also stays unrestricted — the client-side resolveAuthor filter remains the backstop.
+     *
+     * @param list<string> $targetUsernames
+     */
+    private function buildAuthorScopedJql(array $targetUsernames, User $triggeredBy, TicketSystem $ticketSystem, DateTimeImmutable $from, DateTimeImmutable $to): string
+    {
+        $dateClause = sprintf('worklogDate >= "%s" AND worklogDate <= "%s"', $from->format('Y-m-d'), $to->format('Y-m-d'));
+
+        if ([] === $targetUsernames) {
+            return $dateClause;
+        }
+
+        $authorTerms = [];
+        foreach ($targetUsernames as $username) {
+            $user = $this->userRepository->findOneByUsername($username);
+
+            // The token owner is most robustly identified by currentUser().
+            if ($user instanceof User && null !== $user->getId() && $user->getId() === $triggeredBy->getId()) {
+                $authorTerms['currentUser()'] = 'currentUser()';
+
+                continue;
+            }
+
+            $identity = $user instanceof User
+                ? $this->targetIdentity($user, $ticketSystem)
+                : new JiraUserIdentity(name: $username);
+            $value = $identity->accountId ?? $identity->name;
+            if (null === $value || '' === $value) {
+                continue;
+            }
+
+            $quoted = '"' . str_replace(['\\', '"'], ['\\\\', '\\"'], $value) . '"';
+            $authorTerms[$quoted] = $quoted;
+        }
+
+        if ([] === $authorTerms) {
+            return $dateClause;
+        }
+
+        return sprintf('worklogAuthor IN (%s) AND %s', implode(', ', array_values($authorTerms)), $dateClause);
+    }
+
+    /**
+     * The target's Jira identity for this ticket system — durable remote_account_id, username
+     * fallback (mirrors SyncWorklogsService::targetIdentity).
+     */
+    private function targetIdentity(User $targetUser, TicketSystem $ticketSystem): JiraUserIdentity
+    {
+        $remoteAccountId = null;
+        foreach ($targetUser->getUserTicketsystems() as $userTicketsystem) {
+            if ($userTicketsystem->getTicketSystem() === $ticketSystem) {
+                $remoteAccountId = $userTicketsystem->getRemoteAccountId();
+                break;
+            }
+        }
+
+        return new JiraUserIdentity(accountId: $remoteAccountId, name: $targetUser->getUsername());
     }
 
     public function processWorklog(ImportRunContext $importRunContext, string $issueKey, JiraWorkLog $jiraWorkLog): void

--- a/src/Service/Sync/ImportWorklogsService.php
+++ b/src/Service/Sync/ImportWorklogsService.php
@@ -201,7 +201,10 @@ class ImportWorklogsService extends AbstractSyncRunService
                 ? $this->targetIdentity($user, $ticketSystem)
                 : new JiraUserIdentity(name: $username);
             $value = $identity->accountId ?? $identity->name;
-            if (null === $value || '' === $value) {
+            if (null === $value) {
+                continue;
+            }
+            if ('' === $value) {
                 continue;
             }
 

--- a/src/Service/Sync/ImportWorklogsService.php
+++ b/src/Service/Sync/ImportWorklogsService.php
@@ -177,9 +177,18 @@ class ImportWorklogsService extends AbstractSyncRunService
             return $dateClause;
         }
 
+        // Fetch every target in one query (avoid N+1 over the loop below).
+        $usersByUsername = [];
+        foreach ($this->userRepository->findBy(['username' => $targetUsernames]) as $user) {
+            $username = $user->getUsername();
+            if (null !== $username) {
+                $usersByUsername[$username] = $user;
+            }
+        }
+
         $authorTerms = [];
         foreach ($targetUsernames as $username) {
-            $user = $this->userRepository->findOneByUsername($username);
+            $user = $usersByUsername[$username] ?? null;
 
             // The token owner is most robustly identified by currentUser().
             if ($user instanceof User && null !== $user->getId() && $user->getId() === $triggeredBy->getId()) {

--- a/tests/Service/ExportServiceTest.php
+++ b/tests/Service/ExportServiceTest.php
@@ -135,7 +135,7 @@ final class ExportServiceTest extends TestCase
             }
 
             /** @param array<int, string> $fields */
-            public function searchTicket(string $jql, array $fields, int $limit = 1): object
+            public function searchTicket(string $jql, array $fields, int $limit = 1, int $startAt = 0): object
             {
                 if ($this->shouldThrow) {
                     throw new Exception('API Error');

--- a/tests/Service/Integration/Jira/JiraCloudApiServiceTest.php
+++ b/tests/Service/Integration/Jira/JiraCloudApiServiceTest.php
@@ -85,6 +85,9 @@ final class JiraCloudApiServiceTest extends TestCase
 
     private string $restResponseBody = '{}';
 
+    /** @var list<string> sequential per-request REST bodies (pagination); falls back to restResponseBody when empty */
+    private array $restResponsePages = [];
+
     protected function setUp(): void
     {
         $this->tokenEncryptionService = $this->createTokenEncryptionService();
@@ -367,6 +370,38 @@ final class JiraCloudApiServiceTest extends TestCase
         self::assertSame(5, $decoded['maxResults'] ?? null);
     }
 
+    public function testSearchIssueKeysWithWorklogsPaginatesAcrossPages(): void
+    {
+        $this->givenStoredTokens('access-1', 'refresh-1', '+1 hour');
+        $this->ticketSystem->setCloudId('cloud-id-9');
+        // Cloud `search/jql` is cursor-based: pages carry nextPageToken/isLast,
+        // never startAt/total. The last page sets isLast and omits the token.
+        $this->restResponsePages = [
+            (string) json_encode(['issues' => [['key' => 'K1'], ['key' => 'K2']], 'nextPageToken' => 'p2', 'isLast' => false]),
+            (string) json_encode(['issues' => [['key' => 'K3'], ['key' => 'K4']], 'nextPageToken' => 'p3', 'isLast' => false]),
+            (string) json_encode(['issues' => [['key' => 'K5']], 'isLast' => true]),
+        ];
+
+        $service = $this->createService();
+        $result = $service->searchIssueKeysWithWorklogs('worklogDate >= "2026-06-01"', 2);
+
+        self::assertSame(['K1', 'K2', 'K3', 'K4', 'K5'], $result->keys);
+        self::assertFalse($result->truncated, 'a fully-paginated search is not truncated');
+        self::assertCount(3, $this->restRequests);
+
+        $tokens = [];
+        foreach ($this->restRequests as $request) {
+            self::assertSame('search/jql', $request['url']);
+            $body = $request['options']['body'] ?? null;
+            self::assertIsString($body);
+            $decoded = json_decode($body, true);
+            self::assertIsArray($decoded);
+            $tokens[] = $decoded['nextPageToken'] ?? null;
+        }
+
+        self::assertSame([null, 'p2', 'p3'], $tokens, 'each page threads the previous nextPageToken');
+    }
+
     public function testOAuth1CallbackIsRejected(): void
     {
         $service = $this->createService();
@@ -484,7 +519,11 @@ final class JiraCloudApiServiceTest extends TestCase
         }
 
         if (str_starts_with($base, 'https://api.atlassian.com/ex/')) {
-            return $this->stubClient($this->restRequests, fn (): string => $this->restResponseBody, null);
+            return $this->stubClient(
+                $this->restRequests,
+                fn (): string => [] !== $this->restResponsePages ? (string) array_shift($this->restResponsePages) : $this->restResponseBody,
+                null,
+            );
         }
 
         throw new LogicException('Unrouted client base_uri: ' . $base);

--- a/tests/Service/Integration/Jira/JiraOAuthApiServiceReadTest.php
+++ b/tests/Service/Integration/Jira/JiraOAuthApiServiceReadTest.php
@@ -22,6 +22,8 @@ use stdClass;
 use Symfony\Component\Routing\RouterInterface;
 use Tests\Traits\TokenEncryptionTestTrait;
 
+use function array_slice;
+
 /**
  * Unit tests for the ADR-023 read methods on the legacy Jira API service.
  *
@@ -85,7 +87,7 @@ final class JiraOAuthApiServiceReadTest extends TestCase
             /**
              * @param array<int, string> $fields
              */
-            public function searchTicket(string $jql, array $fields, int $limit = 1): mixed
+            public function searchTicket(string $jql, array $fields, int $limit = 1, int $startAt = 0): mixed
             {
                 return $this->searchResponse;
             }
@@ -143,15 +145,17 @@ final class JiraOAuthApiServiceReadTest extends TestCase
 
     public function testSearchIssueKeysCollectsKeysAndDetectsTruncation(): void
     {
+        // A server that keeps returning a full page (pageCount == limit) and
+        // never signals the end (no total) drives the offset loop to its
+        // defensive page cap, which is the only path that sets `truncated`.
         $searchResponse = (object) [
-            'total' => 700,
             'issues' => [(object) ['key' => 'ABC-1'], (object) ['key' => 'ABC-2']],
         ];
 
-        $result = $this->serviceWithCannedResponses([], $searchResponse)->searchIssueKeysWithWorklogs('worklogAuthor = currentUser()', 500);
+        $result = $this->serviceWithCannedResponses([], $searchResponse)->searchIssueKeysWithWorklogs('worklogAuthor = currentUser()', 2);
 
-        self::assertSame(['ABC-1', 'ABC-2'], $result->keys);
         self::assertTrue($result->truncated);
+        self::assertSame(['ABC-1', 'ABC-2'], array_slice($result->keys, 0, 2));
     }
 
     public function testSearchIssueKeysNotTruncatedWhenComplete(): void

--- a/tests/Service/Sync/ImportWorklogsServiceTest.php
+++ b/tests/Service/Sync/ImportWorklogsServiceTest.php
@@ -19,10 +19,12 @@ use App\Entity\Project;
 use App\Entity\SyncRun;
 use App\Entity\TicketSystem;
 use App\Entity\User;
+use App\Entity\UserTicketsystem;
 use App\Entity\WorklogSyncState;
 use App\Enum\SyncItemKind;
 use App\Enum\SyncRunStatus;
 use App\Repository\EntryRepository;
+use App\Repository\UserRepository;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use App\Service\Integration\Jira\JiraOAuthApiService;
 use App\Service\Sync\EntryWorklogProjector;
@@ -52,7 +54,9 @@ final class ImportWorklogsServiceTest extends TestCase
     private TicketProjectResolver&MockObject $projectResolver;
     private JiraAuthorMapper&MockObject $authorMapper;
     private DayClassService&MockObject $dayClassService;
+    private UserRepository&MockObject $userRepository;
     private ImportWorklogsService $service;
+    private ?string $capturedJql = null;
     private User $triggeredBy;
     private User $author;
     private TicketSystem $ticketSystem;
@@ -70,6 +74,7 @@ final class ImportWorklogsServiceTest extends TestCase
         $this->projectResolver = $this->createMock(TicketProjectResolver::class);
         $this->authorMapper = $this->createMock(JiraAuthorMapper::class);
         $this->dayClassService = $this->createMock(DayClassService::class);
+        $this->userRepository = $this->createMock(UserRepository::class);
 
         $apiFactory = $this->createMock(JiraOAuthApiFactory::class);
         $apiFactory->method('create')->willReturn($this->api);
@@ -88,6 +93,7 @@ final class ImportWorklogsServiceTest extends TestCase
         $this->project = self::createStub(Project::class);
         $this->project->method('getCustomer')->willReturn($customer);
         $this->triggeredBy = self::createStub(User::class);
+        $this->triggeredBy->method('getId')->willReturn(1);
         $this->author = self::createStub(User::class);
         $this->author->method('getId')->willReturn(7);
         $this->author->method('getUsername')->willReturn('jdoe');
@@ -102,6 +108,7 @@ final class ImportWorklogsServiceTest extends TestCase
             $this->projectResolver,
             $this->authorMapper,
             $this->dayClassService,
+            $this->userRepository,
             new MockClock('2026-07-09 12:00:00'),
         );
     }
@@ -367,5 +374,45 @@ final class ImportWorklogsServiceTest extends TestCase
         $this->dayClassService->expects(self::once())->method('recalculate')->with(55, '2026-06-10');
 
         $this->import();
+    }
+
+    public function testNonEmptyTargetScopesSearchJqlByAuthor(): void
+    {
+        $this->captureSearchJql();
+        $target = new User()->setUsername('jdoe');
+        $userTicketsystem = new UserTicketsystem();
+        $userTicketsystem->setTicketSystem($this->ticketSystem)->setRemoteAccountId('acc-jdoe');
+        $target->getUserTicketsystems()->add($userTicketsystem);
+        $this->userRepository->method('findOneByUsername')->willReturnCallback(
+            static fn (string $username): ?User => 'jdoe' === $username ? $target : null,
+        );
+
+        $this->import(targetUsernames: ['jdoe']);
+
+        self::assertIsString($this->capturedJql);
+        self::assertStringContainsString('worklogAuthor IN ("acc-jdoe")', $this->capturedJql);
+        self::assertStringContainsString('worklogDate >= "2026-06-01"', $this->capturedJql);
+    }
+
+    public function testEmptyTargetLeavesSearchJqlAuthorUnrestricted(): void
+    {
+        $this->captureSearchJql();
+
+        $this->import();
+
+        self::assertIsString($this->capturedJql);
+        self::assertStringNotContainsString('worklogAuthor', $this->capturedJql);
+        self::assertStringContainsString('worklogDate >= "2026-06-01"', $this->capturedJql);
+    }
+
+    private function captureSearchJql(): void
+    {
+        $this->api->method('searchIssueKeysWithWorklogs')->willReturnCallback(
+            function (string $jql): JiraIssueKeySearchResult {
+                $this->capturedJql = $jql;
+
+                return new JiraIssueKeySearchResult([], false);
+            },
+        );
     }
 }

--- a/tests/Service/Sync/ImportWorklogsServiceTest.php
+++ b/tests/Service/Sync/ImportWorklogsServiceTest.php
@@ -383,9 +383,7 @@ final class ImportWorklogsServiceTest extends TestCase
         $userTicketsystem = new UserTicketsystem();
         $userTicketsystem->setTicketSystem($this->ticketSystem)->setRemoteAccountId('acc-jdoe');
         $target->getUserTicketsystems()->add($userTicketsystem);
-        $this->userRepository->method('findOneByUsername')->willReturnCallback(
-            static fn (string $username): ?User => 'jdoe' === $username ? $target : null,
-        );
+        $this->userRepository->method('findBy')->willReturn([$target]);
 
         $this->import(targetUsernames: ['jdoe']);
 


### PR DESCRIPTION
Fixes two ADR-023 worklog **import**-path issues surfaced in a preview run (the sync path already handled both).

## 1. skipped_author — author-scope the fetch
The import JQL was `worklogDate >= X AND worklogDate <= Y` with **no** `worklogAuthor` clause, so Jira returned every issue anyone logged work on in the range and `resolveAuthor` discarded the rest client-side (2533 `skipped_author` in a real run). When `targetUsernames` is set, the search now adds `worklogAuthor IN (…)` — `currentUser()` for the token owner, else the target's durable `accountId` (username fallback) — mirroring `SyncWorklogsService`.

**Import-all preserved:** empty `targetUsernames` (PO import-all / shadow-user mode) stays author-unrestricted, as does the case where no target resolves to an identity. `resolveAuthor` remains the client-side backstop.

## 2. truncated — paginate instead of capping
`searchIssueKeysWithWorklogs` did a single request capped at `maxResults=500` and told the user to *narrow the date range* (bad UX). Now:
- **Server/DC** (`search/`): loops on `startAt` until a short page or `total` is reached.
- **Jira Cloud** (`search/jql`, which dropped `startAt`/`total`): a dedicated override paginates on `nextPageToken`/`isLast` — the offset loop would otherwise re-fetch page 1 and silently drop issues 501+.

`truncated` is now only set if a defensive page cap is hit.

## Verification (in the dev image against this branch)
PHPStan L10 clean; php-cs-fixer clean (6 files); `tests/Service/Integration/Jira` 227/227; `tests/Service/Sync` + import-command 116/116. New tests: author-clause present/absent by target set; Server offset + Cloud cursor pagination accumulate all pages.

Companion follow-up (separate): a project import for admins/POs so `unresolved_project` prefixes (SRVMO/JOT/…) resolve.