### PR TITLE
fix(i18n): render the server-side header in the user's saved locale

### DIFF
--- a/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/src/EventSubscriber/UserLocaleSubscriber.php
@@ -32,7 +32,12 @@ use Symfony\Component\Translation\LocaleSwitcher;
  * listener; the LocaleSwitcher call propagates it to all locale-aware
  * services directly. The request locale is still set for consumers that read
  * it (e.g. app.request.locale in error templates). Runs on sub-requests too,
- * so error pages rendered as sub-requests get the user's locale as well.
+ * so error pages rendered as sub-requests get the user's locale even when
+ * the exception fired before this listener ran on the main request (e.g. a
+ * 403 from the firewall at priority 8). A request dispatched with an
+ * explicit `_locale` attribute is left untouched — error sub-requests carry
+ * none (ErrorListener::duplicateRequest() replaces the attributes), so the
+ * guard only skips requests that were given a fixed locale on purpose.
  */
 final readonly class UserLocaleSubscriber implements EventSubscriberInterface
 {
@@ -52,6 +57,14 @@ final readonly class UserLocaleSubscriber implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $requestEvent): void
     {
+        $request = $requestEvent->getRequest();
+
+        // An explicit `_locale` (route parameter or a sub-request dispatched
+        // in a fixed locale) wins over the user's saved locale.
+        if ($request->attributes->has('_locale')) {
+            return;
+        }
+
         $user = $this->security->getUser();
         if (!$user instanceof User) {
             return;
@@ -60,7 +73,7 @@ final readonly class UserLocaleSubscriber implements EventSubscriberInterface
         // Normalize on read like User::getSettings() does — legacy rows may
         // hold values outside the supported de/en/es/fr/ru set.
         $locale = $this->localizationService->normalizeLocale($user->getLocale());
-        $requestEvent->getRequest()->setLocale($locale);
+        $request->setLocale($locale);
         $this->localeSwitcher->setLocale($locale);
     }
 }

--- a/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/src/EventSubscriber/UserLocaleSubscriber.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\User;
+use App\Service\Util\LocalizationService;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Translation\LocaleSwitcher;
+
+/**
+ * Sets the request + translator locale from the authenticated user's saved locale.
+ *
+ * The server-rendered chrome (templates/partials/header.html.twig) translates
+ * through the translator locale. Without this subscriber every request kept
+ * the configured default locale, so the header rendered in the app default
+ * while the SPA content followed the user's saved locale (issue #618).
+ *
+ * Priority 4: below the security firewall (8), so the token exists when we
+ * read the user. Symfony's LocaleAwareListener syncs the translator from the
+ * request at priority 15 — BEFORE the firewall — so setting the request
+ * locale alone can never reach the translator from a firewall-dependent
+ * listener; the LocaleSwitcher call propagates it to all locale-aware
+ * services directly. The request locale is still set for consumers that read
+ * it (e.g. app.request.locale in error templates). Runs on sub-requests too,
+ * so error pages rendered as sub-requests get the user's locale as well.
+ */
+final readonly class UserLocaleSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private Security $security,
+        private LocaleSwitcher $localeSwitcher,
+        private LocalizationService $localizationService,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 4],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $requestEvent): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        // Normalize on read like User::getSettings() does — legacy rows may
+        // hold values outside the supported de/en/es/fr/ru set.
+        $locale = $this->localizationService->normalizeLocale($user->getLocale());
+        $requestEvent->getRequest()->setLocale($locale);
+        $this->localeSwitcher->setLocale($locale);
+    }
+}

--- a/tests/Controller/UiSpaActionTest.php
+++ b/tests/Controller/UiSpaActionTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
+use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\AbstractWebTestCase;
 
@@ -49,6 +51,47 @@ final class UiSpaActionTest extends AbstractWebTestCase
         $this->assertStatusCode(200);
         $content = (string) $this->client->getResponse()->getContent();
         self::assertStringContainsString('window.APP_CONFIG', $content);
+    }
+
+    public function testHeaderIsGermanForGermanLocaleUser(): void
+    {
+        // Seeded user 1 'unittest' has locale 'de' (sql/unittest/002_testdata.sql).
+        $this->client->request(Request::METHOD_GET, '/ui');
+
+        $this->assertStatusCode(200);
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('<html lang="de">', $content);
+        self::assertStringContainsString('>Übersicht<', $content);
+        self::assertStringContainsString('title="Abmelden"', $content);
+    }
+
+    public function testHeaderFollowsUserLocaleOverDefaultLocale(): void
+    {
+        // The test env default_locale is 'de' (config/packages/test/translation.yaml),
+        // so only a user whose saved locale DIFFERS from the default can tell
+        // "header follows the user" apart from "header follows the default".
+        $this->setUserLocale(1, 'en');
+
+        $this->client->request(Request::METHOD_GET, '/ui');
+
+        $this->assertStatusCode(200);
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('<html lang="en">', $content);
+        self::assertStringContainsString('>Overview<', $content);
+        self::assertStringContainsString('title="Logout"', $content);
+        self::assertStringNotContainsString('Übersicht', $content);
+        self::assertStringNotContainsString('Abmelden', $content);
+    }
+
+    private function setUserLocale(int $userId, string $locale): void
+    {
+        self::assertNotNull($this->serviceContainer);
+        $doctrine = $this->serviceContainer->get('doctrine');
+        self::assertInstanceOf(ManagerRegistry::class, $doctrine);
+        $user = $doctrine->getRepository(User::class)->find($userId);
+        self::assertInstanceOf(User::class, $user);
+        $user->setLocale($locale);
+        $doctrine->getManager()->flush();
     }
 
     public function testAnonymousUserIsRedirectedToLogin(): void

--- a/tests/EventSubscriber/UserLocaleSubscriberTest.php
+++ b/tests/EventSubscriber/UserLocaleSubscriberTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Entity\User;
+use App\EventSubscriber\UserLocaleSubscriber;
+use App\Service\Util\LocalizationService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Translation\LocaleSwitcher;
+
+/**
+ * @internal
+ */
+#[CoversClass(UserLocaleSubscriber::class)]
+final class UserLocaleSubscriberTest extends TestCase
+{
+    private const string DEFAULT_LOCALE = 'en';
+
+    private LocaleSwitcher $localeSwitcher;
+
+    protected function setUp(): void
+    {
+        $this->localeSwitcher = new LocaleSwitcher(self::DEFAULT_LOCALE, []);
+    }
+
+    public function testAppliesTheUsersSavedLocaleToRequestAndTranslator(): void
+    {
+        $request = Request::create('/ui');
+
+        $this->dispatch($request, user: self::userWithLocale('de'));
+
+        self::assertSame('de', $request->getLocale());
+        self::assertSame('de', $this->localeSwitcher->getLocale());
+    }
+
+    public function testNormalizesAnUnsupportedLegacyLocale(): void
+    {
+        $request = Request::create('/ui');
+
+        $this->dispatch($request, user: self::userWithLocale('xx'));
+
+        self::assertSame('en', $request->getLocale());
+        self::assertSame('en', $this->localeSwitcher->getLocale());
+    }
+
+    public function testAnonymousRequestKeepsTheDefaultLocale(): void
+    {
+        $request = Request::create('/login');
+
+        $this->dispatch($request, user: null);
+
+        self::assertSame(self::DEFAULT_LOCALE, $request->getLocale());
+        self::assertSame(self::DEFAULT_LOCALE, $this->localeSwitcher->getLocale());
+    }
+
+    public function testErrorSubRequestGetsTheUsersLocale(): void
+    {
+        // Mirror ErrorListener::duplicateRequest(): the error sub-request is a
+        // clone of the failing request whose attributes are REPLACED, so no
+        // `_locale` survives — the user's locale must still be applied.
+        $subRequest = Request::create('/ui')->duplicate(null, null, [
+            '_controller' => 'error_controller',
+            'exception' => new RuntimeException('boom'),
+        ]);
+
+        $this->dispatch($subRequest, user: self::userWithLocale('de'), requestType: HttpKernelInterface::SUB_REQUEST);
+
+        self::assertSame('de', $subRequest->getLocale());
+        self::assertSame('de', $this->localeSwitcher->getLocale());
+    }
+
+    public function testSubRequestWithAnExplicitLocaleIsLeftUntouched(): void
+    {
+        // A sub-request dispatched in a fixed locale (fragment, localized
+        // rendering) carries `_locale`; the user's saved locale must not win.
+        $subRequest = Request::create('/_fragment');
+        $subRequest->attributes->set('_locale', 'fr');
+        $subRequest->setLocale('fr');
+
+        $this->dispatch($subRequest, user: self::userWithLocale('de'), requestType: HttpKernelInterface::SUB_REQUEST);
+
+        self::assertSame('fr', $subRequest->getLocale());
+        self::assertSame(self::DEFAULT_LOCALE, $this->localeSwitcher->getLocale());
+    }
+
+    private function dispatch(
+        Request $request,
+        ?User $user,
+        int $requestType = HttpKernelInterface::MAIN_REQUEST,
+    ): void {
+        $security = self::createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $subscriber = new UserLocaleSubscriber($security, $this->localeSwitcher, new LocalizationService());
+        $subscriber->onKernelRequest(new RequestEvent(self::createStub(HttpKernelInterface::class), $request, $requestType));
+    }
+
+    private static function userWithLocale(string $locale): User
+    {
+        $user = new User();
+        $user->setLocale($locale);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Description

The server-rendered header (`templates/partials/header.html.twig`) always translated with the app default locale (`en`) while the SPA main content followed the user's saved locale — German table, English header (#618). Root cause: the request locale was never set from the authenticated user; the SPA content is localized through a separate channel (`window.APP_CONFIG.locale` → Paraglide).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issue

Closes #618

## Changes Made

- New `src/EventSubscriber/UserLocaleSubscriber.php` on `kernel.request` at priority 4 (below the firewall at 8, so the security token exists) setting the request locale from the authenticated `App\Entity\User`'s saved locale, normalized via `LocalizationService` like `User::getSettings()`.
- Symfony 8.1's `LocaleAwareListener` syncs the translator from the request at priority **+15** — *before* the firewall — so a firewall-dependent listener cannot reach the translator by setting the request locale alone. The subscriber therefore also propagates the locale to all locale-aware services via `LocaleSwitcher`.
- No catalog changes: all 26 header `trans` keys already exist in every `translations/messages.{en,de,es,fr,ru}.yml`.

Side effect (intended): every translated server response now follows the user's saved locale (e.g. translated API messages), not only the header.

## Testing

- [x] Unit tests pass (`make test`) — full suite, 2692 tests
- [x] Static analysis passes (`make check-all`) — phpstan L10, php-cs-fixer, rector dry-run, phpat
- [ ] Manual testing completed
- [x] E2E tests pass (if applicable) — `navigation.spec.ts` + `login.spec.ts` (20/20); e2e nav helpers use `data-nav` selectors, no visible-text header lookups (grepped)

New tests in `tests/Controller/UiSpaActionTest.php`:
- `testHeaderFollowsUserLocaleOverDefaultLocale` — the discriminating case: the test env `default_locale` is `de`, so the test flips user 1 to `en` and asserts the header renders `Overview`/`lang="en"` and no `Übersicht`. Fails without the subscriber (verified pre-fix).
- `testHeaderIsGermanForGermanLocaleUser` — the issue's acceptance criterion for a `de` user.

## Code Quality

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes (or properly documented)

## Migration Notes

None.