### PR TITLE
feat(personio): admin UI to review and confirm employee-id matches (ADR-024 P3)

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -677,5 +677,17 @@
   "entry_source_agent_hint": "Von einem Agenten erfasst (Maschinenzeit), keine menschliche Arbeit",
   "entry_estimated": "geschätzt",
   "entry_estimated_hint": "Die menschliche Zeit ist eine vom Agenten abgeleitete Schätzung – vor der Anrechnung als Anwesenheit prüfen",
-  "auswertung_agent_hours": "Agenten-Stunden"
+  "auswertung_agent_hours": "Agenten-Stunden",
+  "personiomatch_admin_title": "Personio-Mitarbeiterzuordnung",
+  "personiomatch_intro": "TimeTracker-Benutzer ihrer Personio-Mitarbeiter-ID zuordnen. Sichere E-Mail-Treffer sind vorausgewählt; Namens-Treffer vor dem Bestätigen prüfen.",
+  "personiomatch_empty": "Keine Benutzer zuzuordnen.",
+  "personiomatch_col_user": "Benutzer",
+  "personiomatch_col_person": "Personio-Person",
+  "personiomatch_col_source": "Zugeordnet über",
+  "personiomatch_col_confirm": "Bestätigen",
+  "personiomatch_source_email": "E-Mail",
+  "personiomatch_source_name": "Name",
+  "personiomatch_confirm_selected": "Auswahl bestätigen",
+  "personiomatch_confirm_error": "Die Zuordnungen konnten nicht angewendet werden.",
+  "personiomatch_applied": "{count} Zuordnung(en) angewendet."
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -677,5 +677,17 @@
   "entry_source_agent_hint": "Recorded by an agent (machine time), not human labour",
   "entry_estimated": "estimated",
   "entry_estimated_hint": "Human time is an agent-derived estimate — review before it counts as attendance",
-  "auswertung_agent_hours": "Agent hours"
+  "auswertung_agent_hours": "Agent hours",
+  "personiomatch_admin_title": "Personio employee match",
+  "personiomatch_intro": "Match TimeTracker users to their Personio employee id. Confident e-mail matches are pre-selected; review the name matches before confirming.",
+  "personiomatch_empty": "No users to match.",
+  "personiomatch_col_user": "User",
+  "personiomatch_col_person": "Personio person",
+  "personiomatch_col_source": "Matched by",
+  "personiomatch_col_confirm": "Confirm",
+  "personiomatch_source_email": "E-mail",
+  "personiomatch_source_name": "Name",
+  "personiomatch_confirm_selected": "Confirm selected",
+  "personiomatch_confirm_error": "Could not apply the matches.",
+  "personiomatch_applied": "Applied {count} mapping(s)."
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -677,5 +677,17 @@
   "entry_source_agent_hint": "Registrado por un agente (tiempo de máquina), no trabajo humano",
   "entry_estimated": "estimado",
   "entry_estimated_hint": "El tiempo humano es una estimación derivada del agente: revísalo antes de contarlo como asistencia",
-  "auswertung_agent_hours": "Horas de agente"
+  "auswertung_agent_hours": "Horas de agente",
+  "personiomatch_admin_title": "Asignación de empleados de Personio",
+  "personiomatch_intro": "Asigna los usuarios de TimeTracker a su id de empleado de Personio. Las coincidencias por correo (fiables) vienen preseleccionadas; revisa las coincidencias por nombre antes de confirmar.",
+  "personiomatch_empty": "No hay usuarios para asignar.",
+  "personiomatch_col_user": "Usuario",
+  "personiomatch_col_person": "Persona de Personio",
+  "personiomatch_col_source": "Coincidencia por",
+  "personiomatch_col_confirm": "Confirmar",
+  "personiomatch_source_email": "Correo",
+  "personiomatch_source_name": "Nombre",
+  "personiomatch_confirm_selected": "Confirmar selección",
+  "personiomatch_confirm_error": "No se pudieron aplicar las asignaciones.",
+  "personiomatch_applied": "{count} asignación(es) aplicada(s)."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -677,5 +677,17 @@
   "entry_source_agent_hint": "Enregistré par un agent (temps machine), pas du travail humain",
   "entry_estimated": "estimé",
   "entry_estimated_hint": "Le temps humain est une estimation dérivée de l'agent — à vérifier avant de le compter comme présence",
-  "auswertung_agent_hours": "Heures agent"
+  "auswertung_agent_hours": "Heures agent",
+  "personiomatch_admin_title": "Association des employés Personio",
+  "personiomatch_intro": "Associez les utilisateurs TimeTracker à leur identifiant d'employé Personio. Les correspondances par e-mail (fiables) sont présélectionnées ; vérifiez les correspondances par nom avant de confirmer.",
+  "personiomatch_empty": "Aucun utilisateur à associer.",
+  "personiomatch_col_user": "Utilisateur",
+  "personiomatch_col_person": "Personne Personio",
+  "personiomatch_col_source": "Correspondance par",
+  "personiomatch_col_confirm": "Confirmer",
+  "personiomatch_source_email": "E-mail",
+  "personiomatch_source_name": "Nom",
+  "personiomatch_confirm_selected": "Confirmer la sélection",
+  "personiomatch_confirm_error": "Impossible d'appliquer les associations.",
+  "personiomatch_applied": "{count} association(s) appliquée(s)."
 }

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -677,5 +677,17 @@
   "entry_source_agent_hint": "Записано агентом (машинное время), не человеческий труд",
   "entry_estimated": "оценка",
   "entry_estimated_hint": "Человеческое время — оценка, выведенная агентом; проверьте до учёта как посещаемость",
-  "auswertung_agent_hours": "Часы агента"
+  "auswertung_agent_hours": "Часы агента",
+  "personiomatch_admin_title": "Сопоставление сотрудников Personio",
+  "personiomatch_intro": "Сопоставьте пользователей TimeTracker с их идентификатором сотрудника Personio. Надёжные совпадения по электронной почте выбраны заранее; проверьте совпадения по имени перед подтверждением.",
+  "personiomatch_empty": "Нет пользователей для сопоставления.",
+  "personiomatch_col_user": "Пользователь",
+  "personiomatch_col_person": "Сотрудник Personio",
+  "personiomatch_col_source": "Совпадение по",
+  "personiomatch_col_confirm": "Подтвердить",
+  "personiomatch_source_email": "Эл. почта",
+  "personiomatch_source_name": "Имя",
+  "personiomatch_confirm_selected": "Подтвердить выбранное",
+  "personiomatch_confirm_error": "Не удалось применить сопоставления.",
+  "personiomatch_applied": "Применено сопоставлений: {count}."
 }

--- a/frontend/src/api/personioEmployeeMatch.ts
+++ b/frontend/src/api/personioEmployeeMatch.ts
@@ -1,0 +1,60 @@
+import { getJson, postJson } from './client'
+
+// ── ADR-024 P3 employee-match DTOs ───────────────────────────────────────────
+// Snake_case, mirroring the backend (GetPersonioEmployeeMatchesAction +
+// ConfirmPersonioEmployeeMatchesAction) the /personio/employee-matches endpoints
+// serialize.
+
+/** How a proposal matched: `email` (e-mail localpart, confident) or `name`
+ *  (firstname.lastname, a weaker fallback). */
+export type MatchSource = 'email' | 'name'
+
+/** One proposed TT user → Personio employee-id match. Nothing is persisted until
+ *  the admin confirms the row. */
+export interface EmployeeMatchProposal {
+  user_id: number
+  username: string
+  person_id: string
+  person_name: string
+  source: MatchSource
+}
+
+/** GET /personio/employee-matches body. */
+export interface EmployeeMatchesResponse {
+  proposals: EmployeeMatchProposal[]
+}
+
+/** One applied mapping returned by the confirm endpoint. */
+export interface AppliedMatch {
+  user_id: number
+  username: string
+  person_id: string
+}
+
+/** POST /personio/employee-matches/confirm body. */
+export interface ConfirmMatchesResult {
+  applied: AppliedMatch[]
+}
+
+/** Base cache key — the confirm action invalidates it so a mapped user drops out
+ *  of the next proposals fetch (the endpoint only lists users with no id yet). */
+export const personioEmployeeMatchKeys = {
+  proposals: ['personio-employee-match', 'proposals'] as const,
+}
+
+/** GET /personio/employee-matches — the unmapped users with their proposed
+ *  Personio employee-id matches. */
+export function employeeMatchesQuery() {
+  return {
+    queryKey: [...personioEmployeeMatchKeys.proposals] as const,
+    queryFn: () => getJson<EmployeeMatchesResponse>('/personio/employee-matches'),
+  }
+}
+
+/** POST /personio/employee-matches/confirm — write the confirmed user→id
+ *  mappings; returns the applied rows. */
+export function confirmEmployeeMatches(
+  matches: { user_id: number; person_id: string }[],
+): Promise<ConfirmMatchesResult> {
+  return postJson<ConfirmMatchesResult>('/personio/employee-matches/confirm', { matches })
+}

--- a/frontend/src/components/SidebarAdminMenu.tsx
+++ b/frontend/src/components/SidebarAdminMenu.tsx
@@ -24,6 +24,7 @@ const ADMIN_ICON: Record<string, () => JSX.Element> = {
   status: () => <><circle cx="12" cy="12" r="9" /><path d="M12 8v4.5M12 16h.01" /></>,
   'worklog-sync': () => <><path d="M4 12a8 8 0 0 1 14-5.3L21 9" /><path d="M21 4v5h-5" /><path d="M20 12a8 8 0 0 1-14 5.3L3 15" /><path d="M3 20v-5h5" /></>,
   'project-import': () => <><path d="M12 3v12" /><path d="M8 11l4 4 4-4" /><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" /></>,
+  'personio-employee-match': () => <><path d="M16 11a4 4 0 1 0-8 0" /><circle cx="12" cy="7" r="0.5" /><path d="M4 21v-1a4 4 0 0 1 4-4h1" /><path d="M15 19l2 2 4-4" /></>,
 }
 
 function adminIco(key: string): JSX.Element {
@@ -129,6 +130,17 @@ export function SidebarAdminMenu() {
             onClick={(event) => { event.preventDefault(); navigate('/admin/project-import') }}
           >
             {adminIco('project-import')}<span class="sidebar-admin-label">{m.projectimport_admin_title()}</span>
+          </a>
+        </li>
+        {/* Personio employee-match review (ADR-024 P3): confirm user→employee-id — no add action. */}
+        <li class="sidebar-admin-item" classList={{ 'is-active': activeKey() === 'personio-employee-match' }}>
+          <a
+            class="sidebar-admin-link"
+            href="/ui/admin/personio-employee-match"
+            aria-current={activeKey() === 'personio-employee-match' ? 'page' : undefined}
+            onClick={(event) => { event.preventDefault(); navigate('/admin/personio-employee-match') }}
+          >
+            {adminIco('personio-employee-match')}<span class="sidebar-admin-label">{m.personiomatch_admin_title()}</span>
           </a>
         </li>
       </ul>

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -7,6 +7,7 @@ import { AdminCrudShell } from '../components/AdminCrudShell'
 import { activeNavLink } from '../header'
 import { m } from '../paraglide/messages.js'
 import AdminStatus from './AdminStatus'
+import PersonioEmployeeMatch from './PersonioEmployeeMatch'
 import ProjectImport from './ProjectImport'
 import WorklogSync from './WorklogSync'
 
@@ -16,6 +17,7 @@ import WorklogSync from './WorklogSync'
 const STATUS_KEY = 'status'
 const WORKLOG_SYNC_KEY = 'worklog-sync'
 const PROJECT_IMPORT_KEY = 'project-import'
+const PERSONIO_MATCH_KEY = 'personio-employee-match'
 
 // Remembers the entity the Admin URL last selected. When a page-level modal
 // (e.g. /ui/settings) opens over Admin, App.tsx re-renders Admin as the modal's
@@ -50,6 +52,9 @@ export default function Admin() {
     }
     if (key === PROJECT_IMPORT_KEY) {
       return PROJECT_IMPORT_KEY
+    }
+    if (key === PERSONIO_MATCH_KEY) {
+      return PERSONIO_MATCH_KEY
     }
 
     return entities.find((entity) => entity.key === key)?.key ?? entities[0]!.key
@@ -155,6 +160,9 @@ export default function Admin() {
         </Match>
         <Match when={activeKey() === PROJECT_IMPORT_KEY}>
           <ProjectImport />
+        </Match>
+        <Match when={activeKey() === PERSONIO_MATCH_KEY}>
+          <PersonioEmployeeMatch />
         </Match>
       </Switch>
     </section>

--- a/frontend/src/pages/PersonioEmployeeMatch.test.tsx
+++ b/frontend/src/pages/PersonioEmployeeMatch.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, screen, waitFor } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import type { EmployeeMatchProposal } from '../api/personioEmployeeMatch'
+import { renderWithProviders } from '../test/renderWithProviders'
+
+const confirmEmployeeMatches = vi.fn()
+
+// One confident e-mail match (pre-checked) and one weaker name match (unchecked).
+const PROPOSALS: EmployeeMatchProposal[] = [
+  { user_id: 2, username: 'developer', person_id: '900', person_name: 'Dev Eloper', source: 'email' },
+  { user_id: 3, username: 'i.myself', person_id: '901', person_name: 'I Myself', source: 'name' },
+]
+
+vi.mock('../api/personioEmployeeMatch', () => ({
+  confirmEmployeeMatches: (...args: unknown[]) => confirmEmployeeMatches(...args),
+  employeeMatchesQuery: () => ({
+    queryKey: ['personio-employee-match', 'proposals'],
+    queryFn: () => Promise.resolve({ proposals: PROPOSALS }),
+  }),
+  personioEmployeeMatchKeys: { proposals: ['personio-employee-match', 'proposals'] },
+}))
+
+vi.mock('../api/client', () => ({
+  apiErrorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error && error.message ? error.message : fallback,
+}))
+
+const { default: PersonioEmployeeMatch } = await import('./PersonioEmployeeMatch')
+
+const FULL_ROLES = ['ROLE_USER', 'ROLE_PL', 'ROLE_ADMIN']
+
+afterEach(() => {
+  cleanup()
+  confirmEmployeeMatches.mockReset()
+  window.APP_CONFIG!.roles = [...FULL_ROLES]
+})
+
+describe('PersonioEmployeeMatch', () => {
+  it('lists the unmapped users and pre-checks only the confident e-mail match', async () => {
+    const { container } = renderWithProviders(() => <PersonioEmployeeMatch />)
+
+    await waitFor(() => expect(screen.getByText('developer')).toBeInTheDocument())
+    expect(screen.getByText('i.myself')).toBeInTheDocument()
+
+    const emailRow = screen.getByLabelText('Confirm — developer') as HTMLInputElement
+    const nameRow = screen.getByLabelText('Confirm — i.myself') as HTMLInputElement
+    expect(emailRow).toBeChecked()
+    expect(nameRow).not.toBeChecked()
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('posts only the checked rows to confirm', async () => {
+    confirmEmployeeMatches.mockResolvedValue({ applied: [{ user_id: 2, username: 'developer', person_id: '900' }] })
+
+    renderWithProviders(() => <PersonioEmployeeMatch />)
+    await waitFor(() => expect(screen.getByText('developer')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm selected' }))
+
+    await waitFor(() => expect(confirmEmployeeMatches).toHaveBeenCalledWith([{ user_id: 2, person_id: '900' }]))
+  })
+
+  it('includes a name match once the admin checks it', async () => {
+    confirmEmployeeMatches.mockResolvedValue({ applied: [] })
+
+    renderWithProviders(() => <PersonioEmployeeMatch />)
+    await waitFor(() => expect(screen.getByText('i.myself')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText('Confirm — i.myself'))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm selected' }))
+
+    await waitFor(() =>
+      expect(confirmEmployeeMatches).toHaveBeenCalledWith([
+        { user_id: 2, person_id: '900' },
+        { user_id: 3, person_id: '901' },
+      ]),
+    )
+  })
+})

--- a/frontend/src/pages/PersonioEmployeeMatch.tsx
+++ b/frontend/src/pages/PersonioEmployeeMatch.tsx
@@ -1,0 +1,180 @@
+import { useQuery, useQueryClient } from '@tanstack/solid-query'
+import { createEffect, createMemo, createSignal, For, Show, type JSX } from 'solid-js'
+
+import { apiErrorMessage } from '../api/client'
+import {
+  confirmEmployeeMatches,
+  type EmployeeMatchProposal,
+  employeeMatchesQuery,
+  type MatchSource,
+  personioEmployeeMatchKeys,
+} from '../api/personioEmployeeMatch'
+import { hasRole } from '../config'
+import { m } from '../paraglide/messages.js'
+
+const sourceLabels: Record<MatchSource, () => string> = {
+  email: m.personiomatch_source_email,
+  name: m.personiomatch_source_name,
+}
+const sourceLabel = (source: MatchSource): string => (sourceLabels[source] ?? (() => source))()
+
+/**
+ * The admin Personio employee-match review screen (ADR-024 P3): list each TT
+ * user that has no Personio employee id yet with its proposed match, let the
+ * admin confirm per row, and post the confirmed mappings. Confident e-mail
+ * matches are pre-checked; the weaker firstname.lastname matches start unchecked
+ * so the admin looks before applying. Rendered as a non-CRUD Administration
+ * sub-page (see Admin.tsx) behind the ROLE_ADMIN route guard.
+ */
+export default function PersonioEmployeeMatch(): JSX.Element {
+  return (
+    <Show when={hasRole('ROLE_ADMIN')}>
+      <PersonioEmployeeMatchArea />
+    </Show>
+  )
+}
+
+function PersonioEmployeeMatchArea(): JSX.Element {
+  const queryClient = useQueryClient()
+  const proposals = useQuery(() => employeeMatchesQuery())
+
+  // Per-user confirm state, keyed by user id. Seeded once the proposals arrive
+  // (and reseeded when the set changes, e.g. after a confirm refresh), with the
+  // confident e-mail matches pre-checked.
+  const [checked, setChecked] = createSignal<Record<number, boolean>>({})
+  let seedKey = ''
+  createEffect(() => {
+    const data = proposals.data
+    if (!data) {
+      return
+    }
+    const key = data.proposals.map((proposal) => `${proposal.user_id}:${proposal.source}`).join(',')
+    if (key === seedKey) {
+      return
+    }
+    seedKey = key
+    const seeded: Record<number, boolean> = {}
+    for (const proposal of data.proposals) {
+      seeded[proposal.user_id] = proposal.source === 'email'
+    }
+    setChecked(seeded)
+  })
+
+  const isChecked = (userId: number): boolean => checked()[userId] ?? false
+
+  function toggle(userId: number, value: boolean): void {
+    setChecked((prev) => ({ ...prev, [userId]: value }))
+  }
+
+  const [busy, setBusy] = createSignal(false)
+  const [error, setError] = createSignal('')
+  const [appliedCount, setAppliedCount] = createSignal<number | null>(null)
+
+  const selected = createMemo(() =>
+    (proposals.data?.proposals ?? [])
+      .filter((proposal) => isChecked(proposal.user_id))
+      .map((proposal) => ({ user_id: proposal.user_id, person_id: proposal.person_id })),
+  )
+
+  const canConfirm = (): boolean => selected().length > 0 && !busy()
+
+  async function confirmSelected(): Promise<void> {
+    const payload = selected()
+    if (payload.length === 0) {
+      return
+    }
+    setBusy(true)
+    setError('')
+    setAppliedCount(null)
+    try {
+      const result = await confirmEmployeeMatches(payload)
+      setAppliedCount(result.applied.length)
+      // The mapped users now have an id — refresh so they drop from the list.
+      void queryClient.invalidateQueries({ queryKey: personioEmployeeMatchKeys.proposals })
+    } catch (caught) {
+      setError(apiErrorMessage(caught, m.personiomatch_confirm_error()))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const hasProposals = (): boolean => (proposals.data?.proposals.length ?? 0) > 0
+
+  return (
+    <div class="personio-employee-match">
+      <section class="status-group">
+        <h2 class="status-group-title">{m.personiomatch_admin_title()}</h2>
+        <p class="field-hint">{m.personiomatch_intro()}</p>
+
+        <Show when={appliedCount() !== null}>
+          <p role="status" class="form-status is-ok">
+            {m.personiomatch_applied({ count: String(appliedCount() ?? 0) })}
+          </p>
+        </Show>
+
+        <Show
+          when={hasProposals()}
+          fallback={<p class="sync-counters-empty">{m.personiomatch_empty()}</p>}
+        >
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{m.personiomatch_col_user()}</th>
+                <th scope="col">{m.personiomatch_col_person()}</th>
+                <th scope="col">{m.personiomatch_col_source()}</th>
+                <th scope="col">{m.personiomatch_col_confirm()}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={proposals.data?.proposals ?? []}>
+                {(proposal: EmployeeMatchProposal) => {
+                  const severity = proposal.source === 'email' ? 'ok' : 'warn'
+
+                  return (
+                    <tr>
+                      <td>
+                        <code>{proposal.username}</code>
+                      </td>
+                      <td>
+                        {proposal.person_name} <span class="import-derived-name">#{proposal.person_id}</span>
+                      </td>
+                      <td>
+                        <span class={`import-source is-${severity}`}>{sourceLabel(proposal.source)}</span>
+                      </td>
+                      <td>
+                        <label class="import-confirm">
+                          <input
+                            type="checkbox"
+                            aria-label={`${m.personiomatch_col_confirm()} — ${proposal.username}`}
+                            checked={isChecked(proposal.user_id)}
+                            disabled={busy()}
+                            onInput={(event) => toggle(proposal.user_id, event.currentTarget.checked)}
+                          />
+                        </label>
+                      </td>
+                    </tr>
+                  )
+                }}
+              </For>
+            </tbody>
+          </table>
+
+          <div class="form-actions">
+            <button
+              type="button"
+              class="primary-button"
+              disabled={!canConfirm()}
+              onClick={() => void confirmSelected()}
+            >
+              {busy() ? m.app_saving() : m.personiomatch_confirm_selected()}
+            </button>
+          </div>
+
+          <Show when={error()}>
+            <span role="alert" class="form-status is-error">{error()}</span>
+          </Show>
+        </Show>
+      </section>
+    </div>
+  )
+}

--- a/src/Controller/Admin/ConfirmPersonioEmployeeMatchesAction.php
+++ b/src/Controller/Admin/ConfirmPersonioEmployeeMatchesAction.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function ctype_digit;
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_decode;
+
+/**
+ * Persist the admin-confirmed ADR-024 P3 employee-id matches: for each confirmed
+ * {user_id, person_id} the user's Personio employee id is set. A non-numeric
+ * Personio id or an unknown user is skipped (reported in the result), never
+ * written wrong. ROLE_ADMIN gated; validated then flushed once.
+ */
+final readonly class ConfirmPersonioEmployeeMatchesAction
+{
+    public function __construct(
+        private UserRepository $userRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    #[Route(path: '/personio/employee-matches/confirm', name: 'personio_employee_matches_confirm', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $content = $request->getContent();
+        $payload = json_decode('' !== $content ? $content : '{}', true);
+        $matches = is_array($payload) && is_array($payload['matches'] ?? null) ? $payload['matches'] : [];
+
+        $applied = [];
+        foreach ($matches as $match) {
+            if (!is_array($match)) {
+                continue;
+            }
+
+            $userId = $match['user_id'] ?? null;
+            $personId = $match['person_id'] ?? null;
+            // Personio employee ids are numeric (the column is a bigint); a
+            // non-numeric id is skipped rather than truncated to a wrong value.
+            if (!is_int($userId)) {
+                continue;
+            }
+            if (!is_string($personId)) {
+                continue;
+            }
+            if (!ctype_digit($personId)) {
+                continue;
+            }
+
+            $user = $this->userRepository->find($userId);
+            if (!$user instanceof User) {
+                continue;
+            }
+
+            $user->setPersonioEmployeeId((int) $personId);
+            $applied[] = ['user_id' => $userId, 'username' => (string) $user->getUsername(), 'person_id' => $personId];
+        }
+
+        $this->entityManager->flush();
+
+        return new JsonResponse(['applied' => $applied], Response::HTTP_OK);
+    }
+}

--- a/src/Controller/Admin/GetPersonioEmployeeMatchesAction.php
+++ b/src/Controller/Admin/GetPersonioEmployeeMatchesAction.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\DTO\Personio\EmployeeMatch;
+use App\Entity\PersonioConfig;
+use App\Repository\PersonioConfigRepository;
+use App\Repository\UserRepository;
+use App\Service\Personio\EmployeeMatcher;
+use App\Service\Personio\PersonioClientFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Throwable;
+
+use function array_map;
+
+/**
+ * Review screen backend (ADR-024 P3): list the proposed TT user -> Personio
+ * employee-id matches for the users that have no id yet, from the Persons API.
+ * Read-only — the admin confirms each row via the confirm endpoint. ROLE_ADMIN
+ * gates admin and PL alike here (a PL carries ROLE_ADMIN, v4 compat).
+ */
+final readonly class GetPersonioEmployeeMatchesAction
+{
+    public function __construct(
+        private PersonioConfigRepository $configRepository,
+        private UserRepository $userRepository,
+        private PersonioClientFactory $clientFactory,
+        private EmployeeMatcher $employeeMatcher,
+    ) {
+    }
+
+    #[Route(path: '/personio/employee-matches', name: 'personio_employee_matches', methods: ['GET'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function __invoke(): JsonResponse
+    {
+        $config = $this->configRepository->findActive();
+        if (!$config instanceof PersonioConfig) {
+            return new JsonResponse(['message' => 'No active Personio configuration.'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $users = $this->userRepository->findWithoutPersonioEmployeeId();
+        if ([] === $users) {
+            return new JsonResponse(['proposals' => []]);
+        }
+
+        try {
+            $persons = $this->clientFactory->create($config)->listPersons();
+        } catch (Throwable) {
+            return new JsonResponse(['message' => 'Could not reach Personio to list persons.'], Response::HTTP_BAD_GATEWAY);
+        }
+
+        $matches = $this->employeeMatcher->match($users, $persons);
+
+        return new JsonResponse(['proposals' => array_map($this->toArray(...), $matches)]);
+    }
+
+    /**
+     * @return array{user_id: int, username: string, person_id: string, person_name: string, source: string}
+     */
+    private function toArray(EmployeeMatch $employeeMatch): array
+    {
+        return [
+            'user_id' => $employeeMatch->userId,
+            'username' => $employeeMatch->username,
+            'person_id' => $employeeMatch->personId,
+            'person_name' => $employeeMatch->personName,
+            'source' => $employeeMatch->source,
+        ];
+    }
+}

--- a/tests/Controller/Admin/PersonioEmployeeMatchActionsTest.php
+++ b/tests/Controller/Admin/PersonioEmployeeMatchActionsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Controller\Admin;
+
+use App\Entity\PersonioConfig;
+use App\Entity\User;
+use App\Service\Personio\PersonioClient;
+use App\Service\Personio\PersonioClientFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+
+use function assert;
+use function json_decode;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * GET /personio/employee-matches and POST /personio/employee-matches/confirm
+ * (ADR-024 P3). The Personio client is stubbed in the container; fixture user
+ * 'developer' (id 2) starts without an employee id.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class PersonioEmployeeMatchActionsTest extends AbstractWebTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $entityManager = self::getContainer()->get('doctrine.orm.entity_manager');
+        assert($entityManager instanceof EntityManagerInterface);
+        $this->entityManager = $entityManager;
+    }
+
+    public function testProposalsMatchByEmailLocalpart(): void
+    {
+        $this->seedActiveConfig();
+        $this->stubPersons([
+            ['id' => '900', 'first_name' => 'Dev', 'last_name' => 'Eloper', 'email' => 'developer@netresearch.de'],
+        ]);
+
+        $this->client->request(Request::METHOD_GET, '/personio/employee-matches', [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertStatusCode(200);
+
+        $proposals = $this->responseData()['proposals'] ?? null;
+        self::assertIsArray($proposals);
+        $developer = null;
+        foreach ($proposals as $proposal) {
+            self::assertIsArray($proposal);
+            if ('developer' === ($proposal['username'] ?? null)) {
+                $developer = $proposal;
+            }
+        }
+
+        self::assertIsArray($developer);
+        self::assertSame('900', $developer['person_id']);
+        self::assertSame('email', $developer['source']);
+    }
+
+    public function testNoActiveConfigReturns422(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/personio/employee-matches', [], [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertStatusCode(422);
+    }
+
+    public function testConfirmAppliesEmployeeId(): void
+    {
+        $this->post(['matches' => [['user_id' => 2, 'person_id' => '900']]]);
+        $this->assertStatusCode(200);
+
+        $applied = $this->responseData()['applied'] ?? null;
+        self::assertIsArray($applied);
+        self::assertCount(1, $applied);
+
+        $this->entityManager->clear();
+        $developer = $this->entityManager->find(User::class, 2);
+        assert($developer instanceof User);
+        self::assertSame(900, $developer->getPersonioEmployeeId());
+    }
+
+    public function testConfirmSkipsNonNumericPersonId(): void
+    {
+        $this->post(['matches' => [['user_id' => 2, 'person_id' => 'not-numeric']]]);
+        $this->assertStatusCode(200);
+
+        $applied = $this->responseData()['applied'] ?? null;
+        self::assertIsArray($applied);
+        self::assertCount(0, $applied);
+
+        $this->entityManager->clear();
+        $developer = $this->entityManager->find(User::class, 2);
+        assert($developer instanceof User);
+        self::assertNull($developer->getPersonioEmployeeId());
+    }
+
+    private function seedActiveConfig(): void
+    {
+        $config = new PersonioConfig();
+        $config->setName('Test Personio')
+            ->setBaseUrl('https://api.personio.test')
+            ->setClientId('cid')
+            ->setClientSecret('secret')
+            ->setActive(true);
+        $this->entityManager->persist($config);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @param list<array{id: string, first_name: ?string, last_name: ?string, email: ?string}> $persons
+     */
+    private function stubPersons(array $persons): void
+    {
+        $client = self::createStub(PersonioClient::class);
+        $client->method('listPersons')->willReturn($persons);
+
+        $factory = self::createStub(PersonioClientFactory::class);
+        $factory->method('create')->willReturn($client);
+        self::getContainer()->set(PersonioClientFactory::class, $factory);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function post(array $payload): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/personio/employee-matches/confirm',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            json_encode($payload, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function responseData(): array
+    {
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+}


### PR DESCRIPTION
The final piece of **ADR-024 P3** — the frontend for the employee auto-match (until now CLI-only). Admins get a review screen instead of the console.

## What it does

A non-CRUD **Administration → Personio employee match** sub-page (beside the project-import review):

- Lists each TT user with **no Personio employee id yet** and its proposed match from the Persons API.
- **Confident e-mail matches are pre-checked**; the weaker `firstname.lastname` matches start unchecked so the admin looks first.
- `Confirm selected` writes the checked user→id mappings; the mapped users drop off on the refresh.

## Backend

- `GET /personio/employee-matches` — proposals (`EmployeeMatcher` over the unmapped users + `listPersons()`), ROLE_ADMIN.
- `POST /personio/employee-matches/confirm` — apply; a non-numeric Personio id or unknown user is **skipped, never written wrong**.

## Frontend

New `PersonioEmployeeMatch` page + API client, wired into `Admin.tsx` and `SidebarAdminMenu`; messages added to all five catalogs (en/de/es/fr/ru).

## Verification (in-container)

Backend: PHPStan L10, php-cs-fixer, phpat, rector clean; action tests (match-by-email, no-config 422, confirm applies, non-numeric skipped); controller suite 390/390. Frontend: typecheck + eslint clean; page tests (pre-check only e-mail, posts checked rows incl. a11y axe pass); full frontend suite 527/527. Routes + DI boot.

This completes ADR-024 P3 (auto-match CLI #607, API/MCP triggers #608, and this UI).