### PR TITLE
fix(sync): derive imported worklog day/start in explicit UTC, not the default TZ

### DIFF
--- a/src/Service/Sync/EntryPullApplier.php
+++ b/src/Service/Sync/EntryPullApplier.php
@@ -56,7 +56,7 @@ class EntryPullApplier
         // Compute new times before mutating (same setTimestamp idiom as import).
         $newDuration = $pullDuration ? $remote->durationMinutes : $entry->getDuration();
         if ($pullStarted) {
-            $start = new DateTime()->setTimestamp($remote->startedTimestamp);
+            $start = $remote->startedAtUtc();
         } else {
             $start = DateTime::createFromInterface($entry->getDay());
             $start->setTime(

--- a/src/Service/Sync/ImportWorklogsService.php
+++ b/src/Service/Sync/ImportWorklogsService.php
@@ -532,7 +532,7 @@ class ImportWorklogsService extends AbstractSyncRunService
      */
     private function buildTimes(WorklogSnapshot $worklogSnapshot): ?array
     {
-        $day = new DateTime()->setTimestamp($worklogSnapshot->startedTimestamp);
+        $day = $worklogSnapshot->startedAtUtc();
         $start = clone $day;
         $end = (clone $start)->modify(sprintf('+%d minutes', $worklogSnapshot->durationMinutes));
 

--- a/src/ValueObject/Sync/WorklogSnapshot.php
+++ b/src/ValueObject/Sync/WorklogSnapshot.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\ValueObject\Sync;
 
 use App\Enum\WorklogField;
+use DateTime;
 use InvalidArgumentException;
 
 use function is_int;
@@ -32,6 +33,20 @@ final readonly class WorklogSnapshot
     public function equals(self $other): bool
     {
         return [] === $this->diff($other);
+    }
+
+    /**
+     * The worklog start as a UTC DateTime. The imported day/start MUST NOT depend
+     * on the runtime's date.timezone: the timestamp is an absolute instant (the
+     * normalizer built it from Jira's ISO `started`, which the NR-JIRA Server
+     * labels `+0000`), so rendering it in UTC recovers the same wall-clock the
+     * worklog carries — on any server config. A fresh mutable DateTime each call,
+     * so callers may clone/modify it.
+     */
+    public function startedAtUtc(): DateTime
+    {
+        // '@'-prefixed constructor is always UTC, independent of the default TZ.
+        return new DateTime('@' . $this->startedTimestamp);
     }
 
     /**

--- a/tests/ValueObject/Sync/WorklogSnapshotTest.php
+++ b/tests/ValueObject/Sync/WorklogSnapshotTest.php
@@ -11,6 +11,7 @@ namespace Tests\ValueObject\Sync;
 
 use App\Enum\WorklogField;
 use App\ValueObject\Sync\WorklogSnapshot;
+use DateTime;
 use PHPUnit\Framework\TestCase;
 
 final class WorklogSnapshotTest extends TestCase
@@ -24,6 +25,27 @@ final class WorklogSnapshotTest extends TestCase
     {
         self::assertTrue($this->snapshot()->equals($this->snapshot()));
         self::assertSame([], $this->snapshot()->diff($this->snapshot()));
+    }
+
+    public function testStartedAtUtcIsIndependentOfTheDefaultTimezone(): void
+    {
+        $timestamp = 1751871600;
+        $previous = date_default_timezone_get();
+        // A non-UTC default would have shifted the old `new DateTime()->setTimestamp()`
+        // idiom — the helper must render the same wall-clock regardless.
+        date_default_timezone_set('Europe/Berlin');
+        try {
+            $started = $this->snapshot(started: $timestamp)->startedAtUtc();
+
+            self::assertSame(0, $started->getOffset());
+            self::assertSame(gmdate('Y-m-d H:i:s', $timestamp), $started->format('Y-m-d H:i:s'));
+            // Proof the default TZ would otherwise have shifted it: the Berlin
+            // render of the same instant differs from the UTC wall-clock.
+            $berlinRender = new DateTime()->setTimestamp($timestamp);
+            self::assertNotSame($berlinRender->format('H:i'), $started->format('H:i'));
+        } finally {
+            date_default_timezone_set($previous);
+        }
     }
 
     public function testDiffListsEveryChangedField(): void


### PR DESCRIPTION
## Why

Found during the live NR-JIRA verification. The worklog import derives the entry **day + start** from the worklog's `started` via:

```php
$day = new DateTime()->setTimestamp($snapshot->startedTimestamp);
```

`new DateTime()->setTimestamp()` renders in the runtime's `date.timezone`. It is correct **today** only because prod runs **UTC** and NR-JIRA Server 9.12.3 labels `started` as `+0000` — a **silent dependency**. If `date.timezone` were ever set to `Europe/Berlin`, every imported start would shift by the offset and late-evening worklogs would cross midnight onto the **wrong day**.

## Fix

- `WorklogSnapshot::startedAtUtc()` — a `'@'`-constructed, always-UTC `DateTime`.
- Used in `ImportWorklogsService::buildTimes()` and `EntryPullApplier`, so the day/start **and** the midnight-crossing guard no longer depend on the server's timezone config.

Behaviour is unchanged on the UTC prod (all existing sync tests pass); a new test pins the independence by deriving under `Europe/Berlin` and asserting the UTC wall-clock is preserved.

## Live verification (NR-JIRA Server 9.12.3, project TEST)

Read + write round-trip confirmed the contract this rests on: `started` posts and reads back as `…+0000` unchanged, `timeSpentSeconds`/`comment` preserved, author is the Server `name`/`emailAddress` (no Cloud `accountId`). The write test created a worklog on a TEST issue and deleted it (204 → 404, no trace left).

## Gates

PHPStan L10, php-cs-fixer, phpat, rector clean. Full unit suite 1931/1931.