### PR TITLE
fix(frontend): refresh header worktime summary on refocus, status poll, and sync mutations

### DIFF
--- a/e2e/summary-refresh.spec.ts
+++ b/e2e/summary-refresh.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type Page } from '@playwright/test';
+import { createEntry, deleteEntry, getActivities } from './helpers/api';
+import { loginIsolated } from './helpers/auth';
+
+/**
+ * The header's TODAY/WEEK/MONTH summary (#worktime-day/-week/-month) is painted
+ * imperatively from GET /api/v2/time-balance, outside TanStack Query. #620: it
+ * refreshed only on init and after Tracking-page mutations, so entries written
+ * out-of-band (another tab, the REST/MCP API) left it stale until F5. This
+ * spec covers the new refocus catch-up against a real out-of-band write. The
+ * 90s poll piggyback is deliberately NOT asserted in e2e — an interval
+ * assertion against the stack's frozen server clock would be meaningless — it
+ * is unit-tested in frontend/src/header.test.ts, as are throttle + hidden-tab.
+ */
+
+const isBalanceFetch = (r: { url(): string }): boolean => r.url().includes('/api/v2/time-balance');
+
+interface Refs {
+  customer: number;
+  project: number;
+  activity: number;
+}
+
+/** First bookable customer/project/activity for the logged-in user, read via
+ *  the same open endpoints the tracking grid uses (/getProjects is
+ *  role-gated, so projects come from /getAllProjects filtered by customer). */
+async function firstBookableRefs(page: Page): Promise<Refs> {
+  const customersResponse = await page.request.get('/getCustomers');
+  const customers = (await customersResponse.json()) as Array<{ customer: { id: number } }>;
+  const customer = customers[0]!.customer.id;
+  const projectsResponse = await page.request.get('/getAllProjects');
+  const projects = (await projectsResponse.json()) as Array<{ project: { id: number; customer: number } }>;
+  const project = projects.map((row) => row.project).find((candidate) => candidate.customer === customer);
+  const activities = (await getActivities(page)) as Array<{ activity: { id: number } }>;
+  return { customer, project: project!.id, activity: activities[0]!.activity.id };
+}
+
+/** True when the current user's /getData/days/{days} range contains the stamp. */
+async function inDayRange(page: Page, days: number, stamp: string): Promise<boolean> {
+  const response = await page.request.get(`/getData/days/${days}`);
+  const rows = (await response.json()) as Array<{ entry: { description: string } }>;
+  return rows.some((row) => row.entry.description === stamp);
+}
+
+/**
+ * The day the SERVER considers "today". The e2e app runs on its own frozen
+ * clock, and only entries dated on ITS today count into the header's TODAY
+ * total — so the spec discovers it instead of assuming a date. Mechanism:
+ * /getData/days/N filters entries by `day >= today − N`, so an anchor entry
+ * planted on a fixed past day D first becomes visible at N = today − D.
+ */
+async function discoverServerToday(page: Page, refs: Refs): Promise<string> {
+  const anchorDay = '2020-01-01';
+  const stamp = `e2e-620-anchor-${Date.now()}`;
+  const anchor = await createEntry(page, {
+    date: anchorDay,
+    start: '00:00',
+    end: '00:01',
+    ...refs,
+    description: stamp,
+  });
+  try {
+    let lo = 1; // days such that the anchor is NOT included (today − D > lo)
+    let hi = 4096; // upper bound: anchor visible (covers today − D ≈ 11 years)
+    expect(await inDayRange(page, hi, stamp)).toBe(true);
+    while (hi - lo > 1) {
+      const mid = Math.floor((lo + hi) / 2);
+      if (await inDayRange(page, mid, stamp)) {
+        hi = mid;
+      } else {
+        lo = mid;
+      }
+    }
+    const today = new Date(`${anchorDay}T00:00:00Z`);
+    today.setUTCDate(today.getUTCDate() + hi);
+    return today.toISOString().slice(0, 10);
+  } finally {
+    await deleteEntry(page, anchor.id);
+  }
+}
+
+/** Best-effort removal of every entry this spec stamped, however old. */
+async function cleanupStamped(page: Page): Promise<void> {
+  const response = await page.request.get('/getData/days/4096').catch(() => null);
+  if (response === null) {
+    return;
+  }
+  const rows = (await response.json()) as Array<{ entry: { id: number; description: string } }>;
+  for (const row of rows) {
+    if (row.entry.description.startsWith('e2e-620-')) {
+      await deleteEntry(page, row.entry.id).catch(() => undefined);
+    }
+  }
+}
+
+test.describe('Header summary refresh (#620)', () => {
+  test('an out-of-band write is picked up when the window regains focus', async ({ page }) => {
+    // Clock control BEFORE navigation: the refocus refresh is throttled, and
+    // the test jumps past the throttle window instead of sleeping through it.
+    await page.clock.install();
+    await loginIsolated(page);
+
+    try {
+      const refs = await firstBookableRefs(page);
+      const serverToday = await discoverServerToday(page, refs);
+
+      // Hard reload of the worklog with the init balance fetch awaited, so the
+      // TODAY total is a settled pre-write baseline.
+      const painted = page.waitForResponse(isBalanceFetch);
+      await page.goto('/ui/tracking');
+      await painted;
+      const day = page.locator('#worktime-day');
+      await expect(day).toBeVisible();
+      const before = (await day.textContent()) ?? '';
+
+      // Out-of-band write while the tab is open: Playwright's request context
+      // shares the session cookie but bypasses the SPA entirely — the same
+      // class as the REST/MCP write in #620. Dated on the server's "today" so
+      // it counts into the TODAY total; the SPA has not observed it.
+      await createEntry(page, {
+        date: serverToday,
+        start: '02:00',
+        end: '03:00',
+        ...refs,
+        description: `e2e-620-${Date.now()}`,
+      });
+
+      // Jump past the refocus throttle, then simulate the tab regaining
+      // focus: the header must refetch the balance and repaint the total,
+      // one hour up (the entries grid refetches on its own via TanStack
+      // Query's refetchOnWindowFocus).
+      await page.clock.fastForward(16_000);
+      const refreshed = page.waitForResponse(isBalanceFetch);
+      await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+      await refreshed;
+      await expect(day).not.toHaveText(before);
+    } finally {
+      await cleanupStamped(page);
+    }
+  });
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData, type QueryClient } from '@tanstack/solid-query'
 
 import { getJson } from './client'
+import { updateWorktime } from '../header'
 import { dmyToIso } from '../lib/timeParse'
 
 // Response shape of GET /interpretation/time (GroupByWorktimeAction):
@@ -170,6 +171,17 @@ interface TrackingEntryRow {
 // the per-range query appends the day count. Exported so the page invalidates and
 // seeds the same key.
 export const ENTRIES_KEY = 'tracking-entries'
+
+// Refresh everything that shows worklog entries but does not observe the
+// mutation: the tracking grid's entries cache and the header's imperatively
+// painted day/week/month totals (#620). Never rejects — both sides handle
+// their own failures — so callers can fire-and-forget it.
+export async function refreshEntriesAndWorktime(queryClient: QueryClient): Promise<void> {
+  await Promise.allSettled([
+    queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] }),
+    updateWorktime(),
+  ])
+}
 
 // The /tracking/save response envelope: the persisted entry, with date as 'd/m/Y'
 // and start/end as 'H:i' (already the cache row shape), so it can seed the cache

--- a/frontend/src/components/ConflictList.test.tsx
+++ b/frontend/src/components/ConflictList.test.tsx
@@ -7,6 +7,13 @@ import type { SyncConflict } from '../api/worklogSync'
 
 const resolveConflict = vi.fn()
 const conflictsQueryFn = vi.fn()
+const updateWorktime = vi.fn()
+
+// A resolve can change local entries, so the component refreshes the header
+// worktime totals (#620) — spy on that imperative bridge.
+vi.mock('../header', () => ({
+  updateWorktime: (...args: unknown[]) => updateWorktime(...args),
+}))
 
 // Mock the API module: the query factory returns a stable key plus a queryFn the
 // test controls, and the write helper is a spy. worklogSyncKeys is echoed so the
@@ -56,6 +63,7 @@ afterEach(() => {
   cleanup()
   resolveConflict.mockReset()
   conflictsQueryFn.mockReset()
+  updateWorktime.mockReset()
 })
 
 describe('ConflictList', () => {
@@ -81,6 +89,10 @@ describe('ConflictList', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Keep remote: ABC-1' }))
     await waitFor(() => expect(resolveConflict).toHaveBeenCalledWith(5, 'remote'))
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['worklog-sync', 'conflicts'] })
+    // The resolution changed a local entry: the worklog grid and the header
+    // day/week/month totals refresh too (#620).
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['tracking-entries'] })
+    expect(updateWorktime).toHaveBeenCalled()
 
     // Success is announced and the resolved row disappears on the refetch.
     await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Conflict resolved.'))
@@ -133,6 +145,8 @@ describe('ConflictList', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Keep local: ABC-1' }))
 
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Could not resolve the conflict.'))
+    // Nothing changed server-side — no header-totals refresh.
+    expect(updateWorktime).not.toHaveBeenCalled()
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/frontend/src/components/ConflictList.tsx
+++ b/frontend/src/components/ConflictList.tsx
@@ -2,7 +2,9 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createSignal, For, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
+import { ENTRIES_KEY } from '../api/queries'
 import { resolveConflict, syncConflictsQuery, worklogSyncKeys, type SyncConflict } from '../api/worklogSync'
+import { updateWorktime } from '../header'
 import { m } from '../paraglide/messages.js'
 
 // Jira reports remote effort in seconds; the local entry stores minutes, so the
@@ -39,6 +41,11 @@ export function ConflictList(props: { user?: string } = {}): JSX.Element {
       setResolved(true)
       // The resolved conflict is gone server-side; refetch drops it from the list.
       void queryClient.invalidateQueries({ queryKey: worklogSyncKeys.conflicts })
+      // Either resolution can change local entries (keeping the remote side
+      // rewrites or deletes one) — refresh the worklog grid and the header
+      // day/week/month totals, which don't observe the entries cache (#620).
+      void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+      void updateWorktime()
     } catch (caught) {
       setError(apiErrorMessage(caught, m.worklogsync_resolve_error()))
     } finally {

--- a/frontend/src/components/ConflictList.tsx
+++ b/frontend/src/components/ConflictList.tsx
@@ -2,9 +2,8 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createSignal, For, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
-import { ENTRIES_KEY } from '../api/queries'
+import { refreshEntriesAndWorktime } from '../api/queries'
 import { resolveConflict, syncConflictsQuery, worklogSyncKeys, type SyncConflict } from '../api/worklogSync'
-import { updateWorktime } from '../header'
 import { m } from '../paraglide/messages.js'
 
 // Jira reports remote effort in seconds; the local entry stores minutes, so the
@@ -44,8 +43,7 @@ export function ConflictList(props: { user?: string } = {}): JSX.Element {
       // Either resolution can change local entries (keeping the remote side
       // rewrites or deletes one) — refresh the worklog grid and the header
       // day/week/month totals, which don't observe the entries cache (#620).
-      void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
-      void updateWorktime()
+      void refreshEntriesAndWorktime(queryClient)
     } catch (caught) {
       setError(apiErrorMessage(caught, m.worklogsync_resolve_error()))
     } finally {

--- a/frontend/src/components/WorklogImportSection.test.tsx
+++ b/frontend/src/components/WorklogImportSection.test.tsx
@@ -7,6 +7,13 @@ import type { SyncRun } from '../api/worklogSync'
 
 const createSyncRun = vi.fn()
 const getJson = vi.fn()
+const updateWorktime = vi.fn()
+
+// A real import creates entries, so the component refreshes the header
+// worktime totals (#620) — spy on that imperative bridge.
+vi.mock('../header', () => ({
+  updateWorktime: (...args: unknown[]) => updateWorktime(...args),
+}))
 
 vi.mock('../api/worklogSync', () => ({
   createSyncRun: (...args: unknown[]) => createSyncRun(...args),
@@ -56,6 +63,7 @@ afterEach(() => {
   cleanup()
   createSyncRun.mockReset()
   getJson.mockReset()
+  updateWorktime.mockReset()
 })
 
 describe('WorklogImportSection', () => {
@@ -95,6 +103,8 @@ describe('WorklogImportSection', () => {
     // The dry-run summary + "nothing imported yet" note appear.
     await waitFor(() => expect(screen.getByText('Would create')).toBeInTheDocument())
     expect(screen.getByText('Preview only — nothing has been imported yet.')).toBeInTheDocument()
+    // A dry run writes nothing — the worklog/header must not refresh yet (#620).
+    expect(updateWorktime).not.toHaveBeenCalled()
 
     // Step 2: execute → dry_run:false, success status, conflicts invalidated.
     fireEvent.click(screen.getByRole('button', { name: 'Execute import' }))
@@ -105,6 +115,10 @@ describe('WorklogImportSection', () => {
     await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Import complete.'))
     expect(screen.getByText('Created')).toBeInTheDocument()
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['worklog-sync', 'conflicts'] })
+    // The real import created entries: the worklog grid and the header
+    // day/week/month totals refresh too (#620).
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['tracking-entries'] })
+    expect(updateWorktime).toHaveBeenCalledTimes(1)
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/frontend/src/components/WorklogImportSection.tsx
+++ b/frontend/src/components/WorklogImportSection.tsx
@@ -2,9 +2,10 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createSignal, For, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
-import { activitiesQuery, ticketSystemsQuery } from '../api/queries'
+import { activitiesQuery, ENTRIES_KEY, ticketSystemsQuery } from '../api/queries'
 import { createSyncRun, worklogSyncKeys, type CreateRunPayload, type SyncRun } from '../api/worklogSync'
 import { appConfig } from '../config'
+import { updateWorktime } from '../header'
 import { isoDate } from '../lib/format'
 import { DateField } from './DateField'
 import { HelpPopover } from './HelpPopover'
@@ -70,6 +71,10 @@ export function WorklogImportSection(): JSX.Element {
         setPreview(null)
         // A real import can park entries as conflicts — refresh any open list.
         void queryClient.invalidateQueries({ queryKey: worklogSyncKeys.conflicts })
+        // It also created entries — refresh the worklog grid and the header
+        // day/week/month totals, which don't observe the entries cache (#620).
+        void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+        void updateWorktime()
       }
     } catch (caught) {
       setError(apiErrorMessage(caught, m.worklogsync_import_error()))

--- a/frontend/src/components/WorklogImportSection.tsx
+++ b/frontend/src/components/WorklogImportSection.tsx
@@ -2,10 +2,9 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createSignal, For, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
-import { activitiesQuery, ENTRIES_KEY, ticketSystemsQuery } from '../api/queries'
+import { activitiesQuery, refreshEntriesAndWorktime, ticketSystemsQuery } from '../api/queries'
 import { createSyncRun, worklogSyncKeys, type CreateRunPayload, type SyncRun } from '../api/worklogSync'
 import { appConfig } from '../config'
-import { updateWorktime } from '../header'
 import { isoDate } from '../lib/format'
 import { DateField } from './DateField'
 import { HelpPopover } from './HelpPopover'
@@ -73,8 +72,7 @@ export function WorklogImportSection(): JSX.Element {
         void queryClient.invalidateQueries({ queryKey: worklogSyncKeys.conflicts })
         // It also created entries — refresh the worklog grid and the header
         // day/week/month totals, which don't observe the entries cache (#620).
-        void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
-        void updateWorktime()
+        void refreshEntriesAndWorktime(queryClient)
       }
     } catch (caught) {
       setError(apiErrorMessage(caught, m.worklogsync_import_error()))

--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -139,6 +139,33 @@ describe('updateWorktime', () => {
     expect(document.getElementById('worktime-day')?.textContent).toBe('7:45')
   })
 
+  it('paints an older successful response when the newer fetch failed', async () => {
+    renderWorktime()
+    const period = { soll_total: 480, soll_so_far: 480, diff: 0, status: 'ok' as const }
+    const balance = (ist: number) => ({
+      today: { ...period, ist },
+      week: { ...period, ist },
+      month: { ...period, ist },
+      warnings: [],
+    })
+    // First call resolves LATE but successfully; the second (newer) call fails.
+    // The older data is still fresher than what's on screen, so it paints.
+    let releaseOlder: (() => void) | undefined
+    vi.mocked(getJson)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseOlder = () => resolve(balance(465))
+      }))
+      .mockRejectedValueOnce(new Error('boom'))
+
+    const older = updateWorktime()
+    const newer = updateWorktime()
+    await newer
+
+    releaseOlder?.()
+    await older
+    expect(document.getElementById('worktime-day')?.textContent).toBe('7:45')
+  })
+
   it('leaves a period neutral when its SOLL so far is zero (weekend/holiday)', async () => {
     renderWorktime()
     vi.mocked(getJson).mockResolvedValue({

--- a/frontend/src/header.test.ts
+++ b/frontend/src/header.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getJson } from './api/client'
 import type { AppConfig } from './config'
-import { formatDays, formatDuration, formatSignedDuration, handleHelpClick, handleShortcut, hideAccessHints, initialsFrom, refreshLoginStatus, showAccessHints, updateWorktime, wireWorktimeDetail, worktimeStatus } from './header'
+import { formatDays, formatDuration, formatSignedDuration, handleHelpClick, handleShortcut, hideAccessHints, initHeaderDynamics, initialsFrom, refreshLoginStatus, showAccessHints, updateWorktime, wireWorktimeDetail, worktimeStatus } from './header'
 import { setShortcutsHelpOpen, shortcutsHelpOpen } from './lib/shortcutsHelp'
 
 // Preserve the module's other exports (SessionExpiredError, postJson, …) and stub
@@ -111,6 +111,34 @@ describe('updateWorktime', () => {
     expect(row.querySelector('[data-wd="delta"]')?.textContent).toBe('+0:30')
   })
 
+  it('never paints a stale response over a newer one (out-of-order fetches)', async () => {
+    renderWorktime()
+    const period = { soll_total: 480, soll_so_far: 480, diff: 0, status: 'ok' as const }
+    const balance = (ist: number) => ({
+      today: { ...period, ist },
+      week: { ...period, ist },
+      month: { ...period, ist },
+      warnings: [],
+    })
+    // First call resolves LATE with the old total; second resolves first with
+    // the new one — the late stale response must not win the paint.
+    let releaseStale: (() => void) | undefined
+    vi.mocked(getJson)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseStale = () => resolve(balance(0))
+      }))
+      .mockResolvedValueOnce(balance(465))
+
+    const stale = updateWorktime()
+    const fresh = updateWorktime()
+    await fresh
+    expect(document.getElementById('worktime-day')?.textContent).toBe('7:45')
+
+    releaseStale?.()
+    await stale
+    expect(document.getElementById('worktime-day')?.textContent).toBe('7:45')
+  })
+
   it('leaves a period neutral when its SOLL so far is zero (weekend/holiday)', async () => {
     renderWorktime()
     vi.mocked(getJson).mockResolvedValue({
@@ -126,6 +154,112 @@ describe('updateWorktime', () => {
     expect(today.classList.contains('is-ok')).toBe(false)
     expect(today.classList.contains('is-under')).toBe(false)
     expect(document.getElementById('worktime-day')?.textContent).toBe('7:30')
+  })
+})
+
+describe('worktime auto-refresh (#620)', () => {
+  const config = { userName: 'dev' } as AppConfig
+  const BALANCE_PATH = '/api/v2/time-balance'
+  const STATUS_PATH = '/status/check'
+
+  // One response object satisfying BOTH header fetches: fetchLoginStatus reads
+  // loginStatus, updateWorktime reads the periods. Calls are counted per path.
+  const response = {
+    loginStatus: true,
+    today: { ist: 465, soll_total: 480, soll_so_far: 480, diff: -15, status: 'behind' },
+    week: { ist: 465, soll_total: 2400, soll_so_far: 480, diff: -15, status: 'behind' },
+    month: { ist: 465, soll_total: 9600, soll_so_far: 480, diff: -15, status: 'behind' },
+    warnings: [],
+  }
+  const calls = (path: string): number =>
+    vi.mocked(getJson).mock.calls.filter(([url]) => url === path).length
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.innerHTML = '<a id="worktime-day">0:00</a>'
+    vi.mocked(getJson).mockResolvedValue(response)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  /** Init the header under this test's fake clock and drop the init-time fetch
+   *  from the counters. (The refocus listeners are wired once per module.) */
+  async function initCleanly(): Promise<void> {
+    initHeaderDynamics(config)
+    await vi.advanceTimersByTimeAsync(0)
+    vi.mocked(getJson).mockClear()
+  }
+
+  it('refetches and repaints the totals when the window regains focus, throttled', async () => {
+    // Absolute far-future time: keeps the throttle state independent from the
+    // other tests in this file (the module keeps its last-refresh timestamp).
+    vi.setSystemTime(new Date('2030-01-01T08:00:00Z'))
+    await initCleanly()
+
+    window.dispatchEvent(new Event('focus'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls(BALANCE_PATH)).toBe(1)
+    expect(document.getElementById('worktime-day')?.textContent).toBe('7:45')
+
+    // focus + visibilitychange fire together on a refocus — no double-fetch.
+    window.dispatchEvent(new Event('focus'))
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls(BALANCE_PATH)).toBe(1)
+
+    // Past the throttle window the next refocus fetches again.
+    await vi.advanceTimersByTimeAsync(16_000)
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls(BALANCE_PATH)).toBe(2)
+  })
+
+  it('does not refetch while the tab stays hidden', async () => {
+    vi.setSystemTime(new Date('2030-02-01T08:00:00Z'))
+    await initCleanly()
+
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls(BALANCE_PATH)).toBe(0)
+
+    // Same event with the tab visible does fetch — only the hidden state blocked it.
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls(BALANCE_PATH)).toBe(1)
+  })
+
+  it('piggybacks the totals on the 90s status poll', async () => {
+    vi.setSystemTime(new Date('2030-03-01T08:00:00Z'))
+    await initCleanly()
+
+    await vi.advanceTimersByTimeAsync(90_000)
+    expect(calls(STATUS_PATH)).toBe(1)
+    expect(calls(BALANCE_PATH)).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(90_000)
+    expect(calls(STATUS_PATH)).toBe(2)
+    expect(calls(BALANCE_PATH)).toBe(2)
+  })
+
+  it('keeps polling when the fetches reject', async () => {
+    vi.setSystemTime(new Date('2030-04-01T08:00:00Z'))
+    await initCleanly()
+    vi.mocked(getJson).mockRejectedValue(new Error('offline'))
+
+    await vi.advanceTimersByTimeAsync(90_000)
+    expect(calls(STATUS_PATH)).toBe(1)
+    expect(calls(BALANCE_PATH)).toBe(1)
+
+    // The failing tick must still reschedule the next one.
+    await vi.advanceTimersByTimeAsync(90_000)
+    expect(calls(STATUS_PATH)).toBe(2)
+    expect(calls(BALANCE_PATH)).toBe(2)
   })
 })
 

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -229,10 +229,13 @@ export function wireWorktimeDetail(): void {
   })
 }
 
-// Monotonic ticket for updateWorktime: with several triggers (init, mutations,
+// Monotonic tickets for updateWorktime: with several triggers (init, mutations,
 // refocus, the status poll) two fetches can be in flight at once, and responses
-// may return out of order — only the latest-started fetch may paint.
+// may return out of order — a response paints only if it is newer than the one
+// on screen. Comparing against the last PAINTED (not last started) fetch keeps
+// an older successful response usable when a newer fetch failed.
 let worktimeFetchSeq = 0
+let worktimePaintedSeq = 0
 
 // Exported so the SolidJS worklog can refresh the header's today/week/month
 // totals right after it saves, edits or deletes an entry — otherwise the header
@@ -241,9 +244,10 @@ export async function updateWorktime(): Promise<void> {
   const seq = ++worktimeFetchSeq
   try {
     const summary = await getJson<TimeBalance>('/api/v2/time-balance')
-    if (seq !== worktimeFetchSeq) {
-      return // a newer refresh started meanwhile; its response paints
+    if (seq <= worktimePaintedSeq) {
+      return // a newer response already painted; don't overwrite it
     }
+    worktimePaintedSeq = seq
     setText('worktime-day', formatDuration(summary.today.ist))
     setText('worktime-week', formatDuration(summary.week.ist))
     // Month shows person-days only; the hours stay in the title for reference.

--- a/frontend/src/header.ts
+++ b/frontend/src/header.ts
@@ -30,6 +30,10 @@ type WorktimeStatus = 'ok' | 'under' | 'neutral'
 
 const STATUS_POLL_INTERVAL_MS = 90_000
 
+// Refocus catch-up (#620): 'focus' and 'visibilitychange' fire together when a
+// tab is refocused, so refreshes within this window collapse into one fetch.
+const WORKTIME_REFOCUS_THROTTLE_MS = 15_000
+
 /** 'H:MM', optionally suffixed with person-days (PT). */
 export function formatDuration(minutes: number, inDays = false): string {
   const days = Math.floor((minutes / (60 * 8)) * 100) / 100
@@ -225,12 +229,21 @@ export function wireWorktimeDetail(): void {
   })
 }
 
+// Monotonic ticket for updateWorktime: with several triggers (init, mutations,
+// refocus, the status poll) two fetches can be in flight at once, and responses
+// may return out of order — only the latest-started fetch may paint.
+let worktimeFetchSeq = 0
+
 // Exported so the SolidJS worklog can refresh the header's today/week/month
 // totals right after it saves, edits or deletes an entry — otherwise the header
 // sums (loaded once on init) go stale until a full page reload (#446).
 export async function updateWorktime(): Promise<void> {
+  const seq = ++worktimeFetchSeq
   try {
     const summary = await getJson<TimeBalance>('/api/v2/time-balance')
+    if (seq !== worktimeFetchSeq) {
+      return // a newer refresh started meanwhile; its response paints
+    }
     setText('worktime-day', formatDuration(summary.today.ist))
     setText('worktime-week', formatDuration(summary.week.ist))
     // Month shows person-days only; the hours stay in the title for reference.
@@ -247,6 +260,41 @@ export async function updateWorktime(): Promise<void> {
   } catch {
     // Header sums are non-critical; leave the rendered defaults.
   }
+}
+
+let lastRefocusRefreshAt = 0
+
+/**
+ * Refetch the totals when the tab becomes visible/focused again, at most once
+ * per throttle window. This is the catch-up for out-of-band writes (another
+ * tab, the REST/MCP API): the entries grid is a TanStack query and refetches
+ * on window focus by default, but the header totals are painted imperatively
+ * and would otherwise keep their stale figures until a full reload (#620).
+ * The timestamp is set synchronously, so the focus + visibilitychange pair a
+ * refocus fires (and any double-wired listener) collapses into one fetch.
+ */
+function refreshWorktimeOnRefocus(): void {
+  const now = Date.now()
+  if (now - lastRefocusRefreshAt < WORKTIME_REFOCUS_THROTTLE_MS) {
+    return
+  }
+  lastRefocusRefreshAt = now
+  void updateWorktime()
+}
+
+let worktimeRefocusWired = false
+
+function wireWorktimeRefocus(): void {
+  if (worktimeRefocusWired) {
+    return
+  }
+  worktimeRefocusWired = true
+  window.addEventListener('focus', refreshWorktimeOnRefocus)
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      refreshWorktimeOnRefocus()
+    }
+  })
 }
 
 // The nav links are rendered in document order (and the overflow script keeps
@@ -624,7 +672,11 @@ export function refreshLoginStatus(config: AppConfig): Promise<void> {
 }
 
 function pollLoginStatus(config: AppConfig): void {
-  void fetchLoginStatus(config).finally(() => {
+  // The worktime totals piggyback on the status poll: an idle-open tab picks up
+  // out-of-band writes (#620) on the same cadence, with no extra timer. Both
+  // fetches swallow their own errors; allSettled makes it explicit that neither
+  // a failing fetch nor the other one can stop the rescheduling.
+  void Promise.allSettled([fetchLoginStatus(config), updateWorktime()]).then(() => {
     setTimeout(() => {
       pollLoginStatus(config)
     }, STATUS_POLL_INTERVAL_MS)
@@ -643,6 +695,7 @@ export function initHeaderDynamics(config: AppConfig): void {
   })
   void updateWorktime()
   wireWorktimeDetail()
+  wireWorktimeRefocus()
   setTimeout(() => {
     pollLoginStatus(config)
   }, STATUS_POLL_INTERVAL_MS)

--- a/frontend/src/pages/WorklogSync.test.tsx
+++ b/frontend/src/pages/WorklogSync.test.tsx
@@ -7,6 +7,13 @@ import type { SyncRun } from '../api/worklogSync'
 
 const createSyncRun = vi.fn()
 const getJson = vi.fn()
+const updateWorktime = vi.fn()
+
+// A real (non-dry) run can change entries, so the page refreshes the header
+// worktime totals (#620) — spy on that imperative bridge.
+vi.mock('../header', () => ({
+  updateWorktime: (...args: unknown[]) => updateWorktime(...args),
+}))
 
 // syncRunsQuery / syncRunQuery are replaced with factories that resolve seeded
 // data; createSyncRun is a spy the trigger form calls.
@@ -111,6 +118,7 @@ afterEach(() => {
   cleanup()
   createSyncRun.mockReset()
   getJson.mockReset()
+  updateWorktime.mockReset()
   window.APP_CONFIG!.roles = [...FULL_ROLES]
 })
 
@@ -143,8 +151,33 @@ describe('WorklogSync', () => {
     await waitFor(() => expect(screen.getByText('Created')).toBeInTheDocument())
     expect(screen.getByRole('status')).toBeInTheDocument()
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['worklog-sync', 'runs'] })
+    // The default trigger is a dry run — it writes nothing, so the worklog grid
+    // and the header totals must not refresh (#620).
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['tracking-entries'] })
+    expect(updateWorktime).not.toHaveBeenCalled()
 
     expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('refreshes the worklog and header totals after a real (non-dry) run', async () => {
+    mockRefs()
+    createSyncRun.mockResolvedValue(makeRun({ type: 'import', counters: { created: 1 } }))
+    const { queryClient } = renderWithProviders(() => <WorklogSync />)
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await waitFor(() => expect(screen.getAllByRole('option', { name: 'Jira Cloud' }).length).toBeGreaterThanOrEqual(2))
+    fireEvent.change(screen.getByLabelText('Ticket system', { selector: '#worklogsync-trigger-ticket' }), {
+      target: { value: '1' },
+    })
+    fireEvent.click(screen.getByLabelText('Dry run')) // uncheck → a real run
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger a run' }))
+
+    await waitFor(() => expect(createSyncRun).toHaveBeenCalledTimes(1))
+    expect(createSyncRun).toHaveBeenLastCalledWith(expect.objectContaining({ dry_run: false }))
+    // A real run can create/change entries: the worklog grid and the header
+    // day/week/month totals refresh (#620).
+    await waitFor(() => expect(updateWorktime).toHaveBeenCalledTimes(1))
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['tracking-entries'] })
   })
 
   it('loads a run detail (with items) when a run is opened', async () => {

--- a/frontend/src/pages/WorklogSync.tsx
+++ b/frontend/src/pages/WorklogSync.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createSignal, For, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
-import { ENTRIES_KEY, ticketSystemsQuery, usersQuery } from '../api/queries'
+import { refreshEntriesAndWorktime, ticketSystemsQuery, usersQuery } from '../api/queries'
 import {
   createSyncRun,
   syncRunQuery,
@@ -15,7 +15,6 @@ import { ConflictList } from '../components/ConflictList'
 import { DateField } from '../components/DateField'
 import { SyncRunSummary } from '../components/SyncRunSummary'
 import { hasRole } from '../config'
-import { updateWorktime } from '../header'
 import { isoDate } from '../lib/format'
 import { m } from '../paraglide/messages.js'
 
@@ -136,8 +135,7 @@ function WorklogSyncArea(): JSX.Element {
         // A real run can create or change entries — refresh the worklog grid and
         // the header day/week/month totals, which don't observe the entries
         // cache (#620). A dry run writes nothing, so it skips the refresh.
-        void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
-        void updateWorktime()
+        void refreshEntriesAndWorktime(queryClient)
       }
     } catch (caught) {
       setError(apiErrorMessage(caught, m.worklogsync_run_error()))

--- a/frontend/src/pages/WorklogSync.tsx
+++ b/frontend/src/pages/WorklogSync.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/solid-query'
 import { createSignal, For, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
-import { ticketSystemsQuery, usersQuery } from '../api/queries'
+import { ENTRIES_KEY, ticketSystemsQuery, usersQuery } from '../api/queries'
 import {
   createSyncRun,
   syncRunQuery,
@@ -15,6 +15,7 @@ import { ConflictList } from '../components/ConflictList'
 import { DateField } from '../components/DateField'
 import { SyncRunSummary } from '../components/SyncRunSummary'
 import { hasRole } from '../config'
+import { updateWorktime } from '../header'
 import { isoDate } from '../lib/format'
 import { m } from '../paraglide/messages.js'
 
@@ -131,6 +132,13 @@ function WorklogSyncArea(): JSX.Element {
       setResult(run)
       // A new run belongs at the top of the history — refresh it.
       void queryClient.invalidateQueries({ queryKey: worklogSyncKeys.runs })
+      if (!dryRun()) {
+        // A real run can create or change entries — refresh the worklog grid and
+        // the header day/week/month totals, which don't observe the entries
+        // cache (#620). A dry run writes nothing, so it skips the refresh.
+        void queryClient.invalidateQueries({ queryKey: [ENTRIES_KEY] })
+        void updateWorktime()
+      }
     } catch (caught) {
       setError(apiErrorMessage(caught, m.worklogsync_run_error()))
     } finally {


### PR DESCRIPTION
## Description

The header's TODAY/WEEK/MONTH summary is painted imperatively by `updateWorktime()` (`frontend/src/header.ts`) and was fetched only at SPA init and after Tracking-page mutations (#446). Entries written out of band — another tab, the REST API, the MCP `log_time` tool — updated the worklog grid on refocus (TanStack `refetchOnWindowFocus`), while the summary kept its init-time figures until F5. This PR closes the missing trigger classes with the minimal imperative approach, consistent with the existing `updateWorktime` pattern.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Closes #620

## Changes Made

- **Refocus catch-up** (`header.ts`): `window` focus + `visibilitychange` (only when visible) re-fetch the balance, throttled to one fetch per 15 s window — the two events fire together on a refocus.
- **Idle tabs**: `updateWorktime()` piggybacks on the existing 90 s status poll via `Promise.allSettled` — no new timer; neither a failing fetch nor the other one can stop the rescheduling.
- **Stale-paint guard**: with several triggers, balance responses can return out of order; a monotonic ticket lets only the latest-started fetch paint.
- **Same bug class in the SPA**: conflict resolution (`ConflictList`), worklog import (`WorklogImportSection`) and non-dry sync runs (`WorklogSync`) now invalidate `ENTRIES_KEY` and refresh the header totals after a successful write. Dry runs deliberately skip the refresh.

## Testing

- [x] Unit tests pass (`bun run test`, 556 tests) — new coverage: refocus fetch + repaint, focus/visibilitychange throttling, hidden-tab suppression, 90 s poll piggyback, poll survival on rejected fetches, out-of-order response guard, and per-component assertions that `updateWorktime` runs after resolve/import/non-dry sync (and not after dry runs or failures)
- [x] Static analysis passes (`bun run lint`, `bun run typecheck`)
- [x] E2E: new `e2e/summary-refresh.spec.ts` covers the out-of-band path end to end — an entry created via the Playwright request context (bypassing the SPA) appears in the TODAY total after a window focus event. The server's frozen "today" is discovered at runtime via `/getData/days/N` bisection instead of assuming a date, so the spec is independent of the stack's clock configuration. The 90 s interval is asserted in unit tests only (interval assertions against the frozen e2e clock are meaningless).

## Code Quality

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] No breaking changes

## Migration Notes

None — frontend-only; `/api/v2/time-balance` is a cheap single-aggregate query (~1 ms after the ASC loose-scan index fix).
