### PR TITLE
fix(tracking): worklog grid keyboard navigation — new-row cursor, ticket-first edit, Tab confirms select

### DIFF
--- a/e2e/helpers/worklog.ts
+++ b/e2e/helpers/worklog.ts
@@ -28,7 +28,7 @@ export async function openTextEditor(page: Page, row: Locator, colKey: string): 
   return editor;
 }
 
-// Open a relation cell's combobox (Add already opens the first one) and pick its
+// Open a relation cell's combobox (unless it already is open) and pick its
 // first available option, committing it.
 export async function pickFirstOption(page: Page, row: Locator, colKey: string, alreadyOpen = false): Promise<void> {
   if (!alreadyOpen) {
@@ -93,7 +93,7 @@ export async function createWorklogEntry(page: Page): Promise<string> {
   const row = page.locator('tr.tracking-row.is-new').first();
   await expect(row).toBeVisible();
 
-  // Add opens the customer combobox; close it so we can set the plain fields first.
+  // Add opens the ticket editor (#588); close it so we can set the plain fields first.
   await page.keyboard.press('Escape');
 
   // Set explicit start/end/description while the row still lacks its required

--- a/e2e/worklog-grid-editing.spec.ts
+++ b/e2e/worklog-grid-editing.spec.ts
@@ -115,7 +115,7 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
     await expect(row.locator('.is-unsaved')).toBeVisible();
     await expect(row.locator('.is-reset')).toBeVisible();
 
-    // Close the auto-opened customer editor so the reset click isn't racing the combobox.
+    // Close the auto-opened ticket editor so the reset click isn't racing it.
     await page.keyboard.press('Escape');
     // Reset discards the unsaved new row (client-side; no /tracking/delete for a temp id).
     await row.locator('.is-reset').click();
@@ -126,6 +126,14 @@ test.describe('Worklog grid — keyboard & clipboard editing', () => {
     await page.getByRole('button', { name: /Add entry|Eintrag hinzufügen/i }).click();
     const row = page.locator('tr.tracking-row.is-new').first();
     await expect(row).toBeVisible();
+
+    // Add starts in the ticket editor (#588); Tab walks on into the first
+    // required relation (customer), staying in edit mode.
+    const ticketEditor = page.locator('td[data-col-key="ticket"][data-inline-editing] input.inline-editor');
+    await expect(ticketEditor).toBeVisible();
+    await expect(ticketEditor).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(row.locator('td[data-col-key="customer"][data-inline-editing]')).toBeVisible();
 
     const arrowEnter = async (): Promise<void> => {
       await expect(page.locator('.combobox-input').first()).toBeVisible();

--- a/frontend/src/lib/chipSelect.test.tsx
+++ b/frontend/src/lib/chipSelect.test.tsx
@@ -54,7 +54,7 @@ describe('ChipSelect (jsdom)', () => {
     // (like Enter accepts it) — Tab must not silently drop the highlighted pick.
     const onCommit = vi.fn()
     render(() => <ChipSelect field={field} label="Customer" initial={0} options={options} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3))
 
     fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' })
     await waitFor(() => expect(screen.getByRole('option', { name: 'Apollo' })).toHaveAttribute('data-highlighted'))
@@ -67,7 +67,7 @@ describe('ChipSelect (jsdom)', () => {
     // fires on input), so Tab-walking across a filled cell must not overwrite it.
     const onCommit = vi.fn()
     render(() => <ChipSelect field={field} label="Customer" initial={8} options={options} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3))
 
     fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Tab' })
     expect(onCommit).toHaveBeenCalledTimes(1)
@@ -152,7 +152,7 @@ describe('ChipSelect (jsdom)', () => {
   it('multi: Tab confirms the highlighted option into the committed array (#588)', async () => {
     const onCommit = vi.fn()
     render(() => <ChipSelect field={teamsField} label="Teams" initial={[1]} options={teamOptions} multiple onCommit={onCommit} onCancel={vi.fn()} />)
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3))
 
     // Typing a filter autohighlights the first match (Design, id 3).
     fireEvent.input(screen.getByRole('combobox'), { target: { value: 'Des' } })

--- a/frontend/src/lib/chipSelect.test.tsx
+++ b/frontend/src/lib/chipSelect.test.tsx
@@ -49,6 +49,31 @@ describe('ChipSelect (jsdom)', () => {
     expect(onCommit).not.toHaveBeenCalledWith(0, expect.anything())
   })
 
+  it('Tab confirms the arrow-highlighted option and commits it as a right-move (#588)', async () => {
+    // The issue-588 flow: arrow to an option, then Tab accepts it AND moves on
+    // (like Enter accepts it) — Tab must not silently drop the highlighted pick.
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={field} label="Customer" initial={0} options={options} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Apollo' })).toHaveAttribute('data-highlighted'))
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Tab' })
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith(7, 'right'))
+  })
+
+  it('Tab on a freshly-opened list commits the current value unchanged', async () => {
+    // Nothing is highlighted before the user types or arrows (autohighlight only
+    // fires on input), so Tab-walking across a filled cell must not overwrite it.
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={field} label="Customer" initial={8} options={options} multiple={false} onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Tab' })
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit).toHaveBeenCalledWith(8, 'right')
+  })
+
   it('Escape cancels the edit without committing', async () => {
     const onCommit = vi.fn()
     const onCancel = vi.fn()
@@ -122,6 +147,18 @@ describe('ChipSelect (jsdom)', () => {
     await waitFor(() => expect(screen.getAllByRole('listitem').length).toBe(2))
     fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Tab' })
     await waitFor(() => expect(onCommit).toHaveBeenCalledWith([1, 3], expect.anything()))
+  })
+
+  it('multi: Tab confirms the highlighted option into the committed array (#588)', async () => {
+    const onCommit = vi.fn()
+    render(() => <ChipSelect field={teamsField} label="Teams" initial={[1]} options={teamOptions} multiple onCommit={onCommit} onCancel={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+
+    // Typing a filter autohighlights the first match (Design, id 3).
+    fireEvent.input(screen.getByRole('combobox'), { target: { value: 'Des' } })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Design' })).toHaveAttribute('data-highlighted'))
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Tab' })
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith([1, 3], 'right'))
   })
 
   it('multi: removing the last chip commits an empty array on Tab', async () => {

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -55,6 +55,9 @@ export function ChipSelect(props: {
 
   const [selected, setSelected] = createSignal<string[]>(initialValues())
   const [inputValue, setInputValue] = createSignal('')
+  // The listbox item the user arrowed/filtered to — mirrored from zag so Tab can
+  // accept it (zag only applies a highlight to the selection on Enter/click).
+  const [highlighted, setHighlighted] = createSignal<string | null>(null)
   // Seed to match `defaultOpen`: Ark enters the open state as the machine's initial
   // state without firing onOpenChange, so a signal seeded false would mis-read the
   // open list as closed and route the first Enter to commit-the-cell.
@@ -128,6 +131,22 @@ export function ChipSelect(props: {
     if (event.key === 'Tab') {
       event.preventDefault()
       event.stopPropagation()
+      // Tab accepts the highlighted option like Enter does (#588), then moves on
+      // as a left/right commit — which stays in the row's edit mode and defers
+      // the save to row-leave (see commitCell), so arrow+Tab in the last required
+      // column flows straight into the next cell instead of stranding the user.
+      // A freshly opened list has no highlight (autohighlight only fires on
+      // typing), so a plain Tab-walk across a filled cell commits it unchanged.
+      const pick = open() ? highlighted() : null
+      if (pick !== null) {
+        if (props.multiple) {
+          if (!selected().includes(pick)) {
+            setSelected([...selected(), pick])
+          }
+        } else {
+          setSelected(pick === CLEAR_VALUE ? [] : [pick])
+        }
+      }
       finish(event.shiftKey ? 'left' : 'right')
     } else if (event.key === 'Escape') {
       event.preventDefault()
@@ -243,6 +262,7 @@ export function ChipSelect(props: {
         }}
         inputValue={inputValue()}
         onInputValueChange={(details) => setInputValue(details.inputValue)}
+        onHighlightChange={(details) => setHighlighted(details.highlightedValue)}
         defaultOpen
         onOpenChange={(details) => {
           setOpen(details.open)

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -117,6 +117,54 @@ export function ChipSelect(props: {
     }
   })
 
+  // Fold the currently highlighted listbox option into the selection, if any.
+  // A freshly opened list has no highlight (autohighlight only fires on
+  // typing), so a plain Tab-walk across a filled cell commits it unchanged.
+  const acceptHighlighted = (): void => {
+    const pick = open() ? highlighted() : null
+    if (pick === null) {
+      return
+    }
+    if (!props.multiple) {
+      setSelected(pick === CLEAR_VALUE ? [] : [pick])
+    } else if (!selected().includes(pick)) {
+      setSelected([...selected(), pick])
+    }
+  }
+
+  const onTabKey = (event: KeyboardEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    // Tab accepts the highlighted option like Enter does (#588), then moves on
+    // as a left/right commit — which stays in the row's edit mode and defers
+    // the save to row-leave (see commitCell), so arrow+Tab in the last required
+    // column flows straight into the next cell instead of stranding the user.
+    acceptHighlighted()
+    finish(event.shiftKey ? 'left' : 'right')
+  }
+
+  const onEnterKey = (event: KeyboardEvent): void => {
+    if (open()) {
+      // The list is open: let zag select the highlighted item; mark that an Enter
+      // (not a click) drove the resulting onSelect so it commits as 'next'.
+      committedByEnter = true
+
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    finish('next')
+  }
+
+  const onBackspaceKey = (event: KeyboardEvent): void => {
+    if (!props.multiple || inputValue() !== '' || selected().length === 0) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation() // don't let the grid/global shortcuts also see the Backspace
+    setSelected(selected().slice(0, -1))
+  }
+
   const onInputKeyDown = (event: KeyboardEvent): void => {
     // Any non-Enter key starts a fresh interaction, so a prior open-Enter that didn't
     // select (empty list / no highlight) can't leak its "guide" intent into a later
@@ -129,43 +177,15 @@ export function ChipSelect(props: {
     // Escape with the list open is handled in onOpenChange (zag consumes it first);
     // this branch covers the closed list and environments where zag doesn't.
     if (event.key === 'Tab') {
-      event.preventDefault()
-      event.stopPropagation()
-      // Tab accepts the highlighted option like Enter does (#588), then moves on
-      // as a left/right commit — which stays in the row's edit mode and defers
-      // the save to row-leave (see commitCell), so arrow+Tab in the last required
-      // column flows straight into the next cell instead of stranding the user.
-      // A freshly opened list has no highlight (autohighlight only fires on
-      // typing), so a plain Tab-walk across a filled cell commits it unchanged.
-      const pick = open() ? highlighted() : null
-      if (pick !== null) {
-        if (props.multiple) {
-          if (!selected().includes(pick)) {
-            setSelected([...selected(), pick])
-          }
-        } else {
-          setSelected(pick === CLEAR_VALUE ? [] : [pick])
-        }
-      }
-      finish(event.shiftKey ? 'left' : 'right')
+      onTabKey(event)
     } else if (event.key === 'Escape') {
       event.preventDefault()
       event.stopPropagation()
       cancel()
     } else if (event.key === 'Enter') {
-      if (open()) {
-        // The list is open: let zag select the highlighted item; mark that an Enter
-        // (not a click) drove the resulting onSelect so it commits as 'next'.
-        committedByEnter = true
-      } else {
-        event.preventDefault()
-        event.stopPropagation()
-        finish('next')
-      }
-    } else if (event.key === 'Backspace' && props.multiple && inputValue() === '' && selected().length > 0) {
-      event.preventDefault()
-      event.stopPropagation() // don't let the grid/global shortcuts also see the Backspace
-      setSelected(selected().slice(0, -1))
+      onEnterKey(event)
+    } else if (event.key === 'Backspace') {
+      onBackspaceKey(event)
     }
   }
 

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -766,7 +766,7 @@ describe('Tracking (Worklog grid)', () => {
       expect(descCell?.querySelector('input')).not.toBeNull()
     })
     expect(container.querySelector('td[data-col-key="activity"]')?.textContent).toContain('QA')
-    expect(postJson.mock.calls.filter((args) => args[0] === '/tracking/save').length).toBe(0)
+    expect(postJson.mock.calls.filter((args) => args[0] === '/tracking/save')).toHaveLength(0)
 
     unmount()
   })

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -720,26 +720,20 @@ describe('Tracking (Worklog grid)', () => {
 
     fireEvent.click(getByRole('button', { name: 'Add entry' }))
 
-    // Add opens the customer select; its search input is body-portalled, so the
-    // grid's focusin can't move the roving cell there — pushNewRow must reset it
-    // to the new row explicitly, else Shift+Tab walks from the header's first
-    // cell and lands on the "Datum" column heading (#588).
-    const input = await waitFor(() => {
-      const el = document.querySelector<HTMLInputElement>('.combobox-input')
-      expect(el).not.toBeNull()
+    // Add starts editing in the new row's TICKET cell (#588 suggestion 1: the
+    // ticket is what most users enter first, and it auto-derives customer and
+    // project) — and pushNewRow hands the row the keyboard cursor.
+    const ticketCell = container.querySelector<HTMLElement>('td[data-row-id="-1"][data-col-key="ticket"]')
+    const input = ticketCell?.querySelector<HTMLInputElement>('input')
+    expect(input).not.toBeNull()
+    expect(document.activeElement).toBe(input)
 
-      return el!
-    })
-    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true })
-
-    // Shift+Tab commits and opens the previous editable cell's editor on the
-    // SAME row (ticket; extTicket is hidden) — never a column heading. The
-    // advance is rAF-deferred for select editors, so poll via waitFor.
-    await waitFor(() => {
-      const ticketCell = container.querySelector<HTMLElement>('td[data-row-id="-1"][data-col-key="ticket"]')
-      expect(ticketCell?.querySelector('input')).not.toBeNull()
-      expect(ticketCell?.contains(document.activeElement)).toBe(true)
-    })
+    // Shift+Tab opens the previous editable cell's editor on the SAME row
+    // (end) — never the "Datum" column heading the stale header cursor gave.
+    fireEvent.keyDown(input!, { key: 'Tab', shiftKey: true })
+    const endCell = container.querySelector<HTMLElement>('td[data-row-id="-1"][data-col-key="end"]')
+    expect(endCell?.querySelector('input')).not.toBeNull()
+    expect(endCell?.contains(document.activeElement)).toBe(true)
     expect(document.activeElement?.closest('th')).toBeNull()
 
     unmount()
@@ -1101,11 +1095,12 @@ describe('Tracking (Worklog grid)', () => {
       projects: [{ project: { id: 4, name: 'Site', customer: 1, active: true } }],
       activities: [{ activity: { id: 5, name: 'Dev' } }],
     })
-    const { getByRole, unmount } = renderTracking()
+    const { getByRole, container, unmount } = renderTracking()
     await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
 
-    // Add opens the customer picker on the new row.
+    // Add a row (editing starts in its ticket cell), then open its customer picker.
     fireEvent.click(getByRole('button', { name: 'Add entry' }))
+    editCell(container, 'customer')
     await waitFor(() => expect(document.querySelectorAll('.combobox-content .combobox-item').length).toBeGreaterThan(0))
     const labels = [...document.querySelectorAll('.combobox-content .combobox-item')].map((el) => el.textContent ?? '')
     expect(labels.some((label) => label.includes('ACME'))).toBe(true)

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -739,6 +739,38 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('Tab in the activity picker confirms the highlighted pick and moves on to description without saving (#588)', async () => {
+    mockTracking({
+      entries: [{ entry: DEFAULT_ENTRY }],
+      customers: [{ customer: { id: 1, name: 'ACME' } }],
+      projects: [{ project: { id: 4, name: 'Site' } }],
+      activities: [{ activity: { id: 5, name: 'Dev' } }, { activity: { id: 6, name: 'QA' } }],
+    })
+    postJson.mockResolvedValue({})
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    // Open the activity picker and filter-highlight another activity (QA).
+    editCell(container, 'activity')
+    await waitFor(() => expect(document.querySelectorAll('.combobox-content .combobox-item').length).toBeGreaterThan(0))
+    const combo = document.querySelector<HTMLInputElement>('.combobox-input')!
+    fireEvent.input(combo, { target: { value: 'QA' } })
+    await waitFor(() => expect(document.querySelector('.combobox-item[data-highlighted]')?.textContent).toContain('QA'))
+
+    // Tab accepts the highlighted pick (like Enter would) AND walks on into the
+    // description editor on the same row — the save is deferred to row-leave, so
+    // the user is not stranded outside edit mode (#588 problem 2).
+    fireEvent.keyDown(combo, { key: 'Tab' })
+    await waitFor(() => {
+      const descCell = container.querySelector<HTMLElement>('td[data-row-id="1"][data-col-key="description"]')
+      expect(descCell?.querySelector('input')).not.toBeNull()
+    })
+    expect(container.querySelector('td[data-col-key="activity"]')?.textContent).toContain('QA')
+    expect(postJson.mock.calls.filter((args) => args[0] === '/tracking/save').length).toBe(0)
+
+    unmount()
+  })
+
   it('Prolong sets the latest entry end to now and saves it', async () => {
     mockApi()
     postJson.mockResolvedValue({})

--- a/frontend/src/pages/Tracking.test.tsx
+++ b/frontend/src/pages/Tracking.test.tsx
@@ -713,6 +713,38 @@ describe('Tracking (Worklog grid)', () => {
     unmount()
   })
 
+  it('a new row owns the keyboard cursor — Shift+Tab walks its cells, not the header (#588)', async () => {
+    mockApi()
+    const { getByRole, container, unmount } = renderTracking()
+    await waitFor(() => expect(getByRole('gridcell', { name: 'ABC-1' })).toBeInTheDocument())
+
+    fireEvent.click(getByRole('button', { name: 'Add entry' }))
+
+    // Add opens the customer select; its search input is body-portalled, so the
+    // grid's focusin can't move the roving cell there — pushNewRow must reset it
+    // to the new row explicitly, else Shift+Tab walks from the header's first
+    // cell and lands on the "Datum" column heading (#588).
+    const input = await waitFor(() => {
+      const el = document.querySelector<HTMLInputElement>('.combobox-input')
+      expect(el).not.toBeNull()
+
+      return el!
+    })
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true })
+
+    // Shift+Tab commits and opens the previous editable cell's editor on the
+    // SAME row (ticket; extTicket is hidden) — never a column heading. The
+    // advance is rAF-deferred for select editors, so poll via waitFor.
+    await waitFor(() => {
+      const ticketCell = container.querySelector<HTMLElement>('td[data-row-id="-1"][data-col-key="ticket"]')
+      expect(ticketCell?.querySelector('input')).not.toBeNull()
+      expect(ticketCell?.contains(document.activeElement)).toBe(true)
+    })
+    expect(document.activeElement?.closest('th')).toBeNull()
+
+    unmount()
+  })
+
   it('Prolong sets the latest entry end to now and saves it', async () => {
     mockApi()
     postJson.mockResolvedValue({})

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -1005,8 +1005,10 @@ export default function Tracking() {
   // Add (Alt+A): a blank entry. suggestedStart inherits the latest entry's end
   // ONLY when that entry is from today; on a fresh day it starts at the current
   // time, not yesterday's (or older) last end.
+  // Editing starts in the ticket column (#588): a ticket number is what most
+  // users enter first, and it auto-derives customer/project via the prefix map.
   function addEntry(): void {
-    pushNewRow({ start: appConfig().suggestTime ? suggestedStart() : '' }, 'customer')
+    pushNewRow({ start: appConfig().suggestTime ? suggestedStart() : '' }, 'ticket')
   }
 
   // Continue: clone the cursor row's (or, with no cursor, the latest entry's)

--- a/frontend/src/pages/Tracking.tsx
+++ b/frontend/src/pages/Tracking.tsx
@@ -992,6 +992,13 @@ export default function Tracking() {
     }
     tempId -= 1
     setNewRows((list) => [row, ...list])
+    // Reset the grid's roving cursor to the new row BEFORE opening the editor:
+    // the editor's Tab/Shift+Tab move walks from the roving td[tabindex="0"], so
+    // leaving it wherever it was (initially the header) made Shift+Tab land on
+    // the "Datum" column heading instead of the previous cell (#588). Order
+    // matters — beginEdit's editor grabs focus on mount, and a later td.focus()
+    // would steal it back out of the input.
+    gridHandle?.focusCell(num(row.id), firstCol)
     editor.beginEdit(num(row.id), firstCol)
   }
 


### PR DESCRIPTION
## Description

Three keyboard-navigation changes on the worklog grid, per the diagnosis in #588:

1. **New-row cursor reset (bug):** `pushNewRow` inserted the row and opened its editor but never moved the grid's roving active cell, which stayed wherever it was — initially the first header cell. The editor's Tab/Shift+Tab walk starts from that roving cell, so Shift+Tab out of a new row's first editor landed on the "Datum" column heading. The grid's focusin correction can't help when the first editor is the body-portalled single-select search input. Fix: `gridHandle.focusCell(rowId, firstCol)` before `beginEdit` (order matters — the editor grabs focus on mount).
2. **Ticket-first initial edit (suggestion 1):** Add now opens the new row's **ticket** editor instead of the customer picker — a ticket number is what most users enter first, and committing it auto-derives customer and project via the existing prefix mapping. Continue still opens in the start column. Kept as its own commit so it can be reverted independently if the muscle-memory change is unwanted.
3. **Tab confirms the highlighted select option (bug):** Tab out of a select/multiselect committed only the already-selected value and silently dropped the arrow/filter-highlighted option — the only way to accept it was Enter, which (intentionally) saves a complete row and leaves inline edit mode, stranding the user before "Beschreibung". Tab now applies the highlight to the selection (mirrored via zag's `onHighlightChange`) and commits as a left/right move, which stays in the row and defers the save to row-leave. Enter keeps its save-on-complete semantics; the `gridEditPref` stay/down preference is untouched. A freshly opened list has no highlight, so a plain Tab-walk across a filled cell still commits it unchanged (pinned by test).

## Before / after (verified live on the e2e stack, developer/dev123)

| Flow | Before | After |
|---|---|---|
| Add (Alt+A) | Customer picker opens; roving cursor stays on the header | Ticket editor opens, focused, cursor on the new row |
| Shift+Tab from the new row's first editor | Focus lands on the "Datum" column heading | The previous editable cell's editor opens on the same row (end) |
| ArrowDown + Tab in "Tätigkeit" | Highlighted pick dropped; Enter required, which saves and exits edit mode | Pick accepted (cell shows it), description editor opens on the same row, no save fired until row-leave |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related Issue

Refs #588 — resolves the maintainer-confirmed items (Shift+Tab focus bug, Tab-confirms-select, ticket-first initial focus). Not covered, per scope: the per-user config option for the initial column (suggestion 2), defaulting the end time to "now", and reworking Enter's leave-edit-mode-after-save behavior (maintainer's "will check this").

## Changes Made

- `frontend/src/pages/Tracking.tsx`: `pushNewRow` resets the roving grid cursor to the new row before opening the editor; `addEntry` starts in the ticket column
- `frontend/src/lib/chipSelect.tsx`: mirror zag's highlight (`onHighlightChange`) and apply it to the selection in the Tab branch before committing
- `frontend/src/pages/Tracking.test.tsx`: new-row cursor/Shift+Tab regression test; activity-arrow-Tab-to-description integration test; customer-picker test adapted to the ticket-first flow
- `frontend/src/lib/chipSelect.test.tsx`: Tab-confirms-highlight (single + multi) and Tab-on-fresh-list-commits-unchanged pinning tests
- `e2e/worklog-grid-editing.spec.ts`, `e2e/helpers/worklog.ts`: adapted to the ticket-first Add flow

## Testing

- [x] Unit tests pass (`bun run test` — 546 tests, incl. 5 new)
- [x] Static analysis passes (`composer analyze`, `composer cs-check`, `bun run lint`, `bun run typecheck`)
- [x] Manual testing completed (live walkthrough on the e2e stack, table above)
- [x] E2E tests pass (`e2e/worklog-grid-editing.spec.ts`, 7/7 serial and with 2 workers)

Note for local e2e runs: the shared e2e DB had drifted from its seed (`i.myself` had `show_future=0`), which made any test creating an entry as that user flaky — real-dated entries are "future" relative to the frozen 2024-01-15 server clock and were filtered out. Restored the seeded value (`show_future=1`); unrelated to this change.

## Code Quality

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or properly documented)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/netresearch/timetracker/blob/main/CONTRIBUTING.md) guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/netresearch/timetracker/blob/main/CODE_OF_CONDUCT.md)
