### PR TITLE
fix(mcp): guard-test completeness, CI-run the MCP suite, declare outputSchema on the list tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           COMPOSE_PROFILES: e2e
         run: |
           docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=coverage app-e2e \
-            php -d memory_limit=2G bin/phpunit --testsuite integration,controller,api-functional --coverage-clover var/coverage/integration.xml
+            php -d memory_limit=2G bin/phpunit --testsuite integration,controller,api-functional,mcp --coverage-clover var/coverage/integration.xml
 
       - name: Upload integration coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -96,6 +96,10 @@
         <testsuite name="api-functional">
             <directory>tests/Api/Functional</directory>
         </testsuite>
+        <!-- MCP tool tests - container-level tool calls with real database, for CI -->
+        <testsuite name="mcp">
+            <directory>tests/Mcp</directory>
+        </testsuite>
     </testsuites>
     <php>
         <server name="APP_ENV" value="test" force="true"/>

--- a/src/Mcp/Tool/ListActivitiesTool.php
+++ b/src/Mcp/Tool/ListActivitiesTool.php
@@ -36,7 +36,27 @@ final readonly class ListActivitiesTool
      *
      * @return array{activities: list<array{id: int, name: string, needs_ticket: bool}>}
      */
-    #[McpTool(name: 'list_activities', description: 'List the activities a time entry can be booked against.')]
+    #[McpTool(
+        name: 'list_activities',
+        description: 'List the activities a time entry can be booked against.',
+        outputSchema: [
+            'type' => 'object',
+            'required' => ['activities'],
+            'properties' => [
+                'activities' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'id' => ['type' => 'integer'],
+                            'name' => ['type' => 'string'],
+                            'needs_ticket' => ['type' => 'boolean'],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    )]
     public function listActivities(): array
     {
         $this->scopeGuard->requireScope('activities:read');

--- a/src/Mcp/Tool/ListProjectsTool.php
+++ b/src/Mcp/Tool/ListProjectsTool.php
@@ -36,7 +36,29 @@ final readonly class ListProjectsTool
      *
      * @return array{projects: list<array{id: int|null, name: string, customer: string|null, customer_id: int|null, ticket_prefixes: string|null}>}
      */
-    #[McpTool(name: 'list_projects', description: 'List bookable projects (active or global) to log time against.')]
+    #[McpTool(
+        name: 'list_projects',
+        description: 'List bookable projects (active or global) to log time against.',
+        outputSchema: [
+            'type' => 'object',
+            'required' => ['projects'],
+            'properties' => [
+                'projects' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'id' => ['type' => ['integer', 'null']],
+                            'name' => ['type' => 'string'],
+                            'customer' => ['type' => ['string', 'null']],
+                            'customer_id' => ['type' => ['integer', 'null']],
+                            'ticket_prefixes' => ['type' => ['string', 'null']],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    )]
     public function listProjects(
         #[Schema(description: 'Only projects for this customer id; omit for all customers.')]
         ?int $customerId = null,

--- a/src/Mcp/Tool/ListRecentEntriesTool.php
+++ b/src/Mcp/Tool/ListRecentEntriesTool.php
@@ -41,7 +41,23 @@ final readonly class ListRecentEntriesTool
      *
      * @return array{entries: list<array<string, mixed>>}
      */
-    #[McpTool(name: 'list_recent_entries', description: "List the authenticated user's own recent time entries.")]
+    #[McpTool(
+        name: 'list_recent_entries',
+        description: "List the authenticated user's own recent time entries.",
+        // The entry item shape (Entry::toArray()) is wide and evolves — keep the
+        // item schema permissive so shape drift never becomes a client-side
+        // validation failure.
+        outputSchema: [
+            'type' => 'object',
+            'required' => ['entries'],
+            'properties' => [
+                'entries' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'object'],
+                ],
+            ],
+        ],
+    )]
     public function listRecentEntries(
         #[Schema(description: 'How many days back to include (1–90).', minimum: 1, maximum: 90)]
         int $days = 7,

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -460,6 +460,35 @@ final class McpToolsTest extends AbstractWebTestCase
     }
 
     /**
+     * The list tools declare an explicit outputSchema so strict clients can
+     * validate the object-shaped results (#585). MCP (and the SDK's Tool
+     * schema) require a declared outputSchema to be of type "object" — a
+     * violation would only surface client-side, so guard it here.
+     */
+    public function testListToolsDeclareAnObjectOutputSchema(): void
+    {
+        $schemas = [];
+        foreach ($this->declaredToolAttributes() as $mcpTool) {
+            if (is_string($mcpTool->name)) {
+                $schemas[$mcpTool->name] = $mcpTool->outputSchema;
+            }
+        }
+
+        foreach (['list_activities', 'list_projects', 'list_recent_entries'] as $tool) {
+            self::assertArrayHasKey($tool, $schemas);
+            self::assertNotNull($schemas[$tool], sprintf('%s must declare an outputSchema (#585)', $tool));
+        }
+
+        foreach ($schemas as $tool => $outputSchema) {
+            if (null === $outputSchema) {
+                continue;
+            }
+
+            self::assertSame('object', $outputSchema['type'] ?? null, sprintf('%s: a declared outputSchema must be of type "object"', $tool));
+        }
+    }
+
+    /**
      * A persisted run + parked conflict state for the sync tools, with the
      * Jira- and Personio-touching services mocked in the container (ADR-023 §6).
      *
@@ -544,6 +573,25 @@ final class McpToolsTest extends AbstractWebTestCase
     private function declaredToolNames(): array
     {
         $names = [];
+        foreach ($this->declaredToolAttributes() as $mcpTool) {
+            if (is_string($mcpTool->name)) {
+                $names[] = $mcpTool->name;
+            }
+        }
+
+        sort($names);
+
+        return $names;
+    }
+
+    /**
+     * All #[McpTool] attribute instances declared under src/Mcp/Tool.
+     *
+     * @return list<McpTool>
+     */
+    private function declaredToolAttributes(): array
+    {
+        $attributes = [];
         $files = glob(dirname(__DIR__, 2) . '/src/Mcp/Tool/*.php');
         self::assertNotFalse($files);
         foreach ($files as $file) {
@@ -551,16 +599,11 @@ final class McpToolsTest extends AbstractWebTestCase
             $class = 'App\\Mcp\\Tool\\' . basename($file, '.php');
             foreach (new ReflectionClass($class)->getMethods() as $method) {
                 foreach ($method->getAttributes(McpTool::class) as $attribute) {
-                    $name = $attribute->newInstance()->name;
-                    if (is_string($name)) {
-                        $names[] = $name;
-                    }
+                    $attributes[] = $attribute->newInstance();
                 }
             }
         }
 
-        sort($names);
-
-        return $names;
+        return $attributes;
     }
 }

--- a/tests/Mcp/McpToolsTest.php
+++ b/tests/Mcp/McpToolsTest.php
@@ -40,6 +40,7 @@ use App\Mcp\Tool\OnboardCustomerTool;
 use App\Mcp\Tool\OnboardProjectTool;
 use App\Mcp\Tool\OnboardUserTool;
 use App\Mcp\Tool\ResolveSyncConflictTool;
+use App\Mcp\Tool\RunPersonioSyncTool;
 use App\Mcp\Tool\SaveContractTool;
 use App\Mcp\Tool\SaveTeamTool;
 use App\Mcp\Tool\SaveTicketSystemTool;
@@ -52,6 +53,7 @@ use App\Repository\ActivityRepository;
 use App\Repository\ProjectRepository;
 use App\Repository\UserRepository;
 use App\Security\ApiToken\ApiAccessToken;
+use App\Service\Personio\AttendanceExportService;
 use App\Service\Sync\ConflictResolutionService;
 use App\Service\Sync\VerifyWorklogsService;
 use App\ValueObject\Sync\ResolutionResult;
@@ -434,6 +436,7 @@ final class McpToolsTest extends AbstractWebTestCase
             'onboard_project' => $container->get(OnboardProjectTool::class)->onboardProject(name: 'Guard Project', customer: '1'),
             'onboard_user' => $container->get(OnboardUserTool::class)->onboardUser(username: 'guard.user', abbr: 'GRD', teamIds: [1]),
             'resolve_sync_conflict' => $container->get(ResolveSyncConflictTool::class)->resolveSyncConflict((int) $syncState->getId(), 'local'),
+            'run_personio_sync' => $container->get(RunPersonioSyncTool::class)->runPersonioSync('export'),
             'save_contract' => $container->get(SaveContractTool::class)->saveContract(user: 'noContract', start: '2020-01-01', end: '2020-12-31'),
             'save_team' => $container->get(SaveTeamTool::class)->saveTeam(name: 'Guard-Team', leadUser: 'unittest'),
             'save_ticketsystem' => $container->get(SaveTicketSystemTool::class)->saveTicketSystem(name: 'Guard-TS', type: 'JIRA'),
@@ -458,7 +461,7 @@ final class McpToolsTest extends AbstractWebTestCase
 
     /**
      * A persisted run + parked conflict state for the sync tools, with the
-     * Jira-touching services mocked in the container (ADR-023 §6).
+     * Jira- and Personio-touching services mocked in the container (ADR-023 §6).
      *
      * @return array{SyncRun, WorklogSyncState}
      */
@@ -518,6 +521,17 @@ final class McpToolsTest extends AbstractWebTestCase
         $resolutionStub = self::createStub(ConflictResolutionService::class);
         $resolutionStub->method('resolve')->willReturn(new ResolutionResult(true, 'pushed_local'));
         $container->set(ConflictResolutionService::class, $resolutionStub);
+
+        $exportStub = self::createStub(AttendanceExportService::class);
+        $exportStub->method('exportUser')->willReturn(
+            new SyncRun()
+                ->setType(SyncRunType::PERSONIO_EXPORT)
+                ->setStatus(SyncRunStatus::COMPLETED)
+                ->setTriggeredBy($unittest)
+                ->setCounters([])
+                ->setStartedAt(new DateTimeImmutable('2026-07-09 11:00:00')),
+        );
+        $container->set(AttendanceExportService::class, $exportStub);
 
         return [$syncRun, $syncState];
     }


### PR DESCRIPTION
## Description

The reported wire-shape defect (top-level JSON array as `structuredContent`) is the same bug as #573 and was fixed by #578, deployed to production on 2026-07-09 (`:profiling-28989d10` and later). This PR adds the hardening that was missing around it, so a regression of this class can never ship silently again:

1. **Guard completeness** — the object-shape guard `testEveryToolReturnsATopLevelJsonObject` fails on current main: `run_personio_sync` (#608) was declared without joining the sweep. The tool is now covered (with `AttendanceExportService` stubbed like the other sync services).
2. **CI activation** — `tests/Mcp` belonged to no phpunit testsuite, so its 77 tests (including the #573 guard) never ran in CI; main was green while the guard failed. A new `mcp` testsuite runs in the integration job. The full suite was run locally in the container first (78 tests / 404 assertions, green).
3. **Declared `outputSchema`** — the issue's second ask. `list_projects`, `list_activities` and `list_recent_entries` now declare an explicit `outputSchema` via `#[McpTool]` (the SDK only emits one when explicitly provided). Item schemas are deliberately permissive — `id`/`customer`/`customer_id`/`ticket_prefixes` are nullable, `entries` items stay a loose `object` — because strict clients enforce a declared schema, and an over-strict one would turn working calls into new validation failures. A reflection test asserts the three tools declare a schema and that every declared `outputSchema` is `type: object`, as MCP requires.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issue

Closes #585

## Changes Made

- `tests/Mcp/McpToolsTest.php`: add `run_personio_sync` to the object-shape guard sweep; add `testListToolsDeclareAnObjectOutputSchema`; factor the `#[McpTool]` attribute sweep into `declaredToolAttributes()`
- `phpunit.xml.dist`: new `mcp` testsuite (`tests/Mcp`)
- `.github/workflows/ci.yml`: integration job runs `--testsuite integration,controller,api-functional,mcp`
- `src/Mcp/Tool/ListProjectsTool.php`, `ListActivitiesTool.php`, `ListRecentEntriesTool.php`: explicit `outputSchema` on the `#[McpTool]` attributes

## Testing

- [x] Unit tests pass (`make test`)
- [x] Static analysis passes (`make check-all`)
- [x] Manual testing completed
- [ ] E2E tests pass (if applicable)

Guard failure reproduced on main before the fix (completeness assertion at `McpToolsTest.php:456`); full `--testsuite mcp` run in the app container: 78 tests, 404 assertions. PHPStan (level 10, incl. tests), PHP-CS-Fixer, Rector dry-run and PHPat all clean. SDK discovery verified to emit the declared schemas (`SchemaGenerator::generateOutputSchema` returns them for all three tools).

## Code Quality

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or properly documented)

## Migration Notes

None. Declaring `outputSchema` is additive: non-validating clients ignore it; strict clients gain a schema that admits the real data (nullable ids, loose entry items).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/netresearch/timetracker/blob/main/CONTRIBUTING.md) guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/netresearch/timetracker/blob/main/CODE_OF_CONDUCT.md)
