### PR TITLE
fix(settings): screen-reader follow-ups from #613

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -179,37 +179,3 @@ export async function getTimeSummary(page: Page): Promise<{
   }
   return await response.json();
 }
-
-/**
- * Get settings data from page context
- */
-export async function getSettingsData(page: Page): Promise<Record<string, unknown>> {
-  return await page.evaluate(() => {
-    return (globalThis as unknown as { settingsData: Record<string, unknown> }).settingsData;
-  });
-}
-
-/**
- * Save user settings via PATCH /api/v2/settings (partial update — absent
- * fields stay unchanged). Returns the persisted settings the API echoes.
- */
-export async function saveSettings(
-  page: Page,
-  settings: {
-    show_empty_line?: boolean;
-    suggest_time?: boolean;
-    show_future?: boolean;
-    locale?: string;
-  }
-): Promise<Record<string, unknown>> {
-  const response = await page.request.patch('/api/v2/settings', {
-    data: settings,
-  });
-
-  if (!response.ok()) {
-    const error = await response.text();
-    throw new Error(`Failed to save settings: ${error}`);
-  }
-
-  return await response.json();
-}

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -200,9 +200,10 @@ test.describe('Settings locale reload', () => {
   test('changing the locale reloads onto the same settings section', async ({ page }) => {
     await goToSettingsPage(page, 'account');
 
-    // The section hydrates its locale <select> from GET /api/v2/settings on
-    // mount; wait for the hydrated German default so the test changes a
-    // settled form from a known baseline, not the pre-hydration value.
+    // Readiness gate only: the select is seeded from APP_CONFIG before the
+    // mount-time GET resolves, and both carry the same DB value ('de'), so
+    // this cannot distinguish pre- from post-hydration. A user edit racing
+    // the GET is protected by AccountSection's touched guard, not this wait.
     const locale = page.locator('select[name="locale"]');
     await expect(locale).toHaveValue('de');
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -201,8 +201,8 @@ test.describe('Settings locale reload', () => {
     await goToSettingsPage(page, 'account');
 
     // The section hydrates its locale <select> from GET /api/v2/settings on
-    // mount; wait for that to settle (German default) before changing it, so the
-    // resolving GET can't reset the new selection.
+    // mount; wait for the hydrated German default so the test changes a
+    // settled form from a known baseline, not the pre-hydration value.
     const locale = page.locator('select[name="locale"]');
     await expect(locale).toHaveValue('de');
 

--- a/frontend/src/components/ApiTokenControls.test.tsx
+++ b/frontend/src/components/ApiTokenControls.test.tsx
@@ -51,6 +51,9 @@ describe('ApiTokenControls', () => {
 
     await waitFor(() => expect(screen.getByLabelText('entries:read')).toBeInTheDocument())
     expect(screen.getByLabelText('projects:write')).toBeInTheDocument()
+    // Exact group name: the "Help: …" trigger inside the legend is kept out of
+    // the accessible name by the fieldset's aria-labelledby.
+    expect(screen.getByRole('group', { name: 'Scopes' })).toBeInTheDocument()
   })
 
   it('prevents selecting a past expiry date', async () => {

--- a/frontend/src/components/ApiTokenControls.tsx
+++ b/frontend/src/components/ApiTokenControls.tsx
@@ -214,9 +214,12 @@ export function ApiTokenControls(): JSX.Element {
           />
         </label>
 
-        <fieldset class="apitoken-scopes-picker">
+        {/* aria-labelledby names the group from the label span alone: the help
+            trigger keeps its visual spot in the legend, but its "Help: …"
+            aria-label stays out of the group's accessible name. */}
+        <fieldset class="apitoken-scopes-picker" aria-labelledby="apitoken-scopes-label">
           <legend>
-            {m.settings_apitoken_scopes_label()}
+            <span id="apitoken-scopes-label">{m.settings_apitoken_scopes_label()}</span>
             <HelpPopover topic={m.settings_apitoken_scopes_label()}>{m.settings_help_token_scopes()}</HelpPopover>
           </legend>
 

--- a/frontend/src/components/SecuritySection.test.tsx
+++ b/frontend/src/components/SecuritySection.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
 
 const postJson = vi.fn()
 
@@ -58,6 +59,17 @@ describe('SecuritySection', () => {
     configure({ localAccount: false })
     render(() => <SecuritySection />)
     expect(screen.queryByLabelText('Current password')).toBeNull()
+  })
+
+  it('exposes the section title once — as both the group name and the h2 outline entry', async () => {
+    const { container } = render(() => <SecuritySection />)
+
+    // The h2 lives inside the legend: one text node serves the outline AND the
+    // group name, so the title is announced once, not twice.
+    expect(screen.getByRole('group', { name: 'Security' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Security' })).toBeInTheDocument()
+
+    expect(await axe(container)).toHaveNoViolations()
   })
 
   it('rejects mismatched new passwords without calling the API', async () => {

--- a/frontend/src/components/SecuritySection.test.tsx
+++ b/frontend/src/components/SecuritySection.test.tsx
@@ -72,6 +72,21 @@ describe('SecuritySection', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
+  it('keeps the help triggers out of the sub-block heading names', async () => {
+    passkeysAvailable = true
+    render(() => <SecuritySection />)
+
+    // Exact names: each "Help: …" trigger is a sibling of its h3, not a child.
+    expect(screen.getByRole('heading', { level: 3, name: 'Two-factor authentication' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: 'Passkeys' })).toBeInTheDocument()
+    // The triggers themselves are still reachable under their own names.
+    expect(screen.getByRole('button', { name: 'Help: Two-factor authentication' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Help: Passkeys' })).toBeInTheDocument()
+
+    // The resource behind the passkey list settles before teardown.
+    await waitFor(() => expect(listPasskeys).toHaveBeenCalled())
+  })
+
   it('rejects mismatched new passwords without calling the API', async () => {
     render(() => <SecuritySection />)
     fireEvent.input(screen.getByLabelText('Current password'), { target: { value: 'oldpass12' } })

--- a/frontend/src/components/SecuritySection.tsx
+++ b/frontend/src/components/SecuritySection.tsx
@@ -35,11 +35,12 @@ export function SecuritySection(): JSX.Element {
   return (
     <div class="stack-form">
       {/* One h2 per settings section so the sub-headings (Passkeys, 2FA, …) nest
-          under an h2 rather than skipping h1 → h3; visually-hidden because the
-          fieldset legend already shows the title. */}
-      <h2 class="visually-hidden">{m.settings_section_security()}</h2>
+          under an h2 rather than skipping h1 → h3. The h2 lives INSIDE the
+          legend: a single text node serves both the outline and the group name,
+          so screen readers don't announce the title twice (hidden heading +
+          identically-named legend). */}
       <fieldset class="settings-group">
-        <legend>{m.settings_section_security()}</legend>
+        <legend><h2>{m.settings_section_security()}</h2></legend>
         <p class="settings-section-hint">{m.settings_section_security_hint()}</p>
 
         <TwoFactorControls initiallyEnabled={config.totpEnabled} />

--- a/frontend/src/components/SecuritySection.tsx
+++ b/frontend/src/components/SecuritySection.tsx
@@ -96,10 +96,12 @@ export function PasskeyControls(props: Readonly<{ onRegistered?: () => void }> =
 
   return (
     <div class="security-block">
-      <h3 class="security-heading">
-        {m.settings_passkey_heading()}
+      {/* The help trigger is a SIBLING of the h3, not a child, so its
+          "Help: …" aria-label stays out of the heading's accessible name. */}
+      <div class="security-heading-row">
+        <h3 class="security-heading">{m.settings_passkey_heading()}</h3>
         <HelpPopover topic={m.settings_passkey_heading()}>{m.settings_help_passkeys()}</HelpPopover>
-      </h3>
+      </div>
       <p class="field-hint">{m.settings_passkey_hint()}</p>
 
       <Show when={(passkeys()?.length ?? 0) > 0}>
@@ -276,10 +278,12 @@ export function TwoFactorControls(props: Readonly<{ initiallyEnabled: boolean; o
 
   return (
     <div class="security-block">
-      <h3 class="security-heading">
-        {m.settings_2fa_heading()}
+      {/* The help trigger is a SIBLING of the h3, not a child, so its
+          "Help: …" aria-label stays out of the heading's accessible name. */}
+      <div class="security-heading-row">
+        <h3 class="security-heading">{m.settings_2fa_heading()}</h3>
         <HelpPopover topic={m.settings_2fa_heading()}>{m.settings_help_totp()}</HelpPopover>
-      </h3>
+      </div>
 
       {/* Backup codes are shown exactly once, right after a successful enrolment. */}
       <Show when={backupCodes()}>

--- a/frontend/src/components/WorklogImportSection.test.tsx
+++ b/frontend/src/components/WorklogImportSection.test.tsx
@@ -73,6 +73,10 @@ describe('WorklogImportSection', () => {
     // Reference selects populate from the mocked endpoints.
     await waitFor(() => expect(screen.getByRole('option', { name: 'Jira Cloud' })).toBeInTheDocument())
 
+    // Exact group name: the "Help: …" trigger inside the legend is kept out of
+    // the accessible name by the fieldset's aria-labelledby.
+    expect(screen.getByRole('group', { name: 'Import Jira worklogs' })).toBeInTheDocument()
+
     fireEvent.change(screen.getByLabelText('Ticket system'), { target: { value: '1' } })
     fireEvent.change(screen.getByLabelText('Default activity'), { target: { value: '2' } })
 

--- a/frontend/src/components/WorklogImportSection.tsx
+++ b/frontend/src/components/WorklogImportSection.tsx
@@ -80,9 +80,12 @@ export function WorklogImportSection(): JSX.Element {
 
   return (
     <div class="stack-form">
-      <fieldset class="settings-group">
+      {/* aria-labelledby names the group from the title span alone: the help
+          trigger keeps its visual spot in the legend, but its "Help: …"
+          aria-label stays out of the group's accessible name. */}
+      <fieldset class="settings-group" aria-labelledby="worklog-import-title">
         <legend>
-          {m.worklogsync_import_title()}
+          <span id="worklog-import-title">{m.worklogsync_import_title()}</span>
           <HelpPopover topic={m.worklogsync_import_title()}>{m.settings_help_import_dryrun()}</HelpPopover>
         </legend>
         <p class="settings-section-hint">{m.worklogsync_import_intro()}</p>

--- a/frontend/src/components/settings/AccountSection.test.tsx
+++ b/frontend/src/components/settings/AccountSection.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
 
 import { AccountSection } from './AccountSection'
 
@@ -116,10 +117,13 @@ describe('AccountSection', () => {
     expect(values).toEqual(['de', 'en', 'es', 'fr', 'ru'])
   })
 
-  it('renders as a labeled group whose fields the save form submits', () => {
-    const { getByRole, getByText } = render(() => <AccountSection />)
+  it('renders as a labeled group whose fields the save form submits', async () => {
+    const { container, getByRole, getByText } = render(() => <AccountSection />)
 
     const account = getByRole('group', { name: 'Account' })
+    // The h2 lives inside the legend: the same node names the group and enters
+    // the page outline, so the title is announced once, not twice.
+    expect(getByRole('heading', { level: 2, name: 'Account' })).toBeInTheDocument()
     // The section states its save semantics right under the title.
     expect(getByText(/press Save to apply/)).toBeInTheDocument()
 
@@ -135,5 +139,7 @@ describe('AccountSection', () => {
     expect(form.querySelector('button[type="submit"]')).not.toBeNull()
     // The Personio opt-in moved to the Sync section — not part of this form.
     expect(form.querySelector('input[name="personio_sync_enabled"]')).toBeNull()
+
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/components/settings/AccountSection.tsx
+++ b/frontend/src/components/settings/AccountSection.tsx
@@ -107,11 +107,12 @@ export function AccountSection() {
 
   return (
     <form class="stack-form" onInput={() => setTouched(true)} onSubmit={(event) => void onSubmit(event)}>
-      {/* One h2 per settings section so the page outline is h1 → h2 (→ h3);
-          visually-hidden because the fieldset legend already shows the title. */}
-      <h2 class="visually-hidden">{m.settings_section_account()}</h2>
+      {/* One h2 per settings section so the page outline is h1 → h2 (→ h3).
+          The h2 lives INSIDE the legend: a single text node serves both the
+          outline and the group name, so screen readers don't announce the
+          title twice (hidden heading + identically-named legend). */}
       <fieldset class="settings-group">
-        <legend>{m.settings_section_account()}</legend>
+        <legend><h2>{m.settings_section_account()}</h2></legend>
         <p class="settings-section-hint">{m.settings_section_account_hint()}</p>
 
         <label class="field">

--- a/frontend/src/components/settings/AppearanceSection.test.tsx
+++ b/frontend/src/components/settings/AppearanceSection.test.tsx
@@ -27,6 +27,9 @@ describe('AppearanceSection', () => {
     const { getByRole, getByText } = render(() => <AppearanceSection />)
 
     const device = getByRole('group', { name: 'Appearance' })
+    // The h2 lives inside the legend: the same node names the group and enters
+    // the page outline, so the title is announced once, not twice.
+    expect(getByRole('heading', { level: 2, name: 'Appearance' })).toBeInTheDocument()
     // The section states its save semantics right under the title.
     expect(getByText(/apply immediately — no Save needed/)).toBeInTheDocument()
 

--- a/frontend/src/components/settings/AppearanceSection.tsx
+++ b/frontend/src/components/settings/AppearanceSection.tsx
@@ -68,11 +68,12 @@ export function AppearanceSection() {
        wrapper is a div (not a sectioning element): the accessible group
        name comes from the fieldset's legend. */
     <div class="stack-form">
-      {/* One h2 per settings section so the page outline is h1 → h2;
-          visually-hidden because the fieldset legend already shows the title. */}
-      <h2 class="visually-hidden">{m.settings_nav_appearance()}</h2>
+      {/* One h2 per settings section so the page outline is h1 → h2.
+          The h2 lives INSIDE the legend: a single text node serves both the
+          outline and the group name, so screen readers don't announce the
+          title twice (hidden heading + identically-named legend). */}
       <fieldset class="settings-group">
-        <legend>{m.settings_nav_appearance()}</legend>
+        <legend><h2>{m.settings_nav_appearance()}</h2></legend>
         <p class="settings-section-hint settings-instant-badge">{m.settings_section_device_hint()}</p>
 
         <label class="field">

--- a/frontend/src/components/settings/TokensSection.tsx
+++ b/frontend/src/components/settings/TokensSection.tsx
@@ -6,11 +6,12 @@ import { ApiTokenControls } from '../ApiTokenControls'
 export function TokensSection() {
   return (
     <div class="stack-form">
-      {/* One h2 per settings section so the page outline is h1 → h2;
-          visually-hidden because the fieldset legend already shows the title. */}
-      <h2 class="visually-hidden">{m.settings_apitoken_heading()}</h2>
+      {/* One h2 per settings section so the page outline is h1 → h2.
+          The h2 lives INSIDE the legend: a single text node serves both the
+          outline and the group name, so screen readers don't announce the
+          title twice (hidden heading + identically-named legend). */}
       <fieldset class="settings-group">
-        <legend>{m.settings_apitoken_heading()}</legend>
+        <legend><h2>{m.settings_apitoken_heading()}</h2></legend>
         <ApiTokenControls />
       </fieldset>
     </div>

--- a/frontend/src/pages/Settings.test.tsx
+++ b/frontend/src/pages/Settings.test.tsx
@@ -44,8 +44,9 @@ describe('Settings shell', () => {
     const { getByRole, queryByRole, unmount } = renderSettings('/settings/security')
 
     expect(getByRole('group', { name: 'Security' })).toBeInTheDocument()
-    // Prefix match: the heading's accessible name also carries its help trigger.
-    expect(getByRole('heading', { name: /^Two-factor authentication/ })).toBeInTheDocument()
+    // Exact match: the help trigger sits beside the h3, so its "Help: …"
+    // aria-label is not part of the heading's accessible name.
+    expect(getByRole('heading', { name: 'Two-factor authentication' })).toBeInTheDocument()
     // Only the active section mounts — account is gone.
     expect(queryByRole('group', { name: 'Account' })).not.toBeInTheDocument()
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1127,6 +1127,14 @@ main:has(.tracking) {
   margin: 0;
 }
 
+/* Sub-block heading + its help trigger on one line. The trigger sits BESIDE
+   the h3 (not inside it) so its "Help: …" aria-label stays out of the
+   heading's accessible name; the trigger's own margin provides the gap. */
+.security-heading-row {
+  align-items: center;
+  display: flex;
+}
+
 /* A one-line state (hint or "2FA is on") next to its action button. Wraps on a
    narrow container so the button never overflows. */
 .security-row {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -912,6 +912,15 @@ main:has(.tracking) {
   padding: 0;
 }
 
+/* The section heading sits INSIDE the legend (one text node names the group
+   AND enters the h1 → h2 outline), so it adopts the legend's styling rather
+   than the .form-page h2 page-title look. */
+.settings-group > legend > h2 {
+  font: inherit;
+  letter-spacing: inherit;
+  margin: 0;
+}
+
 /* One-line answer to "when do these settings apply?", under the title. */
 .settings-section-hint {
   color: var(--color-text-muted);


### PR DESCRIPTION
## Description

The three accessibility/cleanup follow-ups called out in #613's "Known follow-ups" section.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Related Issue

Follow-ups from #613.

## Changes Made

- **Double screen-reader announcement**: each settings section's visually-hidden `h2` duplicated the fieldset `legend` text. The `h2` now lives *inside* the `legend` (valid HTML), so one text node serves both the heading outline and the group name; a scoped CSS reset keeps the rendered title pixel-identical. SyncSection keeps its hidden `h2` — its three legends carry different titles, so no duplication existed there.
- **Help triggers in accessible names**: the `HelpPopover` buttons sat inside `h3`/`legend` elements, concatenating "Help: …" into heading and group names. Security `h3`s now sit beside their trigger in a flex row; the two fieldsets whose legend held a trigger are named via `aria-labelledby` on a title span. The heading-name test queries are back to exact-match strings (the prefix regex loosened in #613 is reverted) and two axe checks were added.
- **e2e cleanup**: caller-less `saveSettings`/`getSettingsData` removed from `e2e/helpers/api.ts` (zero callers proven by grep); the locale-wait comment in `settings.spec.ts` now states its actual rationale (readiness gate — the edit-vs-hydration race is guarded in `AccountSection`, not by the wait).

## Testing

- [x] Unit tests pass (frontend 541 tests, incl. new exact-name and axe assertions)
- [x] Static analysis passes (eslint, tsc)
- [x] Manual testing completed (accessibility tree verified in the browser: exact group/heading names, popover still opens)
- [x] E2E tests pass (`settings.spec.ts` + `accessibility.spec.ts`, 15/15)

## Code Quality

- [x] Code follows project coding standards
- [x] Self-review completed (adversarial review pass; its one finding fixed on the branch)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or properly documented)

## Screenshots

Rendering is unchanged by design (scoped `legend > h2` reset); verification screenshots of all four sections are available on request.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/netresearch/timetracker/blob/main/CONTRIBUTING.md) guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/netresearch/timetracker/blob/main/CODE_OF_CONDUCT.md)
