### PR TITLE
fix(sync): stop re-proposing already-imported projects in the review

### DIFF
--- a/src/Controller/Admin/GetProjectImportProposalsAction.php
+++ b/src/Controller/Admin/GetProjectImportProposalsAction.php
@@ -12,6 +12,7 @@ namespace App\Controller\Admin;
 use App\DTO\Sync\ProjectImportProposal;
 use App\Entity\TicketSystem;
 use App\Entity\User;
+use App\Repository\ProjectRepository;
 use App\Repository\SyncRunRepository;
 use App\Service\Sync\ProjectImportProposalService;
 use Doctrine\Persistence\ManagerRegistry;
@@ -22,7 +23,9 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
+use function array_diff;
 use function array_map;
+use function array_values;
 
 /**
  * Review screen backend (ADR-026 P1): list the unresolved Jira prefixes parked
@@ -39,6 +42,7 @@ final readonly class GetProjectImportProposalsAction
     public function __construct(
         private ManagerRegistry $managerRegistry,
         private SyncRunRepository $syncRunRepository,
+        private ProjectRepository $projectRepository,
         private ProjectImportProposalService $projectImportProposalService,
     ) {
     }
@@ -61,7 +65,16 @@ final readonly class GetProjectImportProposalsAction
             return new JsonResponse(['message' => 'Ticket system not found.'], Response::HTTP_NOT_FOUND);
         }
 
+        // Parked prefixes still list a prefix a later import already resolved
+        // (the historical sync item is never rewritten). Drop the prefixes a
+        // project now owns on this ticket system, so an imported project stops
+        // being re-proposed — and its Jira/Tempo derivation is skipped too.
         $prefixes = $this->syncRunRepository->findUnresolvedProjectPrefixes($ticketSystem);
+        $owned = $this->projectRepository->findOwnedJiraIds($prefixes, $ticketSystem);
+        if ([] !== $owned) {
+            $prefixes = array_values(array_diff($prefixes, $owned));
+        }
+
         $proposals = $this->projectImportProposalService->proposeForKeys($prefixes, $ticketSystem, $user);
 
         return new JsonResponse([

--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -140,6 +140,32 @@ class ProjectRepository extends ServiceEntityRepository
     }
 
     /**
+     * The subset of $jiraIds a project already claims on $ticketSystem — the
+     * prefixes to drop from the ADR-026 P1 project-import review because they
+     * now resolve. One query for the whole batch; empty in, empty out.
+     *
+     * @param list<string> $jiraIds
+     *
+     * @return list<string>
+     */
+    public function findOwnedJiraIds(array $jiraIds, TicketSystem $ticketSystem): array
+    {
+        if ([] === $jiraIds) {
+            return [];
+        }
+
+        /** @var list<string> */
+        return $this->createQueryBuilder('p')
+            ->select('DISTINCT p.jiraId')
+            ->where('p.ticketSystem = :ticketSystem')
+            ->andWhere('p.jiraId IN (:jiraIds)')
+            ->setParameter('ticketSystem', $ticketSystem)
+            ->setParameter('jiraIds', $jiraIds)
+            ->getQuery()
+            ->getSingleColumnResult();
+    }
+
+    /**
      * All projects booking on the given ticket system (ADR-023 import: ticket→project resolution).
      *
      * @return list<Project>

--- a/src/Repository/SyncRunRepository.php
+++ b/src/Repository/SyncRunRepository.php
@@ -66,9 +66,11 @@ class SyncRunRepository extends ServiceEntityRepository
     /**
      * Distinct Jira key PREFIXES (the part before the first '-') of the
      * UNRESOLVED_PROJECT items parked by the most recent $runLimit sync runs of
-     * a ticket system (ADR-026 P1). These are the prefixes with no owning TT
-     * project — the input to the project-import review screen. Sorted for a
-     * stable order; empty when nothing is parked.
+     * a ticket system (ADR-026 P1) — the raw input to the project-import review
+     * screen. A prefix stays listed even after a later import resolves it (the
+     * historical item is never rewritten), so the caller drops prefixes a
+     * project now owns via {@see ProjectRepository::findOwnedJiraIds()}.
+     * Sorted for a stable order; empty when nothing is parked.
      *
      * @return list<string>
      */

--- a/tests/Controller/Admin/GetProjectImportProposalsActionTest.php
+++ b/tests/Controller/Admin/GetProjectImportProposalsActionTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Tests\Controller\Admin;
 
+use App\Entity\Customer;
+use App\Entity\Project;
 use App\Entity\SyncRun;
 use App\Entity\SyncRunItem;
 use App\Entity\TicketSystem;
@@ -94,6 +96,35 @@ final class GetProjectImportProposalsActionTest extends AbstractWebTestCase
         self::assertSame('SRVMO', $error['jira_key']);
         self::assertSame('error', $error['derivation_source']);
         self::assertNull($error['derived_customer_name']);
+    }
+
+    public function testExcludesPrefixesAlreadyOwnedByAProject(): void
+    {
+        // SRVMO and JOT are both parked, but SRVMO was already imported (a
+        // project now owns it on this ticket system). The review must stop
+        // re-proposing SRVMO — and never call Jira/Tempo for it.
+        $this->seedUnresolved(['SRVMO-1', 'JOT-9']);
+        $this->seedProjectOwning('SRVMO');
+
+        $this->stubApiFactory(
+            projectInfo: [
+                'JOT' => ['id' => 23050, 'name' => 'Job Tool', 'categoryName' => 'NR: IT'],
+            ],
+            // SRVMO would throw if it reached the service — it must not.
+            throwKeys: ['SRVMO'],
+            tenant: ['/rest/tempo-accounts/1/account/project/23050' => []],
+        );
+
+        $this->get(self::URI . '?ticketSystem=1');
+        $this->assertStatusCode(200);
+
+        $data = $this->responseData();
+        self::assertCount(1, $data['proposals']);
+
+        $only = $data['proposals'][0];
+        self::assertIsArray($only);
+        self::assertSame('JOT', $only['jira_key']);
+        self::assertSame('category', $only['derivation_source']);
     }
 
     public function testEmptyProposalsWhenNothingParked(): void
@@ -226,6 +257,31 @@ final class GetProjectImportProposalsActionTest extends AbstractWebTestCase
                 ->setCreatedAt(new DateTimeImmutable('2026-07-05 10:00:00'));
             $this->entityManager->persist($item);
         }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Give ticket system 1 a project that already claims $prefix as its jira_id —
+     * the "already imported" state that must exclude the prefix from the review.
+     */
+    private function seedProjectOwning(string $prefix): void
+    {
+        $ticketSystem = $this->entityManager->find(TicketSystem::class, 1);
+        assert($ticketSystem instanceof TicketSystem);
+
+        $customer = new Customer()->setName('Owned Co')->setActive(true)->setGlobal(false);
+        $this->entityManager->persist($customer);
+
+        $project = new Project()
+            ->setName('Already Imported')
+            ->setCustomer($customer)
+            ->setJiraId($prefix)
+            ->setTicketSystem($ticketSystem)
+            ->setActive(true)
+            ->setGlobal(false)
+            ->setEstimation(0);
+        $this->entityManager->persist($project);
 
         $this->entityManager->flush();
     }


### PR DESCRIPTION
## Symptom

On `/ui/admin/project-import`, after importing a proposed project the **same prefix is proposed again** on the next load.

## Root cause

`SyncRunRepository::findUnresolvedProjectPrefixes()` returns the distinct prefixes of the `UNRESOLVED_PROJECT` items parked by the most recent sync runs. Those historical sync items are never rewritten when a later import resolves the prefix, so an imported prefix keeps coming back — the method's own docblock claimed "prefixes with no owning TT project", but it never checked for an owning project.

## Fix

- New `ProjectRepository::findOwnedJiraIds(array $jiraIds, TicketSystem): list<string>` — one batch query for the subset of candidate prefixes a project already claims on the ticket system.
- `GetProjectImportProposalsAction` drops those owned prefixes **before** `proposeForKeys`, so an imported project stops being re-proposed — and its Jira/Tempo derivation calls are skipped too.
- Corrected the `findUnresolvedProjectPrefixes` docblock to match its real contract (raw parked prefixes; owner-filtering is the caller's job).

## Tests

Added `testExcludesPrefixesAlreadyOwnedByAProject`: two parked prefixes, one already owned by a project — only the un-owned one is proposed, and the owned prefix never reaches the (throwing) Jira stub. Reproduces the bug (fails without the filter: the owned prefix returns as an error row).

Gates run in-container: PHPStan L10, php-cs-fixer, phpat, rector clean; the project-import controller/service/repository tests pass (36/36).