### PR TITLE
feat(import): ADR-026 P2+P3 — stable customer key + opt-in ad-hoc project auto-create

### DIFF
--- a/frontend/src/api/projectImport.ts
+++ b/frontend/src/api/projectImport.ts
@@ -37,13 +37,17 @@ export interface ProposalsResponse {
 }
 
 /** One confirmed row for POST /project-import/confirm. Exactly one of
- *  `customer_id` (pick existing) / `customer_name` (create-or-find-by-name). */
+ *  `customer_id` (pick existing) / `customer_name` (create-or-find-by-name).
+ *  `customer_key` is the stable Tempo key (ADR-026 P2), sent only alongside
+ *  `customer_name` when the name is still the derived one, so the created (or
+ *  name-matched) customer is keyed for idempotent re-imports. */
 export interface ConfirmRow {
   jira_key: string
   project_name: string
   ticket_system_id: number
   customer_id?: number
   customer_name?: string
+  customer_key?: string
 }
 
 /** One persisted result row (ProjectImportConfirmationService::confirm). */

--- a/frontend/src/pages/ProjectImport.test.tsx
+++ b/frontend/src/pages/ProjectImport.test.tsx
@@ -163,6 +163,63 @@ describe('ProjectImport', () => {
     await waitFor(() => expect(screen.getByText('Created')).toBeInTheDocument())
   })
 
+  it('sends the stable Tempo key when the confirmed new customer is still the derived one', async () => {
+    // Customer list WITHOUT 'Netresearch' → the derived 'Netresearch' has no
+    // existing match, so the row defaults to a NEW customer keeping the derived
+    // name, and its stable Tempo key (NR) rides along (ADR-026 P2).
+    getJson.mockImplementation((path: string) => {
+      if (path === '/getTicketSystems') {
+        return Promise.resolve([{ ticketSystem: { id: 1, name: 'Jira Cloud', active: true } }])
+      }
+      if (path === '/getAllCustomers') {
+        return Promise.resolve([{ customer: { id: 6, name: 'Netresearch Solutions', active: true } }])
+      }
+
+      return Promise.resolve([])
+    })
+    confirmProjectImport.mockResolvedValue({ projects: [] })
+    renderWithProviders(() => <ProjectImport />)
+    await selectTicketSystem()
+
+    const confirm = screen.getByLabelText('Confirm — SRVMO') as HTMLInputElement
+    await waitFor(() => expect(confirm).not.toBeDisabled())
+    fireEvent.input(confirm, { target: { checked: true } })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm selected' }))
+
+    await waitFor(() => expect(confirmProjectImport).toHaveBeenCalledTimes(1))
+    expect(confirmProjectImport).toHaveBeenLastCalledWith([
+      {
+        jira_key: 'SRVMO',
+        project_name: 'Server Monitoring',
+        ticket_system_id: 1,
+        customer_name: 'Netresearch',
+        customer_key: 'NR',
+      },
+    ])
+  })
+
+  it('omits the Tempo key when the admin types a different new name', async () => {
+    mockRefs()
+    confirmProjectImport.mockResolvedValue({ projects: [] })
+    renderWithProviders(() => <ProjectImport />)
+    await selectTicketSystem()
+
+    // Override the confident row to a hand-typed different new name — no key.
+    fireEvent.change(screen.getByLabelText('Customer — SRVMO'), { target: { value: 'new' } })
+    fireEvent.input(screen.getByLabelText('New customer name — SRVMO'), {
+      target: { value: 'Totally Different Ltd' },
+    })
+    const confirm = screen.getByLabelText('Confirm — SRVMO') as HTMLInputElement
+    await waitFor(() => expect(confirm).not.toBeDisabled())
+    fireEvent.input(confirm, { target: { checked: true } })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm selected' }))
+
+    await waitFor(() => expect(confirmProjectImport).toHaveBeenCalledTimes(1))
+    expect(confirmProjectImport).toHaveBeenLastCalledWith([
+      { jira_key: 'SRVMO', project_name: 'Server Monitoring', ticket_system_id: 1, customer_name: 'Totally Different Ltd' },
+    ])
+  })
+
   it('does not expose the screen to a non-admin', () => {
     mockRefs()
     window.APP_CONFIG!.roles = ['ROLE_USER']

--- a/frontend/src/pages/ProjectImport.tsx
+++ b/frontend/src/pages/ProjectImport.tsx
@@ -170,10 +170,20 @@ function ProjectImportArea(): JSX.Element {
         project_name: (proposal.project_name ?? '').trim() || proposal.jira_id_prefix,
         ticket_system_id: tsId,
       }
+      if (row.choice !== 'new') {
+        out.push({ ...base, customer_id: Number(row.choice) })
+        continue
+      }
+      // Carry the stable Tempo key (ADR-026 P2) only when the new name is still
+      // the derived one — a hand-typed different name gets no key.
+      const newName = row.newName.trim()
+      const derivedName = (proposal.derived_customer_name ?? '').trim()
+      const isDerived =
+        newName !== '' && newName === derivedName && (proposal.derived_customer_key ?? '') !== ''
       out.push(
-        row.choice === 'new'
-          ? { ...base, customer_name: row.newName.trim() }
-          : { ...base, customer_id: Number(row.choice) },
+        isDerived
+          ? { ...base, customer_name: newName, customer_key: proposal.derived_customer_key ?? undefined }
+          : { ...base, customer_name: newName },
       )
     }
 

--- a/migrations/Version20260712_AutoImportProjectsFlag.php
+++ b/migrations/Version20260712_AutoImportProjectsFlag.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add `ticket_systems.auto_import_unresolved_projects` (ADR-026 P3): the opt-in
+ * gate for ad-hoc auto-create of unresolved Jira projects during worklog import.
+ * Defaults to FALSE so existing systems keep the current park-on-unresolved
+ * behaviour untouched — auto-create (which writes billing data) is only ever
+ * reached once an admin flips this flag on.
+ */
+final class Version20260712_AutoImportProjectsFlag extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add opt-in ticket_systems.auto_import_unresolved_projects flag for ADR-026 P3 ad-hoc project auto-create';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ticket_systems ADD auto_import_unresolved_projects TINYINT(1) NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ticket_systems DROP COLUMN auto_import_unresolved_projects');
+    }
+}

--- a/migrations/Version20260712_CustomerTempoKey.php
+++ b/migrations/Version20260712_CustomerTempoKey.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add `customers.tempo_customer_key` (ADR-026 P2): a nullable, UNIQUE stable key
+ * so the Tempo->Customer mapping is idempotent across import runs — a re-import
+ * or a P3 auto-create resolves the existing Customer by key instead of spawning
+ * a duplicate on name drift. NULL (default) for every existing customer; the
+ * UNIQUE index tolerates multiple NULLs (MySQL/MariaDB), so no default is needed.
+ */
+final class Version20260712_CustomerTempoKey extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add nullable UNIQUE customers.tempo_customer_key for idempotent Tempo->Customer upserts (ADR-026 P2)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE customers ADD tempo_customer_key VARCHAR(63) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX uniq_customers_tempo_customer_key ON customers (tempo_customer_key)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_customers_tempo_customer_key ON customers');
+        $this->addSql('ALTER TABLE customers DROP COLUMN tempo_customer_key');
+    }
+}

--- a/migrations/Version20260712_CustomerTempoKey.php
+++ b/migrations/Version20260712_CustomerTempoKey.php
@@ -34,7 +34,7 @@ final class Version20260712_CustomerTempoKey extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP INDEX uniq_customers_tempo_customer_key ON customers');
-        $this->addSql('ALTER TABLE customers DROP COLUMN tempo_customer_key');
+        $this->addSql('DROP INDEX IF EXISTS uniq_customers_tempo_customer_key ON customers');
+        $this->addSql('ALTER TABLE customers DROP COLUMN IF EXISTS tempo_customer_key');
     }
 }

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -157,6 +157,7 @@ CREATE TABLE `ticket_systems` (
   `oauth2_client_secret` VARCHAR(255) NULL,
   `cloud_id` VARCHAR(64) NULL,
   `sync_default_activity_id` INT NULL DEFAULT NULL,
+  `auto_import_unresolved_projects` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `fk_ts_sync_activity` (`sync_default_activity_id`),

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -130,7 +130,9 @@ CREATE TABLE `customers` (
   `name` varchar(255) NOT NULL,
   `active` int(1) unsigned NOT NULL default '0',
   `global` int(1) unsigned NOT NULL default '0',
-  PRIMARY KEY (`id`)
+  `tempo_customer_key` varchar(63) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_customers_tempo_customer_key` (`tempo_customer_key`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 

--- a/src/Dto/ProjectImportConfirmRowDto.php
+++ b/src/Dto/ProjectImportConfirmRowDto.php
@@ -22,6 +22,12 @@ use Symfony\Component\Validator\Constraints as Assert;
  * {@see \App\Service\Sync\ProjectImportConfirmationService} since it depends on
  * both fields together.
  *
+ * $customer_key is the optional stable Tempo customer key (ADR-026 P2): when a
+ * new-name row was derived from Tempo, the SPA forwards proposal.derived_customer_key
+ * so the created (or name-matched) Customer gets the stable key, making the
+ * mapping idempotent across runs. It is honoured only on the by-name path, never
+ * when $customer_id picks an explicit existing customer (that keeps its identity).
+ *
  * Property names are snake_case to bind directly to the SPA's JSON body (no
  * serializer name converter is configured — see the other request DTOs).
  */
@@ -36,6 +42,7 @@ final readonly class ProjectImportConfirmRowDto
         public int $ticket_system_id = 0,
         public ?int $customer_id = null,
         public ?string $customer_name = null,
+        public ?string $customer_key = null,
     ) {
     }
 }

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: CustomerRepository::class)]
 #[ORM\Table(name: 'customers')]
+#[ORM\UniqueConstraint(name: 'uniq_customers_tempo_customer_key', columns: ['tempo_customer_key'])]
 class Customer extends Base
 {
     /**
@@ -29,6 +30,15 @@ class Customer extends Base
 
     #[ORM\Column(type: 'string', length: 255)]
     protected string $name = '';
+
+    /**
+     * Stable Tempo customer key (ADR-026 P2): the `customer.key` from the linked
+     * Tempo Account, used to upsert a Customer idempotently across import runs so
+     * name drift never spawns a duplicate. NULL for customers never derived from
+     * Tempo; the UNIQUE index tolerates multiple NULLs (MySQL/MariaDB).
+     */
+    #[ORM\Column(name: 'tempo_customer_key', type: 'string', length: 63, nullable: true)]
+    protected ?string $tempoCustomerKey = null;
 
     /**
      * @var bool
@@ -119,6 +129,26 @@ class Customer extends Base
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    /**
+     * Get the stable Tempo customer key (ADR-026 P2), or null when never derived.
+     */
+    public function getTempoCustomerKey(): ?string
+    {
+        return $this->tempoCustomerKey;
+    }
+
+    /**
+     * Set the stable Tempo customer key (ADR-026 P2).
+     *
+     * @return $this
+     */
+    public function setTempoCustomerKey(?string $tempoCustomerKey): static
+    {
+        $this->tempoCustomerKey = $tempoCustomerKey;
+
+        return $this;
     }
 
     /**

--- a/src/Entity/TicketSystem.php
+++ b/src/Entity/TicketSystem.php
@@ -113,6 +113,15 @@ class TicketSystem extends Base
     protected ?Activity $syncDefaultActivity = null;
 
     /**
+     * Opt-in gate (ADR-026 P3): when true, a worklog import may ad-hoc auto-create
+     * a Project + derived Customer for an unresolved Jira prefix — but only when
+     * the derivation yields exactly one confident customer. Default false keeps
+     * the park-on-unresolved behaviour, so auto-create (billing data) is opt-in.
+     */
+    #[ORM\Column(name: 'auto_import_unresolved_projects', type: 'boolean', nullable: false, options: ['default' => 0])]
+    protected bool $autoImportUnresolvedProjects = false;
+
+    /**
      * Credential fields that must never leave the server. They are needed only
      * server-side, so both the list endpoint (GetTicketSystemsAction) and the
      * save response (SaveTicketSystemAction) strip them. Base::toArray() emits
@@ -444,6 +453,21 @@ class TicketSystem extends Base
     public function setSyncDefaultActivity(?Activity $syncDefaultActivity): static
     {
         $this->syncDefaultActivity = $syncDefaultActivity;
+
+        return $this;
+    }
+
+    public function getAutoImportUnresolvedProjects(): bool
+    {
+        return $this->autoImportUnresolvedProjects;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setAutoImportUnresolvedProjects(bool $autoImportUnresolvedProjects): static
+    {
+        $this->autoImportUnresolvedProjects = $autoImportUnresolvedProjects;
 
         return $this;
     }

--- a/src/Enum/SyncItemKind.php
+++ b/src/Enum/SyncItemKind.php
@@ -24,6 +24,7 @@ enum SyncItemKind: string
     case CONFLICT = 'conflict';
     case PROBABLE_DUPLICATE = 'probable_duplicate';
     case UNRESOLVED_PROJECT = 'unresolved_project';
+    case PROJECT_AUTO_IMPORTED = 'project_auto_imported';
     case SHADOW_USER_CREATED = 'shadow_user_created';
     case TRUNCATED = 'truncated';
     case ERROR = 'error';

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -113,4 +113,16 @@ class CustomerRepository extends ServiceEntityRepository
 
         return $result instanceof Customer ? $result : null;
     }
+
+    /**
+     * The customer carrying this stable Tempo customer key (ADR-026 P2), if any —
+     * the idempotency key for the Tempo->Customer upsert: a re-import resolves the
+     * existing Customer by key instead of duplicating it on name drift.
+     */
+    public function findOneByTempoCustomerKey(string $tempoCustomerKey): ?Customer
+    {
+        $result = $this->findOneBy(['tempoCustomerKey' => $tempoCustomerKey]);
+
+        return $result instanceof Customer ? $result : null;
+    }
 }

--- a/src/Service/Sync/CustomerUpserter.php
+++ b/src/Service/Sync/CustomerUpserter.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Sync;
+
+use App\Entity\Customer;
+use App\Repository\CustomerRepository;
+use Doctrine\Persistence\ObjectManager;
+
+/**
+ * Resolve-or-create a Customer from a name and an optional stable Tempo key,
+ * making the Tempo->Customer mapping idempotent across runs (ADR-026 P2).
+ *
+ * Extracted from {@see ProjectImportConfirmationService} so the P1 confirm flow
+ * and the P3 ad-hoc import auto-create share one upsert — the confidence gate
+ * lives in the callers, the idempotent write lives here.
+ */
+final readonly class CustomerUpserter
+{
+    public function __construct(
+        private CustomerRepository $customerRepository,
+    ) {
+    }
+
+    /**
+     * Resolve-or-create a Customer:
+     *
+     *  1. a key given & a customer already carries it -> reuse (name drift ignored);
+     *  2. else match by name -> reuse, backfilling the key when the row had none;
+     *  3. else create a new Customer with the name (+ the key when supplied).
+     *
+     * The by-name / by-key arrays are the caller's within-batch (or within-run)
+     * reuse caches, so a customer created for an earlier row/prefix is reused by
+     * a later one before the flush — avoiding a UNIQUE-key collision on the
+     * unflushed key.
+     *
+     * @param array<string, Customer> $customersByName     within-batch reuse by name
+     * @param array<string, Customer> $customersByTempoKey within-batch reuse by key
+     */
+    public function upsert(string $name, ?string $tempoKey, array &$customersByName, array &$customersByTempoKey, ObjectManager $objectManager): Customer
+    {
+        if (null !== $tempoKey) {
+            if (isset($customersByTempoKey[$tempoKey])) {
+                return $customersByTempoKey[$tempoKey];
+            }
+
+            $byKey = $this->customerRepository->findOneByTempoCustomerKey($tempoKey);
+            if ($byKey instanceof Customer) {
+                $customersByTempoKey[$tempoKey] = $byKey;
+
+                return $byKey;
+            }
+        }
+
+        $customer = $customersByName[$name] ?? $this->customerRepository->findOneByName($name);
+        if ($customer instanceof Customer) {
+            $this->backfillTempoKey($customer, $tempoKey, $customersByTempoKey);
+            $customersByName[$name] = $customer;
+
+            return $customer;
+        }
+
+        $customer = new Customer();
+        $customer->setName($name)
+            ->setActive(true)
+            ->setGlobal(false);
+        if (null !== $tempoKey) {
+            $customer->setTempoCustomerKey($tempoKey);
+            $customersByTempoKey[$tempoKey] = $customer;
+        }
+
+        $objectManager->persist($customer);
+        $customersByName[$name] = $customer;
+
+        return $customer;
+    }
+
+    /**
+     * Stamp the stable Tempo key onto a name-matched customer that has none, so a
+     * later run resolves it by key. A customer already keyed keeps its key.
+     *
+     * @param array<string, Customer> $customersByTempoKey
+     */
+    private function backfillTempoKey(Customer $customer, ?string $tempoKey, array &$customersByTempoKey): void
+    {
+        if (null === $tempoKey) {
+            return;
+        }
+
+        $existing = $customer->getTempoCustomerKey();
+        if (null === $existing || '' === $existing) {
+            $customer->setTempoCustomerKey($tempoKey);
+        }
+
+        $customersByTempoKey[$tempoKey] = $customer;
+    }
+}

--- a/src/Service/Sync/CustomerUpserter.php
+++ b/src/Service/Sync/CustomerUpserter.php
@@ -93,11 +93,12 @@ final readonly class CustomerUpserter
             return;
         }
 
+        // Only cache under this key if we actually backfilled it — caching a customer that already
+        // holds a DIFFERENT key would create a cache-vs-DB key mismatch.
         $existing = $customer->getTempoCustomerKey();
         if (null === $existing || '' === $existing) {
             $customer->setTempoCustomerKey($tempoKey);
+            $customersByTempoKey[$tempoKey] = $customer;
         }
-
-        $customersByTempoKey[$tempoKey] = $customer;
     }
 }

--- a/src/Service/Sync/ImportRunContext.php
+++ b/src/Service/Sync/ImportRunContext.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace App\Service\Sync;
 
 use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Project;
 use App\Entity\SyncRun;
 use App\Entity\TicketSystem;
 use App\Entity\User;
@@ -30,6 +32,22 @@ final class ImportRunContext
     /** @var array<string, true> issue keys whose unresolved project was already announced */
     public array $unresolvedAnnounced = [];
 
+    /**
+     * Per-run, per-prefix ad-hoc auto-create result (ADR-026 P3): a prefix is
+     * derived once (Tempo/Jira calls are expensive) and both outcomes cache —
+     * the created Project and the parked null. Keyed by Jira prefix; use
+     * array_key_exists to tell "cached null" from "not yet derived".
+     *
+     * @var array<string, ?Project>
+     */
+    public array $autoImportCache = [];
+
+    /** @var array<string, Customer> run-level Tempo-key reuse for P3 auto-created customers (avoids a UNIQUE-key clash on an unflushed key) */
+    public array $customersByTempoKey = [];
+
+    /** @var array<string, Customer> run-level name reuse for P3 auto-created customers */
+    public array $customersByName = [];
+
     /** @var array<string, array{user: User, day: string}> (user, day) pairs needing day-class recalculation */
     public array $affectedDays = [];
 
@@ -40,6 +58,7 @@ final class ImportRunContext
      */
     public function __construct(
         public readonly SyncRun $syncRun,
+        public readonly User $triggeredBy,
         public readonly TicketSystem $ticketSystem,
         public readonly Activity $activity,
         public readonly array $targetUsernames,

--- a/src/Service/Sync/ImportWorklogsService.php
+++ b/src/Service/Sync/ImportWorklogsService.php
@@ -444,11 +444,24 @@ class ImportWorklogsService extends AbstractSyncRunService
      */
     private function deriveAndCreateProject(ImportRunContext $importRunContext, string $prefix): ?Project
     {
-        $proposals = $this->projectImportProposalService->proposeForKeys(
-            [$prefix],
-            $importRunContext->ticketSystem,
-            $importRunContext->triggeredBy,
-        );
+        try {
+            $proposals = $this->projectImportProposalService->proposeForKeys(
+                [$prefix],
+                $importRunContext->ticketSystem,
+                $importRunContext->triggeredBy,
+            );
+        } catch (Throwable $throwable) {
+            // A Jira/Tempo failure while deriving must not abort the whole import run — park this prefix.
+            $importRunContext->syncRun->incrementCounter('errors');
+            $this->addItem(
+                $importRunContext->syncRun,
+                SyncItemKind::ERROR,
+                issueKey: $prefix,
+                reason: substr('auto-import proposal derivation failed: ' . $throwable->getMessage(), 0, 255),
+            );
+
+            return null;
+        }
 
         if (1 !== count($proposals)) {
             return null;

--- a/src/Service/Sync/ImportWorklogsService.php
+++ b/src/Service/Sync/ImportWorklogsService.php
@@ -11,6 +11,7 @@ namespace App\Service\Sync;
 
 use App\DTO\Jira\JiraUserIdentity;
 use App\DTO\Jira\JiraWorkLog;
+use App\DTO\Sync\ProjectImportProposal;
 use App\Entity\Activity;
 use App\Entity\Customer;
 use App\Entity\Entry;
@@ -38,13 +39,16 @@ use Throwable;
 
 use function array_key_exists;
 use function array_values;
+use function count;
 use function implode;
 use function in_array;
 use function mb_substr;
 use function spl_object_id;
 use function sprintf;
 use function str_replace;
+use function strstr;
 use function substr;
+use function trim;
 
 /**
  * ADR-023 Phase 2: imports Jira worklogs as pre-synced TT entries. Never dispatches
@@ -62,6 +66,8 @@ class ImportWorklogsService extends AbstractSyncRunService
         private readonly JiraAuthorMapper $jiraAuthorMapper,
         private readonly DayClassService $dayClassService,
         private readonly UserRepository $userRepository,
+        private readonly ProjectImportProposalService $projectImportProposalService,
+        private readonly CustomerUpserter $customerUpserter,
         ClockInterface $clock,
     ) {
         parent::__construct($entityManager, $clock);
@@ -130,6 +136,7 @@ class ImportWorklogsService extends AbstractSyncRunService
 
         $importRunContext = new ImportRunContext(
             syncRun: $syncRun,
+            triggeredBy: $triggeredBy,
             ticketSystem: $ticketSystem,
             activity: $activity,
             targetUsernames: $targetUsernames,
@@ -376,6 +383,14 @@ class ImportWorklogsService extends AbstractSyncRunService
             return $resolution->project;
         }
 
+        // ADR-026 P3: opt-in ad-hoc auto-create of an unresolved prefix's project.
+        // Only reached when the ticket system flips the flag on AND the derivation
+        // yields exactly one confident customer; otherwise it falls through to park.
+        $autoCreated = $this->autoImportProject($importRunContext, $issueKey);
+        if ($autoCreated instanceof Project) {
+            return $autoCreated;
+        }
+
         $importRunContext->syncRun->incrementCounter('unresolved_project');
         if (!isset($importRunContext->unresolvedAnnounced[$issueKey])) {
             $importRunContext->unresolvedAnnounced[$issueKey] = true;
@@ -383,6 +398,120 @@ class ImportWorklogsService extends AbstractSyncRunService
         }
 
         return null;
+    }
+
+    /**
+     * ADR-026 P3 ad-hoc auto-create, gated three ways: the ticket-system opt-in
+     * flag, a derivable Jira prefix, and (inside {@see deriveAndCreateProject})
+     * the confidence check. A dry run never writes billing data, so it never
+     * auto-creates — the prefix parks and is reported as unresolved as today.
+     *
+     * The result (created Project or parked null) caches per prefix so a prefix
+     * is derived once per run, not once per issue.
+     */
+    private function autoImportProject(ImportRunContext $importRunContext, string $issueKey): ?Project
+    {
+        if (!$importRunContext->ticketSystem->getAutoImportUnresolvedProjects()) {
+            return null;
+        }
+
+        if ($importRunContext->dryRun) {
+            return null;
+        }
+
+        $prefix = strstr($issueKey, '-', true);
+        if (false === $prefix || '' === $prefix) {
+            return null;
+        }
+
+        if (array_key_exists($prefix, $importRunContext->autoImportCache)) {
+            return $importRunContext->autoImportCache[$prefix];
+        }
+
+        $project = $this->deriveAndCreateProject($importRunContext, $prefix);
+        $importRunContext->autoImportCache[$prefix] = $project;
+
+        return $project;
+    }
+
+    /**
+     * Derive a proposal for one prefix and auto-create Project + Customer only
+     * when it is confident (ADR-026 P3 safety model): the customer must come
+     * from tempo | tempo-default | category with a non-empty name — ambiguous,
+     * none, error and not-a-project all park (return null). The Customer is
+     * upserted idempotently via the shared {@see CustomerUpserter}, reusing the
+     * P2 stable Tempo key so a re-run resolves the existing customer.
+     */
+    private function deriveAndCreateProject(ImportRunContext $importRunContext, string $prefix): ?Project
+    {
+        $proposals = $this->projectImportProposalService->proposeForKeys(
+            [$prefix],
+            $importRunContext->ticketSystem,
+            $importRunContext->triggeredBy,
+        );
+
+        if (1 !== count($proposals)) {
+            return null;
+        }
+
+        $proposal = $proposals[0];
+        if (!$this->isConfident($proposal)) {
+            return null;
+        }
+
+        $customerName = trim((string) $proposal->derivedCustomerName);
+        $tempoKey = null === $proposal->derivedCustomerKey ? null : trim($proposal->derivedCustomerKey);
+        $tempoKey = '' === $tempoKey ? null : $tempoKey;
+
+        $customer = $this->customerUpserter->upsert(
+            $customerName,
+            $tempoKey,
+            $importRunContext->customersByName,
+            $importRunContext->customersByTempoKey,
+            $this->entityManager,
+        );
+
+        $projectName = null !== $proposal->projectName && '' !== trim($proposal->projectName)
+            ? trim($proposal->projectName)
+            : $prefix;
+
+        $project = new Project();
+        $project->setName($projectName)
+            ->setCustomer($customer)
+            ->setJiraId($prefix)
+            ->setTicketSystem($importRunContext->ticketSystem)
+            ->setActive(true)
+            ->setGlobal(false)
+            ->setEstimation(0);
+        $this->entityManager->persist($project);
+
+        $importRunContext->syncRun->incrementCounter('auto_imported_project');
+        $this->addItem(
+            $importRunContext->syncRun,
+            SyncItemKind::PROJECT_AUTO_IMPORTED,
+            issueKey: $prefix,
+            reason: substr(sprintf('auto-created project %s -> customer "%s" (%s)', $prefix, $customerName, $proposal->derivationSource), 0, 255),
+        );
+
+        return $project;
+    }
+
+    /**
+     * The ADR-026 P3 confidence gate: auto-create only from a single confident
+     * customer — a tempo | tempo-default | category source with a non-empty
+     * derived name. Never from ambiguous, none, error or not-a-project.
+     */
+    private function isConfident(ProjectImportProposal $proposal): bool
+    {
+        if (!in_array($proposal->derivationSource, [
+            ProjectImportProposal::SOURCE_TEMPO,
+            ProjectImportProposal::SOURCE_TEMPO_DEFAULT,
+            ProjectImportProposal::SOURCE_CATEGORY,
+        ], true)) {
+            return false;
+        }
+
+        return null !== $proposal->derivedCustomerName && '' !== trim($proposal->derivedCustomerName);
     }
 
     /**

--- a/src/Service/Sync/ProjectImportConfirmationService.php
+++ b/src/Service/Sync/ProjectImportConfirmationService.php
@@ -53,8 +53,10 @@ final readonly class ProjectImportConfirmationService
     {
         $objectManager = $this->managerRegistry->getManager();
 
-        /** @var array<string, Customer> $newCustomersByName reuse a to-be-created customer within the batch */
-        $newCustomersByName = [];
+        /** @var array<string, Customer> $customersByName reuse a resolved/created customer by name within the batch */
+        $customersByName = [];
+        /** @var array<string, Customer> $customersByTempoKey reuse a resolved/created customer by stable Tempo key within the batch */
+        $customersByTempoKey = [];
         /** @var array<string, Project> $projectsByKey reuse a to-be-created project within the batch */
         $projectsByKey = [];
 
@@ -75,7 +77,7 @@ final readonly class ProjectImportConfirmationService
                 continue;
             }
 
-            $customer = $this->resolveCustomer($row, $newCustomersByName, $objectManager);
+            $customer = $this->resolveCustomer($row, $customersByName, $customersByTempoKey, $objectManager);
 
             $project = new Project();
             $project->setName(trim($row->project_name))
@@ -140,13 +142,18 @@ final readonly class ProjectImportConfirmationService
     }
 
     /**
-     * Override by id (existing customer) OR resolve by name (found, else created).
+     * Override by id (existing customer, kept as-is) OR resolve-or-create by name,
+     * carrying the row's optional stable Tempo key into the upsert (ADR-026 P2).
      *
-     * @param array<string, Customer> $newCustomersByName
+     * An explicit $customer_id pick keeps its own identity — the Tempo key is NOT
+     * applied to it, so choosing an existing customer never rebrands its key.
+     *
+     * @param array<string, Customer> $customersByName
+     * @param array<string, Customer> $customersByTempoKey
      *
      * @throws InvalidArgumentException on an unknown id or a blank name with no id
      */
-    private function resolveCustomer(ProjectImportConfirmRowDto $row, array &$newCustomersByName, ObjectManager $objectManager): Customer
+    private function resolveCustomer(ProjectImportConfirmRowDto $row, array &$customersByName, array &$customersByTempoKey, ObjectManager $objectManager): Customer
     {
         if (null !== $row->customer_id) {
             $customer = $this->customerRepository->find($row->customer_id);
@@ -162,12 +169,43 @@ final readonly class ProjectImportConfirmationService
             throw new InvalidArgumentException('A customer id or a non-empty customer name is required.');
         }
 
-        if (isset($newCustomersByName[$name])) {
-            return $newCustomersByName[$name];
+        $tempoKey = trim((string) $row->customer_key);
+        $tempoKey = '' === $tempoKey ? null : $tempoKey;
+
+        return $this->upsertCustomer($name, $tempoKey, $customersByName, $customersByTempoKey, $objectManager);
+    }
+
+    /**
+     * Resolve-or-create a Customer from a name and an optional stable Tempo key,
+     * making the Tempo->Customer mapping idempotent across runs (ADR-026 P2):
+     *
+     *  1. a key given & a customer already carries it -> reuse (name drift ignored);
+     *  2. else match by name -> reuse, backfilling the key when the row had none;
+     *  3. else create a new Customer with the name (+ the key when supplied).
+     *
+     * @param array<string, Customer> $customersByName     within-batch reuse by name
+     * @param array<string, Customer> $customersByTempoKey within-batch reuse by key
+     */
+    private function upsertCustomer(string $name, ?string $tempoKey, array &$customersByName, array &$customersByTempoKey, ObjectManager $objectManager): Customer
+    {
+        if (null !== $tempoKey) {
+            if (isset($customersByTempoKey[$tempoKey])) {
+                return $customersByTempoKey[$tempoKey];
+            }
+
+            $byKey = $this->customerRepository->findOneByTempoCustomerKey($tempoKey);
+            if ($byKey instanceof Customer) {
+                $customersByTempoKey[$tempoKey] = $byKey;
+
+                return $byKey;
+            }
         }
 
-        $customer = $this->customerRepository->findOneByName($name);
+        $customer = $customersByName[$name] ?? $this->customerRepository->findOneByName($name);
         if ($customer instanceof Customer) {
+            $this->backfillTempoKey($customer, $tempoKey, $customersByTempoKey);
+            $customersByName[$name] = $customer;
+
             return $customer;
         }
 
@@ -175,9 +213,34 @@ final readonly class ProjectImportConfirmationService
         $customer->setName($name)
             ->setActive(true)
             ->setGlobal(false);
+        if (null !== $tempoKey) {
+            $customer->setTempoCustomerKey($tempoKey);
+            $customersByTempoKey[$tempoKey] = $customer;
+        }
+
         $objectManager->persist($customer);
-        $newCustomersByName[$name] = $customer;
+        $customersByName[$name] = $customer;
 
         return $customer;
+    }
+
+    /**
+     * Stamp the stable Tempo key onto a name-matched customer that has none, so a
+     * later run resolves it by key. A customer already keyed keeps its key.
+     *
+     * @param array<string, Customer> $customersByTempoKey
+     */
+    private function backfillTempoKey(Customer $customer, ?string $tempoKey, array &$customersByTempoKey): void
+    {
+        if (null === $tempoKey) {
+            return;
+        }
+
+        $existing = $customer->getTempoCustomerKey();
+        if (null === $existing || '' === $existing) {
+            $customer->setTempoCustomerKey($tempoKey);
+        }
+
+        $customersByTempoKey[$tempoKey] = $customer;
     }
 }

--- a/src/Service/Sync/ProjectImportConfirmationService.php
+++ b/src/Service/Sync/ProjectImportConfirmationService.php
@@ -41,6 +41,7 @@ final readonly class ProjectImportConfirmationService
         private ManagerRegistry $managerRegistry,
         private ProjectRepository $projectRepository,
         private CustomerRepository $customerRepository,
+        private CustomerUpserter $customerUpserter,
     ) {
     }
 
@@ -172,75 +173,6 @@ final readonly class ProjectImportConfirmationService
         $tempoKey = trim((string) $row->customer_key);
         $tempoKey = '' === $tempoKey ? null : $tempoKey;
 
-        return $this->upsertCustomer($name, $tempoKey, $customersByName, $customersByTempoKey, $objectManager);
-    }
-
-    /**
-     * Resolve-or-create a Customer from a name and an optional stable Tempo key,
-     * making the Tempo->Customer mapping idempotent across runs (ADR-026 P2):
-     *
-     *  1. a key given & a customer already carries it -> reuse (name drift ignored);
-     *  2. else match by name -> reuse, backfilling the key when the row had none;
-     *  3. else create a new Customer with the name (+ the key when supplied).
-     *
-     * @param array<string, Customer> $customersByName     within-batch reuse by name
-     * @param array<string, Customer> $customersByTempoKey within-batch reuse by key
-     */
-    private function upsertCustomer(string $name, ?string $tempoKey, array &$customersByName, array &$customersByTempoKey, ObjectManager $objectManager): Customer
-    {
-        if (null !== $tempoKey) {
-            if (isset($customersByTempoKey[$tempoKey])) {
-                return $customersByTempoKey[$tempoKey];
-            }
-
-            $byKey = $this->customerRepository->findOneByTempoCustomerKey($tempoKey);
-            if ($byKey instanceof Customer) {
-                $customersByTempoKey[$tempoKey] = $byKey;
-
-                return $byKey;
-            }
-        }
-
-        $customer = $customersByName[$name] ?? $this->customerRepository->findOneByName($name);
-        if ($customer instanceof Customer) {
-            $this->backfillTempoKey($customer, $tempoKey, $customersByTempoKey);
-            $customersByName[$name] = $customer;
-
-            return $customer;
-        }
-
-        $customer = new Customer();
-        $customer->setName($name)
-            ->setActive(true)
-            ->setGlobal(false);
-        if (null !== $tempoKey) {
-            $customer->setTempoCustomerKey($tempoKey);
-            $customersByTempoKey[$tempoKey] = $customer;
-        }
-
-        $objectManager->persist($customer);
-        $customersByName[$name] = $customer;
-
-        return $customer;
-    }
-
-    /**
-     * Stamp the stable Tempo key onto a name-matched customer that has none, so a
-     * later run resolves it by key. A customer already keyed keeps its key.
-     *
-     * @param array<string, Customer> $customersByTempoKey
-     */
-    private function backfillTempoKey(Customer $customer, ?string $tempoKey, array &$customersByTempoKey): void
-    {
-        if (null === $tempoKey) {
-            return;
-        }
-
-        $existing = $customer->getTempoCustomerKey();
-        if (null === $existing || '' === $existing) {
-            $customer->setTempoCustomerKey($tempoKey);
-        }
-
-        $customersByTempoKey[$tempoKey] = $customer;
+        return $this->customerUpserter->upsert($name, $tempoKey, $customersByName, $customersByTempoKey, $objectManager);
     }
 }

--- a/src/Service/Sync/SyncRunContext.php
+++ b/src/Service/Sync/SyncRunContext.php
@@ -33,6 +33,7 @@ final class SyncRunContext
         public readonly TicketSystem $ticketSystem,
         public readonly JiraOAuthApiService $api,
         public readonly bool $dryRun,
+        public readonly User $tokenOwner,
     ) {
     }
 }

--- a/src/Service/Sync/SyncWorklogsService.php
+++ b/src/Service/Sync/SyncWorklogsService.php
@@ -103,7 +103,7 @@ class SyncWorklogsService extends AbstractSyncRunService
 
         return $this->executeRun($syncRun, function () use ($syncRun, $targetUser, $tokenOwner, $ticketSystem, $from, $to, $dryRun): void {
             $api = $this->jiraOAuthApiFactory->create($tokenOwner, $ticketSystem);
-            $context = new SyncRunContext($syncRun, $ticketSystem, $api, $dryRun);
+            $context = new SyncRunContext($syncRun, $ticketSystem, $api, $dryRun, $tokenOwner);
             [$jql, $matchesAuthor] = $this->buildRead($api, $targetUser, $tokenOwner, $ticketSystem, $from, $to);
             $this->runUserSync($context, $targetUser, $matchesAuthor, $jql, $from, $to);
         });
@@ -692,6 +692,7 @@ class SyncWorklogsService extends AbstractSyncRunService
         $targetUsername = $targetUser->getUsername();
         $importRunContext = new ImportRunContext(
             syncRun: $context->syncRun,
+            triggeredBy: $context->tokenOwner,
             ticketSystem: $context->ticketSystem,
             activity: $activity,
             targetUsernames: null !== $targetUsername ? [$targetUsername] : [],

--- a/tests/Controller/Admin/ConfirmProjectImportActionTest.php
+++ b/tests/Controller/Admin/ConfirmProjectImportActionTest.php
@@ -162,6 +162,98 @@ final class ConfirmProjectImportActionTest extends AbstractWebTestCase
         self::assertCount(0, $this->entityManager->getRepository(Customer::class)->findBy(['name' => 'Ignored Customer']));
     }
 
+    public function testSameTempoKeyCreatesCustomerOnceAcrossConfirms(): void
+    {
+        // ADR-026 P2: two SEPARATE confirms of the same Tempo customer (same
+        // stable key) — even with a drifted name — must resolve to ONE customer.
+        $this->post(['rows' => [[
+            'jira_key' => 'TKA',
+            'project_name' => 'Tempo Alpha',
+            'ticket_system_id' => 1,
+            'customer_name' => 'Deutsche Post AG',
+            'customer_key' => 'DP',
+        ]]]);
+        $this->assertStatusCode(200);
+        $firstCustomerId = $this->responseData()['projects'][0]['customer_id'];
+        self::assertIsInt($firstCustomerId);
+
+        // Second run: SAME key, DRIFTED name -> reuse the keyed customer.
+        $this->post(['rows' => [[
+            'jira_key' => 'TKB',
+            'project_name' => 'Tempo Beta',
+            'ticket_system_id' => 1,
+            'customer_name' => 'Deutsche Post',
+            'customer_key' => 'DP',
+        ]]]);
+        $this->assertStatusCode(200);
+        self::assertSame($firstCustomerId, $this->responseData()['projects'][0]['customer_id']);
+
+        $this->entityManager->clear();
+        $byKey = $this->entityManager->getRepository(Customer::class)->findBy(['tempoCustomerKey' => 'DP']);
+        self::assertCount(1, $byKey);
+        // The first name stands; the drifted name did not rename or duplicate it.
+        self::assertSame('Deutsche Post AG', $byKey[0]->getName());
+    }
+
+    public function testSameTempoKeyTwiceInOneBatchDoesNotDuplicate(): void
+    {
+        // Two rows in ONE batch sharing a key but naming it differently: one customer.
+        $this->post(['rows' => [
+            ['jira_key' => 'BKA', 'project_name' => 'A', 'ticket_system_id' => 1, 'customer_name' => 'Acme Anvils', 'customer_key' => 'ACM'],
+            ['jira_key' => 'BKB', 'project_name' => 'B', 'ticket_system_id' => 1, 'customer_name' => 'Acme Corp', 'customer_key' => 'ACM'],
+        ]]);
+        $this->assertStatusCode(200);
+
+        $data = $this->responseData();
+        self::assertCount(2, $data['projects']);
+        self::assertSame($data['projects'][0]['customer_id'], $data['projects'][1]['customer_id']);
+
+        $this->entityManager->clear();
+        self::assertCount(1, $this->entityManager->getRepository(Customer::class)->findBy(['tempoCustomerKey' => 'ACM']));
+    }
+
+    public function testNameMatchBackfillsTempoKey(): void
+    {
+        // A by-name match onto an existing key-less customer stamps the key so a
+        // later run resolves it by key. Fixture customer 1 has no Tempo key.
+        $this->post(['rows' => [[
+            'jira_key' => 'BFL',
+            'project_name' => 'Backfill',
+            'ticket_system_id' => 1,
+            'customer_name' => 'Der Bäcker von nebenan',
+            'customer_key' => 'BAK',
+        ]]]);
+        $this->assertStatusCode(200);
+        self::assertSame(1, $this->responseData()['projects'][0]['customer_id']);
+
+        $this->entityManager->clear();
+        $customer = $this->entityManager->find(Customer::class, 1);
+        self::assertInstanceOf(Customer::class, $customer);
+        self::assertSame('BAK', $customer->getTempoCustomerKey());
+        // No second customer was created for that name.
+        self::assertCount(1, $this->entityManager->getRepository(Customer::class)->findBy(['name' => 'Der Bäcker von nebenan']));
+    }
+
+    public function testCustomerIdOverrideKeepsIdentityIgnoringTempoKey(): void
+    {
+        // An explicit existing-customer pick keeps its own identity: a stray
+        // customer_key must NOT be stamped onto it (fixture customer 2 stays key-less).
+        $this->post(['rows' => [[
+            'jira_key' => 'OVK',
+            'project_name' => 'Override Keyed',
+            'ticket_system_id' => 1,
+            'customer_id' => 2,
+            'customer_key' => 'SHOULDNOTAPPLY',
+        ]]]);
+        $this->assertStatusCode(200);
+        self::assertSame(2, $this->responseData()['projects'][0]['customer_id']);
+
+        $this->entityManager->clear();
+        $customer = $this->entityManager->find(Customer::class, 2);
+        self::assertInstanceOf(Customer::class, $customer);
+        self::assertNull($customer->getTempoCustomerKey());
+    }
+
     public function testBlankCustomerNameWithoutIdRejected(): void
     {
         $this->post(['rows' => [[

--- a/tests/Enum/SyncEnumsTest.php
+++ b/tests/Enum/SyncEnumsTest.php
@@ -40,7 +40,7 @@ final class SyncEnumsTest extends TestCase
     public function testSyncItemKindValues(): void
     {
         self::assertSame(
-            ['remote_only', 'local_only', 'never_synced', 'diverged', 'local_dirty', 'remote_dirty', 'mergeable', 'conflict', 'probable_duplicate', 'unresolved_project', 'shadow_user_created', 'truncated', 'error'],
+            ['remote_only', 'local_only', 'never_synced', 'diverged', 'local_dirty', 'remote_dirty', 'mergeable', 'conflict', 'probable_duplicate', 'unresolved_project', 'project_auto_imported', 'shadow_user_created', 'truncated', 'error'],
             array_column(SyncItemKind::cases(), 'value'),
         );
     }

--- a/tests/Service/Sync/ImportWorklogsServiceTest.php
+++ b/tests/Service/Sync/ImportWorklogsServiceTest.php
@@ -23,13 +23,16 @@ use App\Entity\UserTicketsystem;
 use App\Entity\WorklogSyncState;
 use App\Enum\SyncItemKind;
 use App\Enum\SyncRunStatus;
+use App\Repository\CustomerRepository;
 use App\Repository\EntryRepository;
 use App\Repository\UserRepository;
 use App\Service\Integration\Jira\JiraOAuthApiFactory;
 use App\Service\Integration\Jira\JiraOAuthApiService;
+use App\Service\Sync\CustomerUpserter;
 use App\Service\Sync\EntryWorklogProjector;
 use App\Service\Sync\ImportWorklogsService;
 use App\Service\Sync\JiraAuthorMapper;
+use App\Service\Sync\ProjectImportProposalService;
 use App\Service\Sync\RemoteWorklogNormalizer;
 use App\Service\Sync\TicketProjectResolver;
 use App\Service\Tracking\DayClassService;
@@ -55,6 +58,7 @@ final class ImportWorklogsServiceTest extends TestCase
     private JiraAuthorMapper&MockObject $authorMapper;
     private DayClassService&MockObject $dayClassService;
     private UserRepository&MockObject $userRepository;
+    private CustomerRepository&MockObject $customerRepository;
     private ImportWorklogsService $service;
     private ?string $capturedJql = null;
     private User $triggeredBy;
@@ -75,6 +79,7 @@ final class ImportWorklogsServiceTest extends TestCase
         $this->authorMapper = $this->createMock(JiraAuthorMapper::class);
         $this->dayClassService = $this->createMock(DayClassService::class);
         $this->userRepository = $this->createMock(UserRepository::class);
+        $this->customerRepository = $this->createMock(CustomerRepository::class);
 
         $apiFactory = $this->createMock(JiraOAuthApiFactory::class);
         $apiFactory->method('create')->willReturn($this->api);
@@ -109,7 +114,40 @@ final class ImportWorklogsServiceTest extends TestCase
             $this->authorMapper,
             $this->dayClassService,
             $this->userRepository,
+            // Real proposal service driven through the mocked Jira/Tempo boundary
+            // ($this->api), so the test exercises the true derivation, not a stub.
+            new ProjectImportProposalService($apiFactory),
+            new CustomerUpserter($this->customerRepository),
             new MockClock('2026-07-09 12:00:00'),
+        );
+    }
+
+    /**
+     * A ticket system with the ADR-026 P3 opt-in flag flipped on (the default
+     * $this->ticketSystem stub returns false, so existing tests keep parking).
+     */
+    private function ticketSystemWithAutoImport(): TicketSystem
+    {
+        $ticketSystem = self::createStub(TicketSystem::class);
+        $ticketSystem->method('getAutoImportUnresolvedProjects')->willReturn(true);
+
+        return $ticketSystem;
+    }
+
+    /**
+     * Stub the Tempo account endpoint for a project id with one confident
+     * customer, yielding a SOURCE_TEMPO proposal.
+     */
+    private function stubConfidentTempo(int $projectId, string $customerName, string $customerKey): void
+    {
+        $account = (object) [
+            'id' => 1,
+            'key' => 'ACC1',
+            'name' => 'Account One',
+            'customer' => (object) ['id' => 10, 'key' => $customerKey, 'name' => $customerName],
+        ];
+        $this->api->method('getFromTenant')->willReturnCallback(
+            static fn (string $path): array => str_contains($path, '/account/project/' . $projectId) ? [$account] : [],
         );
     }
 
@@ -144,6 +182,11 @@ final class ImportWorklogsServiceTest extends TestCase
     private function import(array $targetUsernames = [], bool $dryRun = false): SyncRun
     {
         return $this->service->import($this->triggeredBy, $this->ticketSystem, new DateTimeImmutable('2026-06-01'), new DateTimeImmutable('2026-06-30'), 1, $targetUsernames, $dryRun);
+    }
+
+    private function importWith(TicketSystem $ticketSystem, bool $dryRun = false): SyncRun
+    {
+        return $this->service->import($this->triggeredBy, $ticketSystem, new DateTimeImmutable('2026-06-01'), new DateTimeImmutable('2026-06-30'), 1, [], $dryRun);
     }
 
     public function testUnknownActivityFailsRun(): void
@@ -261,6 +304,121 @@ final class ImportWorklogsServiceTest extends TestCase
         $items = $syncRun->getItems()->toArray();
         self::assertCount(1, $items);
         self::assertSame(SyncItemKind::UNRESOLVED_PROJECT, $items[0]->getKind());
+    }
+
+    public function testAutoImportFlagOffParksAndNeverDerives(): void
+    {
+        // The default $this->ticketSystem stub returns false for the P3 flag —
+        // the derivation boundary must not be touched at all.
+        $this->api->expects(self::never())->method('getProjectInfo');
+        $this->stubRemote(['SRVMO-1'], ['SRVMO-1' => [$this->worklog()]]);
+        $this->entryRepository->method('findOneByWorklogIdAndTicketSystem')->willReturn(null);
+        $this->authorMapper->method('remoteKey')->willReturn('acc-jdoe');
+        $this->authorMapper->method('find')->willReturn($this->author);
+        $this->projectResolver->method('resolve')->willReturn(new ProjectResolution(null, 'no project for prefix SRVMO on this ticket system'));
+
+        $syncRun = $this->import();
+
+        self::assertSame(1, $syncRun->getCounters()['unresolved_project'] ?? 0);
+        self::assertSame(0, $syncRun->getCounters()['auto_imported_project'] ?? 0);
+        self::assertSame([], array_filter($this->persisted, static fn (object $o): bool => $o instanceof Project));
+        self::assertSame([], array_filter($this->persisted, static fn (object $o): bool => $o instanceof Customer));
+    }
+
+    public function testAutoImportFlagOnConfidentCreatesProjectAndCustomer(): void
+    {
+        $ticketSystem = $this->ticketSystemWithAutoImport();
+        $this->stubRemote(['SRVMO-1'], ['SRVMO-1' => [$this->worklog()]]);
+        $this->api->method('getProjectInfo')->willReturn(['id' => 20350, 'name' => 'Server Monitoring', 'categoryName' => 'NR: IT']);
+        $this->stubConfidentTempo(20350, 'Netresearch', 'NR');
+        $this->customerRepository->method('findOneByTempoCustomerKey')->willReturn(null);
+        $this->customerRepository->method('findOneByName')->willReturn(null);
+        $this->projectResolver->method('resolve')->willReturn(new ProjectResolution(null, 'no project for prefix SRVMO on this ticket system'));
+        $this->authorMapper->method('remoteKey')->willReturn('acc-jdoe');
+        $this->authorMapper->method('find')->willReturn($this->author);
+        $this->entryRepository->method('findOneByWorklogIdAndTicketSystem')->willReturn(null);
+        $this->entryRepository->method('findUnlinkedDuplicate')->willReturn(null);
+
+        $syncRun = $this->importWith($ticketSystem);
+
+        self::assertSame(SyncRunStatus::COMPLETED, $syncRun->getStatus());
+        self::assertSame(1, $syncRun->getCounters()['auto_imported_project'] ?? 0);
+        self::assertSame(0, $syncRun->getCounters()['unresolved_project'] ?? 0);
+        self::assertSame(1, $syncRun->getCounters()['created'] ?? 0);
+
+        $projects = array_values(array_filter($this->persisted, static fn (object $o): bool => $o instanceof Project));
+        self::assertCount(1, $projects);
+        self::assertSame('SRVMO', $projects[0]->getJiraId());
+        self::assertSame('Server Monitoring', $projects[0]->getName());
+
+        $customers = array_values(array_filter($this->persisted, static fn (object $o): bool => $o instanceof Customer));
+        self::assertCount(1, $customers);
+        self::assertSame('Netresearch', $customers[0]->getName());
+        self::assertSame('NR', $customers[0]->getTempoCustomerKey());
+        self::assertSame($customers[0], $projects[0]->getCustomer());
+
+        // The worklog imported onto the auto-created project.
+        $entries = array_values(array_filter($this->persisted, static fn (object $o): bool => $o instanceof Entry));
+        self::assertCount(1, $entries);
+        self::assertSame('SRVMO-1', $entries[0]->getTicket());
+        self::assertSame($projects[0], $entries[0]->getProject());
+
+        $kinds = array_map(static fn ($item) => $item->getKind(), $syncRun->getItems()->toArray());
+        self::assertContains(SyncItemKind::PROJECT_AUTO_IMPORTED, $kinds);
+    }
+
+    public function testAutoImportFlagOnAmbiguousParks(): void
+    {
+        $ticketSystem = $this->ticketSystemWithAutoImport();
+        $this->stubRemote(['NRFE-1'], ['NRFE-1' => [$this->worklog()]]);
+        $this->api->method('getProjectInfo')->willReturn(['id' => 10212, 'name' => 'NR Frontend', 'categoryName' => 'NR: IT']);
+        // Two distinct customers, no single default link -> ambiguous -> park.
+        $accounts = [
+            (object) ['id' => 1, 'key' => 'A1', 'name' => 'Acc 1', 'customer' => (object) ['id' => 10, 'key' => 'NR', 'name' => 'Netresearch']],
+            (object) ['id' => 2, 'key' => 'A2', 'name' => 'Acc 2', 'customer' => (object) ['id' => 20, 'key' => 'NRSO', 'name' => 'Netresearch Solutions']],
+        ];
+        $this->api->method('getFromTenant')->willReturnCallback(
+            static fn (string $path): array => str_contains($path, '/account/project/10212') ? $accounts : [],
+        );
+        $this->projectResolver->method('resolve')->willReturn(new ProjectResolution(null, 'no project for prefix NRFE on this ticket system'));
+        $this->authorMapper->method('remoteKey')->willReturn('acc-jdoe');
+        $this->authorMapper->method('find')->willReturn($this->author);
+        $this->entryRepository->method('findOneByWorklogIdAndTicketSystem')->willReturn(null);
+
+        $syncRun = $this->importWith($ticketSystem);
+
+        self::assertSame(1, $syncRun->getCounters()['unresolved_project'] ?? 0);
+        self::assertSame(0, $syncRun->getCounters()['auto_imported_project'] ?? 0);
+        self::assertSame(0, $syncRun->getCounters()['created'] ?? 0);
+        self::assertSame([], array_filter($this->persisted, static fn (object $o): bool => $o instanceof Project));
+        self::assertSame([], array_filter($this->persisted, static fn (object $o): bool => $o instanceof Customer));
+    }
+
+    public function testAutoImportDerivesPrefixOncePerRun(): void
+    {
+        $ticketSystem = $this->ticketSystemWithAutoImport();
+        // Two issues sharing the SRVMO prefix — the prefix must be derived once.
+        $this->stubRemote(
+            ['SRVMO-1', 'SRVMO-2'],
+            ['SRVMO-1' => [$this->worklog(5001)], 'SRVMO-2' => [$this->worklog(5002)]],
+        );
+        $this->api->expects(self::once())->method('getProjectInfo')->willReturn(['id' => 20350, 'name' => 'Server Monitoring', 'categoryName' => null]);
+        $this->stubConfidentTempo(20350, 'Netresearch', 'NR');
+        $this->customerRepository->method('findOneByTempoCustomerKey')->willReturn(null);
+        $this->customerRepository->method('findOneByName')->willReturn(null);
+        $this->projectResolver->method('resolve')->willReturn(new ProjectResolution(null, 'no project for prefix SRVMO on this ticket system'));
+        $this->authorMapper->method('remoteKey')->willReturn('acc-jdoe');
+        $this->authorMapper->method('find')->willReturn($this->author);
+        $this->entryRepository->method('findOneByWorklogIdAndTicketSystem')->willReturn(null);
+        $this->entryRepository->method('findUnlinkedDuplicate')->willReturn(null);
+
+        $syncRun = $this->importWith($ticketSystem);
+
+        // Derived once, one project + customer, but both worklogs imported onto it.
+        self::assertSame(1, $syncRun->getCounters()['auto_imported_project'] ?? 0);
+        self::assertSame(2, $syncRun->getCounters()['created'] ?? 0);
+        self::assertCount(1, array_filter($this->persisted, static fn (object $o): bool => $o instanceof Project));
+        self::assertCount(1, array_filter($this->persisted, static fn (object $o): bool => $o instanceof Customer));
     }
 
     public function testProbableDuplicateParks(): void

--- a/tests/Service/Sync/ImportWorklogsServiceTest.php
+++ b/tests/Service/Sync/ImportWorklogsServiceTest.php
@@ -394,6 +394,26 @@ final class ImportWorklogsServiceTest extends TestCase
         self::assertSame([], array_filter($this->persisted, static fn (object $o): bool => $o instanceof Customer));
     }
 
+    public function testAutoImportFlagOnNoneParks(): void
+    {
+        $ticketSystem = $this->ticketSystemWithAutoImport();
+        $this->stubRemote(['SRVMO-1'], ['SRVMO-1' => [$this->worklog()]]);
+        // A real project, but no Tempo customer and no category -> SOURCE_NONE -> park.
+        $this->api->method('getProjectInfo')->willReturn(['id' => 20350, 'name' => 'Server Monitoring', 'categoryName' => null]);
+        $this->api->method('getFromTenant')->willReturn([]);
+        $this->projectResolver->method('resolve')->willReturn(new ProjectResolution(null, 'no project for prefix SRVMO on this ticket system'));
+        $this->authorMapper->method('remoteKey')->willReturn('acc-jdoe');
+        $this->authorMapper->method('find')->willReturn($this->author);
+        $this->entryRepository->method('findOneByWorklogIdAndTicketSystem')->willReturn(null);
+
+        $syncRun = $this->importWith($ticketSystem);
+
+        self::assertSame(1, $syncRun->getCounters()['unresolved_project'] ?? 0);
+        self::assertSame(0, $syncRun->getCounters()['auto_imported_project'] ?? 0);
+        self::assertSame([], array_filter($this->persisted, static fn (object $o): bool => $o instanceof Project));
+        self::assertSame([], array_filter($this->persisted, static fn (object $o): bool => $o instanceof Customer));
+    }
+
     public function testAutoImportDerivesPrefixOncePerRun(): void
     {
         $ticketSystem = $this->ticketSystemWithAutoImport();


### PR DESCRIPTION
Follow-up to [#601](https://github.com/netresearch/timetracker/pull/601) ([ADR-026](docs/adr/ADR-026-jira-project-import.md) §Phasing).

## P2 — stable customer key (idempotent upsert)
`customers.tempo_customer_key` (nullable, unique). A shared `CustomerUpserter` resolves-or-creates by **Tempo customer key first**, then name (backfilling the key), else creates — so re-imports and auto-create never spawn duplicate customers on name drift. The confirm flow forwards the derived key; a `customer_id` override keeps its own identity. Proven idempotent (same key twice → one customer, even with a drifted name).

## P3 — opt-in ad-hoc auto-create during import
When a worklog hits an `unresolved_project` prefix, the import can now **self-heal** by creating the TT project + derived customer — but only behind three gates, in order:
1. **Opt-in flag** `ticket_systems.auto_import_unresolved_projects` (default **false** → parks exactly as before).
2. **Never in a dry run** (dry runs stay strictly read-only).
3. **Confidence-or-park:** creates only for a single `tempo`/`tempo-default`/`category` customer with a non-empty name; `ambiguous`/`none`/`error`/`not-a-project` always park.

The customer goes through the P2 `CustomerUpserter` (no duplicates); the project is idempotent on `jira_id`+ticketSystem; a prefix is derived **once per run** (cached), not per issue. Both the import and sync unmatched-worklog paths reach the same gated code, carrying the run's token owner for the Tempo/Jira derivation. The P1 human-confirm flow is untouched.

## Tests / gates
Backend: PHPStan L10 (full), phpat, rector, cs-fixer clean; Sync suite green incl. flag-off-parks, confident-create, ambiguous-parks, none-parks, per-run-cache, and P2 idempotency. Frontend: typecheck/lint/test green. Migrations up/down verified.

Built P2→P3 via ultracode workflows, each implement→review→fix, self-verified. **Auto-create is opt-in and off by default** — no behaviour change until a ticket system enables the flag.