### PR TITLE
ci: concurrency groups + E2E 4 shards (measured speed wins from #624)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: ["**"]
 
+# Supersede an in-flight run when new commits land on the same ref. Scoped to
+# non-default refs so every main commit still gets a complete run (bisect
+# granularity); PR force-push/rapid-push bursts stop competing for the runner
+# pool, which is what inflates wall-clock under contention.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   setup:
     name: Setup Dependencies
@@ -297,7 +305,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -365,7 +373,7 @@ jobs:
           # Verify coverage is enabled
           curl -s http://localhost:8766/coverage.php?action=status || echo "Coverage endpoint not responding"
 
-      - name: Run E2E tests (shard ${{ matrix.shard }}/10)
+      - name: Run E2E tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         env:
           COMPOSE_PROFILES: e2e
         run: |
@@ -375,7 +383,7 @@ jobs:
           docker compose run --rm \
             -e E2E_BASE_URL=http://httpd-e2e:80 \
             -e CI=true \
-            app-e2e bash -c "npx playwright install chromium && npx playwright test --shard=${{ matrix.shard }}/10 -x"
+            app-e2e bash -c "npx playwright install chromium && npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }} -x"
 
       - name: Collect E2E coverage
         if: always()
@@ -416,7 +424,7 @@ jobs:
 
   # Single aggregate gate: green only when every job above succeeded. Lets branch
   # protection require one check ("CI Success") instead of enumerating all jobs +
-  # the 10 e2e shard names.
+  # the e2e shard names (whose count is the strategy matrix size).
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '30 2 * * 1' # Weekly on Monday
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,10 @@ on:
       - "v*.*.*"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main, master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Description

The two lowest-risk, highest-impact measures from #624 — the CI speed analysis.

## Type of Change

- [x] Performance improvement

## Related Issue

Refs #624

## Changes Made

- **Concurrency groups with cancel-in-progress** on `ci`, `docker-publish`, `codeql`, `security`. Scoped to non-default refs (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`): every main commit still gets a complete run (bisect granularity preserved), while PR force-push/rapid-push bursts stop competing for the runner pool. That contention is what inflated the measured median from 254s (isolated push) to 560s (3–4-push bursts).
- **E2E matrix 10 → 4 shards.** Measured per-shard overhead was 88s fixed setup vs ~17s actual test; the 10-shard matrix spent ~1050s runner-time to run ~191s of tests. Four shards (~131s each) stay under the 166s Integration-Tests gate, so wall-clock is unchanged while runner-time drops ~500s/run and the job count falls 16 → 10 (less burst queueing). Shard denominators now derive from `strategy.job-total` instead of a hard-coded `/10`.

## Testing

- YAML validated; the aggregate `CI Success` gate reads the `e2e` matrix result (not per-shard names), so the shard-count change needs no gate edit.
- This PR's own CI run is the verification — including that all 4 shards stay green and under the gate. Post-merge I'll confirm the per-shard timings from the run and bump to 5 shards if one shard runs hot.

## Not included (deliberately)

The rest of #624 — flattening the job graph (S1), image-diet/zstd pulls, PHP-tool caches, pcov — each needs its own verification push and is tracked in the issue.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] I agree to follow the Code of Conduct