### PR TITLE
fix(frontend): agent badge clears 7:1 contrast in dark theme

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -648,7 +648,11 @@ main:has(.tracking) {
 
 .entry-badge.is-agent {
   background: var(--color-accent-soft);
-  color: var(--color-accent-text);
+  /* Badge-scoped text colour: the app-wide --color-accent-text clears WCAG AA
+     but the badge holds itself to 7:1 (AAA). On the dark accent-soft ground
+     (#0f3a40) the token's #6fd0dd is 6.91:1 — a shade lighter (#7fd4e0) is
+     7.29:1. Light theme's accent-text already passes 7:1, so it stays. */
+  color: light-dark(var(--color-accent-text), #7fd4e0);
 }
 
 .entry-badge.is-estimated {


### PR DESCRIPTION
The agent entry badge (`.entry-badge.is-agent`, ADR-025) inherited the app-wide `--color-accent-text` token. On the dark `--color-accent-soft` ground (`#0f3a40`) that text (`#6fd0dd`) measures **6.91:1** — under the frontend's self-set **7:1 (AAA)** contrast bar (`frontend/CLAUDE.md`: "7:1 contrast in BOTH color schemes").

## Change

Badge-scoped text override to `#7fd4e0` (**7.29:1** on the same ground), via `light-dark()` so only the dark arm changes:

```css
.entry-badge.is-agent {
  background: var(--color-accent-soft);
  color: light-dark(var(--color-accent-text), #7fd4e0);
}
```

The light arm keeps `var(--color-accent-text)` (already ≥7:1), and the ~15 other call sites of the global token are untouched.

## Scope

One CSS declaration. No message-catalog, TS, or markup change.