### PR TITLE
feat(personio): auto-match TT users to Personio employee ids (ADR-024 P3)

### DIFF
--- a/docs/adr/ADR-024-personio-attendance-absence-sync.md
+++ b/docs/adr/ADR-024-personio-attendance-absence-sync.md
@@ -1,6 +1,6 @@
 # ADR-024: Personio Attendance Export and Absence Import
 
-**Status:** Accepted — P1 (attendance export) implemented 2026-07-11; P2 (absence import) implemented 2026-07-12; P3 (auto-match/API) pending.
+**Status:** Accepted — P1 (attendance export) implemented 2026-07-11; P2 (absence import) implemented 2026-07-12; P3 employee auto-match (CLI) implemented 2026-07-12; P3 remainder (frontend match UI, optional API/MCP triggers) pending.
 **Date:** 2026-07-10
 **Relates to:** [ADR-023](ADR-023-jira-worklog-bidirectional-sync.md) (the sync/run/audit infrastructure and the opt-in accountability model this ADR reuses), [ADR-021](ADR-021-api-token-authentication.md) (PAT scopes for any later API surface), [ADR-011](ADR-011-security-architecture.md) (encryption-at-rest via `TokenEncryptionService`).
 

--- a/docs/personio-sync.md
+++ b/docs/personio-sync.md
@@ -13,7 +13,17 @@ TimeTracker exports each opted-in user's worklogs to Personio as daily **work at
 
 1. **Personio API credential.** In Personio, create an API client (client id + secret) with permission to read/write attendances. Note the base URL (usually `https://api.personio.de`).
 2. **Configure TimeTracker.** As an admin, open **Administration → Personio** and create the config: name, base URL, client id, client secret (stored encrypted; leave the secret field blank on later edits to keep the stored value), and the **absence project** (used by the later absence-import phase). Mark it active.
-3. **Map employees.** Set each participating user's Personio employee id (`users.personio_employee_id`). For P1 this is manual; automatic matching via the Persons API arrives in P3.
+3. **Map employees.** Each participating user needs their Personio employee id (`users.personio_employee_id`). Auto-match it from the Persons API:
+
+   ```bash
+   # preview the proposed matches
+   docker exec timetracker php bin/console tt:match-personio-employees
+
+   # write them
+   docker exec timetracker php bin/console tt:match-personio-employees --apply
+   ```
+
+   Matching is by e-mail localpart or `firstname.lastname`; a username that matches zero or several Personio persons is skipped (never guessed) and stays for manual mapping. Re-runnable — it only ever looks at users without an id yet.
 4. **Users opt in.** Each user enables **Settings → "Meine Arbeitszeiten an Personio übertragen"**. Only opted-in, mapped users are exported.
 
 ## Running the export

--- a/src/Command/TtMatchPersonioEmployeesCommand.php
+++ b/src/Command/TtMatchPersonioEmployeesCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\PersonioConfig;
+use App\Entity\User;
+use App\Repository\PersonioConfigRepository;
+use App\Repository\UserRepository;
+use App\Service\Personio\EmployeeMatcher;
+use App\Service\Personio\PersonioClientFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function count;
+use function ctype_digit;
+use function sprintf;
+
+/**
+ * ADR-024 P3: proposes (and, with --apply, writes) TT user -> Personio employee-id
+ * matches, so the manual mapping the export/import rely on can be filled in
+ * automatically. Matches by e-mail localpart or firstname.lastname; ambiguous
+ * usernames are skipped, never guessed. Preview by default.
+ */
+#[AsCommand(name: 'tt:match-personio-employees', description: 'Auto-match TT users to Personio employee ids (ADR-024 P3)')]
+class TtMatchPersonioEmployeesCommand extends Command
+{
+    public function __construct(
+        private readonly PersonioConfigRepository $configRepository,
+        private readonly PersonioClientFactory $clientFactory,
+        private readonly UserRepository $userRepository,
+        private readonly EmployeeMatcher $employeeMatcher,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    public function __invoke(
+        InputInterface $input,
+        OutputInterface $output,
+        #[Option(description: 'Write the matched employee ids (default: preview only)', name: 'apply')]
+        bool $apply = false,
+    ): int {
+        $symfonyStyle = new SymfonyStyle($input, $output);
+
+        $config = $this->configRepository->findActive();
+        if (!$config instanceof PersonioConfig) {
+            $symfonyStyle->error('No active Personio configuration.');
+
+            return 1;
+        }
+
+        $users = $this->userRepository->findWithoutPersonioEmployeeId();
+        if ([] === $users) {
+            $symfonyStyle->note('Every user already has a Personio employee id.');
+
+            return Command::SUCCESS;
+        }
+
+        $matches = $this->employeeMatcher->match($users, $this->clientFactory->create($config)->listPersons());
+        if ([] === $matches) {
+            $symfonyStyle->note('No confident matches for the ' . count($users) . ' unmapped user(s).');
+
+            return Command::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($matches as $match) {
+            $rows[] = [$match->username, $match->personId, $match->personName, $match->source];
+        }
+        $symfonyStyle->table(['User', 'Personio id', 'Personio name', 'Matched by'], $rows);
+
+        if (!$apply) {
+            $symfonyStyle->note('Preview only — re-run with --apply to write these employee ids.');
+
+            return Command::SUCCESS;
+        }
+
+        $usersById = [];
+        foreach ($users as $user) {
+            $usersById[(int) $user->getId()] = $user;
+        }
+
+        $applied = 0;
+        foreach ($matches as $match) {
+            // Personio employee ids are numeric (the column is a bigint); skip a
+            // non-numeric id rather than truncate it to a wrong value.
+            if (!ctype_digit($match->personId)) {
+                $symfonyStyle->warning(sprintf('Skipped %s: non-numeric Personio id "%s".', $match->username, $match->personId));
+
+                continue;
+            }
+
+            $user = $usersById[$match->userId] ?? null;
+            if ($user instanceof User) {
+                $user->setPersonioEmployeeId((int) $match->personId);
+                ++$applied;
+            }
+        }
+
+        $this->entityManager->flush();
+        $symfonyStyle->success(sprintf('Applied %d employee-id mapping(s).', $applied));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DTO/Personio/EmployeeMatch.php
+++ b/src/DTO/Personio/EmployeeMatch.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\DTO\Personio;
+
+/**
+ * A proposed TT user -> Personio employee-id match (ADR-024 P3): the outcome of
+ * {@see \App\Service\Personio\EmployeeMatcher}. `source` records HOW it matched
+ * (`email` = e-mail localpart, `name` = firstname.lastname) so a reviewer sees
+ * the confidence before it is applied.
+ */
+final readonly class EmployeeMatch
+{
+    public function __construct(
+        public int $userId,
+        public string $username,
+        public string $personId,
+        public string $personName,
+        public string $source,
+    ) {
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -193,6 +193,24 @@ class UserRepository extends ServiceEntityRepository
     }
 
     /**
+     * Users with no Personio employee id yet — the candidates the P3 auto-match
+     * tries to map (ADR-024 §1).
+     *
+     * @return list<User>
+     */
+    public function findWithoutPersonioEmployeeId(): array
+    {
+        /** @var list<User> $users */
+        $users = $this->createQueryBuilder('user')
+            ->where('user.personioEmployeeId IS NULL')
+            ->orderBy('user.username', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $users;
+    }
+
+    /**
      * @return array<int, array{user: array{id:int, username:string, type:string, abbr:string, locale:string}}>
      */
     public function getUserById(int $currentUserId): array

--- a/src/Service/Personio/EmployeeMatcher.php
+++ b/src/Service/Personio/EmployeeMatcher.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Personio;
+
+use App\DTO\Personio\EmployeeMatch;
+use App\Entity\User;
+
+use function count;
+use function mb_strtolower;
+use function sprintf;
+use function strstr;
+use function trim;
+
+/**
+ * Proposes TT user -> Personio employee-id matches (ADR-024 P3).
+ *
+ * Two strategies, in order of confidence: the Personio e-mail localpart equals
+ * the TT username, or the `firstname.lastname` of the person equals it (the
+ * company's username scheme). A username that matches exactly one person is a
+ * proposal; zero or several (ambiguous) matches are skipped — never guessed.
+ * Pure and side-effect free: it neither reads nor writes the database.
+ */
+final readonly class EmployeeMatcher
+{
+    /**
+     * @param list<User>                                                                       $users   TT users to match (typically those without an employee id yet)
+     * @param list<array{id: string, first_name: ?string, last_name: ?string, email: ?string}> $persons Personio persons ({@see PersonioClient::listPersons()})
+     *
+     * @return list<EmployeeMatch>
+     */
+    public function match(array $users, array $persons): array
+    {
+        $matches = [];
+        foreach ($users as $user) {
+            $username = mb_strtolower(trim((string) $user->getUsername()));
+            if ('' === $username) {
+                continue;
+            }
+
+            $candidates = $this->candidatesFor($username, $persons);
+            // Exactly one distinct person -> a confident proposal; 0 or >1 -> skip.
+            if (1 !== count($candidates)) {
+                continue;
+            }
+
+            $candidate = array_first($candidates);
+            $matches[] = new EmployeeMatch(
+                (int) $user->getId(),
+                (string) $user->getUsername(),
+                $candidate['id'],
+                $candidate['name'],
+                $candidate['source'],
+            );
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Persons matching $username, keyed by person id (deduped). E-mail wins over
+     * name as the recorded source when a person matches both ways.
+     *
+     * @param list<array{id: string, first_name: ?string, last_name: ?string, email: ?string}> $persons
+     *
+     * @return array<string, array{id: string, name: string, source: string}>
+     */
+    private function candidatesFor(string $username, array $persons): array
+    {
+        $candidates = [];
+        foreach ($persons as $person) {
+            $id = $person['id'];
+            if ('' === $id) {
+                continue;
+            }
+
+            $source = $this->matchSource($username, $person);
+            if (null === $source) {
+                continue;
+            }
+
+            // First match for a person wins; e-mail (checked first) beats name.
+            $candidates[$id] ??= [
+                'id' => $id,
+                'name' => trim(sprintf('%s %s', $person['first_name'] ?? '', $person['last_name'] ?? '')),
+                'source' => $source,
+            ];
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * How $username matches $person, or null. E-mail localpart first (reliable),
+     * then the firstname.lastname scheme.
+     *
+     * @param array{id: string, first_name: ?string, last_name: ?string, email: ?string} $person
+     */
+    private function matchSource(string $username, array $person): ?string
+    {
+        $email = $person['email'];
+        if (null !== $email && '' !== $email) {
+            $before = strstr($email, '@', true);
+            $localpart = mb_strtolower(trim(false === $before ? $email : $before));
+            if ($localpart === $username) {
+                return 'email';
+            }
+        }
+
+        $first = mb_strtolower(trim((string) $person['first_name']));
+        $last = mb_strtolower(trim((string) $person['last_name']));
+        if ('' !== $first && '' !== $last && sprintf('%s.%s', $first, $last) === $username) {
+            return 'name';
+        }
+
+        return null;
+    }
+}

--- a/tests/Command/TtMatchPersonioEmployeesCommandTest.php
+++ b/tests/Command/TtMatchPersonioEmployeesCommandTest.php
@@ -19,6 +19,7 @@ use App\Service\Personio\PersonioClient;
 use App\Service\Personio\PersonioClientFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -31,10 +32,10 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[AllowMockObjectsWithoutExpectations]
 final class TtMatchPersonioEmployeesCommandTest extends TestCase
 {
-    private PersonioConfigRepository $configRepository;
-    private UserRepository $userRepository;
-    private PersonioClient $client;
-    private EntityManagerInterface $entityManager;
+    private PersonioConfigRepository&MockObject $configRepository;
+    private UserRepository&MockObject $userRepository;
+    private PersonioClient&MockObject $client;
+    private EntityManagerInterface&MockObject $entityManager;
 
     /**
      * @param list<User>                                                                       $users

--- a/tests/Command/TtMatchPersonioEmployeesCommandTest.php
+++ b/tests/Command/TtMatchPersonioEmployeesCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Command;
+
+use App\Command\TtMatchPersonioEmployeesCommand;
+use App\Entity\PersonioConfig;
+use App\Entity\User;
+use App\Repository\PersonioConfigRepository;
+use App\Repository\UserRepository;
+use App\Service\Personio\EmployeeMatcher;
+use App\Service\Personio\PersonioClient;
+use App\Service\Personio\PersonioClientFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class TtMatchPersonioEmployeesCommandTest extends TestCase
+{
+    private PersonioConfigRepository $configRepository;
+    private UserRepository $userRepository;
+    private PersonioClient $client;
+    private EntityManagerInterface $entityManager;
+
+    /**
+     * @param list<User>                                                                       $users
+     * @param list<array{id: string, first_name: ?string, last_name: ?string, email: ?string}> $persons
+     */
+    private function tester(array $users, array $persons, bool $active = true): CommandTester
+    {
+        $this->configRepository = $this->createMock(PersonioConfigRepository::class);
+        $this->configRepository->method('findActive')->willReturn($active ? new PersonioConfig() : null);
+
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->userRepository->method('findWithoutPersonioEmployeeId')->willReturn($users);
+
+        $this->client = $this->createMock(PersonioClient::class);
+        $this->client->method('listPersons')->willReturn($persons);
+        $clientFactory = $this->createMock(PersonioClientFactory::class);
+        $clientFactory->method('create')->willReturn($this->client);
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        return new CommandTester(
+            new TtMatchPersonioEmployeesCommand(
+                $this->configRepository,
+                $clientFactory,
+                $this->userRepository,
+                new EmployeeMatcher(),
+                $this->entityManager,
+            ),
+        );
+    }
+
+    public function testPreviewListsProposalsWithoutWriting(): void
+    {
+        $user = $this->user(7, 'sebastian.mendel');
+        $tester = $this->tester([$user], [$this->person('100', 'Sebastian', 'Mendel', 'sebastian.mendel@netresearch.de')]);
+
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('sebastian.mendel', $tester->getDisplay());
+        self::assertStringContainsString('100', $tester->getDisplay());
+        self::assertNull($user->getPersonioEmployeeId());
+    }
+
+    public function testApplyWritesEmployeeId(): void
+    {
+        $user = $this->user(7, 'sebastian.mendel');
+        $tester = $this->tester([$user], [$this->person('100', 'Sebastian', 'Mendel', 'sebastian.mendel@netresearch.de')]);
+
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(100, $user->getPersonioEmployeeId());
+        self::assertStringContainsString('Applied 1', $tester->getDisplay());
+    }
+
+    public function testNoActiveConfigFails(): void
+    {
+        $tester = $this->tester([], [], active: false);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('No active Personio configuration', $tester->getDisplay());
+    }
+
+    public function testAllMappedNote(): void
+    {
+        $tester = $this->tester([], []);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('already', $tester->getDisplay());
+    }
+
+    public function testNoConfidentMatchesNote(): void
+    {
+        $tester = $this->tester(
+            [$this->user(7, 'sebastian.mendel')],
+            [$this->person('100', 'Alice', 'Adams', 'alice.adams@netresearch.de')],
+        );
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('No confident matches', $tester->getDisplay());
+    }
+
+    private function user(int $id, string $username): User
+    {
+        $user = new User()->setUsername($username);
+        $property = new ReflectionProperty(User::class, 'id');
+        $property->setValue($user, $id);
+
+        return $user;
+    }
+
+    /**
+     * @return array{id: string, first_name: ?string, last_name: ?string, email: ?string}
+     */
+    private function person(string $id, ?string $first, ?string $last, ?string $email): array
+    {
+        return ['id' => $id, 'first_name' => $first, 'last_name' => $last, 'email' => $email];
+    }
+}

--- a/tests/Service/Personio/EmployeeMatcherTest.php
+++ b/tests/Service/Personio/EmployeeMatcherTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Service\Personio;
+
+use App\DTO\Personio\EmployeeMatch;
+use App\Entity\User;
+use App\Service\Personio\EmployeeMatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+#[CoversClass(EmployeeMatcher::class)]
+#[CoversClass(EmployeeMatch::class)]
+final class EmployeeMatcherTest extends TestCase
+{
+    private EmployeeMatcher $matcher;
+
+    protected function setUp(): void
+    {
+        $this->matcher = new EmployeeMatcher();
+    }
+
+    public function testMatchesByEmailLocalpart(): void
+    {
+        $matches = $this->matcher->match(
+            [$this->user(7, 'sebastian.mendel')],
+            [$this->person('100', 'Sebastian', 'Mendel', 'sebastian.mendel@netresearch.de')],
+        );
+
+        self::assertCount(1, $matches);
+        self::assertSame(7, $matches[0]->userId);
+        self::assertSame('100', $matches[0]->personId);
+        self::assertSame('Sebastian Mendel', $matches[0]->personName);
+        self::assertSame('email', $matches[0]->source);
+    }
+
+    public function testFallsBackToFirstnameLastnameWhenEmailAbsent(): void
+    {
+        $matches = $this->matcher->match(
+            [$this->user(7, 'sebastian.mendel')],
+            [$this->person('100', 'Sebastian', 'Mendel', null)],
+        );
+
+        self::assertCount(1, $matches);
+        self::assertSame('name', $matches[0]->source);
+    }
+
+    public function testEmailWinsOverNameAsSource(): void
+    {
+        $matches = $this->matcher->match(
+            [$this->user(7, 'sebastian.mendel')],
+            [$this->person('100', 'Sebastian', 'Mendel', 'sebastian.mendel@netresearch.de')],
+        );
+
+        self::assertSame('email', $matches[0]->source);
+    }
+
+    public function testNoMatchLeavesUserUnmatched(): void
+    {
+        $matches = $this->matcher->match(
+            [$this->user(7, 'sebastian.mendel')],
+            [$this->person('100', 'Alice', 'Adams', 'alice.adams@netresearch.de')],
+        );
+
+        self::assertSame([], $matches);
+    }
+
+    public function testAmbiguousMatchIsSkipped(): void
+    {
+        // Two distinct persons match the same username -> no guess.
+        $matches = $this->matcher->match(
+            [$this->user(7, 'sebastian.mendel')],
+            [
+                $this->person('100', 'Sebastian', 'Mendel', 'sebastian.mendel@netresearch.de'),
+                $this->person('200', 'Sebastian', 'Mendel', null),
+            ],
+        );
+
+        self::assertSame([], $matches);
+    }
+
+    public function testCaseInsensitiveMatch(): void
+    {
+        $matches = $this->matcher->match(
+            [$this->user(7, 'Sebastian.Mendel')],
+            [$this->person('100', 'Sebastian', 'Mendel', 'Sebastian.Mendel@Netresearch.de')],
+        );
+
+        self::assertCount(1, $matches);
+    }
+
+    public function testBlankUsernameIsSkipped(): void
+    {
+        $matches = $this->matcher->match(
+            [$this->user(7, '')],
+            [$this->person('100', 'Sebastian', 'Mendel', 'sebastian.mendel@netresearch.de')],
+        );
+
+        self::assertSame([], $matches);
+    }
+
+    private function user(int $id, string $username): User
+    {
+        $user = new User()->setUsername($username);
+        $property = new ReflectionProperty(User::class, 'id');
+        $property->setValue($user, $id);
+
+        return $user;
+    }
+
+    /**
+     * @return array{id: string, first_name: ?string, last_name: ?string, email: ?string}
+     */
+    private function person(string $id, ?string $first, ?string $last, ?string $email): array
+    {
+        return ['id' => $id, 'first_name' => $first, 'last_name' => $last, 'email' => $email];
+    }
+}


### PR DESCRIPTION
Implements the concrete piece of **ADR-024 P3** — the employee auto-match that fills in the `personio_employee_id` the export (P1) and import (P2) both depend on. Until now that mapping was manual.

## What it does

`tt:match-personio-employees [--apply]` (preview by default):

- Reads Personio persons (`PersonioClient::listPersons()`, built in P1) and proposes a match for each TT user that has **no employee id yet**.
- **Two strategies** (ADR §1): e-mail localpart == username, else `firstname.lastname` == username. E-mail wins as the recorded source.
- A username matching **zero or several** persons is **skipped, never guessed** — it stays for manual mapping.
- `--apply` writes the ids (a non-numeric Personio id is skipped rather than truncated); preview otherwise. Re-runnable — only ever looks at unmapped users.

This sidesteps ADR-024 verification point #4 (whether `/v2/persons` exposes e-mail) by trying **both** strategies.

## Files

- `EmployeeMatch` DTO + `EmployeeMatcher` service (pure, no DB — unit-tested directly).
- `UserRepository::findWithoutPersonioEmployeeId()`.
- `TtMatchPersonioEmployeesCommand`. Operator guide + ADR status updated.

## Verification (in-container)

PHPStan L10, php-cs-fixer, phpat, rector clean. Unit tests: matcher (email/name/ambiguous/no-match/case/blank), command (preview-no-write, apply-writes, no-config, all-mapped, no-matches). Full unit suite **1925/1925**. Command DI-wired (`--help` boots).

## Remaining P3 (not in this PR)

The frontend match-review UI and the **optional** v2 API/MCP triggers (scopes `sync:read`/`sync:write`) — deliberately deferred; this delivers the CLI auto-match that unblocks real Personio runs.