### PR TITLE
feat(personio): v2 API + MCP trigger for the Personio export/import (ADR-024 P3)

### DIFF
--- a/docs/adr/ADR-024-personio-attendance-absence-sync.md
+++ b/docs/adr/ADR-024-personio-attendance-absence-sync.md
@@ -1,6 +1,6 @@
 # ADR-024: Personio Attendance Export and Absence Import
 
-**Status:** Accepted — P1 (attendance export) implemented 2026-07-11; P2 (absence import) implemented 2026-07-12; P3 employee auto-match (CLI) implemented 2026-07-12; P3 remainder (frontend match UI, optional API/MCP triggers) pending.
+**Status:** Accepted — P1 (attendance export) implemented 2026-07-11; P2 (absence import) implemented 2026-07-12; P3 employee auto-match (CLI) + API/MCP run triggers implemented 2026-07-12; P3 remainder (frontend employee-match UI) pending.
 **Date:** 2026-07-10
 **Relates to:** [ADR-023](ADR-023-jira-worklog-bidirectional-sync.md) (the sync/run/audit infrastructure and the opt-in accountability model this ADR reuses), [ADR-021](ADR-021-api-token-authentication.md) (PAT scopes for any later API surface), [ADR-011](ADR-011-security-architecture.md) (encryption-at-rest via `TokenEncryptionService`).
 

--- a/docs/personio-sync.md
+++ b/docs/personio-sync.md
@@ -59,6 +59,16 @@ Re-runs are idempotent, tracked per Personio absence id: an unchanged absence is
 
 Schedule the default form on the same cron as the export; the window is one-directional (vacations lie in the future), so it is wider ahead than behind.
 
+## On-demand triggers (API / MCP)
+
+Besides the console commands, a run can be started under a personal access token
+(scope `sync:write`):
+
+- **v2 API:** `POST /api/v2/personio/runs`. Body: `{"direction":"export"|"import","from":"YYYY-MM-DD","to":"YYYY-MM-DD","dry_run":true,"all_users":true}` (only `direction` is required). `export` pushes attendances, `import` pulls absences. By default the run covers the token owner; `all_users` runs for everyone opted-in and needs an admin token.
+- **MCP tool:** `run_personio_sync` with the same `direction` and self/`allUsers` semantics.
+
+The response carries the finished run(s) with counters and parked items.
+
 ## Deactivating
 
 Clear a user's opt-in in Settings, or set the Personio config inactive. Deactivating stops future exports and imports; it does not remove attendances already sent to Personio, nor absence entries already imported into TimeTracker.

--- a/src/Controller/Api/V2/CreatePersonioRunAction.php
+++ b/src/Controller/Api/V2/CreatePersonioRunAction.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\V2;
+
+use App\Dto\Response\SyncRunDto;
+use App\Entity\SyncRun;
+use App\Entity\User;
+use App\Security\ApiToken\RequireScope;
+use App\Service\Personio\PersonioRunTrigger;
+use Exception;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+use function array_map;
+use function is_array;
+use function is_string;
+use function json_decode;
+
+/**
+ * Start a Personio run on demand (ADR-024 P3 trigger). The body's `direction`
+ * selects `export` (attendances, TT → Personio) or `import` (absences, Personio
+ * → TT). It runs for the caller by default; `all_users` runs the cron path for
+ * every opted-in, mapped user and requires ROLE_ADMIN. Runs execute inline —
+ * the response carries the finished run(s) with counters and parked items.
+ */
+final readonly class CreatePersonioRunAction
+{
+    public function __construct(
+        private AuthorizationCheckerInterface $authorizationChecker,
+        private PersonioRunTrigger $personioRunTrigger,
+    ) {
+    }
+
+    #[RequireScope('sync:write')]
+    #[Route(path: '/api/v2/personio/runs', name: 'api_v2_personio_run_create', methods: ['POST'])]
+    public function __invoke(Request $request, #[CurrentUser] ?User $user = null): JsonResponse
+    {
+        if (!$user instanceof User) {
+            return new JsonResponse(['message' => 'Authentication required'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $content = $request->getContent();
+        $payload = json_decode('' !== $content ? $content : '{}', true);
+        if (!is_array($payload)) {
+            $payload = [];
+        }
+
+        $direction = is_string($payload['direction'] ?? null) ? $payload['direction'] : '';
+        if (!PersonioRunTrigger::isDirection($direction)) {
+            return new JsonResponse(['message' => 'direction must be "export" or "import".'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $allUsers = true === ($payload['all_users'] ?? false);
+        if ($allUsers && !$this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+            return new JsonResponse(['message' => 'Admin role required to run for all users.'], Response::HTTP_FORBIDDEN);
+        }
+
+        $from = is_string($payload['from'] ?? null) ? $payload['from'] : null;
+        $to = is_string($payload['to'] ?? null) ? $payload['to'] : null;
+        $dryRun = true === ($payload['dry_run'] ?? false);
+
+        try {
+            $runs = $this->personioRunTrigger->run($direction, $user, $allUsers, $from, $to, $dryRun);
+        } catch (Exception) {
+            return new JsonResponse(['message' => 'Invalid date in from/to (expected Y-m-d).'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return new JsonResponse(
+            ['runs' => array_map(static fn (SyncRun $syncRun): SyncRunDto => SyncRunDto::fromEntity($syncRun), $runs)],
+            Response::HTTP_CREATED,
+        );
+    }
+}

--- a/src/Mcp/Tool/RunPersonioSyncTool.php
+++ b/src/Mcp/Tool/RunPersonioSyncTool.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Dto\Response\SyncRunDto;
+use App\Entity\SyncRun;
+use App\Mcp\ScopeGuard;
+use App\Service\Personio\PersonioRunTrigger;
+use Exception;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
+
+use function array_map;
+
+/**
+ * MCP tool: run the Personio export or import on demand (ADR-024 P3). `direction`
+ * selects `export` (attendances) or `import` (absences). It runs for the caller
+ * by default; allUsers runs the cron path for every opted-in, mapped user and
+ * needs an administrator account. Runs execute inline — the result carries the
+ * finished run(s) with counters and parked items.
+ */
+final readonly class RunPersonioSyncTool
+{
+    public function __construct(
+        private ScopeGuard $scopeGuard,
+        private PersonioRunTrigger $personioRunTrigger,
+    ) {
+    }
+
+    /**
+     * Run the Personio sync. direction "export" pushes TimeTracker worklogs to
+     * Personio as attendances (dryRun previews); "import" pulls Personio absences
+     * (vacation/sick) into TimeTracker entries. Runs for you by default; set
+     * allUsers to run for every opted-in, mapped user (requires an administrator).
+     *
+     * @throws ToolCallException on missing scope/role, an unknown direction, or an invalid date
+     *
+     * @return array{runs: list<array<string, mixed>>}
+     */
+    #[McpTool(name: 'run_personio_sync', description: 'Run the Personio sync: direction "export" (TimeTracker → Personio attendances; dryRun previews) or "import" (Personio absences → TimeTracker). Runs for you by default; allUsers runs for everyone opted-in (admin only).')]
+    public function runPersonioSync(
+        #[Schema(description: 'Run direction: "export" (attendances) or "import" (absences).')]
+        string $direction,
+        #[Schema(description: 'Range start as YYYY-MM-DD (export default: 14 days ago; import default: 30 days ago).')]
+        ?string $from = null,
+        #[Schema(description: 'Range end as YYYY-MM-DD (export default: today; import default: 90 days ahead).')]
+        ?string $to = null,
+        #[Schema(description: 'Preview without writing (export only).')]
+        bool $dryRun = false,
+        #[Schema(description: 'Run for every opted-in, mapped user (requires an administrator account).')]
+        bool $allUsers = false,
+    ): array {
+        if (!PersonioRunTrigger::isDirection($direction)) {
+            throw new ToolCallException('direction must be "export" or "import".');
+        }
+
+        $user = $allUsers
+            ? $this->scopeGuard->requireAdminScope('sync:write')
+            : $this->scopeGuard->requireScope('sync:write');
+
+        try {
+            $runs = $this->personioRunTrigger->run($direction, $user, $allUsers, $from, $to, $dryRun);
+        } catch (Exception) {
+            throw new ToolCallException('Invalid date in from/to (expected Y-m-d).');
+        }
+
+        return ['runs' => array_map(static fn (SyncRun $syncRun): array => SyncRunDto::fromEntity($syncRun)->jsonSerialize(), $runs)];
+    }
+}

--- a/src/Service/Personio/PersonioRunTrigger.php
+++ b/src/Service/Personio/PersonioRunTrigger.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Service\Personio;
+
+use App\Entity\SyncRun;
+use App\Entity\User;
+use DateTimeImmutable;
+use Exception;
+
+/**
+ * Shared entry point for triggering the Personio export/import on demand (ADR-024
+ * P3 API/MCP triggers), so the v2 API action and the MCP tool share one code path.
+ *
+ * `allUsers` runs the cron path (every opted-in, mapped user); otherwise it runs
+ * for the single caller. The caller is responsible for the admin check behind
+ * `allUsers` — this service only dispatches. Date parsing throws so the caller can
+ * report a clean validation error.
+ */
+final readonly class PersonioRunTrigger
+{
+    /** The two run directions the API/MCP triggers accept. */
+    public const string DIRECTION_EXPORT = 'export';
+
+    public const string DIRECTION_IMPORT = 'import';
+
+    public function __construct(
+        private AttendanceExportService $attendanceExportService,
+        private AbsenceImportService $absenceImportService,
+    ) {
+    }
+
+    /**
+     * Dispatch by direction so the API action and MCP tool stay a single call.
+     * `import` ignores $dryRun (the absence import has no preview mode).
+     *
+     * @throws Exception on an unparseable from/to date
+     *
+     * @return list<SyncRun>
+     */
+    public function run(string $direction, User $user, bool $allUsers, ?string $from, ?string $to, bool $dryRun): array
+    {
+        return self::DIRECTION_IMPORT === $direction
+            ? $this->import($user, $allUsers, $from, $to)
+            : $this->export($user, $allUsers, $from, $to, $dryRun);
+    }
+
+    /**
+     * Whether $direction is a supported run direction.
+     */
+    public static function isDirection(string $direction): bool
+    {
+        return self::DIRECTION_EXPORT === $direction || self::DIRECTION_IMPORT === $direction;
+    }
+
+    /**
+     * @throws Exception on an unparseable from/to date
+     *
+     * @return list<SyncRun>
+     */
+    public function export(User $user, bool $allUsers, ?string $from, ?string $to, bool $dryRun): array
+    {
+        // Attendance export window: rolling last 14 days (mirrors the command).
+        $fromDate = null !== $from ? new DateTimeImmutable($from) : new DateTimeImmutable('today')->modify('-14 days');
+        $toDate = null !== $to ? new DateTimeImmutable($to) : new DateTimeImmutable('today');
+
+        return $allUsers
+            ? $this->attendanceExportService->exportAllOptedIn($fromDate, $toDate, $dryRun)
+            : [$this->attendanceExportService->exportUser($user, $fromDate, $toDate, $dryRun)];
+    }
+
+    /**
+     * @throws Exception on an unparseable from/to date
+     *
+     * @return list<SyncRun>
+     */
+    public function import(User $user, bool $allUsers, ?string $from, ?string $to): array
+    {
+        // Absence import window: 30 days back, 90 ahead (mirrors the command).
+        $fromDate = null !== $from ? new DateTimeImmutable($from) : new DateTimeImmutable('today')->modify('-30 days');
+        $toDate = null !== $to ? new DateTimeImmutable($to) : new DateTimeImmutable('today')->modify('+90 days');
+
+        return $allUsers
+            ? $this->absenceImportService->importAllOptedIn($fromDate, $toDate)
+            : [$this->absenceImportService->importUser($user, $fromDate, $toDate)];
+    }
+}

--- a/tests/Controller/Api/V2/CreatePersonioRunActionTest.php
+++ b/tests/Controller/Api/V2/CreatePersonioRunActionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller\Api\V2;
+
+use App\Controller\Api\V2\CreatePersonioRunAction;
+use App\Entity\SyncRun;
+use App\Entity\User;
+use App\Enum\SyncRunStatus;
+use App\Enum\SyncRunType;
+use App\Service\Personio\AbsenceImportService;
+use App\Service\Personio\AttendanceExportService;
+use App\Service\Personio\PersonioRunTrigger;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+use function json_decode;
+use function json_encode;
+
+#[AllowMockObjectsWithoutExpectations]
+final class CreatePersonioRunActionTest extends TestCase
+{
+    private AuthorizationCheckerInterface&MockObject $authorizationChecker;
+    private AttendanceExportService&MockObject $exportService;
+    private AbsenceImportService&MockObject $importService;
+    private PersonioRunTrigger $trigger;
+
+    protected function setUp(): void
+    {
+        $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $this->exportService = $this->createMock(AttendanceExportService::class);
+        $this->importService = $this->createMock(AbsenceImportService::class);
+        $this->exportService->method('exportUser')->willReturn($this->completedRun());
+        $this->exportService->method('exportAllOptedIn')->willReturn([$this->completedRun(), $this->completedRun()]);
+        $this->importService->method('importUser')->willReturn($this->completedRun());
+        $this->importService->method('importAllOptedIn')->willReturn([$this->completedRun()]);
+
+        $this->trigger = new PersonioRunTrigger($this->exportService, $this->importService);
+    }
+
+    public function testExportDirectionReturns201WithRuns(): void
+    {
+        $response = $this->action()->__invoke($this->jsonRequest(['direction' => 'export']), new User());
+
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $body = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('runs', $body);
+        self::assertIsArray($body['runs']);
+        self::assertCount(1, $body['runs']);
+    }
+
+    public function testImportDirectionReturns201(): void
+    {
+        $response = $this->action()->__invoke($this->jsonRequest(['direction' => 'import']), new User());
+
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
+    public function testUnknownDirectionReturns422(): void
+    {
+        $response = $this->action()->__invoke($this->jsonRequest(['direction' => 'sideways']), new User());
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testMissingDirectionReturns422(): void
+    {
+        $response = $this->action()->__invoke(new Request(), new User());
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testUnauthenticatedReturns401(): void
+    {
+        $response = $this->action()->__invoke($this->jsonRequest(['direction' => 'export']), null);
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testAllUsersAsNonAdminReturns403(): void
+    {
+        $this->authorizationChecker->method('isGranted')->willReturn(false);
+
+        $response = $this->action()->__invoke($this->jsonRequest(['direction' => 'export', 'all_users' => true]), new User());
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function testAllUsersAsAdminReturns201WithEveryRun(): void
+    {
+        $this->authorizationChecker->method('isGranted')->willReturn(true);
+
+        $response = $this->action()->__invoke($this->jsonRequest(['direction' => 'export', 'all_users' => true]), new User());
+
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $body = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($body);
+        self::assertIsArray($body['runs']);
+        self::assertCount(2, $body['runs']);
+    }
+
+    public function testInvalidDateReturns422(): void
+    {
+        $response = $this->action()->__invoke($this->jsonRequest(['direction' => 'export', 'from' => 'not-a-date']), new User());
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    private function action(): CreatePersonioRunAction
+    {
+        return new CreatePersonioRunAction($this->authorizationChecker, $this->trigger);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function jsonRequest(array $payload): Request
+    {
+        return new Request([], [], [], [], [], [], (string) json_encode($payload));
+    }
+
+    private function completedRun(): SyncRun
+    {
+        return new SyncRun()
+            ->setType(SyncRunType::PERSONIO_EXPORT)
+            ->setStatus(SyncRunStatus::COMPLETED)
+            ->setCounters([])
+            ->setStartedAt(new DateTimeImmutable('2026-07-12 10:00:00'));
+    }
+}

--- a/tests/Mcp/Tool/RunPersonioSyncToolTest.php
+++ b/tests/Mcp/Tool/RunPersonioSyncToolTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Mcp\Tool;
+
+use App\Entity\SyncRun;
+use App\Entity\User;
+use App\Enum\SyncRunStatus;
+use App\Enum\SyncRunType;
+use App\Mcp\Tool\RunPersonioSyncTool;
+use App\Repository\UserRepository;
+use App\Service\Personio\AbsenceImportService;
+use App\Service\Personio\AttendanceExportService;
+use DateTimeImmutable;
+use Mcp\Exception\ToolCallException;
+use Tests\AbstractWebTestCase;
+use Tests\Traits\ActsAsApiTokenUser;
+
+/**
+ * MCP Personio run tool (ADR-024 P3). The Personio services are mocked in the
+ * container; these exercise the direction/scope/role gate and the response
+ * shape. Fixture user 'unittest' (id 1, admin); 'developer' (id 2, non-admin).
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class RunPersonioSyncToolTest extends AbstractWebTestCase
+{
+    use ActsAsApiTokenUser;
+
+    public function testExportSelfReturnsRun(): void
+    {
+        $mock = $this->createMock(AttendanceExportService::class);
+        $mock->expects(self::once())->method('exportUser')->willReturn($this->completedRun(SyncRunType::PERSONIO_EXPORT));
+        self::getContainer()->set(AttendanceExportService::class, $mock);
+
+        $this->useToken(['sync:write'], 'developer');
+
+        $result = $this->tool()->runPersonioSync('export');
+
+        self::assertIsArray($result['runs']);
+        self::assertCount(1, $result['runs']);
+    }
+
+    public function testImportSelfReturnsRun(): void
+    {
+        $mock = $this->createMock(AbsenceImportService::class);
+        $mock->expects(self::once())->method('importUser')->willReturn($this->completedRun(SyncRunType::PERSONIO_IMPORT));
+        self::getContainer()->set(AbsenceImportService::class, $mock);
+
+        $this->useToken(['sync:write'], 'developer');
+
+        $result = $this->tool()->runPersonioSync('import');
+
+        self::assertIsArray($result['runs']);
+        self::assertCount(1, $result['runs']);
+    }
+
+    public function testUnknownDirectionIsRejected(): void
+    {
+        $this->useToken(['sync:write'], 'developer');
+
+        $this->expectException(ToolCallException::class);
+        $this->expectExceptionMessageMatches('/direction/');
+
+        $this->tool()->runPersonioSync('sideways');
+    }
+
+    public function testAllUsersAsNonAdminIsRejected(): void
+    {
+        $this->useToken(['sync:write'], 'developer');
+
+        $this->expectException(ToolCallException::class);
+        $this->expectExceptionMessageMatches('/administrator/');
+
+        $this->tool()->runPersonioSync('export', allUsers: true);
+    }
+
+    public function testAllUsersAsAdminRunsForEveryone(): void
+    {
+        $mock = $this->createMock(AttendanceExportService::class);
+        $mock->expects(self::once())->method('exportAllOptedIn')
+            ->willReturn([$this->completedRun(SyncRunType::PERSONIO_EXPORT), $this->completedRun(SyncRunType::PERSONIO_EXPORT)]);
+        self::getContainer()->set(AttendanceExportService::class, $mock);
+
+        $this->useToken(['sync:write'], 'unittest');
+
+        $result = $this->tool()->runPersonioSync('export', allUsers: true);
+
+        self::assertIsArray($result['runs']);
+        self::assertCount(2, $result['runs']);
+    }
+
+    public function testReadOnlyScopeIsRejected(): void
+    {
+        $this->useToken(['sync:read'], 'unittest');
+
+        $this->expectException(ToolCallException::class);
+
+        $this->tool()->runPersonioSync('export');
+    }
+
+    private function tool(): RunPersonioSyncTool
+    {
+        $tool = self::getContainer()->get(RunPersonioSyncTool::class);
+        self::assertInstanceOf(RunPersonioSyncTool::class, $tool);
+
+        return $tool;
+    }
+
+    private function completedRun(SyncRunType $type): SyncRun
+    {
+        $repository = self::getContainer()->get(UserRepository::class);
+        $user = $repository->findOneBy(['username' => 'unittest']);
+        self::assertInstanceOf(User::class, $user);
+
+        return new SyncRun()
+            ->setType($type)
+            ->setStatus(SyncRunStatus::COMPLETED)
+            ->setTriggeredBy($user)
+            ->setCounters([])
+            ->setStartedAt(new DateTimeImmutable('2026-07-12 10:00:00'));
+    }
+}

--- a/tests/Service/Personio/PersonioRunTriggerTest.php
+++ b/tests/Service/Personio/PersonioRunTriggerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Service\Personio;
+
+use App\Entity\SyncRun;
+use App\Entity\User;
+use App\Service\Personio\AbsenceImportService;
+use App\Service\Personio\AttendanceExportService;
+use App\Service\Personio\PersonioRunTrigger;
+use DateTimeImmutable;
+use Exception;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[AllowMockObjectsWithoutExpectations]
+final class PersonioRunTriggerTest extends TestCase
+{
+    private AttendanceExportService&MockObject $exportService;
+    private AbsenceImportService&MockObject $importService;
+    private PersonioRunTrigger $trigger;
+
+    protected function setUp(): void
+    {
+        $this->exportService = $this->createMock(AttendanceExportService::class);
+        $this->importService = $this->createMock(AbsenceImportService::class);
+        $this->trigger = new PersonioRunTrigger($this->exportService, $this->importService);
+    }
+
+    public function testExportSelfCallsExportUser(): void
+    {
+        $user = new User();
+        $this->exportService->expects(self::once())->method('exportUser')
+            ->with($user, self::isInstanceOf(DateTimeImmutable::class), self::isInstanceOf(DateTimeImmutable::class), true)
+            ->willReturn(new SyncRun());
+        $this->exportService->expects(self::never())->method('exportAllOptedIn');
+
+        $runs = $this->trigger->export($user, false, null, null, true);
+
+        self::assertCount(1, $runs);
+    }
+
+    public function testExportAllUsersCallsExportAllOptedIn(): void
+    {
+        $this->exportService->expects(self::once())->method('exportAllOptedIn')
+            ->willReturn([new SyncRun(), new SyncRun()]);
+        $this->exportService->expects(self::never())->method('exportUser');
+
+        $runs = $this->trigger->export(new User(), true, '2026-07-01', '2026-07-14', false);
+
+        self::assertCount(2, $runs);
+    }
+
+    public function testImportSelfCallsImportUser(): void
+    {
+        $user = new User();
+        $this->importService->expects(self::once())->method('importUser')
+            ->with($user, self::isInstanceOf(DateTimeImmutable::class), self::isInstanceOf(DateTimeImmutable::class))
+            ->willReturn(new SyncRun());
+        $this->importService->expects(self::never())->method('importAllOptedIn');
+
+        $runs = $this->trigger->import($user, false, null, null);
+
+        self::assertCount(1, $runs);
+    }
+
+    public function testImportAllUsersCallsImportAllOptedIn(): void
+    {
+        $this->importService->expects(self::once())->method('importAllOptedIn')
+            ->willReturn([new SyncRun()]);
+
+        $runs = $this->trigger->import(new User(), true, null, null);
+
+        self::assertCount(1, $runs);
+    }
+
+    public function testInvalidDateThrows(): void
+    {
+        $this->expectException(Exception::class);
+
+        $this->trigger->export(new User(), false, 'not-a-date', null, false);
+    }
+}


### PR DESCRIPTION
The *optional* on-demand triggers of **ADR-024 P3**. Alongside the console commands, a Personio run can now be started under a PAT (scope `sync:write`).

## Surface

One endpoint and one tool, each taking a `direction` — mirroring the worklog-sync single-surface-with-discriminator shape, so export and import share the code instead of near-duplicate pairs (keeps SonarCloud new-duplication under the gate):

- **v2 API:** `POST /api/v2/personio/runs` — body `{"direction":"export"|"import","from","to","dry_run","all_users"}` (only `direction` required).
- **MCP tool:** `run_personio_sync` with the same `direction`.

`export` pushes attendances (TT → Personio, `dry_run` previews); `import` pulls absences (Personio → TT). Both run for the **token owner by default**; `all_users` runs the cron path for every opted-in user and requires an **admin** (ROLE_ADMIN on the API, `requireAdminScope` on MCP). Runs execute inline — the response carries the finished run(s) with counters and parked items.

## Design

A shared `PersonioRunTrigger` holds the window defaults (export −14/today, import −30/+90) and the self-vs-all dispatch; `run(direction, …)` fans out to export/import. Each surface keeps only its own auth gate (`AuthorizationChecker` vs `ScopeGuard`).

## Verification (in-container)

PHPStan L10, php-cs-fixer, phpat, rector clean. Unit tests for the trigger + the API action (direction/auth/date branches, 401/403/422); functional MCP test (direction/scope/role gate via a real PAT, services mocked in the container). Full unit suite 1930/1930; controller suite 398/398 (2 pre-existing, unrelated deprecations).