### PR TITLE
feat(personio): import Personio absences as TimeTracker entries (ADR-024 P2)

### DIFF
--- a/docs/adr/ADR-024-personio-attendance-absence-sync.md
+++ b/docs/adr/ADR-024-personio-attendance-absence-sync.md
@@ -1,6 +1,6 @@
 # ADR-024: Personio Attendance Export and Absence Import
 
-**Status:** Accepted — P1 (attendance export) implemented 2026-07-11; P2 (absence import) + P3 (auto-match/API) pending.
+**Status:** Accepted — P1 (attendance export) implemented 2026-07-11; P2 (absence import) implemented 2026-07-12; P3 (auto-match/API) pending.
 **Date:** 2026-07-10
 **Relates to:** [ADR-023](ADR-023-jira-worklog-bidirectional-sync.md) (the sync/run/audit infrastructure and the opt-in accountability model this ADR reuses), [ADR-021](ADR-021-api-token-authentication.md) (PAT scopes for any later API surface), [ADR-011](ADR-011-security-architecture.md) (encryption-at-rest via `TokenEncryptionService`).
 

--- a/docs/personio-sync.md
+++ b/docs/personio-sync.md
@@ -1,6 +1,6 @@
 # Personio Sync — Operator Guide
 
-TimeTracker exports each opted-in user's worklogs to Personio as daily **work attendances** (ADR-024 P1). Absence import (Personio → TT) is a later phase.
+TimeTracker exports each opted-in user's worklogs to Personio as daily **work attendances** (ADR-024 P1), and imports their Personio **absences** (vacation/sick) back as TimeTracker day entries (ADR-024 P2). The same per-user opt-in covers both directions.
 
 ## How it works
 
@@ -33,6 +33,22 @@ Schedule the default form on a cron (like `tt:sync-subtickets`); the 14-day roll
 
 Each run is recorded as a `SyncRun` (type `personio_export`, one per user) with per-day counters (`created`, `updated`, `in_sync`, `deleted`, `errors`) and items for anything parked (approved-attendance conflicts, errors). The `--dry-run` form reports `would_create` / `would_update` / `would_delete` without writing.
 
+## Running the absence import
+
+```bash
+# a single user
+docker exec timetracker php bin/console tt:import-personio-absences --user=<username>
+
+# a specific window (default: 30 days back, 90 days ahead)
+docker exec timetracker php bin/console tt:import-personio-absences --from=2026-07-01 --to=2026-09-30
+```
+
+Per opted-in, mapped user the import reads Personio's absence periods in the window and creates **one TimeTracker entry per working day**: start 08:00, duration = the user's contract hours for that weekday (a half-day boundary halves it; a non-working weekday gets no entry), on the configured **absence project**. The activity comes from the Personio absence type name — `urlaub` → Urlaub, `krank` → Krank; a type that matches neither, or an hourly (non-day) type, is **parked** as an `unresolved_absence_type` item rather than guessed. No Jira echo is dispatched for imported absences.
+
+Re-runs are idempotent, tracked per Personio absence id: an unchanged absence is skipped, a changed one is rebuilt, and an absence cancelled in Personio has its entries removed — the rebuild and the removal happen **only while the TimeTracker entries are still the untouched imports**; a locally edited entry parks the case as a conflict instead. Each run is a `SyncRun` (type `personio_import`) with counters (`imported`, `updated`, `in_sync`, `cancelled`, `conflicts`, `unresolved_type`, `no_contract`).
+
+Schedule the default form on the same cron as the export; the window is one-directional (vacations lie in the future), so it is wider ahead than behind.
+
 ## Deactivating
 
-Clear a user's opt-in in Settings, or set the Personio config inactive. Deactivating stops future exports; it does not remove attendances already sent to Personio.
+Clear a user's opt-in in Settings, or set the Personio config inactive. Deactivating stops future exports and imports; it does not remove attendances already sent to Personio, nor absence entries already imported into TimeTracker.

--- a/migrations/Version20260712_PersonioAbsenceImport.php
+++ b/migrations/Version20260712_PersonioAbsenceImport.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260712_PersonioAbsenceImport extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-024 P2: personio_absence_import table (Personio absence id -> created TT entry ids + signature)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE personio_absence_import (
+                id INT AUTO_INCREMENT NOT NULL,
+                user_id INT NOT NULL,
+                last_sync_run_id INT DEFAULT NULL,
+                absence_id VARCHAR(191) NOT NULL,
+                entry_ids JSON NOT NULL,
+                signature JSON NOT NULL,
+                last_imported_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)',
+                UNIQUE INDEX uniq_personio_absence_id (absence_id),
+                INDEX idx_personio_absence_user (user_id),
+                PRIMARY KEY (id),
+                CONSTRAINT fk_personio_absence_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+                CONSTRAINT fk_personio_absence_run FOREIGN KEY (last_sync_run_id) REFERENCES sync_runs (id) ON DELETE SET NULL
+            )
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE personio_absence_import');
+    }
+}

--- a/sql/full.sql
+++ b/sql/full.sql
@@ -442,6 +442,24 @@ CREATE TABLE `personio_attendance_export` (
   CONSTRAINT `fk_personio_export_run` FOREIGN KEY (`last_sync_run_id`) REFERENCES `sync_runs` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+--
+-- Tabellenstruktur für Tabelle `personio_absence_import` (ADR-024 P2)
+--
+CREATE TABLE `personio_absence_import` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `last_sync_run_id` int(11) DEFAULT NULL,
+  `absence_id` varchar(191) NOT NULL,
+  `entry_ids` json NOT NULL,
+  `signature` json NOT NULL,
+  `last_imported_at` datetime NOT NULL COMMENT '(DC2Type:datetime_immutable)',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_personio_absence_id` (`absence_id`),
+  KEY `idx_personio_absence_user` (`user_id`),
+  CONSTRAINT `fk_personio_absence_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_personio_absence_run` FOREIGN KEY (`last_sync_run_id`) REFERENCES `sync_runs` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 
 --
 -- Tabellenstruktur für Tabelle `contracts`

--- a/src/Command/TtImportPersonioAbsencesCommand.php
+++ b/src/Command/TtImportPersonioAbsencesCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Enum\SyncRunStatus;
+use App\Service\Personio\AbsenceImportService;
+use App\Service\Sync\SyncRunConsoleRenderer;
+use DateTimeImmutable;
+use Doctrine\Persistence\ManagerRegistry;
+use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function sprintf;
+use function trim;
+
+/**
+ * ADR-024 P2: the cron entry point that imports opted-in users' Personio absences
+ * (vacation/sick) as TimeTracker day entries. Rescans a rolling window (default:
+ * 30 days back, 90 days ahead — vacations lie in the future) and is idempotent:
+ * unchanged absences are skipped, changed ones rebuilt, and cancellations delete
+ * their entries. Without --user every opted-in, employee-mapped user is imported;
+ * with --user a single named user is imported.
+ */
+#[AsCommand(name: 'tt:import-personio-absences', description: 'Import opted-in users\' Personio absences as TimeTracker entries (ADR-024 P2)')]
+class TtImportPersonioAbsencesCommand extends Command
+{
+    public function __construct(
+        private readonly AbsenceImportService $absenceImportService,
+        private readonly ManagerRegistry $managerRegistry,
+        private readonly SyncRunConsoleRenderer $syncRunConsoleRenderer,
+    ) {
+        parent::__construct();
+    }
+
+    public function __invoke(
+        InputInterface $input,
+        OutputInterface $output,
+        #[Option(description: 'Start date (Y-m-d); default: 30 days ago', name: 'from')]
+        ?string $from = null,
+        #[Option(description: 'End date (Y-m-d); default: 90 days ahead', name: 'to')]
+        ?string $to = null,
+        #[Option(description: 'Import only this TT username; default: every opted-in, employee-mapped user', name: 'user')]
+        ?string $user = null,
+    ): int {
+        $symfonyStyle = new SymfonyStyle($input, $output);
+
+        if ((null !== $from && '' === trim($from)) || (null !== $to && '' === trim($to))) {
+            $symfonyStyle->error('Invalid date in --from/--to: must not be blank (expected Y-m-d)');
+
+            return 1;
+        }
+
+        try {
+            $fromDate = null !== $from ? new DateTimeImmutable($from) : new DateTimeImmutable('today')->modify('-30 days');
+            $toDate = null !== $to ? new DateTimeImmutable($to) : new DateTimeImmutable('today')->modify('+90 days');
+        } catch (Exception) {
+            $symfonyStyle->error(sprintf('Invalid date in --from/--to (expected Y-m-d): %s / %s', $from ?? '-', $to ?? '-'));
+
+            return 1;
+        }
+
+        if (null !== $user) {
+            $account = $this->managerRegistry->getRepository(User::class)->findOneBy(['username' => $user]);
+            if (!$account instanceof User) {
+                $symfonyStyle->error('User not found: ' . $user);
+
+                return 1;
+            }
+
+            $runs = [$this->absenceImportService->importUser($account, $fromDate, $toDate)];
+        } else {
+            $runs = $this->absenceImportService->importAllOptedIn($fromDate, $toDate);
+        }
+
+        if ([] === $runs) {
+            $symfonyStyle->note('Nothing to import: no user opted in with a Personio employee id mapped.');
+
+            return Command::SUCCESS;
+        }
+
+        $failed = false;
+        foreach ($runs as $syncRun) {
+            $this->syncRunConsoleRenderer->render($symfonyStyle, $syncRun, 'Personio import');
+            if (SyncRunStatus::FAILED === $syncRun->getStatus()) {
+                $failed = true;
+            }
+        }
+
+        return $failed ? 1 : Command::SUCCESS;
+    }
+}

--- a/src/DTO/Personio/AbsencePeriod.php
+++ b/src/DTO/Personio/AbsencePeriod.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\DTO\Personio;
+
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+
+/**
+ * A single Personio v2 absence period ({@see https://developer.personio.de}).
+ *
+ * Half days are encoded per boundary as `starts_from.type` / `ends_at.type`
+ * (`FIRST_HALF` = morning, `SECOND_HALF` = afternoon; null = a full boundary) —
+ * not a boolean and not a fractional amount. TT only needs "is this boundary a
+ * half day", so {@see startsHalf()} / {@see endsHalf()} collapse the enum.
+ *
+ * `endDateTime` is nullable: an open-ended absence (e.g. long-term sick leave)
+ * carries no end (ADR-024 §4).
+ */
+final readonly class AbsencePeriod
+{
+    public function __construct(
+        public ?string $id,
+        public string $personId,
+        public string $absenceTypeId,
+        public string $startDateTime,
+        public ?string $startHalf,
+        public ?string $endDateTime,
+        public ?string $endHalf,
+        public ?string $approvalStatus,
+        public ?string $comment,
+    ) {
+    }
+
+    /**
+     * Build from a decoded Personio API item (stdClass).
+     */
+    public static function fromApiResponse(object $response): self
+    {
+        /** @var array<string, mixed> $data */
+        $data = (array) $response;
+
+        return new self(
+            self::stringOrNull($data['id'] ?? null),
+            self::nestedString($data['person'] ?? null, 'id'),
+            self::nestedString($data['absence_type'] ?? null, 'id'),
+            self::nestedString($data['starts_from'] ?? null, 'date_time'),
+            self::nestedStringOrNull($data['starts_from'] ?? null, 'type'),
+            self::nestedStringOrNull($data['ends_at'] ?? null, 'date_time'),
+            self::nestedStringOrNull($data['ends_at'] ?? null, 'type'),
+            self::nestedStringOrNull($data['approval'] ?? null, 'status'),
+            self::stringOrNull($data['comment'] ?? null),
+        );
+    }
+
+    /**
+     * Whether the start boundary is a half day (either morning or afternoon).
+     */
+    public function startsHalf(): bool
+    {
+        return null !== $this->startHalf;
+    }
+
+    /**
+     * Whether the end boundary is a half day (either morning or afternoon).
+     */
+    public function endsHalf(): bool
+    {
+        return null !== $this->endHalf;
+    }
+
+    private static function nestedString(mixed $node, string $key): string
+    {
+        return self::nestedStringOrNull($node, $key) ?? '';
+    }
+
+    private static function nestedStringOrNull(mixed $node, string $key): ?string
+    {
+        if (is_object($node)) {
+            $node = (array) $node;
+        }
+
+        if (is_array($node) && isset($node[$key])) {
+            return self::stringOrNull($node[$key]);
+        }
+
+        return null;
+    }
+
+    private static function stringOrNull(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/DTO/Personio/AbsenceType.php
+++ b/src/DTO/Personio/AbsenceType.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\DTO\Personio;
+
+use function is_float;
+use function is_int;
+use function is_string;
+use function mb_strtolower;
+
+/**
+ * A single Personio v2 absence type ({@see https://developer.personio.de}).
+ *
+ * The import maps a period's type to a TT {@see \App\Entity\Activity} by NAME
+ * (ADR-024 §4: "krank" -> Krank, "urlaub" -> Urlaub); the id links a period to
+ * its type, the name drives the mapping. `unit` distinguishes DAY-based leave
+ * (vacation/sick — what P2 imports) from HOUR-based leave.
+ */
+final readonly class AbsenceType
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public ?string $category,
+        public ?string $unit,
+    ) {
+    }
+
+    /**
+     * Build from a decoded Personio API item (stdClass).
+     */
+    public static function fromApiResponse(object $response): self
+    {
+        /** @var array<string, mixed> $data */
+        $data = (array) $response;
+
+        return new self(
+            self::nestedString($data, 'id'),
+            self::nestedString($data, 'name'),
+            self::stringOrNull($data['category'] ?? null),
+            self::stringOrNull($data['unit'] ?? null),
+        );
+    }
+
+    /**
+     * Personio measures this leave in whole/half DAYS (vs HOUR-based). Only
+     * day-based absences map to a per-day TT entry in P2.
+     */
+    public function isDayBased(): bool
+    {
+        return null === $this->unit || 'DAY' === $this->unit;
+    }
+
+    /**
+     * A lower-cased name for the ADR-024 §4 substring activity match.
+     */
+    public function normalizedName(): string
+    {
+        return mb_strtolower($this->name);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function nestedString(array $data, string $key): string
+    {
+        return self::stringOrNull($data[$key] ?? null) ?? '';
+    }
+
+    private static function stringOrNull(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Entity/PersonioAbsenceImport.php
+++ b/src/Entity/PersonioAbsenceImport.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Model\Base;
+use App\Repository\PersonioAbsenceImportRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Per Personio absence, the TT entries the import created for it (ADR-024 §4):
+ * the created entry ids plus a signature of the source absence, so re-runs are
+ * idempotent (unchanged -> skip) and a cancelled/changed absence can delete or
+ * rebuild exactly its own entries.
+ */
+#[ORM\Entity(repositoryClass: PersonioAbsenceImportRepository::class)]
+#[ORM\Table(name: 'personio_absence_import')]
+#[ORM\UniqueConstraint(name: 'uniq_personio_absence_id', columns: ['absence_id'])]
+#[ORM\Index(name: 'idx_personio_absence_user', columns: ['user_id'])]
+class PersonioAbsenceImport extends Base
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    protected ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected ?User $user = null;
+
+    #[ORM\Column(name: 'absence_id', type: 'string', length: 191)]
+    protected ?string $absenceId = null;
+
+    /** @var list<int> */
+    #[ORM\Column(name: 'entry_ids', type: 'json')]
+    protected array $entryIds = [];
+
+    /**
+     * The source-absence fields that, when they change, mean the import must
+     * rebuild its entries: start/end date-time, the half-day boundary markers,
+     * and the absence type id.
+     *
+     * @var array<string, string|null>
+     */
+    #[ORM\Column(name: 'signature', type: 'json')]
+    protected array $signature = [];
+
+    #[ORM\Column(name: 'last_imported_at', type: 'datetime_immutable')]
+    protected ?DateTimeImmutable $lastImportedAt = null;
+
+    #[ORM\ManyToOne(targetEntity: SyncRun::class)]
+    #[ORM\JoinColumn(name: 'last_sync_run_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    protected ?SyncRun $lastSyncRun = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getAbsenceId(): ?string
+    {
+        return $this->absenceId;
+    }
+
+    public function setAbsenceId(string $absenceId): static
+    {
+        $this->absenceId = $absenceId;
+
+        return $this;
+    }
+
+    /** @return list<int> */
+    public function getEntryIds(): array
+    {
+        return $this->entryIds;
+    }
+
+    /** @param list<int> $entryIds */
+    public function setEntryIds(array $entryIds): static
+    {
+        $this->entryIds = $entryIds;
+
+        return $this;
+    }
+
+    /** @return array<string, string|null> */
+    public function getSignature(): array
+    {
+        return $this->signature;
+    }
+
+    /** @param array<string, string|null> $signature */
+    public function setSignature(array $signature): static
+    {
+        $this->signature = $signature;
+
+        return $this;
+    }
+
+    public function getLastImportedAt(): ?DateTimeImmutable
+    {
+        return $this->lastImportedAt;
+    }
+
+    public function setLastImportedAt(DateTimeImmutable $lastImportedAt): static
+    {
+        $this->lastImportedAt = $lastImportedAt;
+
+        return $this;
+    }
+
+    public function getLastSyncRun(): ?SyncRun
+    {
+        return $this->lastSyncRun;
+    }
+
+    public function setLastSyncRun(?SyncRun $lastSyncRun): static
+    {
+        $this->lastSyncRun = $lastSyncRun;
+
+        return $this;
+    }
+}

--- a/src/Enum/SyncItemKind.php
+++ b/src/Enum/SyncItemKind.php
@@ -25,6 +25,7 @@ enum SyncItemKind: string
     case PROBABLE_DUPLICATE = 'probable_duplicate';
     case UNRESOLVED_PROJECT = 'unresolved_project';
     case PROJECT_AUTO_IMPORTED = 'project_auto_imported';
+    case UNRESOLVED_ABSENCE_TYPE = 'unresolved_absence_type';
     case SHADOW_USER_CREATED = 'shadow_user_created';
     case TRUNCATED = 'truncated';
     case ERROR = 'error';

--- a/src/Repository/PersonioAbsenceImportRepository.php
+++ b/src/Repository/PersonioAbsenceImportRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\PersonioAbsenceImport;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PersonioAbsenceImport>
+ */
+class PersonioAbsenceImportRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PersonioAbsenceImport::class);
+    }
+
+    public function findOneByAbsenceId(string $absenceId): ?PersonioAbsenceImport
+    {
+        return $this->findOneBy(['absenceId' => $absenceId]);
+    }
+
+    /**
+     * The import records for a user, keyed by Personio absence id — the set the
+     * import diffs against Personio to spot cancellations (records with no
+     * matching remote absence in the window).
+     *
+     * @return array<string, PersonioAbsenceImport>
+     */
+    public function findByUserIndexedByAbsenceId(User $user): array
+    {
+        $indexed = [];
+        foreach ($this->findBy(['user' => $user]) as $record) {
+            $absenceId = $record->getAbsenceId();
+            if (null !== $absenceId) {
+                $indexed[$absenceId] = $record;
+            }
+        }
+
+        return $indexed;
+    }
+}

--- a/src/Service/Personio/AbsenceImportService.php
+++ b/src/Service/Personio/AbsenceImportService.php
@@ -1,0 +1,480 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Personio;
+
+use App\DTO\Personio\AbsencePeriod;
+use App\DTO\Personio\AbsenceType;
+use App\Entity\Activity;
+use App\Entity\Contract;
+use App\Entity\Customer;
+use App\Entity\Entry;
+use App\Entity\PersonioAbsenceImport;
+use App\Entity\PersonioConfig;
+use App\Entity\Project;
+use App\Entity\SyncRun;
+use App\Entity\User;
+use App\Enum\EntryClass;
+use App\Enum\SyncItemKind;
+use App\Enum\SyncRunStatus;
+use App\Enum\SyncRunType;
+use App\Repository\ActivityRepository;
+use App\Repository\PersonioAbsenceImportRepository;
+use App\Repository\PersonioConfigRepository;
+use App\Repository\UserRepository;
+use App\Service\Sync\AbstractSyncRunService;
+use App\Service\Tracking\DayClassService;
+use App\Service\Util\ContractHoursResolver;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
+use RuntimeException;
+
+use function mb_substr;
+use function round;
+use function str_contains;
+use function usort;
+
+/**
+ * Imports opted-in users' Personio absences as TT day entries (ADR-024 §4).
+ *
+ * Per absence period, one entry is created per working day: start 08:00, duration
+ * = the user's contract hours for that weekday ({@see ContractHoursResolver}),
+ * halved when Personio marks the boundary a half day; activity resolved from the
+ * Personio time-off type NAME ("krank" -> Krank, "urlaub" -> Urlaub), project =
+ * the configured absence project. Unknown/hourly types are parked, never guessed.
+ *
+ * Idempotency & cancellation are tracked per Personio absence id in
+ * {@see PersonioAbsenceImport}: a signature of the source absence detects change
+ * (unchanged -> skip; changed -> rebuild), and a stored absence no longer present
+ * in Personio's window is cancelled and its entries removed — both only while the
+ * TT entries are still the untouched imports, else the case is parked. No
+ * EntryEvent is dispatched (no Jira echo); day classes are recalculated as in the
+ * Jira import.
+ */
+class AbsenceImportService extends AbstractSyncRunService
+{
+    /** Every absence entry starts at 08:00 (ADR-024 §4). */
+    private const string START_TIME = '08:00:00';
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly PersonioAbsenceImportRepository $importRepository,
+        private readonly PersonioConfigRepository $configRepository,
+        private readonly PersonioClientFactory $clientFactory,
+        private readonly UserRepository $userRepository,
+        private readonly ActivityRepository $activityRepository,
+        private readonly ContractHoursResolver $contractHoursResolver,
+        private readonly DayClassService $dayClassService,
+        ClockInterface $clock,
+    ) {
+        parent::__construct($entityManager, $clock);
+    }
+
+    /**
+     * Imports one user's absences across the window, producing a single run.
+     */
+    public function importUser(User $user, DateTimeImmutable $from, DateTimeImmutable $to): SyncRun
+    {
+        $syncRun = new SyncRun()
+            ->setType(SyncRunType::PERSONIO_IMPORT)
+            ->setStatus(SyncRunStatus::RUNNING)
+            ->setTriggeredBy($user)
+            ->setScope([
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+            ])
+            ->setCounters([])
+            ->setStartedAt($this->now());
+
+        return $this->executeRun($syncRun, function () use ($syncRun, $user, $from, $to): void {
+            $config = $this->configRepository->findActive();
+            if (!$config instanceof PersonioConfig) {
+                throw new RuntimeException('no active Personio configuration');
+            }
+
+            $absenceProject = $config->getAbsenceProject();
+            if (!$absenceProject instanceof Project) {
+                throw new RuntimeException('no absence project configured');
+            }
+
+            $employeeId = $user->getPersonioEmployeeId();
+            if (null === $employeeId) {
+                throw new RuntimeException('no Personio employee id mapped');
+            }
+
+            $client = $this->clientFactory->create($config);
+            $personId = (string) $employeeId;
+
+            $typesById = $this->indexTypes($client->listAbsenceTypes());
+            $contracts = $this->sortedContracts($user);
+
+            /** @var array<string, true> $seen absence ids present in this window */
+            $seen = [];
+            /** @var array<string, true> $affectedDays 'Y-m-d' keys to recalculate */
+            $affectedDays = [];
+
+            foreach ($client->listAbsencePeriods($personId, $from, $to) as $period) {
+                if (null === $period->id) {
+                    continue;
+                }
+                $seen[$period->id] = true;
+                $this->importAbsence($syncRun, $user, $period, $typesById, $absenceProject, $contracts, $to, $affectedDays);
+            }
+
+            $this->handleCancellations($syncRun, $user, $from, $to, $seen, $absenceProject, $affectedDays);
+
+            foreach (array_keys($affectedDays) as $dayKey) {
+                $this->dayClassService->recalculate((int) $user->getId(), $dayKey);
+            }
+        });
+    }
+
+    /**
+     * Cron entry point: import for every opted-in, employee-mapped user.
+     *
+     * @return list<SyncRun>
+     */
+    public function importAllOptedIn(DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        $runs = [];
+        foreach ($this->userRepository->findPersonioExportEnabled() as $user) {
+            $runs[] = $this->importUser($user, $from, $to);
+        }
+
+        return $runs;
+    }
+
+    /**
+     * @param array<string, AbsenceType> $typesById
+     * @param Contract[]                 $contracts
+     * @param array<string, true>        $affectedDays
+     */
+    private function importAbsence(SyncRun $syncRun, User $user, AbsencePeriod $period, array $typesById, Project $absenceProject, array $contracts, DateTimeImmutable $windowTo, array &$affectedDays): void
+    {
+        $type = $typesById[$period->absenceTypeId] ?? null;
+        if (!$type instanceof AbsenceType || !$type->isDayBased()) {
+            $this->parkUnresolvedType($syncRun, $period, $type);
+
+            return;
+        }
+
+        $activity = $this->resolveActivity($type);
+        if (!$activity instanceof Activity) {
+            $this->parkUnresolvedType($syncRun, $period, $type);
+
+            return;
+        }
+
+        $start = new DateTimeImmutable($period->startDateTime)->setTime(0, 0);
+        // A bounded absence materialises its FULL span (once); only an open-ended
+        // one (no end — e.g. long-term sick leave) is capped at the window end.
+        // The effective end goes into the signature, so as the window rolls the
+        // open-ended case reads as changed and extends, while a bounded one stays
+        // in sync — never leaving a long absence half-imported.
+        $last = null !== $period->endDateTime
+            ? new DateTimeImmutable($period->endDateTime)->setTime(0, 0)
+            : $windowTo->setTime(0, 0);
+
+        $signature = $this->signatureOf($period, $start, $last);
+        $stored = $this->importRepository->findOneByAbsenceId((string) $period->id);
+
+        if ($stored instanceof PersonioAbsenceImport && $stored->getSignature() === $signature) {
+            $syncRun->incrementCounter('in_sync');
+
+            return;
+        }
+
+        // Changed absence: only rebuild when the existing entries are still the
+        // untouched imports; a locally edited entry parks the case instead.
+        if ($stored instanceof PersonioAbsenceImport && !$this->removeOwnedEntries($stored, $absenceProject, $affectedDays)) {
+            $syncRun->incrementCounter('conflicts');
+            $this->addItem($syncRun, SyncItemKind::CONFLICT, issueKey: (string) $period->id, reason: 'absence entries modified locally; not rebuilt');
+
+            return;
+        }
+
+        $entryIds = $this->createEntries($user, $period, $activity, $absenceProject, $contracts, $start, $last, $affectedDays, $syncRun);
+        $this->persistState($syncRun, $user, (string) $period->id, $entryIds, $signature, $stored);
+        $syncRun->incrementCounter($stored instanceof PersonioAbsenceImport ? 'updated' : 'imported');
+    }
+
+    /**
+     * Creates one entry per working day of the absence and returns the new ids.
+     *
+     * @param Contract[]          $contracts
+     * @param array<string, true> $affectedDays
+     *
+     * @return list<int>
+     */
+    private function createEntries(User $user, AbsencePeriod $period, Activity $activity, Project $absenceProject, array $contracts, DateTimeImmutable $start, DateTimeImmutable $last, array &$affectedDays, SyncRun $syncRun): array
+    {
+        $customer = $absenceProject->getCustomer();
+        $description = mb_substr($this->describe($period, $activity), 0, Entry::DESCRIPTION_MAX_LENGTH);
+
+        $entries = [];
+        $current = $start;
+        while ($current <= $last) {
+            $minutes = $this->minutesFor($current, $start, $last, $period, $contracts, $syncRun);
+            if ($minutes > 0) {
+                $entry = $this->buildEntry($user, $current, $minutes, $activity, $absenceProject, $customer, $description);
+                $this->entityManager->persist($entry);
+                $entries[] = $entry;
+                $affectedDays[$current->format('Y-m-d')] = true;
+            }
+            $current = $current->modify('+1 day');
+        }
+
+        // One flush so the created entries get their ids before they are recorded.
+        if ([] !== $entries) {
+            $this->entityManager->flush();
+        }
+
+        $entryIds = [];
+        foreach ($entries as $entry) {
+            $id = $entry->getId();
+            if (null !== $id) {
+                $entryIds[] = $id;
+            }
+        }
+
+        return $entryIds;
+    }
+
+    /**
+     * The entry duration for one absence day: the weekday's contract hours,
+     * halved when this day is a half-day boundary. Zero on a non-working day.
+     *
+     * @param Contract[] $contracts
+     */
+    private function minutesFor(DateTimeImmutable $day, DateTimeImmutable $start, DateTimeImmutable $last, AbsencePeriod $period, array $contracts, SyncRun $syncRun): int
+    {
+        $contract = $this->contractHoursResolver->validContract($contracts, $day);
+        if (!$contract instanceof Contract) {
+            $syncRun->incrementCounter('no_contract');
+        }
+
+        $hours = $this->contractHoursResolver->weekdayHours($contract, (int) $day->format('w'));
+        if ($hours <= 0.0) {
+            return 0;
+        }
+
+        $dayKey = $day->format('Y-m-d');
+        $halfStart = $dayKey === $start->format('Y-m-d') && $period->startsHalf();
+        $halfEnd = $dayKey === $last->format('Y-m-d') && $period->endsHalf();
+        if ($halfStart || $halfEnd) {
+            $hours /= 2;
+        }
+
+        return (int) round($hours * 60);
+    }
+
+    private function buildEntry(User $user, DateTimeImmutable $day, int $minutes, Activity $activity, Project $absenceProject, ?Customer $customer, string $description): Entry
+    {
+        $entry = new Entry()
+            ->setUser($user)
+            ->setProject($absenceProject)
+            ->setActivity($activity)
+            ->setDescription($description)
+            ->setDay($day->format('Y-m-d'))
+            ->setStart(self::START_TIME)
+            ->setEnd(new DateTimeImmutable(self::START_TIME)->modify('+' . $minutes . ' minutes')->format('H:i:s'))
+            ->setDuration($minutes)
+            ->setClass(EntryClass::PLAIN);
+
+        if ($customer instanceof Customer) {
+            $entry->setCustomer($customer);
+        }
+
+        return $entry;
+    }
+
+    /**
+     * Stored absences no longer present in Personio's window are cancellations:
+     * remove their entries when still untouched, else park the case.
+     *
+     * @param array<string, true> $seen
+     * @param array<string, true> $affectedDays
+     */
+    private function handleCancellations(SyncRun $syncRun, User $user, DateTimeImmutable $from, DateTimeImmutable $to, array $seen, Project $absenceProject, array &$affectedDays): void
+    {
+        $fromKey = $from->format('Y-m-d');
+        $toKey = $to->format('Y-m-d');
+
+        foreach ($this->importRepository->findByUserIndexedByAbsenceId($user) as $absenceId => $stored) {
+            if (isset($seen[$absenceId])) {
+                continue;
+            }
+
+            // Only records whose absence started inside this window are in scope;
+            // one outside the window is simply not fetched, not cancelled.
+            $signatureStart = (string) ($stored->getSignature()['start'] ?? '');
+            if ('' === $signatureStart) {
+                continue;
+            }
+            if ($signatureStart < $fromKey) {
+                continue;
+            }
+            if ($signatureStart > $toKey) {
+                continue;
+            }
+
+            if (!$this->removeOwnedEntries($stored, $absenceProject, $affectedDays)) {
+                $syncRun->incrementCounter('conflicts');
+                $this->addItem($syncRun, SyncItemKind::CONFLICT, issueKey: $absenceId, reason: 'cancelled absence has locally-modified entries; not removed');
+
+                continue;
+            }
+
+            $this->entityManager->remove($stored);
+            $syncRun->incrementCounter('cancelled');
+        }
+    }
+
+    /**
+     * Deletes the entries a stored absence created, but ONLY while each is still
+     * the untouched import (right project + a leave activity). Returns false —
+     * touching nothing — if any entry diverged, so the caller can park it.
+     *
+     * @param array<string, true> $affectedDays
+     */
+    private function removeOwnedEntries(PersonioAbsenceImport $stored, Project $absenceProject, array &$affectedDays): bool
+    {
+        $entries = [];
+        foreach ($stored->getEntryIds() as $entryId) {
+            $entry = $this->entityManager->find(Entry::class, $entryId);
+            if (null === $entry) {
+                continue; // already gone — nothing to guard or delete
+            }
+            if (!$this->isOwnedImportEntry($entry, $absenceProject)) {
+                return false; // diverged: refuse to touch any of them
+            }
+            $entries[] = $entry;
+        }
+
+        foreach ($entries as $entry) {
+            $day = $entry->getDay();
+            if (null !== $day) {
+                $affectedDays[$day->format('Y-m-d')] = true;
+            }
+            $this->entityManager->remove($entry);
+        }
+        $this->entityManager->flush();
+
+        return true;
+    }
+
+    private function isOwnedImportEntry(Entry $entry, Project $absenceProject): bool
+    {
+        $project = $entry->getProject();
+        $activity = $entry->getActivity();
+
+        return $project instanceof Project
+            && $project->getId() === $absenceProject->getId()
+            && $activity instanceof Activity
+            && ($activity->isSick() || $activity->isHoliday());
+    }
+
+    /**
+     * @param list<int>                  $entryIds
+     * @param array<string, string|null> $signature
+     */
+    private function persistState(SyncRun $syncRun, User $user, string $absenceId, array $entryIds, array $signature, ?PersonioAbsenceImport $stored): void
+    {
+        if (!$stored instanceof PersonioAbsenceImport) {
+            $stored = new PersonioAbsenceImport()->setUser($user)->setAbsenceId($absenceId);
+            $this->entityManager->persist($stored);
+        }
+
+        $stored->setEntryIds($entryIds)
+            ->setSignature($signature)
+            ->setLastImportedAt($this->now())
+            ->setLastSyncRun($syncRun);
+    }
+
+    private function resolveActivity(AbsenceType $type): ?Activity
+    {
+        $name = $type->normalizedName();
+        if (str_contains($name, 'krank')) {
+            return $this->activityRepository->findOneByName(Activity::SICK);
+        }
+        if (str_contains($name, 'urlaub')) {
+            return $this->activityRepository->findOneByName(Activity::HOLIDAY);
+        }
+
+        return null;
+    }
+
+    private function parkUnresolvedType(SyncRun $syncRun, AbsencePeriod $period, ?AbsenceType $type): void
+    {
+        $syncRun->incrementCounter('unresolved_type');
+        $this->addItem(
+            $syncRun,
+            SyncItemKind::UNRESOLVED_ABSENCE_TYPE,
+            issueKey: (string) $period->id,
+            reason: 'no TT activity for Personio absence type: ' . ($type instanceof AbsenceType ? $type->name : $period->absenceTypeId),
+        );
+    }
+
+    private function describe(AbsencePeriod $period, Activity $activity): string
+    {
+        return null !== $period->comment && '' !== $period->comment ? $period->comment : $activity->getName();
+    }
+
+    /**
+     * The fields that, when changed, mean the entries must be rebuilt. `end` is
+     * the EFFECTIVE last day materialised (the window end for an open-ended
+     * absence), not the raw remote end — so a rolling window extends an
+     * open-ended absence while leaving a bounded one in sync.
+     *
+     * @return array<string, string|null>
+     */
+    private function signatureOf(AbsencePeriod $period, DateTimeImmutable $start, DateTimeImmutable $last): array
+    {
+        return [
+            'start' => $start->format('Y-m-d'),
+            'end' => $last->format('Y-m-d'),
+            'startHalf' => $period->startHalf,
+            'endHalf' => $period->endHalf,
+            'typeId' => $period->absenceTypeId,
+        ];
+    }
+
+    /**
+     * @param list<AbsenceType> $types
+     *
+     * @return array<string, AbsenceType>
+     */
+    private function indexTypes(array $types): array
+    {
+        $indexed = [];
+        foreach ($types as $type) {
+            $indexed[$type->id] = $type;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * The user's contracts, newest start first — the order
+     * {@see ContractHoursResolver::validContract()} expects.
+     *
+     * @return Contract[]
+     */
+    private function sortedContracts(User $user): array
+    {
+        $contracts = $user->getContracts()->toArray();
+        usort(
+            $contracts,
+            static fn (Contract $a, Contract $b): int => $b->getStart()->format('Y-m-d') <=> $a->getStart()->format('Y-m-d'),
+        );
+
+        return $contracts;
+    }
+}

--- a/src/Service/Personio/PersonioClient.php
+++ b/src/Service/Personio/PersonioClient.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace App\Service\Personio;
 
+use App\DTO\Personio\AbsencePeriod;
+use App\DTO\Personio\AbsenceType;
 use App\DTO\Personio\AttendancePeriod;
 use App\Exception\Personio\PersonioApiException;
 use DateTimeImmutable;
@@ -59,6 +61,15 @@ class PersonioClient
     /** Page size requested from the cursor-paginated list endpoints. */
     private const int PAGE_SIZE = 200;
 
+    /** The absence endpoints cap `limit` at 100 (attendance/persons allow 200). */
+    private const int ABSENCE_PAGE_SIZE = 100;
+
+    /**
+     * Personio absence timestamps are timezone-less (`DateTimeWithoutTimezone`,
+     * e.g. `2026-07-06T00:00:00.000`); the date-range filter takes the same shape.
+     */
+    private const string ABSENCE_DATE_FORMAT = 'Y-m-d\TH:i:s.v';
+
     private ?Client $client = null;
 
     private ?string $accessToken = null;
@@ -91,6 +102,45 @@ class PersonioClient
                 'limit' => self::PAGE_SIZE,
             ],
             static fn (object $item): AttendancePeriod => AttendancePeriod::fromApiResponse($item),
+        );
+    }
+
+    /**
+     * Lists the person's absence periods whose start falls within the window
+     * (ADR-024 §4). Filtered on `starts_from` — mirrors the attendance window.
+     *
+     * @throws PersonioApiException
+     *
+     * @return list<AbsencePeriod>
+     */
+    public function listAbsencePeriods(string $personId, DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        return $this->paginate(
+            'v2/absence-periods',
+            [
+                'person.id' => $personId,
+                'starts_from.date_time.gte' => $from->format(self::ABSENCE_DATE_FORMAT),
+                'starts_from.date_time.lte' => $to->format(self::ABSENCE_DATE_FORMAT),
+                'limit' => self::ABSENCE_PAGE_SIZE,
+            ],
+            static fn (object $item): AbsencePeriod => AbsencePeriod::fromApiResponse($item),
+        );
+    }
+
+    /**
+     * Lists all absence types (id -> name/unit), the lookup that resolves a
+     * period's type to a TT activity by name (ADR-024 §4).
+     *
+     * @throws PersonioApiException
+     *
+     * @return list<AbsenceType>
+     */
+    public function listAbsenceTypes(): array
+    {
+        return $this->paginate(
+            'v2/absence-types',
+            ['limit' => self::ABSENCE_PAGE_SIZE],
+            static fn (object $item): AbsenceType => AbsenceType::fromApiResponse($item),
         );
     }
 

--- a/tests/Command/TtImportPersonioAbsencesCommandTest.php
+++ b/tests/Command/TtImportPersonioAbsencesCommandTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Command;
+
+use App\Command\TtImportPersonioAbsencesCommand;
+use App\Entity\SyncRun;
+use App\Entity\User;
+use App\Enum\SyncRunStatus;
+use App\Enum\SyncRunType;
+use App\Service\Personio\AbsenceImportService;
+use App\Service\Sync\SyncRunConsoleRenderer;
+use DateTimeImmutable;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class TtImportPersonioAbsencesCommandTest extends TestCase
+{
+    /**
+     * @param MockObject&AbsenceImportService $importService
+     */
+    private function commandTester(?User $user, MockObject $importService): CommandTester
+    {
+        $userRepository = $this->createMock(ObjectRepository::class);
+        $userRepository->method('findOneBy')->willReturn($user);
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->method('getRepository')->willReturn($userRepository);
+
+        return new CommandTester(
+            new TtImportPersonioAbsencesCommand($importService, $managerRegistry, new SyncRunConsoleRenderer()),
+        );
+    }
+
+    /**
+     * @param list<SyncRun> $runs
+     *
+     * @return MockObject&AbsenceImportService
+     */
+    private function importService(?array $runs = null): MockObject
+    {
+        $importService = $this->createMock(AbsenceImportService::class);
+        if (null !== $runs) {
+            $importService->method('importAllOptedIn')->willReturn($runs);
+        }
+
+        return $importService;
+    }
+
+    /**
+     * @param array<string, int> $counters
+     */
+    private function syncRun(SyncRunStatus $syncRunStatus, array $counters = []): SyncRun
+    {
+        return new SyncRun()
+            ->setType(SyncRunType::PERSONIO_IMPORT)
+            ->setStatus($syncRunStatus)
+            ->setCounters($counters)
+            ->setStartedAt(new DateTimeImmutable('2026-07-09 12:00:00'))
+            ->setFinishedAt(new DateTimeImmutable('2026-07-09 12:00:05'));
+    }
+
+    public function testImportsAllByDefault(): void
+    {
+        $importService = $this->createMock(AbsenceImportService::class);
+        $importService->expects(self::once())->method('importAllOptedIn')
+            ->willReturn([
+                $this->syncRun(SyncRunStatus::COMPLETED, ['imported' => 3]),
+                $this->syncRun(SyncRunStatus::COMPLETED, ['in_sync' => 2]),
+            ]);
+
+        $tester = $this->commandTester(null, $importService);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('imported', $tester->getDisplay());
+        self::assertStringContainsString('in_sync', $tester->getDisplay());
+    }
+
+    public function testImportsSingleUserWithUserOption(): void
+    {
+        $importService = $this->createMock(AbsenceImportService::class);
+        $importService->expects(self::once())->method('importUser')
+            ->willReturn($this->syncRun(SyncRunStatus::COMPLETED, ['imported' => 1]));
+        $importService->expects(self::never())->method('importAllOptedIn');
+
+        $tester = $this->commandTester(self::createStub(User::class), $importService);
+
+        $exitCode = $tester->execute(['--user' => 'alice']);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('imported', $tester->getDisplay());
+    }
+
+    public function testUnknownUserFails(): void
+    {
+        $tester = $this->commandTester(null, $this->importService());
+
+        $exitCode = $tester->execute(['--user' => 'ghost']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('User not found', $tester->getDisplay());
+    }
+
+    public function testInvalidDateFails(): void
+    {
+        $tester = $this->commandTester(null, $this->importService());
+
+        $exitCode = $tester->execute(['--from' => 'nope']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Invalid date', $tester->getDisplay());
+    }
+
+    public function testFailedRunExitsNonZero(): void
+    {
+        $tester = $this->commandTester(
+            null,
+            $this->importService([
+                $this->syncRun(SyncRunStatus::COMPLETED),
+                $this->syncRun(SyncRunStatus::FAILED),
+            ]),
+        );
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(1, $exitCode);
+    }
+
+    public function testDefaultWindowIsMinus30Plus90(): void
+    {
+        $expectedFrom = new DateTimeImmutable('today')->modify('-30 days')->format('Y-m-d');
+        $expectedTo = new DateTimeImmutable('today')->modify('+90 days')->format('Y-m-d');
+
+        $importService = $this->createMock(AbsenceImportService::class);
+        $importService->expects(self::once())->method('importAllOptedIn')
+            ->with(
+                self::callback(static fn (DateTimeImmutable $from): bool => $from->format('Y-m-d') === $expectedFrom),
+                self::callback(static fn (DateTimeImmutable $to): bool => $to->format('Y-m-d') === $expectedTo),
+            )
+            ->willReturn([$this->syncRun(SyncRunStatus::COMPLETED)]);
+
+        $tester = $this->commandTester(null, $importService);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(0, $exitCode);
+    }
+}

--- a/tests/DTO/Personio/AbsencePeriodTest.php
+++ b/tests/DTO/Personio/AbsencePeriodTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\DTO\Personio;
+
+use App\DTO\Personio\AbsencePeriod;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+
+/**
+ * @internal
+ *
+ * @covers \App\DTO\Personio\AbsencePeriod
+ */
+final class AbsencePeriodTest extends TestCase
+{
+    public function testParsesFullMultiDayVacation(): void
+    {
+        $period = AbsencePeriod::fromApiResponse($this->decode(<<<'JSON'
+            {
+                "id": "abc-123",
+                "person": {"id": "42"},
+                "absence_type": {"id": "type-vac"},
+                "starts_from": {"date_time": "2026-07-06T00:00:00.000", "type": null},
+                "ends_at": {"date_time": "2026-07-10T00:00:00.000", "type": null},
+                "approval": {"status": "APPROVED"},
+                "comment": "Summer break"
+            }
+            JSON));
+
+        self::assertSame('abc-123', $period->id);
+        self::assertSame('42', $period->personId);
+        self::assertSame('type-vac', $period->absenceTypeId);
+        self::assertSame('2026-07-06T00:00:00.000', $period->startDateTime);
+        self::assertSame('2026-07-10T00:00:00.000', $period->endDateTime);
+        self::assertSame('APPROVED', $period->approvalStatus);
+        self::assertSame('Summer break', $period->comment);
+        self::assertFalse($period->startsHalf());
+        self::assertFalse($period->endsHalf());
+    }
+
+    public function testCollapsesHalfDayBoundaryEnumToABoolean(): void
+    {
+        $period = AbsencePeriod::fromApiResponse($this->decode(<<<'JSON'
+            {
+                "id": "abc-124",
+                "person": {"id": "42"},
+                "absence_type": {"id": "type-vac"},
+                "starts_from": {"date_time": "2026-07-06T00:00:00.000", "type": "SECOND_HALF"},
+                "ends_at": {"date_time": "2026-07-06T00:00:00.000", "type": "SECOND_HALF"},
+                "approval": {"status": "PENDING"},
+                "comment": null
+            }
+            JSON));
+
+        self::assertSame('SECOND_HALF', $period->startHalf);
+        self::assertTrue($period->startsHalf());
+        self::assertTrue($period->endsHalf());
+        self::assertNull($period->comment);
+    }
+
+    public function testOpenEndedAbsenceHasNullEnd(): void
+    {
+        $period = AbsencePeriod::fromApiResponse($this->decode(<<<'JSON'
+            {
+                "id": "abc-125",
+                "person": {"id": "7"},
+                "absence_type": {"id": "type-sick"},
+                "starts_from": {"date_time": "2026-07-06T00:00:00.000", "type": null},
+                "ends_at": null,
+                "approval": {"status": "APPROVED"}
+            }
+            JSON));
+
+        self::assertNull($period->endDateTime);
+        self::assertNull($period->endHalf);
+        self::assertFalse($period->endsHalf());
+        self::assertNull($period->comment);
+    }
+
+    private function decode(string $json): object
+    {
+        $decoded = json_decode($json, false);
+        self::assertIsObject($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/DTO/Personio/AbsenceTypeTest.php
+++ b/tests/DTO/Personio/AbsenceTypeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\DTO\Personio;
+
+use App\DTO\Personio\AbsenceType;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+
+/**
+ * @internal
+ *
+ * @covers \App\DTO\Personio\AbsenceType
+ */
+final class AbsenceTypeTest extends TestCase
+{
+    public function testParsesDayBasedVacationType(): void
+    {
+        $type = AbsenceType::fromApiResponse($this->decode(<<<'JSON'
+            {"id": "type-vac", "name": "Urlaub", "category": "PAID_VACATION", "unit": "DAY"}
+            JSON));
+
+        self::assertSame('type-vac', $type->id);
+        self::assertSame('Urlaub', $type->name);
+        self::assertSame('PAID_VACATION', $type->category);
+        self::assertSame('DAY', $type->unit);
+        self::assertTrue($type->isDayBased());
+        self::assertSame('urlaub', $type->normalizedName());
+    }
+
+    public function testHourBasedTypeIsNotDayBased(): void
+    {
+        $type = AbsenceType::fromApiResponse($this->decode(<<<'JSON'
+            {"id": "type-doc", "name": "Doctor Visit", "category": "OTHER", "unit": "HOUR"}
+            JSON));
+
+        self::assertFalse($type->isDayBased());
+    }
+
+    public function testMissingUnitDefaultsToDayBased(): void
+    {
+        $type = AbsenceType::fromApiResponse($this->decode(<<<'JSON'
+            {"id": "type-x", "name": "Krank"}
+            JSON));
+
+        self::assertNull($type->unit);
+        self::assertTrue($type->isDayBased());
+        self::assertNull($type->category);
+    }
+
+    private function decode(string $json): object
+    {
+        $decoded = json_decode($json, false);
+        self::assertIsObject($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Entity/PersonioAbsenceImportTest.php
+++ b/tests/Entity/PersonioAbsenceImportTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\PersonioAbsenceImport;
+use App\Entity\User;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+final class PersonioAbsenceImportTest extends TestCase
+{
+    public function testFluentSetters(): void
+    {
+        $user = new User();
+        $record = new PersonioAbsenceImport();
+        $record->setUser($user)
+            ->setAbsenceId('abs-abc')
+            ->setEntryIds([501, 502])
+            ->setSignature(['start' => '2026-07-06T00:00:00.000', 'end' => '2026-07-08T00:00:00.000', 'typeId' => 'type-vac'])
+            ->setLastImportedAt(new DateTimeImmutable('2026-07-06 09:00:00'));
+
+        self::assertSame($user, $record->getUser());
+        self::assertSame('abs-abc', $record->getAbsenceId());
+        self::assertSame([501, 502], $record->getEntryIds());
+        self::assertSame('type-vac', $record->getSignature()['typeId']);
+        self::assertNull($record->getLastSyncRun());
+    }
+}

--- a/tests/Enum/SyncEnumsTest.php
+++ b/tests/Enum/SyncEnumsTest.php
@@ -40,7 +40,7 @@ final class SyncEnumsTest extends TestCase
     public function testSyncItemKindValues(): void
     {
         self::assertSame(
-            ['remote_only', 'local_only', 'never_synced', 'diverged', 'local_dirty', 'remote_dirty', 'mergeable', 'conflict', 'probable_duplicate', 'unresolved_project', 'project_auto_imported', 'shadow_user_created', 'truncated', 'error'],
+            ['remote_only', 'local_only', 'never_synced', 'diverged', 'local_dirty', 'remote_dirty', 'mergeable', 'conflict', 'probable_duplicate', 'unresolved_project', 'project_auto_imported', 'unresolved_absence_type', 'shadow_user_created', 'truncated', 'error'],
             array_column(SyncItemKind::cases(), 'value'),
         );
     }

--- a/tests/Service/Personio/AbsenceImportServiceTest.php
+++ b/tests/Service/Personio/AbsenceImportServiceTest.php
@@ -1,0 +1,438 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Service\Personio;
+
+use App\DTO\Personio\AbsencePeriod;
+use App\DTO\Personio\AbsenceType;
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Entry;
+use App\Entity\PersonioAbsenceImport;
+use App\Entity\PersonioConfig;
+use App\Entity\Project;
+use App\Entity\SyncRun;
+use App\Entity\User;
+use App\Enum\EntrySource;
+use App\Enum\SyncItemKind;
+use App\Enum\SyncRunStatus;
+use App\Repository\ActivityRepository;
+use App\Repository\PersonioAbsenceImportRepository;
+use App\Repository\PersonioConfigRepository;
+use App\Repository\UserRepository;
+use App\Service\Personio\AbsenceImportService;
+use App\Service\Personio\PersonioClient;
+use App\Service\Personio\PersonioClientFactory;
+use App\Service\Tracking\DayClassService;
+use App\Service\Util\ContractHoursResolver;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Symfony\Component\Clock\MockClock;
+
+use function array_filter;
+use function array_values;
+use function is_int;
+use function str_contains;
+
+#[CoversClass(AbsenceImportService::class)]
+#[CoversClass(AbsencePeriod::class)]
+#[CoversClass(AbsenceType::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class AbsenceImportServiceTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $entityManager;
+    private PersonioAbsenceImportRepository&MockObject $importRepository;
+    private PersonioConfigRepository&MockObject $configRepository;
+    private PersonioClient&MockObject $client;
+    private UserRepository&MockObject $userRepository;
+    private ActivityRepository&MockObject $activityRepository;
+    private AbsenceImportService $service;
+
+    private Project $absenceProject;
+
+    /** @var list<object> */
+    private array $persisted = [];
+
+    /** @var list<object> */
+    private array $removed = [];
+
+    /** @var array<int, Entry> Entry stub store for find(Entry::class, id) */
+    private array $entriesById = [];
+
+    /** @var array<string, PersonioAbsenceImport> keyed by absence id */
+    private array $storedByAbsenceId = [];
+
+    private int $entitySeq = 0;
+
+    protected function setUp(): void
+    {
+        $this->absenceProject = new Project()->setName('Absence')->setCustomer(new Customer()->setName('Internal'));
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager->method('isOpen')->willReturn(true);
+        $this->entityManager->method('persist')->willReturnCallback(function (object $object): void {
+            $this->persisted[] = $object;
+        });
+        $this->entityManager->method('remove')->willReturnCallback(function (object $object): void {
+            $this->removed[] = $object;
+        });
+        // Mimic the DB assigning ids on flush, so the import can record entry ids.
+        $this->entityManager->method('flush')->willReturnCallback(function (): void {
+            foreach ($this->persisted as $object) {
+                if ($object instanceof Entry && null === $object->getId()) {
+                    $this->setId($object, ++$this->entitySeq);
+                }
+            }
+        });
+        $this->entityManager->method('find')->willReturnCallback(
+            fn (string $class, mixed $id): ?Entry => Entry::class === $class && is_int($id) ? ($this->entriesById[$id] ?? null) : null,
+        );
+
+        $this->importRepository = $this->createMock(PersonioAbsenceImportRepository::class);
+        $this->importRepository->method('findOneByAbsenceId')->willReturnCallback(
+            fn (string $absenceId): ?PersonioAbsenceImport => $this->storedByAbsenceId[$absenceId] ?? null,
+        );
+        $this->importRepository->method('findByUserIndexedByAbsenceId')->willReturnCallback(
+            fn (): array => $this->storedByAbsenceId,
+        );
+
+        $this->configRepository = $this->createMock(PersonioConfigRepository::class);
+        $this->client = $this->createMock(PersonioClient::class);
+        $clientFactory = $this->createMock(PersonioClientFactory::class);
+        $clientFactory->method('create')->willReturn($this->client);
+        $this->userRepository = $this->createMock(UserRepository::class);
+
+        $this->activityRepository = $this->createMock(ActivityRepository::class);
+        $this->activityRepository->method('findOneByName')->willReturnCallback(
+            static fn (string $name): Activity => new Activity()->setName($name),
+        );
+
+        $this->service = new AbsenceImportService(
+            $this->entityManager,
+            $this->importRepository,
+            $this->configRepository,
+            $clientFactory,
+            $this->userRepository,
+            $this->activityRepository,
+            new ContractHoursResolver(),
+            $this->createMock(DayClassService::class),
+            new MockClock('2026-07-01 12:00:00'),
+        );
+    }
+
+    public function testImportsNewVacationCreatesOneEntryPerWorkingDay(): void
+    {
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([$this->type('type-vac', 'Urlaub')]);
+        // Mon 06 -> Wed 08, all weekdays -> 3 entries at the default 8h (no contract).
+        $this->client->method('listAbsencePeriods')->willReturn([
+            $this->period('abs-1', '2026-07-06', '2026-07-08', 'type-vac'),
+        ]);
+
+        $run = $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame(SyncRunStatus::COMPLETED, $run->getStatus());
+        self::assertSame(1, $run->getCounters()['imported'] ?? 0);
+
+        $entries = $this->persistedEntries();
+        self::assertCount(3, $entries);
+        foreach ($entries as $entry) {
+            self::assertSame(480, $entry->getDuration());
+            self::assertSame('08:00:00', $entry->getStart()->format('H:i:s'));
+            self::assertSame(EntrySource::HUMAN, $entry->getSource());
+            self::assertSame('Urlaub', $entry->getActivity()?->getName());
+            self::assertSame($this->absenceProject, $entry->getProject());
+        }
+
+        $state = $this->persistedState();
+        self::assertCount(3, $state->getEntryIds());
+        self::assertSame('type-vac', $state->getSignature()['typeId']);
+    }
+
+    public function testHalfDayBoundaryHalvesDuration(): void
+    {
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([$this->type('type-vac', 'Urlaub')]);
+        // Single day, marked a half day at both boundaries (start==end).
+        $this->client->method('listAbsencePeriods')->willReturn([
+            $this->period('abs-1', '2026-07-06', '2026-07-06', 'type-vac', 'SECOND_HALF', 'SECOND_HALF'),
+        ]);
+
+        $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        $entries = $this->persistedEntries();
+        self::assertCount(1, $entries);
+        self::assertSame(240, $entries[0]->getDuration());
+    }
+
+    public function testWeekendDaysProduceNoEntry(): void
+    {
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([$this->type('type-vac', 'Urlaub')]);
+        // Fri 10 -> Mon 13 spans Sat+Sun: only Fri and Mon are working days.
+        $this->client->method('listAbsencePeriods')->willReturn([
+            $this->period('abs-1', '2026-07-10', '2026-07-13', 'type-vac'),
+        ]);
+
+        $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertCount(2, $this->persistedEntries());
+    }
+
+    public function testOpenEndedAbsenceCapsAtWindowEndAndRecordsIt(): void
+    {
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([$this->type('type-sick', 'Krank')]);
+        // No end date (open-ended sick leave): materialise up to the window end.
+        $this->client->method('listAbsencePeriods')->willReturn([
+            new AbsencePeriod('abs-1', '42', 'type-sick', '2026-07-06T00:00:00.000', null, null, null, 'APPROVED', null),
+        ]);
+
+        // Window Mon 06 -> Wed 08: three working days, capped at the window end.
+        $this->service->importUser($this->mappedUser(), $this->day('2026-07-06'), $this->day('2026-07-08'));
+
+        self::assertCount(3, $this->persistedEntries());
+        // The effective (capped) end is recorded, so a later, wider window reads
+        // as changed and extends the absence rather than skipping it.
+        self::assertSame('2026-07-08', $this->persistedState()->getSignature()['end']);
+    }
+
+    public function testUnchangedAbsenceSkips(): void
+    {
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([$this->type('type-vac', 'Urlaub')]);
+        $period = $this->period('abs-1', '2026-07-06', '2026-07-06', 'type-vac');
+        $this->client->method('listAbsencePeriods')->willReturn([$period]);
+
+        $this->storedByAbsenceId['abs-1'] = new PersonioAbsenceImport()
+            ->setUser($this->mappedUser())
+            ->setAbsenceId('abs-1')
+            ->setEntryIds([501])
+            ->setSignature([
+                'start' => '2026-07-06',
+                'end' => '2026-07-06',
+                'startHalf' => null,
+                'endHalf' => null,
+                'typeId' => 'type-vac',
+            ])
+            ->setLastImportedAt(new DateTimeImmutable('2026-06-30 09:00:00'));
+
+        $run = $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame(1, $run->getCounters()['in_sync'] ?? 0);
+        self::assertSame([], $this->persistedEntries());
+    }
+
+    public function testUnknownAbsenceTypeIsParked(): void
+    {
+        $this->activeConfig();
+        // "Sabbatical" matches neither "krank" nor "urlaub" -> no TT activity.
+        $this->client->method('listAbsenceTypes')->willReturn([$this->type('type-x', 'Sabbatical')]);
+        $this->client->method('listAbsencePeriods')->willReturn([
+            $this->period('abs-1', '2026-07-06', '2026-07-06', 'type-x'),
+        ]);
+
+        $run = $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame([], $this->persistedEntries());
+        self::assertTrue($this->runHasItem($run, SyncItemKind::UNRESOLVED_ABSENCE_TYPE));
+    }
+
+    public function testHourlyTypeIsParked(): void
+    {
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([$this->type('type-doc', 'Urlaub', 'HOUR')]);
+        $this->client->method('listAbsencePeriods')->willReturn([
+            $this->period('abs-1', '2026-07-06', '2026-07-06', 'type-doc'),
+        ]);
+
+        $run = $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame([], $this->persistedEntries());
+        self::assertTrue($this->runHasItem($run, SyncItemKind::UNRESOLVED_ABSENCE_TYPE));
+    }
+
+    public function testCancelledAbsenceRemovesItsEntries(): void
+    {
+        $user = $this->mappedUser();
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([]);
+        // Personio returns nothing in the window: the stored absence was cancelled.
+        $this->client->method('listAbsencePeriods')->willReturn([]);
+
+        $ownedEntry = $this->ownedEntry($user);
+        $this->entriesById[501] = $ownedEntry;
+        $this->storedByAbsenceId['abs-1'] = new PersonioAbsenceImport()
+            ->setUser($user)
+            ->setAbsenceId('abs-1')
+            ->setEntryIds([501])
+            ->setSignature(['start' => '2026-07-06', 'end' => '2026-07-06', 'startHalf' => null, 'endHalf' => null, 'typeId' => 'type-vac'])
+            ->setLastImportedAt(new DateTimeImmutable('2026-06-30 09:00:00'));
+
+        $run = $this->service->importUser($user, $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame(1, $run->getCounters()['cancelled'] ?? 0);
+        self::assertContains($ownedEntry, $this->removed);
+        self::assertContains($this->storedByAbsenceId['abs-1'], $this->removed);
+    }
+
+    public function testCancelledButLocallyModifiedEntryParksConflict(): void
+    {
+        $user = $this->mappedUser();
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([]);
+        $this->client->method('listAbsencePeriods')->willReturn([]);
+
+        // The entry was reassigned to a non-leave activity: it diverged, so the
+        // cancellation must not delete it.
+        $divergedEntry = new Entry()->setUser($user)->setProject($this->absenceProject)->setActivity(new Activity()->setName('Development'));
+        $this->entriesById[501] = $divergedEntry;
+        $this->storedByAbsenceId['abs-1'] = new PersonioAbsenceImport()
+            ->setUser($user)
+            ->setAbsenceId('abs-1')
+            ->setEntryIds([501])
+            ->setSignature(['start' => '2026-07-06', 'end' => '2026-07-06', 'startHalf' => null, 'endHalf' => null, 'typeId' => 'type-vac'])
+            ->setLastImportedAt(new DateTimeImmutable('2026-06-30 09:00:00'));
+
+        $run = $this->service->importUser($user, $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame(1, $run->getCounters()['conflicts'] ?? 0);
+        self::assertTrue($this->runHasItem($run, SyncItemKind::CONFLICT));
+        self::assertNotContains($divergedEntry, $this->removed);
+    }
+
+    public function testNoActiveConfigFailsRun(): void
+    {
+        $this->configRepository->method('findActive')->willReturn(null);
+
+        $run = $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame(SyncRunStatus::FAILED, $run->getStatus());
+        self::assertTrue($this->runHasItem($run, SyncItemKind::ERROR, 'no active Personio configuration'));
+    }
+
+    public function testNoAbsenceProjectFailsRun(): void
+    {
+        $this->configRepository->method('findActive')->willReturn(new PersonioConfig());
+
+        $run = $this->service->importUser($this->mappedUser(), $this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertSame(SyncRunStatus::FAILED, $run->getStatus());
+        self::assertTrue($this->runHasItem($run, SyncItemKind::ERROR, 'no absence project configured'));
+    }
+
+    public function testImportAllOptedInIteratesEnabledUsers(): void
+    {
+        $this->activeConfig();
+        $this->client->method('listAbsenceTypes')->willReturn([]);
+        $this->client->method('listAbsencePeriods')->willReturn([]);
+        $this->userRepository->method('findPersonioExportEnabled')->willReturn([
+            $this->mappedUser(),
+            $this->mappedUser(),
+        ]);
+
+        $runs = $this->service->importAllOptedIn($this->day('2026-07-01'), $this->day('2026-07-31'));
+
+        self::assertCount(2, $runs);
+    }
+
+    private function activeConfig(): void
+    {
+        $this->configRepository->method('findActive')->willReturn(
+            new PersonioConfig()->setAbsenceProject($this->absenceProject),
+        );
+    }
+
+    private function mappedUser(): User
+    {
+        return new User()->setPersonioEmployeeId(42);
+    }
+
+    private function ownedEntry(User $user): Entry
+    {
+        return new Entry()
+            ->setUser($user)
+            ->setProject($this->absenceProject)
+            ->setActivity(new Activity()->setName(Activity::HOLIDAY))
+            ->setDay('2026-07-06');
+    }
+
+    private function type(string $id, string $name, string $unit = 'DAY'): AbsenceType
+    {
+        return new AbsenceType($id, $name, null, $unit);
+    }
+
+    private function period(string $id, string $startDay, string $endDay, string $typeId, ?string $startHalf = null, ?string $endHalf = null): AbsencePeriod
+    {
+        return new AbsencePeriod(
+            $id,
+            '42',
+            $typeId,
+            $startDay . 'T00:00:00.000',
+            $startHalf,
+            $endDay . 'T00:00:00.000',
+            $endHalf,
+            'APPROVED',
+            null,
+        );
+    }
+
+    private function day(string $date): DateTimeImmutable
+    {
+        return new DateTimeImmutable($date . ' 00:00:00');
+    }
+
+    /**
+     * @return list<Entry>
+     */
+    private function persistedEntries(): array
+    {
+        return array_values(array_filter(
+            $this->persisted,
+            static fn (object $object): bool => $object instanceof Entry,
+        ));
+    }
+
+    private function persistedState(): PersonioAbsenceImport
+    {
+        foreach ($this->persisted as $object) {
+            if ($object instanceof PersonioAbsenceImport) {
+                return $object;
+            }
+        }
+
+        self::fail('No PersonioAbsenceImport was persisted.');
+    }
+
+    private function setId(Entry $entry, int $id): void
+    {
+        $property = new ReflectionProperty(Entry::class, 'id');
+        $property->setValue($entry, $id);
+    }
+
+    private function runHasItem(SyncRun $run, SyncItemKind $kind, ?string $reasonContains = null): bool
+    {
+        foreach ($run->getItems() as $item) {
+            if ($item->getKind() !== $kind) {
+                continue;
+            }
+
+            if (null === $reasonContains || str_contains($item->getReason(), $reasonContains)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Service/Personio/PersonioClientTest.php
+++ b/tests/Service/Personio/PersonioClientTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Tests\Service\Personio;
 
+use App\DTO\Personio\AbsencePeriod;
+use App\DTO\Personio\AbsenceType;
 use App\DTO\Personio\AttendancePeriod;
 use App\Exception\Personio\PersonioApiException;
 use App\Service\Personio\PersonioClient;
@@ -30,6 +32,8 @@ use function json_encode;
  */
 #[CoversClass(PersonioClient::class)]
 #[CoversClass(AttendancePeriod::class)]
+#[CoversClass(AbsencePeriod::class)]
+#[CoversClass(AbsenceType::class)]
 #[CoversClass(PersonioApiException::class)]
 final class PersonioClientTest extends TestCase
 {
@@ -147,6 +151,68 @@ final class PersonioClientTest extends TestCase
         $secondQuery = $listRequests[1]['options']['query'] ?? null;
         self::assertIsArray($secondQuery);
         self::assertSame('CUR2', $secondQuery['cursor'] ?? null);
+    }
+
+    public function testListAbsencePeriodsParsesAndSendsWindowFilter(): void
+    {
+        $this->handler = static fn (string $method, string $path): Response => new Response(200, [], (string) json_encode([
+            '_data' => [[
+                'id' => 'abs-1',
+                'person' => ['id' => 'emp-9'],
+                'absence_type' => ['id' => 'type-vac'],
+                'starts_from' => ['date_time' => '2026-07-06T00:00:00.000', 'type' => null],
+                'ends_at' => ['date_time' => '2026-07-08T00:00:00.000', 'type' => 'FIRST_HALF'],
+                'approval' => ['status' => 'APPROVED'],
+                'comment' => 'holiday',
+            ]],
+            '_meta' => ['links' => ['next' => null]],
+        ]));
+
+        $client = $this->createClient();
+        $periods = $client->listAbsencePeriods(
+            'emp-9',
+            new DateTimeImmutable('2026-07-01T00:00:00'),
+            new DateTimeImmutable('2026-07-31T00:00:00'),
+        );
+
+        self::assertCount(1, $periods);
+        self::assertContainsOnlyInstancesOf(AbsencePeriod::class, $periods);
+        self::assertSame('abs-1', $periods[0]->id);
+        self::assertSame('emp-9', $periods[0]->personId);
+        self::assertSame('type-vac', $periods[0]->absenceTypeId);
+        self::assertSame('2026-07-08T00:00:00.000', $periods[0]->endDateTime);
+        self::assertTrue($periods[0]->endsHalf());
+
+        $request = $this->apiRequests()[0];
+        self::assertSame('v2/absence-periods', $request['path']);
+        $query = $request['options']['query'] ?? null;
+        self::assertIsArray($query);
+        self::assertSame('emp-9', $query['person.id'] ?? null);
+        self::assertSame('2026-07-01T00:00:00.000', $query['starts_from.date_time.gte'] ?? null);
+        self::assertSame('2026-07-31T00:00:00.000', $query['starts_from.date_time.lte'] ?? null);
+        self::assertSame(100, $query['limit'] ?? null);
+    }
+
+    public function testListAbsenceTypesParses(): void
+    {
+        $this->handler = static fn (string $method, string $path): Response => new Response(200, [], (string) json_encode([
+            '_data' => [
+                ['id' => 'type-vac', 'name' => 'Urlaub', 'category' => 'PAID_VACATION', 'unit' => 'DAY'],
+                ['id' => 'type-sick', 'name' => 'Krank', 'category' => 'SICK_LEAVE', 'unit' => 'DAY'],
+            ],
+            '_meta' => ['links' => ['next' => null]],
+        ]));
+
+        $client = $this->createClient();
+        $types = $client->listAbsenceTypes();
+
+        self::assertCount(2, $types);
+        self::assertContainsOnlyInstancesOf(AbsenceType::class, $types);
+        self::assertSame('Urlaub', $types[0]->name);
+        self::assertSame('urlaub', $types[0]->normalizedName());
+        self::assertTrue($types[1]->isDayBased());
+
+        self::assertSame('v2/absence-types', $this->apiRequests()[0]['path']);
     }
 
     public function testUpdateAndDeleteHitCorrectPaths(): void


### PR DESCRIPTION
Implements **ADR-024 P2** — absence import (Personio → TimeTracker), the counterpart to the P1 attendance export. The same per-user opt-in gates both directions.

## What it does

`tt:import-personio-absences [--from --to] [--user]` (default window **−30/+90 days** — vacations lie in the future). Per opted-in, employee-mapped user:

- Reads Personio absence periods and creates **one TT entry per working day**: start 08:00, duration = the user's contract hours for that weekday (`ContractHoursResolver`; a half-day boundary halves it; a non-working weekday gets none), on the configured **absence project**.
- **Activity by name** (ADR-024 §4): `urlaub` → Urlaub, `krank` → Krank. A type matching neither, or an hourly (non-day) type, is **parked** as a new `unresolved_absence_type` item — never guessed.
- **No Jira echo** (no `EntryEvent`); day classes recalculated as in the Jira import.

## Idempotency & cancellation

Tracked per Personio absence id in a new `personio_absence_import` table via a **signature** of the source absence:

- unchanged → skip · changed → rebuild · cancelled (gone from the window) → remove entries.
- Rebuild/removal only touch entries **still owned by the import** (right project + a leave activity); a locally edited entry **parks a conflict** instead of clobbering it.
- A bounded absence materialises its **full span once**; an open-ended one (null end — long-term sick) is capped at the window end and that cap is **recorded in the signature**, so a rolling window extends it rather than leaving it half-imported.

## API shape (pinned against developer.personio.de)

`/v2/absence-periods` — half days are the per-boundary enum `starts_from.type`/`ends_at.type` (`FIRST_HALF`/`SECOND_HALF`); `ends_at` nullable; cursor pagination (`_data`/`_meta.links.next`); `limit` cap **100**. `/v2/absence-types` — id/name/category/unit.

## Files

New: `AbsencePeriod`/`AbsenceType` DTOs, `PersonioClient::listAbsencePeriods/listAbsenceTypes`, `PersonioAbsenceImport` entity + repo, `Version20260712_PersonioAbsenceImport` migration (+ `sql/full.sql`), `AbsenceImportService`, `TtImportPersonioAbsencesCommand`, `SyncItemKind::UNRESOLVED_ABSENCE_TYPE`. Operator guide + ADR status updated.

## Verification (in-container)

PHPStan L10, php-cs-fixer, phpat, rector clean. New unit tests for DTO parsing, client, service (happy path, half-day, weekend skip, open-ended cap, unchanged/unknown/hourly/cancel/conflict), entity, command. Full unit suite **1918/1918**; controller suite 386/386 (2 pre-existing, unrelated deprecations — not from this change). No live Personio token needed; fixtures encode the pinned shapes.