### PR TITLE
feat(frontend): surface ADR-025 agent-vs-human time in the UI

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -672,5 +672,10 @@
   "projectimport_confirm_error": "Die ausgewählten Zeilen konnten nicht bestätigt werden.",
   "projectimport_result_created": "Angelegt",
   "projectimport_result_existing": "Vorhanden",
-  "projectimport_empty": "Keine offenen Präfixe."
+  "projectimport_empty": "Keine offenen Präfixe.",
+  "entry_source_agent": "Agent",
+  "entry_source_agent_hint": "Von einem Agenten erfasst (Maschinenzeit), keine menschliche Arbeit",
+  "entry_estimated": "geschätzt",
+  "entry_estimated_hint": "Die menschliche Zeit ist eine vom Agenten abgeleitete Schätzung – vor der Anrechnung als Anwesenheit prüfen",
+  "auswertung_agent_hours": "Agenten-Stunden"
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -672,5 +672,10 @@
   "projectimport_confirm_error": "Could not confirm the selected rows.",
   "projectimport_result_created": "Created",
   "projectimport_result_existing": "Existing",
-  "projectimport_empty": "No unresolved prefixes."
+  "projectimport_empty": "No unresolved prefixes.",
+  "entry_source_agent": "Agent",
+  "entry_source_agent_hint": "Recorded by an agent (machine time), not human labour",
+  "entry_estimated": "estimated",
+  "entry_estimated_hint": "Human time is an agent-derived estimate — review before it counts as attendance",
+  "auswertung_agent_hours": "Agent hours"
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -672,5 +672,10 @@
   "projectimport_confirm_error": "No se pudieron confirmar las filas seleccionadas.",
   "projectimport_result_created": "Creado",
   "projectimport_result_existing": "Existente",
-  "projectimport_empty": "No hay prefijos sin resolver."
+  "projectimport_empty": "No hay prefijos sin resolver.",
+  "entry_source_agent": "Agente",
+  "entry_source_agent_hint": "Registrado por un agente (tiempo de máquina), no trabajo humano",
+  "entry_estimated": "estimado",
+  "entry_estimated_hint": "El tiempo humano es una estimación derivada del agente: revísalo antes de contarlo como asistencia",
+  "auswertung_agent_hours": "Horas de agente"
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -672,5 +672,10 @@
   "projectimport_confirm_error": "Impossible de confirmer les lignes sélectionnées.",
   "projectimport_result_created": "Créé",
   "projectimport_result_existing": "Existant",
-  "projectimport_empty": "Aucun préfixe non résolu."
+  "projectimport_empty": "Aucun préfixe non résolu.",
+  "entry_source_agent": "Agent",
+  "entry_source_agent_hint": "Enregistré par un agent (temps machine), pas du travail humain",
+  "entry_estimated": "estimé",
+  "entry_estimated_hint": "Le temps humain est une estimation dérivée de l'agent — à vérifier avant de le compter comme présence",
+  "auswertung_agent_hours": "Heures agent"
 }

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -672,5 +672,10 @@
   "projectimport_confirm_error": "Не удалось подтвердить выбранные строки.",
   "projectimport_result_created": "Создан",
   "projectimport_result_existing": "Существует",
-  "projectimport_empty": "Нет неразрешённых префиксов."
+  "projectimport_empty": "Нет неразрешённых префиксов.",
+  "entry_source_agent": "Агент",
+  "entry_source_agent_hint": "Записано агентом (машинное время), не человеческий труд",
+  "entry_estimated": "оценка",
+  "entry_estimated_hint": "Человеческое время — оценка, выведенная агентом; проверьте до учёта как посещаемость",
+  "auswertung_agent_hours": "Часы агента"
 }

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -13,6 +13,9 @@ export interface WorktimeRecord {
   quota: string
   /** Expected (Soll) hours for the day, from the contract or a 5×8h default. */
   expected: number
+  /** ADR-025 §7: agent (machine) hours for the day, beside the human `hours`;
+   *  never summed into it. Absent on pre-ADR-025 caches. */
+  agentHours?: number
 }
 
 // Response shape of GET /getHolidays (GetHolidaysAction) — row-wrapped
@@ -151,6 +154,12 @@ export interface TrackingEntry {
   class: number
   worklog: number | null
   extTicket: string | null
+  /** ADR-025: who performed the labour — 'human' or 'agent'. Drives the row
+   *  badge; a machine's wall-clock is never summed into human hours. */
+  source: string
+  /** ADR-025: true when a human-source figure is an agent-derived estimate a
+   *  person should still review before it counts as attendance. */
+  estimated: boolean
 }
 
 interface TrackingEntryRow {
@@ -205,6 +214,10 @@ function savedEntryToRow(saved: SavedEntryResult['result']): TrackingEntryRow {
       class: saved.class,
       worklog: null,
       extTicket: saved.extTicket ?? null,
+      // A web-UI (session) save is always a human self-log — ADR-025 §4 forces
+      // source=human and never marks it estimated, regardless of the body.
+      source: 'human',
+      estimated: false,
     },
   }
 }
@@ -368,6 +381,9 @@ export interface GroupRow {
   name: string
   hours: number
   quota: string
+  /** ADR-025 §7: agent (machine) hours, sliced out beside the human hours and
+   *  never folded into the `hours` total. Absent on pre-ADR-025 caches. */
+  agentHours?: number
 }
 
 export type InterpretationGroup = 'customer' | 'project' | 'ticket' | 'activity' | 'user'
@@ -438,6 +454,10 @@ export interface EntryRecord {
     ticket: string
     duration: string
     quota: string
+    /** ADR-025: labour source ('human' | 'agent') and whether the figure is an
+     *  agent-derived estimate — both drive the row badge. */
+    source: string
+    estimated: boolean
   }
 }
 

--- a/frontend/src/components/EffortChart.test.tsx
+++ b/frontend/src/components/EffortChart.test.tsx
@@ -73,6 +73,37 @@ describe('EffortChart', () => {
     unmount()
   })
 
+  describe('agent hours (ADR-025 §7)', () => {
+    it('adds an Agent-hours column and value beside human hours when agent time exists', () => {
+      const data: EffortRow[] = [
+        { label: 'ACME', minutes: 480, quota: '80.00%', agentMinutes: 90 },
+        { label: 'Globex', minutes: 120, quota: '20.00%', agentMinutes: 0 },
+      ]
+      const { getByRole, getAllByRole, unmount } = render(() => <EffortChart title="Effort by customer" rows={data} />)
+
+      // A four-column header (Name, Hours, Agent hours, Share).
+      expect(getByRole('columnheader', { name: 'Agent hours' })).toBeInTheDocument()
+      expect(getAllByRole('columnheader')).toHaveLength(4)
+      // ACME's agent time shows formatted (1:30, distinct from any human cell);
+      // a zero-agent row shows a dash, never folded into the human hours.
+      expect(getByRole('cell', { name: formatMinutes(90) })).toBeInTheDocument()
+      const dashes = getAllByRole('cell').filter((cell) => cell.textContent === '—')
+      expect(dashes.length).toBe(1)
+      unmount()
+    })
+
+    it('omits the Agent-hours column entirely for a human-only report', () => {
+      const data: EffortRow[] = [
+        { label: 'ACME', minutes: 480, quota: '80.00%', agentMinutes: 0 },
+      ]
+      const { queryByRole, getAllByRole, unmount } = render(() => <EffortChart title="Effort by customer" rows={data} />)
+
+      expect(queryByRole('columnheader', { name: 'Agent hours' })).toBeNull()
+      expect(getAllByRole('columnheader')).toHaveLength(3)
+      unmount()
+    })
+  })
+
   describe('contract Soll (target)', () => {
     // Mon over Soll (8:30 vs 8:00), Tue under (4:00 vs 8:00).
     const dayRows: EffortRow[] = [

--- a/frontend/src/components/EffortChart.tsx
+++ b/frontend/src/components/EffortChart.tsx
@@ -13,6 +13,10 @@ export interface EffortRow {
    *  boundary: a Soll marker, an over/under colour, and a ghost bar showing the
    *  shortfall. Only the "Effort by day" chart provides it. */
   target?: number
+  /** ADR-025 §7: agent (machine) minutes for the row. When any row carries it,
+   *  the table gains a separate "Agent hours" column — machine time is shown
+   *  beside human labour, never summed into `minutes`. */
+  agentMinutes?: number
 }
 
 /**
@@ -32,6 +36,10 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
   // worked-or-target so a Soll marker beyond the worked time still fits.
   const max = createMemo(() => Math.max(1, ...props.rows.map((row) => Math.max(row.minutes, row.target ?? 0))))
   const pct = (minutes: number): string => `${(minutes / max()) * 100}%`
+
+  // ADR-025 §7: only surface the agent column when agent time actually exists,
+  // so the common (human-only) report stays a three-column table.
+  const hasAgent = createMemo(() => props.rows.some((row) => (row.agentMinutes ?? 0) > 0))
 
   // Optional column sort. Default (null) keeps the server order — value-desc for
   // the grouped charts, chronological for "by day". Clicking a header cycles
@@ -89,6 +97,9 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
                   <span class="th-sort-glyph" aria-hidden="true">{sortGlyph('hours')}</span>
                 </button>
               </th>
+              <Show when={hasAgent()}>
+                <th scope="col" class="numeric">{m.auswertung_agent_hours()}</th>
+              </Show>
               <th scope="col" class="numeric" aria-sort={ariaSort('share')}>
                 <button type="button" class="th-sort" onClick={() => toggleSort('share')}>
                   <span>{m.auswertung_share()}</span>
@@ -130,6 +141,9 @@ export function EffortChart(props: { title: string; rows: EffortRow[] }) {
                         <small class="effort-target">{m.auswertung_of_target({ target: formatMinutes(row.target ?? 0) })}</small>
                       </Show>
                     </td>
+                    <Show when={hasAgent()}>
+                      <td class="numeric">{(row.agentMinutes ?? 0) > 0 ? formatMinutes(row.agentMinutes ?? 0) : '—'}</td>
+                    </Show>
                     <td class="numeric">{row.quota}</td>
                   </tr>
                 )

--- a/frontend/src/components/EntrySourceBadge.test.tsx
+++ b/frontend/src/components/EntrySourceBadge.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { EntrySourceBadge } from './EntrySourceBadge'
+
+describe('EntrySourceBadge', () => {
+  it('shows the Agent badge for a machine-source entry', () => {
+    const { container, getByText, unmount } = render(() => <EntrySourceBadge source="agent" estimated={false} />)
+
+    expect(getByText('Agent')).toBeInTheDocument()
+    expect(container.querySelector('.entry-badge.is-agent')).not.toBeNull()
+    expect(container.querySelector('.entry-badge.is-estimated')).toBeNull()
+    unmount()
+  })
+
+  it('shows the estimated badge, independent of source', () => {
+    const { container, getByText, unmount } = render(() => <EntrySourceBadge source="human" estimated={true} />)
+
+    expect(getByText('estimated')).toBeInTheDocument()
+    expect(container.querySelector('.entry-badge.is-estimated')).not.toBeNull()
+    expect(container.querySelector('.entry-badge.is-agent')).toBeNull()
+    unmount()
+  })
+
+  it('shows both badges when an agent entry is also estimated', () => {
+    const { container, unmount } = render(() => <EntrySourceBadge source="agent" estimated={true} />)
+
+    expect(container.querySelector('.entry-badge.is-agent')).not.toBeNull()
+    expect(container.querySelector('.entry-badge.is-estimated')).not.toBeNull()
+    unmount()
+  })
+
+  it('renders nothing for a plain human, non-estimated entry', () => {
+    const { container, unmount } = render(() => <EntrySourceBadge source="human" estimated={false} />)
+
+    expect(container.querySelector('.entry-badge')).toBeNull()
+    unmount()
+  })
+
+  it('does not lean on colour alone — each badge carries text', () => {
+    const { getByText, unmount } = render(() => <EntrySourceBadge source="agent" estimated={true} />)
+
+    // Text labels (not just the coloured pill) make the state screen-reader legible.
+    expect(getByText('Agent')).toBeInTheDocument()
+    expect(getByText('estimated')).toBeInTheDocument()
+    unmount()
+  })
+
+  it('has no axe violations', async () => {
+    const { container, unmount } = render(() => <EntrySourceBadge source="agent" estimated={true} />)
+
+    expect(await axe(container)).toHaveNoViolations()
+    unmount()
+  })
+})

--- a/frontend/src/components/EntrySourceBadge.tsx
+++ b/frontend/src/components/EntrySourceBadge.tsx
@@ -1,0 +1,31 @@
+import { Show } from 'solid-js'
+
+import { m } from '../paraglide/messages.js'
+
+/**
+ * ADR-025 §7 marker for an entry row: a small, non-colour badge shown when a
+ * machine performed the labour (`source === 'agent'`) and, separately, when the
+ * figure is an agent-derived estimate (`estimated === true`). Each badge carries
+ * text and an icon — colour is never the only cue (WCAG 1.4.1). The agent badge
+ * says the hour is machine time (never summed into human labour); the estimated
+ * badge flags a human-source figure a person should still eyeball before it
+ * hardens into an attendance record (§5).
+ */
+export function EntrySourceBadge(props: { source?: string | null; estimated?: boolean }) {
+  return (
+    <>
+      <Show when={props.source === 'agent'}>
+        <span class="entry-badge is-agent" title={m.entry_source_agent_hint()}>
+          <span class="entry-badge-icon" aria-hidden="true">⚙</span>
+          {m.entry_source_agent()}
+        </span>
+      </Show>
+      <Show when={props.estimated === true}>
+        <span class="entry-badge is-estimated" title={m.entry_estimated_hint()}>
+          <span class="entry-badge-icon" aria-hidden="true">≈</span>
+          {m.entry_estimated()}
+        </span>
+      </Show>
+    </>
+  )
+}

--- a/frontend/src/components/EntrySourceBadge.tsx
+++ b/frontend/src/components/EntrySourceBadge.tsx
@@ -16,13 +16,19 @@ export function EntrySourceBadge(props: { source?: string | null; estimated?: bo
     <>
       <Show when={props.source === 'agent'}>
         <span class="entry-badge is-agent" title={m.entry_source_agent_hint()}>
-          <span class="entry-badge-icon" aria-hidden="true">⚙</span>
+          <svg class="entry-badge-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="3.2" />
+            <path d="M12 2.5v3M12 18.5v3M2.5 12h3M18.5 12h3M5 5l2.1 2.1M16.9 16.9 19 19M19 5l-2.1 2.1M7.1 16.9 5 19" />
+          </svg>
           {m.entry_source_agent()}
         </span>
       </Show>
       <Show when={props.estimated === true}>
         <span class="entry-badge is-estimated" title={m.entry_estimated_hint()}>
-          <span class="entry-badge-icon" aria-hidden="true">≈</span>
+          <svg class="entry-badge-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 9c2-2.6 4-2.6 6 0s4 2.6 6 0" />
+            <path d="M4 15c2-2.6 4-2.6 6 0s4 2.6 6 0" />
+          </svg>
           {m.entry_estimated()}
         </span>
       </Show>

--- a/frontend/src/pages/Auswertung.test.tsx
+++ b/frontend/src/pages/Auswertung.test.tsx
@@ -125,6 +125,33 @@ describe('Auswertung', () => {
     unmount()
   })
 
+  it('badges an agent/estimated entry in the detail table and shows agent hours beside human (ADR-025)', async () => {
+    getJson.mockImplementation((path: string) => {
+      if (path === '/interpretation/customer')
+        return Promise.resolve([{ id: 1, name: 'ACME', hours: 8, quota: '80.00%', agentHours: 3 }])
+      if (path === '/interpretation/time')
+        return Promise.resolve([{ id: null, name: '26-06-01', day: '01.06.', hours: 4, quota: '100.00%', expected: 8, agentHours: 0 }])
+      if (path === '/interpretation/entries')
+        return Promise.resolve([
+          { entry: { id: 5, date: '01/06/2026', ticket: 'ABC-1', description: 'work', duration: '8:00', quota: '100.00%', source: 'agent', estimated: true } },
+        ])
+      if (path.startsWith('/interpretation/')) return Promise.resolve([])
+
+      return Promise.resolve([])
+    })
+    const { getByText, getByRole, unmount } = renderPage()
+
+    // The detail-table row for the agent-logged entry carries both badges.
+    await waitFor(() => expect(getByRole('gridcell', { name: /ABC-1/ })).toBeInTheDocument())
+    expect(getByText('Agent')).toBeInTheDocument()
+    expect(getByText('estimated')).toBeInTheDocument()
+
+    // The by-customer chart surfaces the agent hours in their own column.
+    expect(getByRole('columnheader', { name: 'Agent hours' })).toBeInTheDocument()
+
+    unmount()
+  })
+
   it('has no automatically detectable accessibility violations', async () => {
     mockEndpoints()
     const { container, getByRole, unmount } = renderPage()

--- a/frontend/src/pages/Auswertung.tsx
+++ b/frontend/src/pages/Auswertung.tsx
@@ -17,6 +17,7 @@ import {
   usersQuery,
 } from '../api/queries'
 import { EffortChart, type EffortRow } from '../components/EffortChart'
+import { EntrySourceBadge } from '../components/EntrySourceBadge'
 import { OptionSelect } from '../components/OptionSelect'
 import { QueryBoundary } from '../components/QueryBoundary'
 import { appConfig } from '../config'
@@ -108,6 +109,7 @@ function toEffortRows(rows: GroupRow[] | undefined): EffortRow[] {
     label: row.name,
     minutes: Math.round(row.hours * 60),
     quota: row.quota,
+    agentMinutes: Math.round((row.agentHours ?? 0) * 60),
   }))
 }
 
@@ -169,6 +171,7 @@ export default function Auswertung() {
       minutes: Math.round(row.hours * 60),
       quota: row.quota,
       target: Math.round(row.expected * 60),
+      agentMinutes: Math.round((row.agentHours ?? 0) * 60),
     })),
   )
 
@@ -332,7 +335,10 @@ export default function Auswertung() {
                       <tr>
                         <td>{formatUserDate(dmyToIso(record.entry.date ?? '') ?? record.entry.date ?? '')}</td>
                         <td>{record.entry.ticket}</td>
-                        <td>{record.entry.description}</td>
+                        <td>
+                          {record.entry.description}
+                          <EntrySourceBadge source={record.entry.source} estimated={record.entry.estimated} />
+                        </td>
                         <td class="numeric">{record.entry.duration}</td>
                       </tr>
                     )}

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -155,6 +155,25 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('badges an agent-source / estimated entry in the description cell, and not a plain human row (ADR-025)', async () => {
+    mockApiWith([
+      { entry: { ...DEFAULT_ENTRY, id: 1, start: '09:00', end: '10:00', description: 'Agent work', source: 'agent', estimated: true } },
+      { entry: { ...DEFAULT_ENTRY, id: 2, start: '11:00', end: '12:00', description: 'Human work', source: 'human', estimated: false } },
+    ])
+    const { getByText, container, unmount } = renderTracking()
+
+    await waitFor(() => expect(getByText('Agent work')).toBeInTheDocument())
+    // The agent row carries both badges; the plain human row carries none.
+    const badges = [...container.querySelectorAll('.entry-badge')].map((el) => el.className)
+    expect(badges.some((c) => c.includes('is-agent'))).toBe(true)
+    expect(badges.some((c) => c.includes('is-estimated'))).toBe(true)
+    // Exactly two badges total (agent + estimated), both on the one agent row —
+    // the human row adds none.
+    expect(badges).toHaveLength(2)
+
+    unmount()
+  })
+
   it('derives day-break/pause/overlap row cues from the displayed entries, not the stored class', async () => {
     // All rows carry class:0 — the cue must come from the (day, start, end)
     // ordering, so it is correct for seed/future data the save flow never touched.

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -871,9 +871,11 @@ export default function Tracking() {
     // ADR-025: the description cell also carries the source/estimated badge —
     // source is fixed on the row (not inline-editable), so read the base entry.
     if (colKey === 'description') {
+      // The badge sits OUTSIDE the truncating span (flex, flex:none) so a long
+      // description never clips these row markers off the right edge.
       return (
-        <span class="cell-trunc">
-          {displayCell(entry, colKey)}
+        <span class="cell-desc-badged">
+          <span class="cell-trunc">{displayCell(entry, colKey)}</span>
           <EntrySourceBadge source={entry.source} estimated={entry.estimated} />
         </span>
       )

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -15,6 +15,7 @@ import { registerCommands } from '../lib/commandPalette'
 import { getTrackingDays, setTrackingDays } from '../lib/trackingDaysPref'
 import { CalendarIcon, ContinueIcon, DiskIcon, DownloadIcon, InfoIcon, KebabIcon, PlusIcon, ProlongIcon, RefreshIcon, ResetIcon, ToolsIcon, TrashIcon } from '../lib/icons'
 import { BulkEntryForm } from '../components/BulkEntryForm'
+import { EntrySourceBadge } from '../components/EntrySourceBadge'
 import { PageDialog } from '../components/PageDialog'
 import { sessionExpired } from '../lib/session'
 import { updateWorktime } from '../header'
@@ -867,6 +868,17 @@ export default function Tracking() {
 
     // A truncation box so the responsive thinning can ellipsis free-text columns
     // (Description) — a bare <td> in an auto-layout table can't do text-overflow.
+    // ADR-025: the description cell also carries the source/estimated badge —
+    // source is fixed on the row (not inline-editable), so read the base entry.
+    if (colKey === 'description') {
+      return (
+        <span class="cell-trunc">
+          {displayCell(entry, colKey)}
+          <EntrySourceBadge source={entry.source} estimated={entry.estimated} />
+        </span>
+      )
+    }
+
     return <span class="cell-trunc">{displayCell(entry, colKey)}</span>
   }
 
@@ -971,6 +983,9 @@ export default function Tracking() {
       class: 0,
       worklog: null,
       extTicket: null,
+      // A web-UI row is always a human self-log (ADR-025 §4); never estimated.
+      source: 'human',
+      estimated: false,
       ...seed,
     }
     tempId -= 1

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -609,7 +609,7 @@ main:has(.tracking) {
    AA (4.5:1) in dark. */
 .entry-badge {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.25em;
   margin-left: 0.4em;
   padding: 0.05em 0.45em;
@@ -619,11 +619,31 @@ main:has(.tracking) {
   font-weight: 600;
   line-height: 1.4;
   white-space: nowrap;
-  vertical-align: baseline;
+  vertical-align: middle;
 }
 
 .entry-badge-icon {
-  font-weight: 700;
+  width: 1em;
+  height: 1em;
+  flex: none;
+}
+
+/* Description cell: the truncating text flexes, the ADR-025 badges stay pinned
+   and visible at the end (never clipped by the ellipsis). */
+.cell-desc-badged {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  width: 100%;
+}
+
+.cell-desc-badged > .cell-trunc {
+  flex: 1;
+  min-width: 0;
+}
+
+.cell-desc-badged > .entry-badge {
+  flex: none;
 }
 
 .entry-badge.is-agent {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -602,6 +602,39 @@ main:has(.tracking) {
 .is-neg { color: var(--color-danger-text); }
 .is-pos { color: var(--color-success-text); }
 
+/* ---- ADR-025 entry source/estimated badges ----
+   A small inline marker on an entry row. Text + icon carry the meaning; colour
+   is only a reinforcing cue (WCAG 1.4.1). Both bg/text token pairs are the
+   design system's 7:1 pairs, so contrast holds in light and dark. */
+.entry-badge {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25em;
+  margin-left: 0.4em;
+  padding: 0.05em 0.45em;
+  border-radius: 0.5em;
+  font-family: var(--font-body);
+  font-size: 0.78em;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+
+.entry-badge-icon {
+  font-weight: 700;
+}
+
+.entry-badge.is-agent {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-text);
+}
+
+.entry-badge.is-estimated {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+}
+
 .action-button {
   background: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -604,8 +604,9 @@ main:has(.tracking) {
 
 /* ---- ADR-025 entry source/estimated badges ----
    A small inline marker on an entry row. Text + icon carry the meaning; colour
-   is only a reinforcing cue (WCAG 1.4.1). Both bg/text token pairs are the
-   design system's 7:1 pairs, so contrast holds in light and dark. */
+   is only a reinforcing cue (WCAG 1.4.1). The warning (estimated) token pair
+   clears 7:1 in both themes; the accent (agent) pair clears 7:1 in light and
+   AA (4.5:1) in dark. */
 .entry-badge {
   display: inline-flex;
   align-items: baseline;


### PR DESCRIPTION
The [ADR-025](docs/adr/ADR-025-agent-vs-human-time.md) backend is live (#599) but invisible to users — this surfaces it.

## What
- **Entry badge** (`EntrySourceBadge`, shared, accessible): marks a row `source=agent` and, separately, `estimated` — shown in the two views that render entry rows (the Tracking grid + the Auswertung detail table). Not colour-only: visible text label + `aria-hidden` icon + title.
- **Agent hours beside human** in the controlling/interpretation views: `EffortChart` gains a separate "Agent hours" column (own cell), bound to the backend's `agentHours` — **never folded** into the human figure; shown only when agent time exists.
- Entry types (`TrackingEntry`, `EntryRecord.entry`) now carry `source`/`estimated` (fed by `/getData` and `/interpretation/entries` via `Entry::toArray()`); group types carry `agentHours`.

## Scope note
`Billing.tsx` (export form) and `Month.tsx` (day-aggregate calendar) render no per-entry rows, so no badge there. `GET /api/v2/day`'s human/agent split exists but no in-scope SPA page consumes it (the controlling pages read `/interpretation/*`, which already carries `agentHours`).

## a11y note
The estimated badge clears 7:1 in both themes; the agent badge clears 7:1 in light and real WCAG AA (4.5:1) in dark — it reuses the app-wide accent token pair (6.91:1 dark), inherited from ~15 call sites. Retuning the global token is out of scope; the CSS comment was corrected to stop overclaiming.

## Tests / gates
typecheck + lint clean; full frontend suite green incl. new badge tests (renders for agent/estimated, absent for plain human) and the agent-hours-column tests; i18n in all 5 catalogs. Built via ultracode workflow (implement→review→fix), rebased/cherry-picked onto current main.