### PR TITLE
fix(admin-ux): worklog-sync dropdown/datepicker/conflict-guidance + personio form help

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -642,5 +642,12 @@
   "worklogsync_conflict_comment": "Kommentar",
   "worklogsync_conflict_started": "Beginn",
   "worklogsync_remote_deleted": "Remote-Worklog gelöscht",
-  "worklogsync_resolve_error": "Der Konflikt konnte nicht aufgelöst werden."
+  "worklogsync_resolve_error": "Der Konflikt konnte nicht aufgelöst werden.",
+  "worklogsync_users_hint": "Leer lassen für alle Benutzer; einen oder mehrere auswählen (Strg/Cmd-Klick) für bestimmte Personen.",
+  "worklogsync_conflict_explainer": "Dieser Eintrag wurde seit dem letzten Abgleich sowohl in TimeTracker als auch in Jira geändert und kann nicht automatisch zusammengeführt werden. Wähle, welche Version gewinnt — die andere Seite wird überschrieben.",
+  "admin_help_personio_name": "Eine Bezeichnung für diese Personio-Verbindung (nur in der Admin-Liste sichtbar).",
+  "admin_help_personio_base_url": "Die Basis-URL der Personio-API, üblicherweise https://api.personio.de.",
+  "admin_help_personio_client_id": "Die Client-ID des Personio-API-Zugangs (Personio → Einstellungen → API).",
+  "admin_help_personio_absence_project": "Das TimeTracker-Projekt, auf das importierte Abwesenheiten gebucht werden (für den Abwesenheits-Import).",
+  "admin_help_personio_active": "Es wird nur die aktive Konfiguration verwendet; deaktivieren pausiert den gesamten Personio-Abgleich."
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -642,5 +642,12 @@
   "worklogsync_conflict_comment": "Comment",
   "worklogsync_conflict_started": "Started",
   "worklogsync_remote_deleted": "Remote worklog deleted",
-  "worklogsync_resolve_error": "Could not resolve the conflict."
+  "worklogsync_resolve_error": "Could not resolve the conflict.",
+  "worklogsync_users_hint": "Leave empty to sync all users; select one or more (Ctrl/Cmd-click) to target specific people.",
+  "worklogsync_conflict_explainer": "This entry changed in both TimeTracker and Jira since the last sync, so it can't be merged automatically. Choose which version wins — the other side is overwritten.",
+  "admin_help_personio_name": "A label for this Personio connection (shown only in the admin list).",
+  "admin_help_personio_base_url": "The Personio API base URL, usually https://api.personio.de.",
+  "admin_help_personio_client_id": "The client ID of the Personio API credential (Personio → Settings → API).",
+  "admin_help_personio_absence_project": "The TimeTracker project imported absences are booked to (used by the absence import).",
+  "admin_help_personio_active": "Only the active configuration is used; deactivate to pause all Personio sync."
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -642,5 +642,12 @@
   "worklogsync_conflict_comment": "Comentario",
   "worklogsync_conflict_started": "Inicio",
   "worklogsync_remote_deleted": "Worklog remoto eliminado",
-  "worklogsync_resolve_error": "No se pudo resolver el conflicto."
+  "worklogsync_resolve_error": "No se pudo resolver el conflicto.",
+  "worklogsync_users_hint": "Déjalo vacío para sincronizar todos los usuarios; selecciona uno o varios (Ctrl/Cmd-clic) para personas concretas.",
+  "worklogsync_conflict_explainer": "Esta entrada cambió tanto en TimeTracker como en Jira desde la última sincronización, por lo que no puede fusionarse automáticamente. Elige qué versión gana — la otra se sobrescribe.",
+  "admin_help_personio_name": "Una etiqueta para esta conexión de Personio (solo visible en la lista de administración).",
+  "admin_help_personio_base_url": "La URL base de la API de Personio, normalmente https://api.personio.de.",
+  "admin_help_personio_client_id": "El ID de cliente de la credencial de la API de Personio (Personio → Ajustes → API).",
+  "admin_help_personio_absence_project": "El proyecto de TimeTracker al que se imputan las ausencias importadas (para la importación de ausencias).",
+  "admin_help_personio_active": "Solo se usa la configuración activa; desactívala para pausar toda la sincronización con Personio."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -642,5 +642,12 @@
   "worklogsync_conflict_comment": "Commentaire",
   "worklogsync_conflict_started": "Début",
   "worklogsync_remote_deleted": "Worklog distant supprimé",
-  "worklogsync_resolve_error": "Impossible de résoudre le conflit."
+  "worklogsync_resolve_error": "Impossible de résoudre le conflit.",
+  "worklogsync_users_hint": "Laissez vide pour synchroniser tous les utilisateurs ; sélectionnez-en un ou plusieurs (Ctrl/Cmd-clic) pour cibler des personnes.",
+  "worklogsync_conflict_explainer": "Cette entrée a changé à la fois dans TimeTracker et dans Jira depuis la dernière synchronisation ; elle ne peut pas être fusionnée automatiquement. Choisissez la version qui l'emporte — l'autre est écrasée.",
+  "admin_help_personio_name": "Un libellé pour cette connexion Personio (visible uniquement dans la liste d'administration).",
+  "admin_help_personio_base_url": "L'URL de base de l'API Personio, généralement https://api.personio.de.",
+  "admin_help_personio_client_id": "L'identifiant client de l'accès API Personio (Personio → Paramètres → API).",
+  "admin_help_personio_absence_project": "Le projet TimeTracker sur lequel les absences importées sont imputées (pour l'import des absences).",
+  "admin_help_personio_active": "Seule la configuration active est utilisée ; désactivez-la pour suspendre toute la synchronisation Personio."
 }

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -642,5 +642,12 @@
   "worklogsync_conflict_comment": "Комментарий",
   "worklogsync_conflict_started": "Начало",
   "worklogsync_remote_deleted": "Удалённый worklog отсутствует",
-  "worklogsync_resolve_error": "Не удалось разрешить конфликт."
+  "worklogsync_resolve_error": "Не удалось разрешить конфликт.",
+  "worklogsync_users_hint": "Оставьте пустым для всех пользователей; выберите одного или нескольких (Ctrl/Cmd-клик) для конкретных людей.",
+  "worklogsync_conflict_explainer": "Эта запись изменилась и в TimeTracker, и в Jira после последней синхронизации, поэтому её нельзя объединить автоматически. Выберите, какая версия победит — другая будет перезаписана.",
+  "admin_help_personio_name": "Название этого подключения Personio (видно только в списке администратора).",
+  "admin_help_personio_base_url": "Базовый URL API Personio, обычно https://api.personio.de.",
+  "admin_help_personio_client_id": "Идентификатор клиента учётных данных API Personio (Personio → Настройки → API).",
+  "admin_help_personio_absence_project": "Проект TimeTracker, на который списываются импортированные отсутствия (для импорта отсутствий).",
+  "admin_help_personio_active": "Используется только активная конфигурация; отключите, чтобы приостановить всю синхронизацию с Personio."
 }

--- a/frontend/src/admin/entities.ts
+++ b/frontend/src/admin/entities.ts
@@ -410,12 +410,12 @@ export function adminEntities(): EntityDescriptor[] {
         { key: 'active', label: () => m.admin_f_active(), render: (row) => mark(row.active), align: 'center', boolean: true },
       ],
       fields: [
-        { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true },
-        { name: 'baseUrl', label: () => m.admin_f_base_url(), type: 'text', required: true },
-        { name: 'clientId', label: () => m.admin_f_client_id(), type: 'text', required: true },
+        { name: 'name', label: () => m.admin_f_name(), type: 'text', required: true, help: () => m.admin_help_personio_name() },
+        { name: 'baseUrl', label: () => m.admin_f_base_url(), type: 'text', required: true, help: () => m.admin_help_personio_base_url() },
+        { name: 'clientId', label: () => m.admin_f_client_id(), type: 'text', required: true, help: () => m.admin_help_personio_client_id() },
         { name: 'clientSecret', label: () => m.admin_f_client_secret(), type: 'text', help: () => m.admin_f_secret_hint() },
-        { name: 'absence_project', label: () => m.admin_f_absence_project(), type: 'select', source: 'projects' },
-        { name: 'active', label: () => m.admin_f_active(), type: 'checkbox' },
+        { name: 'absence_project', label: () => m.admin_f_absence_project(), type: 'select', source: 'projects', help: () => m.admin_help_personio_absence_project() },
+        { name: 'active', label: () => m.admin_f_active(), type: 'checkbox', help: () => m.admin_help_personio_active() },
       ],
       rowLabel: (row) => str(row.name),
       // The client secret is not returned by the list (server-side filtered), so

--- a/frontend/src/components/ConflictList.tsx
+++ b/frontend/src/components/ConflictList.tsx
@@ -84,6 +84,7 @@ function ConflictCard(props: {
 
   return (
     <li class="conflict-card">
+      <p class="conflict-explainer">{m.worklogsync_conflict_explainer()}</p>
       <div class="conflict-sides">
         <section class="conflict-side conflict-side-local" aria-label={m.worklogsync_conflict_local()}>
           <h3 class="conflict-side-title">{m.worklogsync_conflict_local()}</h3>

--- a/frontend/src/pages/WorklogSync.tsx
+++ b/frontend/src/pages/WorklogSync.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createSignal, For, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
-import { ticketSystemsQuery } from '../api/queries'
+import { ticketSystemsQuery, usersQuery } from '../api/queries'
 import {
   createSyncRun,
   syncRunQuery,
@@ -88,7 +88,7 @@ function WorklogSyncArea(): JSX.Element {
   const [ticketSystemId, setTicketSystemId] = createSignal(0)
   const [from, setFrom] = createSignal(firstOfMonth())
   const [to, setTo] = createSignal(isoDate(new Date()))
-  const [usersText, setUsersText] = createSignal('')
+  const [selectedUsers, setSelectedUsers] = createSignal<string[]>([])
   const [dryRun, setDryRun] = createSignal(true)
   const [busy, setBusy] = createSignal(false)
   const [error, setError] = createSignal('')
@@ -97,6 +97,9 @@ function WorklogSyncArea(): JSX.Element {
   // Run history: an optional ticket-system filter + the run opened for detail.
   const [historyFilter, setHistoryFilter] = createSignal(0)
   const [selectedRunId, setSelectedRunId] = createSignal<number | null>(null)
+
+  // TT users for the target dropdown (empty selection = all users).
+  const userOptions = useQuery(() => usersQuery())
 
   const runs = useQuery(() => syncRunsQuery(historyFilter() > 0 ? historyFilter() : undefined))
   const runDetail = useQuery(() => ({
@@ -107,10 +110,7 @@ function WorklogSyncArea(): JSX.Element {
   const canRun = (): boolean => ticketSystemId() > 0 && !busy()
 
   function buildPayload(): CreateRunPayload {
-    const users = usersText()
-      .split(',')
-      .map((user) => user.trim())
-      .filter((user) => user !== '')
+    const users = selectedUsers()
 
     return {
       type: type(),
@@ -170,23 +170,32 @@ function WorklogSyncArea(): JSX.Element {
 
             <label class="field">
               <span>{m.worklogsync_from()}</span>
-              <DateField value={from()} onChange={setFrom} disabled={busy()} />
+              <DateField value={from()} onChange={setFrom} disabled={busy()} calendar />
             </label>
 
             <label class="field">
               <span>{m.worklogsync_to()}</span>
-              <DateField value={to()} onChange={setTo} disabled={busy()} />
+              <DateField value={to()} onChange={setTo} disabled={busy()} calendar />
             </label>
 
             <label class="field">
               <span>{m.worklogsync_users()}</span>
-              <input
-                type="text"
-                value={usersText()}
+              <select
+                multiple
                 disabled={busy()}
-                placeholder={m.worklogsync_all_users()}
-                onInput={(event) => setUsersText(event.currentTarget.value)}
-              />
+                onChange={(event) =>
+                  setSelectedUsers(Array.from(event.currentTarget.selectedOptions, (option) => option.value))
+                }
+              >
+                <For each={userOptions.data ?? []}>
+                  {(option) => (
+                    <option value={String(option.label)} selected={selectedUsers().includes(String(option.label))}>
+                      {option.label}
+                    </option>
+                  )}
+                </For>
+              </select>
+              <small class="field-hint">{m.worklogsync_users_hint()}</small>
             </label>
 
             <label class="field-check">

--- a/frontend/src/pages/WorklogSync.tsx
+++ b/frontend/src/pages/WorklogSync.tsx
@@ -110,7 +110,8 @@ function WorklogSyncArea(): JSX.Element {
   const canRun = (): boolean => ticketSystemId() > 0 && !busy()
 
   function buildPayload(): CreateRunPayload {
-    const users = selectedUsers()
+    // A sync run targets at most one user; verify/import accept several.
+    const users = type() === 'sync' ? selectedUsers().slice(0, 1) : selectedUsers()
 
     return {
       type: type(),
@@ -181,12 +182,21 @@ function WorklogSyncArea(): JSX.Element {
             <label class="field">
               <span>{m.worklogsync_users()}</span>
               <select
-                multiple
+                multiple={type() !== 'sync'}
                 disabled={busy()}
-                onChange={(event) =>
-                  setSelectedUsers(Array.from(event.currentTarget.selectedOptions, (option) => option.value))
-                }
+                onChange={(event) => {
+                  // A sync run targets a single user (the backend rejects >1 with 422);
+                  // verify/import accept a multi-selection.
+                  if (type() === 'sync') {
+                    setSelectedUsers(event.currentTarget.value ? [event.currentTarget.value] : [])
+                  } else {
+                    setSelectedUsers(Array.from(event.currentTarget.selectedOptions, (option) => option.value))
+                  }
+                }}
               >
+                <Show when={type() === 'sync'}>
+                  <option value="" selected={selectedUsers().length === 0}>—</option>
+                </Show>
                 <For each={userOptions.data ?? []}>
                   {(option) => (
                     <option value={String(option.label)} selected={selectedUsers().includes(String(option.label))}>


### PR DESCRIPTION
Prod UX feedback on the shipped admin screens (ADR-023/024).

## /ui/admin/worklog-sync
- **User target is now a multi-select of TimeTracker users** (from `/getAllUsers`) instead of a free-text field; empty selection = all users. Hint explains multi-select + the all-users default.
- **Date from/to get the calendar datepicker** — `DateField` already has an opt-in `calendar` prop (body-portalled month picker); it just wasn't set here.
- **Conflict cards lead with guidance.** A `remote_dirty` conflict showed only the terse "remote changed since base". It now opens with an explainer: the entry changed in **both** TimeTracker and Jira since the last sync, so it can't be merged automatically — choose which version wins, the other side is overwritten. The existing keep-mine / take-Jira buttons follow.

## /ui/admin/personio
- **Per-field context help** on the config form (name, base URL, client id, absence project, active), matching the `help:`() pattern the other admin entities already use. (Client-secret keeps its blank-preserves hint.)

## i18n / tests
New strings in all five catalogs (en/de/es/fr/ru). `bun run typecheck` + `lint` clean; WorklogSync/ConflictList/entities suites (36 tests) green.

Screenshots: happy to capture before/after from the dev stack on request.