### PR TITLE
fix(security): block editing another user's entry via saveAction (IDOR) [v4]

### DIFF
--- a/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
+++ b/src/Netresearch/TimeTrackerBundle/Controller/CrudController.php
@@ -276,6 +276,23 @@ class CrudController extends BaseController
             if($request->get('id') != 0) {
                 $entry = $doctrine->getRepository('NetresearchTimeTrackerBundle:Entry')
                     ->find($request->get('id'));
+
+                if (!$entry) {
+                    $message = $this->get('translator')->trans('No entry for id.');
+                    return new Error($message, 404);
+                }
+
+                // Security fix: a user may only edit their OWN entry. Without this
+                // an attacker could POST save with another user's entry id and
+                // overwrite it — even reassigning ownership to themselves (setUser
+                // below). Mirrors v6 SaveEntryAction's "already owned by a different
+                // user" guard; unlike delete there is no PL bypass — nobody rewrites
+                // another user's entry.
+                $owner = $entry->getUser();
+                if (!is_object($owner) || $owner->getId() != $this->getUserId($request)) {
+                    $message = $this->get('translator')->trans('You are not allowed to edit this entry.');
+                    return new Error($message, 403);
+                }
             } else {
                 $entry = new Entry();
             }

--- a/tests/src/Netresearch/TimeTrackerBundle/Controller/CrudControllerTest.php
+++ b/tests/src/Netresearch/TimeTrackerBundle/Controller/CrudControllerTest.php
@@ -131,6 +131,26 @@ class CrudControllerTest extends BaseTest
         $this->assertStatusCode(403, 'A developer must not be able to delete a foreign entry');
     }
 
+    public function testSaveForeignEntryIsForbidden()
+    {
+        // Security (IDOR fix): a plain developer must not EDIT another user's
+        // entry. 'developer' is loginId 2 (type DEV); entry 2 is owned by user 1
+        // (i.myself, a PL), so it is foreign. Without the ownership guard,
+        // saveAction would load entry 2, reassign it to the developer (setUser)
+        // and overwrite its fields — an IDOR write, worse than the delete one.
+        $this->logInSession('developer');
+        $this->client->request('POST', '/tracking/save', [
+            'id'       => 2,
+            'start'    => '10:00:00',
+            'end'      => '10:30:00',
+            'project'  => 1,
+            'customer' => 1,
+            'activity' => 1,
+            'date'     => '2024-01-01',
+        ]);
+        $this->assertStatusCode(403, 'A developer must not be able to edit a foreign entry');
+    }
+
     //-------------- Bulkentry routes ----------------------------------------
 
     public function testBulkentryActionNonExistendPreset()


### PR DESCRIPTION
## Vulnerability (IDOR write)

`CrudController::saveAction` loads an entry by the request `id` **without an ownership check**, then unconditionally `setUser(currentUser)` and overwrites its fields:

```php
if ($request->get('id') != 0) {
    $entry = $repo->find($request->get('id'));   // any entry, no owner check
}
// ...
$entry->setUser($currentUser);                    // reassigns ownership
```

A logged-in user can POST `/tracking/save` with **another user's entry id** to overwrite that entry's content **and reassign its ownership to themselves**. It is the same IDOR class as the already-fixed delete path — and worse (alter + steal, not just remove).

## Fix

Guard the edit path before any mutation, mirroring the merged delete-IDOR guard and v6 `SaveEntryAction`'s "already owned by a different user" policy:

- non-existent id → **404**
- entry owned by a different user (or a null owner) → **403**

Unlike delete there is **no PL bypass** — nobody rewrites another user's entry (matches v6).

Adds `testSaveForeignEntryIsForbidden` (developer editing a PL-owned entry → 403), alongside the existing `testDeleteForeignEntryIsForbidden`.

## ⚠️ Verification status — read before merge

This is a **legacy/EOL** branch (Symfony 3 / PHP 7) with **no test CI** and a stack that is not runnable in the current workspace. The fix is:

- **syntax-checked** (`php -l` clean on both files),
- **pattern-verified** against the merged delete-IDOR guard (#564) and v6's proven `SaveEntryAction` policy.

The added functional test was **NOT executed locally**. Please run `phpunit` in a v4-compatible env before merging, or I can set up a minimal test workflow / env if you want it actually gated.