### PR TITLE
fix(security): make "Stay logged in" survive a browser restart

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -130,10 +130,21 @@ security:
         # lock them to admins. Inert in dev/test/prod (no such routes/firewall match).
         - { path: ^/_(profiler|wdt), roles: ROLE_ADMIN }
         # The 2FA form (/2fa) and code check (/2fa_check) are reached while the
-        # login is half-done — the catch-all's IS_AUTHENTICATED_FULLY would block
-        # them, so allow the in-progress state explicitly (must precede ^/).
+        # login is half-done — the catch-all would block them (a TwoFactorToken
+        # is neither remembered nor full), so allow the in-progress state
+        # explicitly (must precede ^/).
         - { path: ^/2fa, roles: IS_AUTHENTICATED_2FA_IN_PROGRESS }
-        - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
+        # Passkey registration (the webauthn-bundle ceremony endpoints, which
+        # carry no controller attribute) demands a full login: a passkey added
+        # from a session resumed via the REMEMBERME cookie would escalate a
+        # stolen cookie into a permanent full-fledged login. Same ADR-018
+        # re-auth posture as the Settings security controllers (must precede ^/).
+        - { path: ^/settings/security/passkeys, roles: IS_AUTHENTICATED_FULLY }
+        # Day-to-day routes accept a session resumed from the 30-day REMEMBERME
+        # cookie ("Stay logged in", #587); FULLY would reject every remembered
+        # session and make the cookie useless. Sensitive endpoints step up to
+        # IS_AUTHENTICATED_FULLY via controller attributes / the rules above.
+        - { path: ^/, roles: IS_AUTHENTICATED_REMEMBERED }
 
         # Uncomment to restrict access to paths starting with /_internal to only localhost
         # - { path: ^/_internal/secure, roles: IS_AUTHENTICATED_ANONYMOUSLY, ip: 127.0.0.1 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -149,14 +149,28 @@ Path-based access control is configured in `security.yaml`:
 access_control:
     - { path: ^/login, roles: PUBLIC_ACCESS }
     - { path: ^/login_check, roles: PUBLIC_ACCESS }
+    - { path: ^/logout, roles: PUBLIC_ACCESS }
     - { path: ^/css, roles: PUBLIC_ACCESS }
     - { path: ^/js, roles: PUBLIC_ACCESS }
     - { path: ^/images, roles: PUBLIC_ACCESS }
     - { path: ^/status/check, roles: PUBLIC_ACCESS }
     - { path: ^/status/page, roles: PUBLIC_ACCESS }
+    - { path: ^/\.well-known/, roles: PUBLIC_ACCESS }
+    - { path: ^/llms\.txt$, roles: PUBLIC_ACCESS }
     - { path: ^/admin, roles: ROLE_ADMIN }
-    - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/_(profiler|wdt), roles: ROLE_ADMIN }
+    - { path: ^/2fa, roles: IS_AUTHENTICATED_2FA_IN_PROGRESS }
+    - { path: ^/settings/security/passkeys, roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/, roles: IS_AUTHENTICATED_REMEMBERED }
 ```
+
+The `^/` catch-all accepts sessions resumed from the 30-day `REMEMBERME`
+cookie ("Stay logged in", issue #587). Sensitive operations — password
+change, passkey add/delete, API-token create/revoke, 2FA enrol/disable,
+admin mutations, impersonation — step up to `IS_AUTHENTICATED_FULLY` via
+controller attributes or the explicit rules above: a session resumed from
+the cookie is redirected to the login form for re-authentication before
+they proceed.
 
 ### User Switching (Impersonation)
 

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -133,6 +133,15 @@ describe('api/client', () => {
       await expect(postJson('/s', {})).rejects.toBeInstanceOf(SessionExpiredError)
       expect(sessionExpired()).toBe(true)
     })
+
+    it('raises session-expired (no navigation) when an ok response is not JSON', async () => {
+      // A remembered session's mutation on a step-up endpoint can be bounced
+      // through /login onto an HTML page other than /login — landing there
+      // must raise the overlay, not feed HTML into JSON.parse (issue #587).
+      mockFetch({ status: 200, redirected: true, url: 'http://localhost/ui/tracking', contentType: 'text/html', body: '<!doctype html>' })
+      await expect(postJson('/s', {})).rejects.toBeInstanceOf(SessionExpiredError)
+      expect(sessionExpired()).toBe(true)
+    })
   })
 
   describe('apiErrorMessage', () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -166,7 +166,12 @@ async function sendJson<T>(
     body: JSON.stringify(payload),
   })
 
-  if (sessionLost(response)) {
+  // Same content-type fallback as getJson: an auth bounce can land on an ok
+  // HTML page other than /login (every JSON endpoint answers JSON), and
+  // feeding that into JSON.parse below would bury the step-up behind a
+  // SyntaxError instead of raising the re-login overlay (#587).
+  const contentType = response.headers.get('content-type') ?? ''
+  if (sessionLost(response) || (response.ok && !contentType.includes('json'))) {
     raiseSessionExpired()
   }
 

--- a/frontend/src/components/LoginForm.test.tsx
+++ b/frontend/src/components/LoginForm.test.tsx
@@ -132,7 +132,33 @@ describe('LoginForm', () => {
     const { unmount } = render(() => <LoginForm config={config} />)
 
     await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
-    expect(loginWithPasskeyAutofill).toHaveBeenCalledWith(expect.any(AbortSignal))
+    expect(loginWithPasskeyAutofill).toHaveBeenCalledWith(expect.any(Function), expect.any(AbortSignal))
+
+    unmount()
+  })
+
+  it('threads the "Stay logged in" checkbox into the passkey logins (#587)', async () => {
+    vi.stubGlobal('location', { ...window.location, assign: vi.fn() })
+    passkeysSupported.mockReturnValue(true)
+    passkeyAutofillSupported.mockResolvedValue(true)
+    // Keep the background ceremony pending — only its remember accessor matters.
+    loginWithPasskeyAutofill.mockReturnValue(new Promise<string>(() => {}))
+
+    const { container, getByRole, unmount } = render(() => <LoginForm config={config} />)
+    await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
+
+    // The remember accessor is evaluated at submit time — flipping the
+    // checkbox changes what an in-flight ceremony will send.
+    const autofillRemember = loginWithPasskeyAutofill.mock.calls[0]![0] as () => boolean
+    expect(autofillRemember()).toBe(true) // default-checked
+
+    fireEvent.click(container.querySelector('input[name="_remember_me"]')!) // uncheck
+    expect(autofillRemember()).toBe(false)
+
+    fireEvent.click(getByRole('button', { name: 'Sign in with a passkey' }))
+    await waitFor(() => expect(loginWithPasskey).toHaveBeenCalled())
+    const buttonRemember = loginWithPasskey.mock.calls[0]![0] as () => boolean
+    expect(buttonRemember()).toBe(false)
 
     unmount()
   })
@@ -142,7 +168,7 @@ describe('LoginForm', () => {
     // Capture the signal handed to the autofill request so we can assert it aborts.
     let signal: AbortSignal | undefined
     loginWithPasskeyAutofill.mockImplementation((...args: unknown[]) => {
-      signal = args[0] as AbortSignal | undefined
+      signal = args[1] as AbortSignal | undefined
 
       return new Promise<string>(() => {}) // never resolves — a live conditional ceremony
     })

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -118,7 +118,7 @@ export function LoginForm(props: { config: LoginConfig }) {
     setSubmitting(true)
     setError(null)
     try {
-      globalThis.location.assign(await loginWithPasskey())
+      globalThis.location.assign(await loginWithPasskey(remember))
     } catch {
       // Includes the user dismissing the native prompt — a quiet inline message.
       setError(m.login_passkey_error())
@@ -149,7 +149,7 @@ export function LoginForm(props: { config: LoginConfig }) {
         if (!(await passkeyAutofillSupported())) {
           return
         }
-        globalThis.location.assign(await loginWithPasskeyAutofill(passkeyAutofill.signal))
+        globalThis.location.assign(await loginWithPasskeyAutofill(remember, passkeyAutofill.signal))
       } catch (caught) {
         // An ApiError means the ceremony produced an assertion but the server
         // rejected it — worth telling the user. Everything else (abort, dismiss,

--- a/frontend/src/components/SessionExpiredOverlay.test.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.test.tsx
@@ -162,6 +162,10 @@ describe('SessionExpiredOverlay', () => {
 
     await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
     expect(loginWithPasskey).toHaveBeenCalledTimes(1)
+    // Mirrors the overlay's password path (which always sends _remember_me):
+    // a re-login must not clear an existing REMEMBERME cookie (#587).
+    const remember = loginWithPasskey.mock.calls[0]![0] as () => boolean
+    expect(remember()).toBe(true)
   })
 
   it('surfaces an inline error when the passkey ceremony fails, without resuming', async () => {
@@ -203,7 +207,10 @@ describe('SessionExpiredOverlay', () => {
     render(() => <SessionExpiredOverlay onSuccess={vi.fn()} />)
 
     await waitFor(() => expect(loginWithPasskeyAutofill).toHaveBeenCalled())
-    expect(loginWithPasskeyAutofill.mock.calls[0]![0]).toBeInstanceOf(AbortSignal)
+    const [remember, signal] = loginWithPasskeyAutofill.mock.calls[0]!
+    expect(signal).toBeInstanceOf(AbortSignal)
+    // Same remember-me parity as the explicit passkey button (#587).
+    expect((remember as () => boolean)()).toBe(true)
   })
 
   it('tears down the autofill when switching to the 2FA code step', async () => {

--- a/frontend/src/components/SessionExpiredOverlay.test.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.test.tsx
@@ -162,10 +162,11 @@ describe('SessionExpiredOverlay', () => {
 
     await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1))
     expect(loginWithPasskey).toHaveBeenCalledTimes(1)
-    // Mirrors the overlay's password path (which always sends _remember_me):
-    // a re-login must not clear an existing REMEMBERME cookie (#587).
+    // Mirrors the overlay's password path (which sends no _remember_me): the
+    // overlay only shows when no valid REMEMBERME cookie exists, so a re-login
+    // must not silently grant a 30-day cookie the user never opted into (#587).
     const remember = loginWithPasskey.mock.calls[0]![0] as () => boolean
-    expect(remember()).toBe(true)
+    expect(remember()).toBe(false)
   })
 
   it('surfaces an inline error when the passkey ceremony fails, without resuming', async () => {
@@ -210,7 +211,7 @@ describe('SessionExpiredOverlay', () => {
     const [remember, signal] = loginWithPasskeyAutofill.mock.calls[0]!
     expect(signal).toBeInstanceOf(AbortSignal)
     // Same remember-me parity as the explicit passkey button (#587).
-    expect((remember as () => boolean)()).toBe(true)
+    expect((remember as () => boolean)()).toBe(false)
   })
 
   it('tears down the autofill when switching to the 2FA code step', async () => {

--- a/frontend/src/components/SessionExpiredOverlay.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.tsx
@@ -63,11 +63,15 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
     setSubmitting(true)
     setError(null)
     try {
+      // No _remember_me here: the overlay only appears when no valid REMEMBERME
+      // cookie rescued the session (a remembered session passes the ^/ rule,
+      // #587), so there is no cookie to preserve — and a re-login must not
+      // grant a 30-day cookie the user never opted into. Opting in stays on
+      // the full login form's checkbox.
       const response = await postForm(cfg.loginPath, {
         _username: username(),
         _password: password(),
         _csrf_token: cfg.csrfToken,
-        _remember_me: 'on',
       })
       const data = (await response.json().catch(() => null)) as { ok?: boolean; twoFactorRequired?: boolean } | null
       if (response.ok && data?.ok === true) {
@@ -130,10 +134,10 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
     try {
       // A passkey is inherently MFA, so this re-establishes a fully-authenticated
       // session in one step. Resume in place (ignore the returned redirect).
-      // remember=true mirrors the overlay's password path, which always sends
-      // _remember_me — otherwise this re-login would clear an existing
-      // REMEMBERME cookie (Symfony cancels old cookies on every login).
-      await loginWithPasskey(() => true)
+      // remember=false mirrors the overlay's password path: the overlay only
+      // shows when no valid REMEMBERME cookie exists (#587), so there is
+      // nothing to preserve and nothing to silently grant.
+      await loginWithPasskey(() => false)
       props.onSuccess()
     } catch {
       // Includes the user dismissing the native prompt — a quiet inline message.
@@ -169,7 +173,7 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
         if (!(await passkeyAutofillSupported())) {
           return
         }
-        await loginWithPasskeyAutofill(() => true, passkeyAutofill.signal)
+        await loginWithPasskeyAutofill(() => false, passkeyAutofill.signal)
         props.onSuccess()
       } catch (caught) {
         if (caught instanceof ApiError) {

--- a/frontend/src/components/SessionExpiredOverlay.tsx
+++ b/frontend/src/components/SessionExpiredOverlay.tsx
@@ -130,7 +130,10 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
     try {
       // A passkey is inherently MFA, so this re-establishes a fully-authenticated
       // session in one step. Resume in place (ignore the returned redirect).
-      await loginWithPasskey()
+      // remember=true mirrors the overlay's password path, which always sends
+      // _remember_me — otherwise this re-login would clear an existing
+      // REMEMBERME cookie (Symfony cancels old cookies on every login).
+      await loginWithPasskey(() => true)
       props.onSuccess()
     } catch {
       // Includes the user dismissing the native prompt — a quiet inline message.
@@ -166,7 +169,7 @@ export function SessionExpiredOverlay(props: { onSuccess: () => void }) {
         if (!(await passkeyAutofillSupported())) {
           return
         }
-        await loginWithPasskeyAutofill(passkeyAutofill.signal)
+        await loginWithPasskeyAutofill(() => true, passkeyAutofill.signal)
         props.onSuccess()
       } catch (caught) {
         if (caught instanceof ApiError) {

--- a/frontend/src/lib/passkeys.test.ts
+++ b/frontend/src/lib/passkeys.test.ts
@@ -32,7 +32,7 @@ describe('passkeys login', () => {
       .mockResolvedValueOnce({ ok: true, redirect: '/ui/tracking' }) // /login/passkey
     startAuthentication.mockResolvedValueOnce({ id: 'assertion' })
 
-    const redirect = await loginWithPasskeyAutofill()
+    const redirect = await loginWithPasskeyAutofill(() => false)
 
     expect(postJson).toHaveBeenNthCalledWith(1, '/login/options', {})
     expect(startAuthentication).toHaveBeenCalledWith(expect.objectContaining({ useBrowserAutofill: true }))
@@ -44,16 +44,43 @@ describe('passkeys login', () => {
     postJson.mockResolvedValueOnce({}).mockResolvedValueOnce({ redirect: '/' })
     startAuthentication.mockResolvedValueOnce({ id: 'x' })
 
-    await loginWithPasskey()
+    await loginWithPasskey(() => false)
 
     expect(startAuthentication).toHaveBeenCalledWith(expect.objectContaining({ useBrowserAutofill: false }))
+  })
+
+  it('appends _remember_me=1 to the result URL when "Stay logged in" is on (#587)', async () => {
+    // The assertion body is raw JSON, which the backend's remember-me listener
+    // does not read — the query parameter is the only opt-in channel.
+    postJson.mockResolvedValueOnce({ challenge: 'c' }).mockResolvedValueOnce({ ok: true })
+    startAuthentication.mockResolvedValueOnce({ id: 'assertion' })
+
+    await loginWithPasskey(() => true)
+
+    expect(postJson).toHaveBeenNthCalledWith(2, '/login/passkey?_remember_me=1', { id: 'assertion' })
+  })
+
+  it('reads the remember choice at submit time, not at ceremony start', async () => {
+    // The conditional-UI ceremony can sit open for minutes — the checkbox
+    // state when the user PICKS a passkey must win.
+    let remember = false
+    postJson.mockResolvedValueOnce({ challenge: 'c' }).mockResolvedValueOnce({ ok: true })
+    startAuthentication.mockImplementationOnce(() => {
+      remember = true
+
+      return Promise.resolve({ id: 'assertion' })
+    })
+
+    await loginWithPasskeyAutofill(() => remember)
+
+    expect(postJson).toHaveBeenNthCalledWith(2, '/login/passkey?_remember_me=1', { id: 'assertion' })
   })
 
   it('falls back to / when the server sends no redirect', async () => {
     postJson.mockResolvedValueOnce({}).mockResolvedValueOnce({ ok: true })
     startAuthentication.mockResolvedValueOnce({ id: 'x' })
 
-    expect(await loginWithPasskeyAutofill()).toBe('/')
+    expect(await loginWithPasskeyAutofill(() => false)).toBe('/')
   })
 
   it('cancelPasskeyCeremony aborts the in-flight ceremony', () => {
@@ -66,7 +93,7 @@ describe('passkeys login', () => {
     const controller = new AbortController()
     controller.abort()
 
-    await expect(loginWithPasskeyAutofill(controller.signal)).rejects.toThrow()
+    await expect(loginWithPasskeyAutofill(() => false, controller.signal)).rejects.toThrow()
     expect(postJson).not.toHaveBeenCalled()
     expect(startAuthentication).not.toHaveBeenCalled()
   })
@@ -80,7 +107,7 @@ describe('passkeys login', () => {
       return Promise.resolve({ challenge: 'c' })
     })
 
-    await expect(loginWithPasskeyAutofill(controller.signal)).rejects.toThrow()
+    await expect(loginWithPasskeyAutofill(() => false, controller.signal)).rejects.toThrow()
     expect(postJson).toHaveBeenCalledTimes(1) // options only; the assertion POST never runs
     expect(startAuthentication).not.toHaveBeenCalled()
   })

--- a/frontend/src/lib/passkeys.ts
+++ b/frontend/src/lib/passkeys.ts
@@ -47,7 +47,7 @@ function abortedError(): DOMException {
  * around that await stops startAuthentication from firing a stray prompt after
  * the caller has moved on.
  */
-async function requestPasskeyLogin(useBrowserAutofill: boolean, signal?: AbortSignal): Promise<string> {
+async function requestPasskeyLogin(useBrowserAutofill: boolean, remember: () => boolean, signal?: AbortSignal): Promise<string> {
   if (signal?.aborted) {
     throw abortedError()
   }
@@ -56,14 +56,20 @@ async function requestPasskeyLogin(useBrowserAutofill: boolean, signal?: AbortSi
     throw abortedError()
   }
   const assertion = await startAuthentication({ optionsJSON, useBrowserAutofill })
-  const result = await postJson<{ ok?: boolean; redirect?: string }>('/login/passkey', assertion as unknown as Record<string, unknown>)
+  // "Stay logged in": the assertion travels as a raw JSON body, which Symfony's
+  // remember-me listener never inspects — it reads the standard `_remember_me`
+  // parameter from attributes/query/form fields only. Carry the choice in the
+  // query string instead, and read it at submit time (not ceremony start) so
+  // the checkbox state at the moment the user picks a passkey counts.
+  const resultPath = remember() ? '/login/passkey?_remember_me=1' : '/login/passkey'
+  const result = await postJson<{ ok?: boolean; redirect?: string }>(resultPath, assertion as unknown as Record<string, unknown>)
 
   return result.redirect ?? '/'
 }
 
 /** Explicit ("Sign in with a passkey" button) modal login. */
-export function loginWithPasskey(): Promise<string> {
-  return requestPasskeyLogin(false)
+export function loginWithPasskey(remember: () => boolean): Promise<string> {
+  return requestPasskeyLogin(false, remember)
 }
 
 /**
@@ -73,8 +79,8 @@ export function loginWithPasskey(): Promise<string> {
  * ceremony, or {@see cancelPasskeyCeremony} during it) or on error — callers
  * stay quiet on the ceremony rejections and surface only a server rejection.
  */
-export function loginWithPasskeyAutofill(signal?: AbortSignal): Promise<string> {
-  return requestPasskeyLogin(true, signal)
+export function loginWithPasskeyAutofill(remember: () => boolean, signal?: AbortSignal): Promise<string> {
+  return requestPasskeyLogin(true, remember, signal)
 }
 
 /**

--- a/src/Controller/Admin/ConfirmPersonioEmployeeMatchesAction.php
+++ b/src/Controller/Admin/ConfirmPersonioEmployeeMatchesAction.php
@@ -40,6 +40,7 @@ final readonly class ConfirmPersonioEmployeeMatchesAction
 
     #[Route(path: '/personio/employee-matches/confirm', name: 'personio_employee_matches_confirm', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request): JsonResponse
     {
         $content = $request->getContent();

--- a/src/Controller/Admin/ConfirmProjectImportAction.php
+++ b/src/Controller/Admin/ConfirmProjectImportAction.php
@@ -37,6 +37,7 @@ final readonly class ConfirmProjectImportAction
 
     #[Route(path: '/project-import/confirm', name: 'project_import_confirm', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] ProjectImportConfirmDto $projectImportConfirmDto): JsonResponse
     {
         try {

--- a/src/Controller/Admin/DeleteActivityAction.php
+++ b/src/Controller/Admin/DeleteActivityAction.php
@@ -27,6 +27,7 @@ final class DeleteActivityAction extends BaseController
 {
     #[Route(path: '/activity/delete', name: 'deleteActivity_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeleteContractAction.php
+++ b/src/Controller/Admin/DeleteContractAction.php
@@ -27,6 +27,7 @@ final class DeleteContractAction extends BaseController
 {
     #[Route(path: '/contract/delete', name: 'deleteContract_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeleteCustomerAction.php
+++ b/src/Controller/Admin/DeleteCustomerAction.php
@@ -27,6 +27,7 @@ final class DeleteCustomerAction extends BaseController
 {
     #[Route(path: '/customer/delete', name: 'deleteCustomer_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeleteHolidayAction.php
+++ b/src/Controller/Admin/DeleteHolidayAction.php
@@ -27,6 +27,7 @@ final class DeleteHolidayAction extends BaseController
 {
     #[Route(path: '/holiday/delete', name: 'deleteHoliday_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] HolidayDeleteDto $holidayDeleteDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeletePersonioConfigAction.php
+++ b/src/Controller/Admin/DeletePersonioConfigAction.php
@@ -27,6 +27,7 @@ final class DeletePersonioConfigAction extends BaseController
 {
     #[Route(path: '/personio-config/delete', name: 'deletePersonioConfig_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeletePresetAction.php
+++ b/src/Controller/Admin/DeletePresetAction.php
@@ -27,6 +27,7 @@ final class DeletePresetAction extends BaseController
 {
     #[Route(path: '/preset/delete', name: 'deletePreset_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeleteProjectAction.php
+++ b/src/Controller/Admin/DeleteProjectAction.php
@@ -27,6 +27,7 @@ final class DeleteProjectAction extends BaseController
 {
     #[Route(path: '/project/delete', name: 'deleteProject_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeleteTeamAction.php
+++ b/src/Controller/Admin/DeleteTeamAction.php
@@ -27,6 +27,7 @@ final class DeleteTeamAction extends BaseController
 {
     #[Route(path: '/team/delete', name: 'deleteTeam_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeleteTicketSystemAction.php
+++ b/src/Controller/Admin/DeleteTicketSystemAction.php
@@ -27,6 +27,7 @@ final class DeleteTicketSystemAction extends BaseController
 {
     #[Route(path: '/ticketsystem/delete', name: 'deleteTicketSystem_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/DeleteUserAction.php
+++ b/src/Controller/Admin/DeleteUserAction.php
@@ -25,6 +25,7 @@ final class DeleteUserAction extends BaseController
 {
     #[Route(path: '/user/delete', name: 'deleteUser_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] IdDto $idDto): JsonResponse|Error|Response
     {
         try {

--- a/src/Controller/Admin/GetPresetsAction.php
+++ b/src/Controller/Admin/GetPresetsAction.php
@@ -30,7 +30,7 @@ final class GetPresetsAction extends BaseController
     // Save/Delete actions.
     #[RequireScope('presets:read')]
     #[Route(path: '/getAllPresets', name: '_getAllPresets_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(#[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Admin/ImportHolidaysAction.php
+++ b/src/Controller/Admin/ImportHolidaysAction.php
@@ -66,6 +66,7 @@ final class ImportHolidaysAction extends BaseController
 
     #[Route(path: '/holiday/import-ical', name: 'importHolidaysIcal_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request): Response|JsonResponse|Error
     {
         $icalContent = $this->readIcalContent($request);

--- a/src/Controller/Admin/ResetUserTwoFactorAction.php
+++ b/src/Controller/Admin/ResetUserTwoFactorAction.php
@@ -43,6 +43,7 @@ final class ResetUserTwoFactorAction extends BaseController
 
     #[Route(path: '/user/reset-2fa', name: 'resetUserTwoFactor_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(
         #[MapRequestPayload]
         IdDto $idDto,

--- a/src/Controller/Admin/SaveActivityAction.php
+++ b/src/Controller/Admin/SaveActivityAction.php
@@ -37,6 +37,7 @@ final class SaveActivityAction extends BaseController
      */
     #[Route(path: '/activity/save', name: 'saveActivity_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] ActivitySaveDto $activitySaveDto): Response|Error|JsonResponse
     {
         $objectRepository = $this->doctrineRegistry->getRepository(Activity::class);

--- a/src/Controller/Admin/SaveContractAction.php
+++ b/src/Controller/Admin/SaveContractAction.php
@@ -38,6 +38,7 @@ final class SaveContractAction extends BaseController
      */
     #[Route(path: '/contract/save', name: 'saveContract_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] ContractSaveDto $contractSaveDto): Response|JsonResponse|Error
     {
         $contractId = $contractSaveDto->id;

--- a/src/Controller/Admin/SaveCustomerAction.php
+++ b/src/Controller/Admin/SaveCustomerAction.php
@@ -43,6 +43,7 @@ final class SaveCustomerAction extends BaseController
      */
     #[Route(path: '/customer/save', name: 'saveCustomer_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] CustomerSaveDto $customerSaveDto): Response|Error|JsonResponse
     {
         $customerId = $customerSaveDto->id;

--- a/src/Controller/Admin/SaveHolidayAction.php
+++ b/src/Controller/Admin/SaveHolidayAction.php
@@ -24,6 +24,7 @@ final class SaveHolidayAction extends BaseController
 {
     #[Route(path: '/holiday/save', name: 'saveHoliday_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] HolidaySaveDto $holidaySaveDto): Response|JsonResponse|Error
     {
         // The day is a validated Y-m-d string (Assert\Date on the DTO).

--- a/src/Controller/Admin/SavePersonioConfigAction.php
+++ b/src/Controller/Admin/SavePersonioConfigAction.php
@@ -43,6 +43,7 @@ final class SavePersonioConfigAction extends BaseController
      */
     #[Route(path: '/personio-config/save', name: 'savePersonioConfig_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] PersonioConfigSaveDto $personioConfigSaveDto): Response|Error|JsonResponse
     {
         $objectRepository = $this->doctrineRegistry->getRepository(PersonioConfig::class);

--- a/src/Controller/Admin/SavePresetAction.php
+++ b/src/Controller/Admin/SavePresetAction.php
@@ -42,6 +42,7 @@ final class SavePresetAction extends BaseController
      */
     #[Route(path: '/preset/save', name: 'savePreset_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] PresetSaveDto $presetSaveDto): Response|JsonResponse|Error
     {
         $id = $presetSaveDto->id;

--- a/src/Controller/Admin/SaveProjectAction.php
+++ b/src/Controller/Admin/SaveProjectAction.php
@@ -42,6 +42,7 @@ final class SaveProjectAction extends BaseController
      */
     #[Route(path: '/project/save', name: 'saveProject_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] ProjectSaveDto $projectSaveDto): Response|Error|JsonResponse
     {
         $ticketSystem = null !== $projectSaveDto->ticket_system ? $this->doctrineRegistry->getRepository(TicketSystem::class)->find($projectSaveDto->ticket_system) : null;

--- a/src/Controller/Admin/SaveTeamAction.php
+++ b/src/Controller/Admin/SaveTeamAction.php
@@ -33,6 +33,7 @@ final class SaveTeamAction extends BaseController
      */
     #[Route(path: '/team/save', name: 'saveTeam_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] TeamSaveDto $teamSaveDto): Response|JsonResponse|Error
     {
         $objectRepository = $this->doctrineRegistry->getRepository(Team::class);

--- a/src/Controller/Admin/SaveTicketSystemAction.php
+++ b/src/Controller/Admin/SaveTicketSystemAction.php
@@ -42,6 +42,7 @@ final class SaveTicketSystemAction extends BaseController
      */
     #[Route(path: '/ticketsystem/save', name: 'saveTicketSystem_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] TicketSystemSaveDto $ticketSystemSaveDto): Response|Error|JsonResponse
     {
         $objectRepository = $this->doctrineRegistry->getRepository(TicketSystem::class);

--- a/src/Controller/Admin/SaveUserAction.php
+++ b/src/Controller/Admin/SaveUserAction.php
@@ -49,6 +49,7 @@ final class SaveUserAction extends BaseController
      */
     #[Route(path: '/user/save', name: 'saveUser_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(#[MapRequestPayload] UserSaveDto $userSaveDto): Response|Error|JsonResponse
     {
         $objectRepository = $this->doctrineRegistry->getRepository(User::class);

--- a/src/Controller/Admin/SyncAllProjectSubticketsAction.php
+++ b/src/Controller/Admin/SyncAllProjectSubticketsAction.php
@@ -22,6 +22,7 @@ final class SyncAllProjectSubticketsAction extends BaseController
 {
     #[Route(path: '/projects/syncsubtickets', name: 'syncAllSubtickets_attr', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(): JsonResponse
     {
         // Legacy route syncs all projects; mirror behavior by iterating all

--- a/src/Controller/Admin/SyncJiraEntriesAction.php
+++ b/src/Controller/Admin/SyncJiraEntriesAction.php
@@ -32,6 +32,7 @@ final class SyncJiraEntriesAction extends BaseController
      */
     #[Route(path: '/syncentries/jira', name: 'syncJiraEntries_attr', methods: ['GET'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request): JsonResponse
     {
         $from = $request->query->get('from');

--- a/src/Controller/Admin/SyncProjectSubticketsAction.php
+++ b/src/Controller/Admin/SyncProjectSubticketsAction.php
@@ -35,6 +35,7 @@ final class SyncProjectSubticketsAction extends BaseController
 
     #[Route(path: '/projects/{project}/syncsubtickets', name: 'syncProjectSubtickets_attr_invokable', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function __invoke(Request $request): JsonResponse|Error|ModelResponse
     {
         // Map path parameter to query for DTO compatibility

--- a/src/Controller/Default/ExportCsvAction.php
+++ b/src/Controller/Default/ExportCsvAction.php
@@ -31,7 +31,7 @@ final class ExportCsvAction extends BaseController
      */
     #[RequireScope('reporting:read')]
     #[Route(path: '/export/{days}', name: '_export_attr', defaults: ['days' => 10000], methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): Response
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/GetActivitiesAction.php
+++ b/src/Controller/Default/GetActivitiesAction.php
@@ -27,7 +27,7 @@ final class GetActivitiesAction extends BaseController
 {
     #[RequireScope('activities:read')]
     #[Route(path: '/getActivities', name: '_getActivities_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(#[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/GetAllProjectsAction.php
+++ b/src/Controller/Default/GetAllProjectsAction.php
@@ -36,7 +36,7 @@ final class GetAllProjectsAction extends BaseController
      */
     #[RequireScope('projects:read')]
     #[Route(path: '/getAllProjects', name: '_getAllProjects_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/GetContractHoursAction.php
+++ b/src/Controller/Default/GetContractHoursAction.php
@@ -51,7 +51,7 @@ final class GetContractHoursAction extends BaseController
      */
     #[RequireScope('contracts:read')]
     #[Route(path: '/getContractHours', name: '_getContractHours_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/GetCustomerAction.php
+++ b/src/Controller/Default/GetCustomerAction.php
@@ -30,7 +30,7 @@ final class GetCustomerAction extends BaseController
      * @throws InvalidArgumentException When project parameter is invalid
      */
     #[Route(path: '/getCustomer', name: '_getCustomer_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request): JsonResponse
     {
         $projectParam = $request->query->get('project');

--- a/src/Controller/Default/GetDataAction.php
+++ b/src/Controller/Default/GetDataAction.php
@@ -34,7 +34,7 @@ final class GetDataAction extends BaseController
     #[RequireScope('entries:read')]
     #[Route(path: '/getData', name: '_getData_attr', methods: ['GET', 'POST'])]
     #[Route(path: '/getData/days/{days}', name: '_getDataDays_attr', defaults: ['days' => 3], methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): JsonResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/GetHolidaysAction.php
+++ b/src/Controller/Default/GetHolidaysAction.php
@@ -34,7 +34,7 @@ final class GetHolidaysAction extends BaseController
      * @throws BadRequestException      When query parameters are malformed
      */
     #[Route(path: '/getHolidays', name: '_getHolidays_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): JsonResponse|RedirectResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/GetSummaryAction.php
+++ b/src/Controller/Default/GetSummaryAction.php
@@ -49,7 +49,7 @@ final class GetSummaryAction extends BaseController
      * @throws Exception                When time calculation operations fail
      */
     #[Route(path: '/getSummary', name: '_getSummary_attr', methods: ['POST'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     #[Deprecated(message: 'superseded by GET /api/v2/entries/{id}/summary (ADR-022); removal in v7')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse|Error
     {

--- a/src/Controller/Default/GetTicketTimeSummaryAction.php
+++ b/src/Controller/Default/GetTicketTimeSummaryAction.php
@@ -48,7 +48,7 @@ final class GetTicketTimeSummaryAction extends BaseController
      */
     #[RequireScope('reporting:read')]
     #[Route(path: '/getTicketTimeSummary/{ticket}', name: '_getTicketTimeSummary_attr', defaults: ['ticket' => null], methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): Response|RedirectResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/GetUsersAction.php
+++ b/src/Controller/Default/GetUsersAction.php
@@ -27,7 +27,7 @@ final class GetUsersAction extends BaseController
 {
     #[RequireScope('users:read')]
     #[Route(path: '/getUsers', name: '_getUsers_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(#[CurrentUser] ?User $user = null): RedirectResponse|Response|JsonResponse
     {
         if (!$user instanceof User) {

--- a/src/Controller/Default/JiraOAuthCallbackAction.php
+++ b/src/Controller/Default/JiraOAuthCallbackAction.php
@@ -59,7 +59,7 @@ final class JiraOAuthCallbackAction extends BaseController
      * @throws JiraApiException    When Jira API operations fail
      */
     #[Route(path: '/jiraoauthcallback', name: 'jiraOAuthCallback', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(Request $request, #[CurrentUser] ?User $user = null): RedirectResponse|Response
     {
         if (!$user instanceof User) {

--- a/src/Controller/Interpretation/GetLastEntriesAction.php
+++ b/src/Controller/Interpretation/GetLastEntriesAction.php
@@ -39,7 +39,7 @@ final class GetLastEntriesAction extends BaseInterpretationController
      */
     #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/entries', name: 'interpretation_entries_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Interpretation/GroupByActivityAction.php
+++ b/src/Controller/Interpretation/GroupByActivityAction.php
@@ -35,7 +35,7 @@ final class GroupByActivityAction extends BaseInterpretationController
 
     #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/activity', name: 'interpretation_activity_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Interpretation/GroupByCustomerAction.php
+++ b/src/Controller/Interpretation/GroupByCustomerAction.php
@@ -34,7 +34,7 @@ final class GroupByCustomerAction extends BaseInterpretationController
 
     #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/customer', name: 'interpretation_customer_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Interpretation/GroupByProjectAction.php
+++ b/src/Controller/Interpretation/GroupByProjectAction.php
@@ -34,7 +34,7 @@ final class GroupByProjectAction extends BaseInterpretationController
 
     #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/project', name: 'interpretation_project_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Interpretation/GroupByTicketAction.php
+++ b/src/Controller/Interpretation/GroupByTicketAction.php
@@ -34,7 +34,7 @@ final class GroupByTicketAction extends BaseInterpretationController
 
     #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/ticket', name: 'interpretation_ticket_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Interpretation/GroupByUserAction.php
+++ b/src/Controller/Interpretation/GroupByUserAction.php
@@ -34,7 +34,7 @@ final class GroupByUserAction extends BaseInterpretationController
 
     #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/user', name: 'interpretation_user_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Interpretation/GroupByWorktimeAction.php
+++ b/src/Controller/Interpretation/GroupByWorktimeAction.php
@@ -52,7 +52,7 @@ final class GroupByWorktimeAction extends BaseInterpretationController
 
     #[RequireScope('reporting:read')]
     #[Route(path: '/interpretation/time', name: 'interpretation_time_attr', methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Contracts\Service\Attribute\Required;
 use Twig\Error\LoaderError;
@@ -54,8 +53,12 @@ class SecurityController extends AbstractController
      */
     public function login(): Response
     {
-        // If user is already authenticated, redirect to start page
-        if ($this->getUser() instanceof UserInterface) {
+        // Only a full-fledged login has nothing to do here — send it to the
+        // start page. A session resumed from the REMEMBERME cookie must fall
+        // through to the form: the security entry point sends it here to step
+        // up when an IS_AUTHENTICATED_FULLY endpoint denies it (#587), and
+        // bouncing it away would make every such endpoint a dead end.
+        if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             return $this->redirectToRoute('_start');
         }
 

--- a/src/Controller/Status/CheckStatusAction.php
+++ b/src/Controller/Status/CheckStatusAction.php
@@ -18,7 +18,7 @@ final class CheckStatusAction extends BaseController
     #[Route(path: '/status/check', name: 'check_status', methods: ['GET'])]
     public function __invoke(): JsonResponse
     {
-        $login = $this->isGranted('IS_AUTHENTICATED_FULLY');
+        $login = $this->isGranted('IS_AUTHENTICATED_REMEMBERED');
 
         return new JsonResponse(['loginStatus' => $login]);
     }

--- a/src/Controller/Status/StatusPageAction.php
+++ b/src/Controller/Status/StatusPageAction.php
@@ -13,7 +13,7 @@ final class StatusPageAction extends BaseController
     #[Route(path: '/status/page', name: 'status_page', methods: ['GET'])]
     public function __invoke(): Response
     {
-        $isLoggedIn = $this->isGranted('IS_AUTHENTICATED_FULLY');
+        $isLoggedIn = $this->isGranted('IS_AUTHENTICATED_REMEMBERED');
         $statusClass = $isLoggedIn ? 'status_active' : 'status_inactive';
 
         $html = <<<HTML

--- a/src/Controller/Tracking/BulkEntryAction.php
+++ b/src/Controller/Tracking/BulkEntryAction.php
@@ -64,7 +64,7 @@ final class BulkEntryAction extends BaseTrackingController
      * @throws Exception           when entry creation or validation fails
      */
     #[Route(path: '/tracking/bulkentry', name: 'timetracking_bulkentry_attr', methods: ['POST'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Tracking/DeleteEntryAction.php
+++ b/src/Controller/Tracking/DeleteEntryAction.php
@@ -40,7 +40,7 @@ final class DeleteEntryAction extends BaseTrackingController
      */
     #[RequireScope('entries:write')]
     #[Route(path: '/tracking/delete', name: 'timetracking_delete_attr', methods: ['POST'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         Request $request,
         #[CurrentUser]

--- a/src/Controller/Tracking/GetEntryAction.php
+++ b/src/Controller/Tracking/GetEntryAction.php
@@ -24,7 +24,7 @@ final class GetEntryAction extends BaseTrackingController
 {
     #[RequireScope('entries:read')]
     #[Route(path: '/tracking/entry/{id}', name: 'timetracking_get_attr', requirements: ['id' => '\d+'], methods: ['GET'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         int $id,
         #[CurrentUser]

--- a/src/Controller/Tracking/SaveEntryAction.php
+++ b/src/Controller/Tracking/SaveEntryAction.php
@@ -79,7 +79,7 @@ final class SaveEntryAction extends BaseTrackingController
      */
     #[RequireScope('entries:write')]
     #[Route(path: '/tracking/save', name: 'timetracking_save_attr', methods: ['POST'])]
-    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
     public function __invoke(
         #[MapRequestPayload]
         EntrySaveDto $entrySaveDto,

--- a/src/EventSubscriber/AccessDeniedSubscriber.php
+++ b/src/EventSubscriber/AccessDeniedSubscriber.php
@@ -67,25 +67,16 @@ final readonly class AccessDeniedSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // A login that is half-done (password ok, 2FA code outstanding) also fails
-        // IS_AUTHENTICATED_FULLY — but it is NOT a stale remember-me session and
-        // must not be logged out. Defer to scheb's ExceptionListener (priority 2),
-        // which answers with the JSON challenge signal or the /2fa redirect.
-        if ($this->security->isGranted('IS_AUTHENTICATED_2FA_IN_PROGRESS')) {
-            return;
-        }
-
-        // Case 2: User is authenticated via remember_me but not fully authenticated
-        // This happens when IS_AUTHENTICATED_FULLY is required but user only has remember_me.
-        // Log out programmatically (session + cookies cleared, redirect to login)
-        // instead of redirecting through /logout: a browser following that
-        // redirect from an address-bar navigation sends no same-origin fetch
-        // metadata and would fail the logout CSRF check.
+        // Case 2: authenticated, but not full-fledged — a session resumed from
+        // the REMEMBERME cookie hitting an IS_AUTHENTICATED_FULLY-guarded
+        // endpoint, or a half-done 2FA login (password ok, code outstanding).
+        // Set no response and defer: Symfony's security ExceptionListener
+        // (priority 1) restarts authentication at the form_login entry point —
+        // saving the target path and redirecting to /login WITHOUT touching the
+        // session or the REMEMBERME cookie (a remembered user must be stepped
+        // up, never logged out, #587) — and scheb's listener (priority 2)
+        // answers the 2FA case with the challenge signal instead.
         if (!$this->security->isGranted('IS_AUTHENTICATED_FULLY')) {
-            $response = $this->security->logout(false)
-                ?? new RedirectResponse($this->router->generate('_login'));
-            $exceptionEvent->setResponse($response);
-
             return;
         }
 

--- a/src/EventSubscriber/RequireFullAuthForImpersonationSubscriber.php
+++ b/src/EventSubscriber/RequireFullAuthForImpersonationSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Event\SwitchUserEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+/**
+ * Locks user impersonation (switch_user, ?simulateUserId=…) to full-fledged
+ * logins. The firewall's SwitchUserListener only checks ROLE_ALLOWED_TO_SWITCH,
+ * which a session resumed from the REMEMBERME cookie still carries — since the
+ * catch-all access rule accepts remembered sessions (#587), a stolen 30-day
+ * cookie of an admin would otherwise be enough to act as any other user. The
+ * thrown exception surfaces as an AccessDeniedException BEFORE the switch
+ * token is stored, and Symfony's ExceptionListener then sends the remembered
+ * admin to the login form for a fresh authentication.
+ */
+final readonly class RequireFullAuthForImpersonationSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        // No interface alias exists in this app (scheb decorates the concrete
+        // service), so reference the decorated resolver by id.
+        #[Autowire(service: 'security.authentication.trust_resolver')]
+        private AuthenticationTrustResolverInterface $trustResolver,
+    ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SecurityEvents::SWITCH_USER => 'onSwitchUser',
+        ];
+    }
+
+    public function onSwitchUser(SwitchUserEvent $switchUserEvent): void
+    {
+        $token = $switchUserEvent->getToken();
+
+        // Exiting an impersonation restores the original token (not a
+        // SwitchUserToken) — nothing to gate there.
+        if (!$token instanceof SwitchUserToken) {
+            return;
+        }
+
+        if (!$this->trustResolver->isFullFledged($token->getOriginalToken())) {
+            throw new AccessDeniedException('Impersonation requires a full login, not a remembered session.');
+        }
+    }
+}

--- a/tests/EventSubscriber/AccessDeniedSubscriberTest.php
+++ b/tests/EventSubscriber/AccessDeniedSubscriberTest.php
@@ -131,8 +131,13 @@ final class AccessDeniedSubscriberTest extends TestCase
         self::assertTrue($rememberMeCookie->isCleared(), 'REMEMBERME cookie should be marked as cleared');
     }
 
-    public function testRememberedUserNeedingFullAuthIsLoggedOutProgrammatically(): void
+    public function testRememberedUserNeedingFullAuthIsDeferredToSymfonyEntryPoint(): void
     {
+        // A session resumed from the REMEMBERME cookie hitting a route that
+        // demands IS_AUTHENTICATED_FULLY must NOT be logged out (#587): the
+        // subscriber sets no response, so Symfony's security ExceptionListener
+        // redirects to the login entry point for a step-up — preserving the
+        // session and the REMEMBERME cookie.
         $user = new User();
         $user->setUsername('testuser');
 
@@ -143,44 +148,15 @@ final class AccessDeniedSubscriberTest extends TestCase
         // User is authenticated via remember_me but NOT fully authenticated
         $this->stubIsGranted(fully: false, twoFactorInProgress: false);
 
-        // The subscriber logs out programmatically (no CSRF-guarded round
-        // trip through /logout) and uses the logout response as-is.
-        $logoutResponse = new RedirectResponse('/login');
         $this->security
-            ->expects(self::once())->method('logout')
-            ->with(false)
-            ->willReturn($logoutResponse);
+            ->expects(self::never())->method('logout');
 
         $request = $this->createRequest(true);
         $event = $this->createExceptionEvent($request, new AccessDeniedException('Access Denied'));
 
         $this->subscriber->onKernelException($event);
 
-        self::assertSame($logoutResponse, $event->getResponse());
-    }
-
-    public function testRememberedUserFallsBackToLoginRedirectWhenLogoutReturnsNoResponse(): void
-    {
-        $user = new User();
-        $user->setUsername('testuser');
-
-        $this->security
-            ->method('getUser')
-            ->willReturn($user);
-        $this->stubIsGranted(fully: false, twoFactorInProgress: false);
-        $this->security
-            ->expects(self::once())->method('logout')
-            ->with(false)
-            ->willReturn(null);
-
-        $request = $this->createRequest(true);
-        $event = $this->createExceptionEvent($request, new AccessDeniedException('Access Denied'));
-
-        $this->subscriber->onKernelException($event);
-
-        $response = $event->getResponse();
-        self::assertInstanceOf(RedirectResponse::class, $response);
-        self::assertSame('/login', $response->getTargetUrl());
+        self::assertNull($event->getResponse());
     }
 
     public function testTwoFactorInProgressIsDeferredToSchebListener(): void

--- a/tests/EventSubscriber/RequireFullAuthForImpersonationSubscriberTest.php
+++ b/tests/EventSubscriber/RequireFullAuthForImpersonationSubscriberTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\RequireFullAuthForImpersonationSubscriber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Event\SwitchUserEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+/**
+ * Unit tests for RequireFullAuthForImpersonationSubscriber: switch_user
+ * (?simulateUserId=…) must be denied when the impersonating token came from
+ * the REMEMBERME cookie instead of a full login (#587 security posture).
+ *
+ * @internal
+ */
+#[CoversClass(RequireFullAuthForImpersonationSubscriber::class)]
+final class RequireFullAuthForImpersonationSubscriberTest extends TestCase
+{
+    private RequireFullAuthForImpersonationSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subscriber = new RequireFullAuthForImpersonationSubscriber(new AuthenticationTrustResolver());
+    }
+
+    public function testSubscribedToSwitchUserEvent(): void
+    {
+        self::assertSame(
+            [SecurityEvents::SWITCH_USER => 'onSwitchUser'],
+            RequireFullAuthForImpersonationSubscriber::getSubscribedEvents(),
+        );
+    }
+
+    public function testRememberedOriginalTokenIsDenied(): void
+    {
+        $admin = new InMemoryUser('admin', null, ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
+        $originalToken = new RememberMeToken($admin, 'main');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->subscriber->onSwitchUser($this->switchEvent($originalToken));
+    }
+
+    public function testFullyAuthenticatedOriginalTokenIsAllowed(): void
+    {
+        // No exception: the switch proceeds for a full login.
+        $this->expectNotToPerformAssertions();
+
+        $admin = new InMemoryUser('admin', null, ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
+        $originalToken = new UsernamePasswordToken($admin, 'main', $admin->getRoles());
+
+        $this->subscriber->onSwitchUser($this->switchEvent($originalToken));
+    }
+
+    public function testExitingImpersonationIsNotGated(): void
+    {
+        // Leaving an impersonation dispatches the event with the ORIGINAL
+        // (non-SwitchUser) token — even a remembered one must pass so the
+        // admin can always back out.
+        $this->expectNotToPerformAssertions();
+
+        $admin = new InMemoryUser('admin', null, ['ROLE_ADMIN']);
+        $exitEvent = new SwitchUserEvent(new Request(), $admin, new RememberMeToken($admin, 'main'));
+
+        $this->subscriber->onSwitchUser($exitEvent);
+    }
+
+    private function switchEvent(TokenInterface $originalToken): SwitchUserEvent
+    {
+        $target = new InMemoryUser('developer', null, ['ROLE_USER']);
+        $switchUserToken = new SwitchUserToken($target, 'main', ['ROLE_USER'], $originalToken);
+
+        return new SwitchUserEvent(new Request(), $target, $switchUserToken);
+    }
+}

--- a/tests/Security/PasskeyRememberMeTest.php
+++ b/tests/Security/PasskeyRememberMeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
+use Symfony\Component\Security\Http\EventListener\CheckRememberMeConditionsListener;
+
+/**
+ * Characterization test for the passkey "Stay logged in" contract (#587).
+ *
+ * The webauthn assertion travels to /login/passkey as a raw JSON body, which
+ * Symfony's CheckRememberMeConditionsListener never inspects — it reads the
+ * `_remember_me` parameter from request attributes, the query string, or form
+ * fields only. The SPA therefore appends `?_remember_me=1` to the result URL
+ * (frontend/src/lib/passkeys.ts). These tests pin that mechanism with the real
+ * listener and its shipped defaults (always_remember_me=false, parameter
+ * `_remember_me` — security.yaml overrides neither): if a Symfony upgrade
+ * stops honoring the query parameter for POST logins, passkey remember-me
+ * breaks and this test flags it.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class PasskeyRememberMeTest extends TestCase
+{
+    public function testQueryParameterEnablesRememberMeForJsonBodyLogin(): void
+    {
+        $badge = $this->dispatchLoginSuccess('/login/passkey?_remember_me=1');
+
+        self::assertTrue($badge->isEnabled(), '?_remember_me=1 on the ceremony result URL must enable remember-me');
+    }
+
+    public function testWithoutQueryParameterRememberMeStaysDisabled(): void
+    {
+        $badge = $this->dispatchLoginSuccess('/login/passkey');
+
+        self::assertFalse($badge->isEnabled(), 'a passkey login without the parameter must not opt in to remember-me');
+    }
+
+    /**
+     * Run the real listener over a login-success event for a JSON-body POST —
+     * the shape of the SPA's webauthn result request.
+     */
+    private function dispatchLoginSuccess(string $uri): RememberMeBadge
+    {
+        $user = new InMemoryUser('unittest', null);
+        $rememberMeBadge = new RememberMeBadge();
+        $passport = new SelfValidatingPassport(
+            new UserBadge('unittest', static fn (): InMemoryUser => $user),
+            [$rememberMeBadge],
+        );
+
+        $request = Request::create(
+            $uri,
+            Request::METHOD_POST,
+            server: ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            content: '{"id":"assertion"}',
+        );
+
+        $loginSuccessEvent = new LoginSuccessEvent(
+            self::createStub(AuthenticatorInterface::class),
+            $passport,
+            new UsernamePasswordToken($user, 'main', $user->getRoles()),
+            $request,
+            null,
+            'main',
+        );
+
+        new CheckRememberMeConditionsListener()->onSuccessfulLogin($loginSuccessEvent);
+
+        return $rememberMeBadge;
+    }
+}

--- a/tests/Security/RememberMeFlowTest.php
+++ b/tests/Security/RememberMeFlowTest.php
@@ -39,6 +39,8 @@ final class RememberMeFlowTest extends AbstractWebTestCase
 
     private const string PROBE_PATH = '/getUsers';
 
+    private const string PATH_LOGIN = '/login';
+
     /** Throwaway fixture value for the seeded test user's local login. */
     private const string VALID_LOGIN = 'Str0ng-Horse-Battery-42';
 
@@ -78,10 +80,7 @@ final class RememberMeFlowTest extends AbstractWebTestCase
 
         // The very first request after the "restart" must be served, not bounced
         // to /login (the pre-#587 behavior force-logged the user out here).
-        $this->client->request(Request::METHOD_GET, self::PROBE_PATH, [], [], [
-            'HTTP_ACCEPT' => 'application/json',
-            'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest',
-        ]);
+        $this->client->request(Request::METHOD_GET, self::PROBE_PATH, [], [], self::jsonHeaders(xhr: true));
         $this->assertStatusCode(200);
 
         self::assertRememberMeCookieNotCleared($this->client->getResponse()->headers->getCookies());
@@ -97,21 +96,17 @@ final class RememberMeFlowTest extends AbstractWebTestCase
         // must re-enter credentials. The response is the form_login entry
         // point's redirect — NOT a logout, so the REMEMBERME cookie survives
         // and day-to-day routes keep working afterwards.
-        $this->client->request(Request::METHOD_GET, '/settings/api-tokens', [], [], [
-            'HTTP_ACCEPT' => 'application/json',
-        ]);
+        $this->client->request(Request::METHOD_GET, '/settings/api-tokens', [], [], self::jsonHeaders());
 
         self::assertResponseRedirects();
         $location = $this->client->getResponse()->headers->get('Location');
         self::assertNotNull($location);
-        self::assertStringContainsString('/login', $location);
+        self::assertStringContainsString(self::PATH_LOGIN, $location);
 
         self::assertRememberMeCookieNotCleared($this->client->getResponse()->headers->getCookies());
 
         // The remembered session is still intact: a normal route stays reachable.
-        $this->client->request(Request::METHOD_GET, self::PROBE_PATH, [], [], [
-            'HTTP_ACCEPT' => 'application/json',
-        ]);
+        $this->client->request(Request::METHOD_GET, self::PROBE_PATH, [], [], self::jsonHeaders());
         $this->assertStatusCode(200);
     }
 
@@ -143,7 +138,7 @@ final class RememberMeFlowTest extends AbstractWebTestCase
 
         // A full-fledged login has nothing to do on /login — the pre-#587
         // redirect to the start page must survive the step-up fix.
-        $this->client->request(Request::METHOD_GET, '/login');
+        $this->client->request(Request::METHOD_GET, self::PATH_LOGIN);
 
         self::assertResponseRedirects('/');
     }
@@ -161,14 +156,12 @@ final class RememberMeFlowTest extends AbstractWebTestCase
         // RequireFullAuthForImpersonationSubscriber does (unit-tested).
         // Either way the remembered user must land on the step-up redirect
         // below — never a completed switch, never a logout.
-        $this->client->request(Request::METHOD_GET, self::PROBE_PATH . '?simulateUserId=2', [], [], [
-            'HTTP_ACCEPT' => 'application/json',
-        ]);
+        $this->client->request(Request::METHOD_GET, self::PROBE_PATH . '?simulateUserId=2', [], [], self::jsonHeaders());
 
         self::assertResponseRedirects();
         $location = $this->client->getResponse()->headers->get('Location');
         self::assertNotNull($location);
-        self::assertStringContainsString('/login', $location);
+        self::assertStringContainsString(self::PATH_LOGIN, $location);
 
         self::assertRememberMeCookieNotCleared($this->client->getResponse()->headers->getCookies());
     }
@@ -203,7 +196,7 @@ final class RememberMeFlowTest extends AbstractWebTestCase
      */
     private function postLogin(bool $withRememberMe): void
     {
-        $this->client->request(Request::METHOD_GET, '/login');
+        $this->client->request(Request::METHOD_GET, self::PATH_LOGIN);
         $html = $this->client->getResponse()->getContent();
         self::assertIsString($html);
         self::assertSame(1, preg_match('/name="_csrf_token" value="([^"]+)"/', $html, $matches), 'login page must render the CSRF token');
@@ -217,10 +210,23 @@ final class RememberMeFlowTest extends AbstractWebTestCase
             $parameters['_remember_me'] = 'on';
         }
 
-        $this->client->request(Request::METHOD_POST, '/login', $parameters, [], [
-            'HTTP_ACCEPT' => 'application/json',
-            'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest',
-        ]);
+        $this->client->request(Request::METHOD_POST, self::PATH_LOGIN, $parameters, [], self::jsonHeaders(xhr: true));
+    }
+
+    /**
+     * Server array for a request the way the SPA issues it: JSON Accept
+     * header, optionally marked as an XHR.
+     *
+     * @return array<string, string>
+     */
+    private static function jsonHeaders(bool $xhr = false): array
+    {
+        $server = ['HTTP_ACCEPT' => 'application/json'];
+        if ($xhr) {
+            $server['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+        }
+
+        return $server;
     }
 
     /**

--- a/tests/Security/RememberMeFlowTest.php
+++ b/tests/Security/RememberMeFlowTest.php
@@ -115,6 +115,39 @@ final class RememberMeFlowTest extends AbstractWebTestCase
         $this->assertStatusCode(200);
     }
 
+    public function testStepUpRedirectLandsOnTheLoginForm(): void
+    {
+        $rememberMe = $this->loginWithRememberMe();
+
+        $this->simulateBrowserRestart($rememberMe);
+
+        // A remembered session's request to a keep-FULLY endpoint 302s to
+        // /login. FOLLOWING that redirect must render the login form — the
+        // step-up the SPA's overlay and a manual navigation both depend on.
+        // (/login used to bounce any authenticated user, remembered included,
+        // to the start page, making every FULLY endpoint a dead end, #587.)
+        $this->client->request(Request::METHOD_GET, '/settings/api-tokens');
+        self::assertResponseRedirects();
+
+        $this->client->followRedirect();
+
+        $this->assertStatusCode(200);
+        $html = $this->client->getResponse()->getContent();
+        self::assertIsString($html);
+        self::assertStringContainsString('id="login"', $html, 'the remembered user must reach the login form to step up');
+    }
+
+    public function testLoginPageBouncesFullyAuthenticatedUsersToStart(): void
+    {
+        $this->loginWithRememberMe();
+
+        // A full-fledged login has nothing to do on /login — the pre-#587
+        // redirect to the start page must survive the step-up fix.
+        $this->client->request(Request::METHOD_GET, '/login');
+
+        self::assertResponseRedirects('/');
+    }
+
     public function testRememberedAdminCannotImpersonateWithoutFullLogin(): void
     {
         $rememberMe = $this->loginWithRememberMe();

--- a/tests/Security/RememberMeFlowTest.php
+++ b/tests/Security/RememberMeFlowTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Security;
+
+use Symfony\Component\BrowserKit\Cookie as BrowserKitCookie;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\AbstractWebTestCase;
+use Tests\Traits\LocalPasswordTestTrait;
+
+use function password_hash;
+
+use const PASSWORD_DEFAULT;
+
+/**
+ * End-to-end coverage for "Stay logged in" (#587): a password login with
+ * `_remember_me` issues the 30-day REMEMBERME cookie, and that cookie alone —
+ * the browser-session cookie is gone after a restart — re-authenticates the
+ * next request instead of bouncing the user to the login form. Sensitive
+ * endpoints (ADR-018 re-auth posture) still demand a full login, but reaching
+ * them with a remembered session must redirect to /login WITHOUT destroying
+ * the remembered session.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class RememberMeFlowTest extends AbstractWebTestCase
+{
+    use LocalPasswordTestTrait;
+    private const string COOKIE_NAME = 'REMEMBERME';
+
+    private const string PROBE_PATH = '/getUsers';
+
+    /** Throwaway fixture value for the seeded test user's local login. */
+    private const string VALID_LOGIN = 'Str0ng-Horse-Battery-42';
+
+    public function testLoginWithRememberMeIssuesThirtyDayCookie(): void
+    {
+        $cookie = $this->loginWithRememberMe();
+
+        // lifetime: 2592000 (30 days) from security.yaml — allow the few
+        // seconds between cookie creation and this assertion.
+        $maxAge = $cookie->getExpiresTime() - time();
+        self::assertGreaterThan(2592000 - 60, $maxAge, 'REMEMBERME must live ~30 days');
+        self::assertLessThanOrEqual(2592000, $maxAge);
+        self::assertTrue($cookie->isHttpOnly());
+    }
+
+    public function testLoginWithoutRememberMeIssuesNoCookie(): void
+    {
+        $this->prepareLocalPassword();
+        $this->postLogin(withRememberMe: false);
+        $this->assertStatusCode(200);
+
+        // Symfony answers a parameter-less login with a CLEARING Set-Cookie
+        // (REMEMBERME=deleted, Max-Age=0) — either that or no header at all is
+        // acceptable; a live 30-day cookie is not.
+        $cookie = $this->responseCookie(self::COOKIE_NAME);
+        self::assertTrue(
+            null === $cookie || $cookie->isCleared(),
+            'No live REMEMBERME cookie may be issued when the checkbox is off',
+        );
+    }
+
+    public function testRememberMeCookieAloneAuthenticatesAfterBrowserRestart(): void
+    {
+        $rememberMe = $this->loginWithRememberMe();
+
+        $this->simulateBrowserRestart($rememberMe);
+
+        // The very first request after the "restart" must be served, not bounced
+        // to /login (the pre-#587 behavior force-logged the user out here).
+        $this->client->request(Request::METHOD_GET, self::PROBE_PATH, [], [], [
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest',
+        ]);
+        $this->assertStatusCode(200);
+
+        self::assertRememberMeCookieNotCleared($this->client->getResponse()->headers->getCookies());
+    }
+
+    public function testSensitiveEndpointRedirectsRememberedUserToLoginWithoutDestroyingCookie(): void
+    {
+        $rememberMe = $this->loginWithRememberMe();
+
+        $this->simulateBrowserRestart($rememberMe);
+
+        // /settings/* carries the ADR-018 re-auth posture: a remembered session
+        // must re-enter credentials. The response is the form_login entry
+        // point's redirect — NOT a logout, so the REMEMBERME cookie survives
+        // and day-to-day routes keep working afterwards.
+        $this->client->request(Request::METHOD_GET, '/settings/api-tokens', [], [], [
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+
+        self::assertResponseRedirects();
+        $location = $this->client->getResponse()->headers->get('Location');
+        self::assertNotNull($location);
+        self::assertStringContainsString('/login', $location);
+
+        self::assertRememberMeCookieNotCleared($this->client->getResponse()->headers->getCookies());
+
+        // The remembered session is still intact: a normal route stays reachable.
+        $this->client->request(Request::METHOD_GET, self::PROBE_PATH, [], [], [
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+        $this->assertStatusCode(200);
+    }
+
+    public function testRememberedAdminCannotImpersonateWithoutFullLogin(): void
+    {
+        $rememberMe = $this->loginWithRememberMe();
+
+        $this->simulateBrowserRestart($rememberMe);
+
+        // switch_user (?simulateUserId=…) is an impersonation grant — a stolen
+        // REMEMBERME cookie must never be enough. For the seeded user 1
+        // (ROLE_ADMIN, no ROLE_ALLOWED_TO_SWITCH) the firewall's role check
+        // denies the switch; for a remembered super-admin the
+        // RequireFullAuthForImpersonationSubscriber does (unit-tested).
+        // Either way the remembered user must land on the step-up redirect
+        // below — never a completed switch, never a logout.
+        $this->client->request(Request::METHOD_GET, self::PROBE_PATH . '?simulateUserId=2', [], [], [
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+
+        self::assertResponseRedirects();
+        $location = $this->client->getResponse()->headers->get('Location');
+        self::assertNotNull($location);
+        self::assertStringContainsString('/login', $location);
+
+        self::assertRememberMeCookieNotCleared($this->client->getResponse()->headers->getCookies());
+    }
+
+    /**
+     * Give the seeded user a known local password, then perform the SPA's XHR
+     * login with the remember-me checkbox ticked; returns the issued cookie.
+     */
+    private function loginWithRememberMe(): Cookie
+    {
+        $this->prepareLocalPassword();
+        $this->postLogin(withRememberMe: true);
+        $this->assertStatusCode(200);
+
+        $cookie = $this->responseCookie(self::COOKIE_NAME);
+        self::assertNotNull($cookie, 'login with _remember_me must issue the REMEMBERME cookie');
+
+        return $cookie;
+    }
+
+    private function prepareLocalPassword(): void
+    {
+        $this->setStoredPassword(1, password_hash(self::VALID_LOGIN, PASSWORD_DEFAULT));
+        // Fresh, unauthenticated "browser" — setUp()'s session belongs to the
+        // pre-password-change token and would be deauthenticated anyway.
+        $this->client->getCookieJar()->clear();
+    }
+
+    /**
+     * POST the password step the way the SPA does (fetch/XHR): render the login
+     * page first for the 'authenticate' CSRF token, then submit credentials.
+     */
+    private function postLogin(bool $withRememberMe): void
+    {
+        $this->client->request(Request::METHOD_GET, '/login');
+        $html = $this->client->getResponse()->getContent();
+        self::assertIsString($html);
+        self::assertSame(1, preg_match('/name="_csrf_token" value="([^"]+)"/', $html, $matches), 'login page must render the CSRF token');
+
+        $parameters = [
+            '_username' => 'unittest',
+            '_password' => self::VALID_LOGIN,
+            '_csrf_token' => $matches[1],
+        ];
+        if ($withRememberMe) {
+            $parameters['_remember_me'] = 'on';
+        }
+
+        $this->client->request(Request::METHOD_POST, '/login', $parameters, [], [
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest',
+        ]);
+    }
+
+    /**
+     * Drop every cookie (the browser-session cookie above all) and carry over
+     * ONLY the REMEMBERME cookie — the state a browser restart leaves behind.
+     */
+    private function simulateBrowserRestart(Cookie $rememberMe): void
+    {
+        $this->client->getCookieJar()->clear();
+        $this->client->getCookieJar()->set(new BrowserKitCookie(
+            self::COOKIE_NAME,
+            (string) $rememberMe->getValue(),
+            (string) $rememberMe->getExpiresTime(),
+            $rememberMe->getPath(),
+        ));
+    }
+
+    private function responseCookie(string $name): ?Cookie
+    {
+        foreach ($this->client->getResponse()->headers->getCookies() as $cookie) {
+            if ($cookie->getName() === $name) {
+                return $cookie;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Cookie> $cookies
+     */
+    private static function assertRememberMeCookieNotCleared(array $cookies): void
+    {
+        foreach ($cookies as $cookie) {
+            if (self::COOKIE_NAME === $cookie->getName()) {
+                self::assertFalse(
+                    $cookie->isCleared(),
+                    'the response must not delete the REMEMBERME cookie',
+                );
+            }
+        }
+    }
+}

--- a/tests/Security/RememberMeRedirectTest.php
+++ b/tests/Security/RememberMeRedirectTest.php
@@ -16,9 +16,10 @@ use function assert;
 /**
  * Regression tests for remember_me authentication edge cases.
  *
- * These tests verify that users authenticated via remember_me (but not fully
- * authenticated) are properly logged out instead of seeing a 403 error or
- * getting stuck in a redirect loop, and that logout CSRF is enforced.
+ * These tests verify that users authenticated via remember_me are served on
+ * day-to-day routes (#587 — the previous force-logout made "Stay logged in"
+ * useless), that a stale REMEMBERME cookie is cleaned up with a redirect to
+ * /login instead of a 403 or a redirect loop, and that logout CSRF is enforced.
  *
  * @internal
  *
@@ -60,33 +61,78 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
     }
 
     /**
-     * Test that a remember_me authenticated user accessing a route requiring
-     * IS_AUTHENTICATED_FULLY is logged out and lands on /login (not 403).
-     *
-     * This is a regression test for the bug where remember_me users would see
-     * "You are not allowed to perform this action" instead of being redirected
-     * to re-authenticate.
+     * A remember_me-authenticated session must be SERVED on day-to-day routes
+     * (#587). The catch-all access rule accepts IS_AUTHENTICATED_REMEMBERED —
+     * the pre-#587 behavior (force-logout to /login on the first request after
+     * a browser restart, which also caused the historic 403/redirect loop)
+     * must not return.
      */
-    public function testRememberMeUserIsLoggedOutNotForbidden(): void
+    public function testRememberMeUserIsServedNotLoggedOut(): void
     {
-        // Get a real user from the database
-        $user = $this->entityManager->getRepository(User::class)->findOneBy([]);
-        if (!$user instanceof User) {
-            self::markTestSkipped('No users in database to test with');
+        $this->authenticateViaRememberMeToken();
+
+        // A day-to-day data route (requires IS_AUTHENTICATED_REMEMBERED)
+        $this->client->request('GET', '/getUsers');
+
+        self::assertResponseIsSuccessful('Remembered user must be served, not logged out');
+
+        // The remembered session must survive: no REMEMBERME cookie deletion.
+        foreach ($this->client->getResponse()->headers->getCookies() as $cookie) {
+            if ('REMEMBERME' === $cookie->getName()) {
+                self::assertFalse($cookie->isCleared(), 'REMEMBERME cookie must not be deleted');
+            }
+        }
+    }
+
+    /**
+     * A remembered session reaching an IS_AUTHENTICATED_FULLY endpoint (ADR-018
+     * re-auth posture) is redirected to /login by the form_login entry point —
+     * a step-up prompt, NOT a logout: the session cookie and REMEMBERME cookie
+     * stay untouched, so day-to-day routes keep working afterwards.
+     */
+    public function testRememberMeUserIsRedirectedToStepUpOnSensitiveRoute(): void
+    {
+        $this->authenticateViaRememberMeToken();
+
+        $this->client->request('GET', '/settings/api-tokens');
+
+        self::assertResponseRedirects();
+        $location = $this->client->getResponse()->headers->get('Location');
+        self::assertNotNull($location);
+        self::assertStringContainsString(self::PATH_LOGIN, $location,
+            'Remembered user must be sent to /login to step up, not shown 403');
+
+        foreach ($this->client->getResponse()->headers->getCookies() as $cookie) {
+            if ('REMEMBERME' === $cookie->getName()) {
+                self::assertFalse($cookie->isCleared(), 'step-up redirect must not delete the REMEMBERME cookie');
+            }
         }
 
-        // Create a RememberMeToken (not fully authenticated)
+        // The remembered session is still alive after the denied request.
+        $this->client->request('GET', '/getUsers');
+        self::assertResponseIsSuccessful('the remembered session must survive a step-up redirect');
+    }
+
+    /**
+     * Store a RememberMeToken (authenticated, but not full-fledged) in a real
+     * session and attach its cookie to the client — the state Symfony's
+     * remember-me authenticator leaves behind after resurrecting a session
+     * from the REMEMBERME cookie.
+     */
+    private function authenticateViaRememberMeToken(): void
+    {
+        $user = $this->entityManager->getRepository(User::class)->find(1);
+        self::assertInstanceOf(User::class, $user);
+
         // Symfony 8: RememberMeToken only takes 2 parameters - $user and $firewallName
         $token = new RememberMeToken($user, 'main');
 
-        // Set the token in the security context via session
         assert(null !== $this->serviceContainer, self::MSG_NO_CONTAINER);
         /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface $session */
         $session = $this->serviceContainer->get('session.factory')->createSession();
         $session->set('_security_main', serialize($token));
         $session->save();
 
-        // Set the session cookie on the client
         $this->client->getCookieJar()->set(new Cookie(
             $session->getName(),
             $session->getId(),
@@ -96,19 +142,6 @@ final class RememberMeRedirectTest extends AbstractWebTestCase
             false,
             true,
         ));
-
-        // Access a route that requires IS_AUTHENTICATED_FULLY
-        $this->client->request('GET', '/');
-
-        // Should be logged out programmatically and redirected, NOT shown 403
-        self::assertResponseRedirects();
-        $location = $this->client->getResponse()->headers->get('Location');
-        self::assertNotNull($location);
-
-        // Case 2 in AccessDeniedSubscriber performs a programmatic logout,
-        // whose response redirects straight to the login page.
-        self::assertStringContainsString(self::PATH_LOGIN, $location,
-            'Remember_me user should be logged out and land on /login, not shown 403');
     }
 
     /**


### PR DESCRIPTION
## Description

"Stay logged in" was a no-op: the REMEMBERME cookie was issued on login but could never be used. The `access_control` catch-all (`^/`) demanded `IS_AUTHENTICATED_FULLY`, which a session resumed from the remember-me cookie can never satisfy (Symfony grants it `IS_AUTHENTICATED_REMEMBERED` only). The resulting `AccessDeniedException` was then handled by `AccessDeniedSubscriber` "Case 2", which force-logged the user out and **deleted the REMEMBERME cookie** — so the very first request after a browser restart bounced the user to the login form, for both password and passkey logins.

A second, independent defect hit passkeys: the webauthn assertion is POSTed as a raw JSON body, which Symfony's `CheckRememberMeConditionsListener` never inspects (it reads `_remember_me` from attributes/query/form fields only), so passkey logins never issued the cookie at all.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Closes #587

## Changes Made

- `access_control`: catch-all `^/` now requires `IS_AUTHENTICATED_REMEMBERED` instead of `IS_AUTHENTICATED_FULLY` (FULLY implies REMEMBERED, so nothing else gains access)
- `AccessDeniedSubscriber`: removed the force-logout "Case 2" — a remembered (or half-2FA) session now defers to Symfony's security `ExceptionListener`, which redirects to the login entry point for a step-up **without** touching the session or the REMEMBERME cookie; the SPA's existing `SessionExpiredOverlay` picks this up for XHR calls (in-place re-login). Case 1 (stale-cookie cleanup for unauthenticated requests) is kept
- Relaxed `#[IsGranted('IS_AUTHENTICATED_FULLY')]` → `IS_AUTHENTICATED_REMEMBERED` on day-to-day endpoints: `Default/*` (getData, getUsers, getCustomer(s), getActivities, getHolidays, getAllProjects, getSummary, getTicketTimeSummary, getContractHours, CSV export, Jira OAuth callback), `Tracking/*` (save/delete/bulk/get entry), `Interpretation/*` (all GroupBy + last entries), `Admin/GetPresetsAction`, and the two `Status/*` logged-in probes
- Passkey login remember-me: the SPA now appends `?_remember_me=1` to the `/login/passkey` result URL (query parameters are read by the remember-me listener; the JSON body is not), evaluated at submit time from the "Stay logged in" checkbox. The session-expired overlay passes remember=true, matching its password path (Symfony cancels old remember-me cookies on every login, so a bare re-login would have dropped an existing cookie)

### Endpoints that KEEP requiring a full login (`IS_AUTHENTICATED_FULLY`)

ADR-018 re-auth posture — a remembered session is redirected to the login step-up for:

| Area | Endpoints |
|---|---|
| Password | `POST /settings/password` |
| Passkeys | `GET /settings/security/passkeys/list`, `POST /settings/security/passkeys/delete`, and the registration ceremony `POST /settings/security/passkeys/options` + `POST /settings/security/passkeys` (bundle routes, gated via a new `access_control` rule — a passkey registered from a stolen cookie would escalate it into a permanent full login) |
| API tokens | `GET /settings/api-tokens`, `POST /settings/api-tokens/create`, `POST /settings/api-tokens/revoke` |
| 2FA | `POST /settings/2fa/totp/start`, `POST /settings/2fa/totp/confirm`, `POST /settings/2fa/disable` |
| Admin mutations (new, on top of `ROLE_ADMIN`) | all `*/save`, `*/delete` (activity, contract, customer, holiday, personio-config, preset, project, team, ticketsystem, user), `holiday/import-ical`, `user/reset-2fa`, `project-import/confirm`, `personio/employee-matches/confirm`, `projects/*/syncsubtickets`, `syncentries/jira` |
| Impersonation | `?simulateUserId=…` (switch_user) — new `RequireFullAuthForImpersonationSubscriber` denies a switch when the impersonating token is not full-fledged |

## Security posture

What a stolen REMEMBERME cookie (30-day TTL, `httponly`, `samesite=lax`, `secure` on HTTPS) can and cannot do now:

- **Can**: read and book work time as the victim — the day-to-day app surface (previously: nothing, because remember-me was effectively disabled; this is the deliberate trade-off that makes "Stay logged in" work)
- **Cannot**: change the password, add/remove passkeys, create/revoke API tokens, enroll/disable 2FA, mutate admin data (customers, projects, users, …), trigger Jira sync, or impersonate other users — all of these force a fresh password/passkey login first
- The cookie is single-user, rotated on each use, and invalidated by logout and by Symfony's token versioning on password change
- scheb 2FA interplay is unchanged: remember-me issuance is deferred until the second factor is completed (`SuppressRememberMeListener`/`TwoFactorAuthenticator`), and a half-done 2FA login still cannot reach any route (a `TwoFactorToken` is neither remembered nor full)

## Testing

- [x] Unit tests pass — full backend suite: 2604 tests, 8592 assertions, 0 failures
- [x] Static analysis passes — PHPStan level 10, PHP-CS-Fixer, Rector, PHPat all clean
- [x] Frontend gates — eslint, tsc, vitest (544 tests) clean
- [x] Manual testing completed — live curl against the e2e stack: login with `_remember_me=on` → `REMEMBERME` with `Max-Age=2592000`; dropped the session cookie (browser-restart simulation) → `GET /` 302 → `/ui/tracking` and `GET /getUsers` 200 with the cookie **re-issued, not deleted** (pre-fix: 302 → `/login` + `REMEMBERME=deleted`); `GET /settings/api-tokens` → 302 → `/login` with the cookie intact and day-to-day routes still alive afterwards; `?simulateUserId=2` → step-up redirect, no switch

New/rewritten tests:

- `tests/Security/RememberMeFlowTest.php` — end-to-end: cookie issued with ~30d Max-Age (and NOT issued without the checkbox), the cookie alone authenticates after a simulated browser restart, a sensitive endpoint redirects to step-up without destroying the cookie, impersonation is blocked for a remembered admin
- `tests/Security/RememberMeRedirectTest.php` — rewritten: it previously pinned the force-logout as intended behavior; now asserts a remembered session is served on day-to-day routes and stepped up (cookie intact) on sensitive ones; stale-cookie cleanup and logout-CSRF tests unchanged
- `tests/Security/PasskeyRememberMeTest.php` — pins the `?_remember_me=1` query-parameter contract the SPA relies on (the JSON body is not consulted) against the real Symfony listener
- `tests/EventSubscriber/AccessDeniedSubscriberTest.php` — Case 2 now defers (no logout, no response)
- `tests/EventSubscriber/RequireFullAuthForImpersonationSubscriberTest.php` — remembered original token denied, full token allowed, impersonation exit not gated
- `frontend/src/lib/passkeys.test.ts`, `LoginForm.test.tsx`, `SessionExpiredOverlay.test.tsx` — remember choice threaded into both passkey ceremonies, evaluated at submit time

## Migration Notes

None. No schema changes; no config changes required in deployments. Sessions and cookies keep working as before — remembered sessions simply stop being destroyed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/netresearch/timetracker/blob/main/CONTRIBUTING.md) guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/netresearch/timetracker/blob/main/CODE_OF_CONDUCT.md)
