### PR TITLE
fix: month weekday alignment, dense-mode side gaps, worklog-sync card spacing

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2792,6 +2792,14 @@ th[aria-sort='descending'] .th-sort-glyph {
   grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
 }
 
+/* Stack the sync sections with the same card rhythm the settings page uses
+   (.settings-page gap) so their borders don't touch. */
+.worklog-sync {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
 .status-group {
   background: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -3458,6 +3458,16 @@ th[aria-sort='descending'] .th-sort-glyph {
   padding: 0.5rem 1rem;
 }
 
+/* Keep a side gap on the reading-width pages (Month, admin, …) at every
+   density — only the full-bleed worklog grid (main:has(.tracking)) rides the
+   viewport edge. Density still tightens the vertical padding. */
+:root[data-density='compact'] main:not(:has(.tracking)) {
+  padding: 0.5rem 2rem;
+}
+:root[data-density='ultra-compact'] main:not(:has(.tracking)) {
+  padding: 0.25rem 2rem;
+}
+
 :root[data-density='compact'] .admin-page,
 :root[data-density='ultra-compact'] .admin-page {
   max-width: none;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4528,8 +4528,10 @@ th[aria-sort='descending'] .th-sort-glyph {
    Self-contained month grid used by the date fields. Monday-first, 44px touch
    targets, design tokens only. Text stays >= 7:1 in both schemes (AAA); the
    selected day uses the darker --color-accent-text so white/near-black day text
-   clears 7:1, and future days reuse the shared --color-future-tint. */
-.calendar {
+   clears 7:1, and future days reuse the shared --color-future-tint.
+   Scoped to div.calendar so these flex rules don't hit the month view's
+   <table class="calendar"> (which shares the base class). */
+div.calendar {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;


### PR DESCRIPTION
## Description

Three layout fixes found on a walkthrough of the month overview and the worklog-sync admin page.

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

All three are CSS-only (`frontend/src/styles/app.css`).

- **Month weekday header misaligned.** The month `<table class="calendar">` and the date-picker `<div class="calendar">` share the `.calendar` class; the picker's `display:flex` rule won the cascade and forced the table into flex (352px wide), which split `thead`/`tbody` into separate anonymous tables so the weekday labels no longer sat over their columns. Scoped the picker rule to `div.calendar`; the table now computes `display:table` and every weekday header centers over its day column (measured offset 0 across all 8 columns, all densities).
- **Cards flush to the edge at compact/ultra-compact density.** The density `main` override dropped horizontal padding to ~10–16px. Added `main:not(:has(.tracking))` keeping a 2rem side gutter at dense modes; vertical padding stays tight. The worklog grid (`main:has(.tracking)`) stays deliberately full-width.
- **No gaps between the worklog-sync cards.** `.worklog-sync` had no layout rule (`display:block`), so the three `.status-group` cards touched. Made it `flex-direction:column; gap:1.4rem`.

## Testing

- [x] `bun run lint` / `typecheck` / `test` (567) green
- [x] Browser-verified before/after at 1440px in comfort, compact and ultra-compact; worklog-grid full-width confirmed as a regression guard

## Checklist

- [x] CONTRIBUTING read
- [x] Code of Conduct