### PR TITLE
feat: searchable comboboxes for data-heavy selects + Auswertung date fields

### DIFF
--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -47,14 +47,16 @@ test.describe('Controlling Export', () => {
     await page.goto('/ui/billing');
     await page.waitForSelector('form.stack-form', { timeout: 15000 });
 
-    // User/Project/Customer default to "all" (0). The export test data lives in
-    // January 2026, so pin year/month explicitly rather than relying on the
-    // page's "current period" defaults (which, under the frozen 2024 clock,
-    // would otherwise query an empty period). The form has five selects in DOM
-    // order: user, project, customer, year, month.
+    // User/Project/Customer default to "all" (0) — they are searchable
+    // comboboxes now, left untouched so no filtering is applied. The export test
+    // data lives in January 2026, so pin year/month explicitly rather than
+    // relying on the page's "current period" defaults (which, under the frozen
+    // 2024 clock, would otherwise query an empty period). Year and month remain
+    // native <select>s and are the only two left in the form, in DOM order:
+    // year, month.
     const selects = page.locator('form.stack-form select');
-    await selects.nth(3).selectOption('2026'); // year
-    await selects.nth(4).selectOption('1'); // month (1 = January)
+    await selects.nth(0).selectOption('2026'); // year
+    await selects.nth(1).selectOption('1'); // month (1 = January)
 
     // The export anchor carries the same-origin /controlling/export href,
     // recomputed reactively from the selected filters.

--- a/e2e/interpretation.spec.ts
+++ b/e2e/interpretation.spec.ts
@@ -22,12 +22,15 @@ test.describe('Evaluation (Auswertung) page', () => {
 
   test('should display the evaluation page with a filter bar', async ({ page }) => {
     await expect(page.locator('form.filter-bar')).toBeVisible();
-    // Selects for customer/project/team/user/activity plus the ticket/description text inputs.
-    expect(await page.locator('form.filter-bar select').count()).toBeGreaterThan(0);
+    // customer/project/team/user/activity are searchable comboboxes now
+    // (SearchableSelect), plus the ticket/description text inputs.
+    expect(await page.locator('form.filter-bar .searchable-select').count()).toBeGreaterThan(0);
   });
 
   test('should have a start and end date filter', async ({ page }) => {
-    await expect(page.locator('form.filter-bar input[type="date"]')).toHaveCount(2);
+    // Start/end are DateField controls now — text inputs that honour the user's
+    // date format with a calendar popover, not native date inputs.
+    await expect(page.locator('form.filter-bar .date-field')).toHaveCount(2);
   });
 
   test('should render effort results when filters are applied', async ({ page }) => {
@@ -40,7 +43,9 @@ test.describe('Evaluation (Auswertung) page', () => {
   });
 
   test('should reset filters back to defaults', async ({ page }) => {
-    const ticket = page.locator('form.filter-bar input[type="text"]').first();
+    // The ticket field is the first free-text input in the filter grid; the
+    // date-range inputs are DateField controls in a separate row above.
+    const ticket = page.locator('form.filter-bar .filter-grid input[type="text"]').first();
     await ticket.fill('ABC-123');
     await expect(ticket).toHaveValue('ABC-123');
 
@@ -142,19 +147,23 @@ test.describe('Entry Filtering', () => {
   });
 
   test('should expose customer/project/user filters defaulting to "all"', async ({ page }) => {
-    // The five relation filters (customer, project, team, user, activity) each
-    // carry a "0" = all option as their first entry.
-    const selects = page.locator('form.filter-bar select');
-    expect(await selects.count()).toBeGreaterThanOrEqual(5);
-    await expect(selects.first().locator('option[value="0"]')).toHaveCount(1);
+    // The five relation filters (customer, project, team, user, activity) are
+    // searchable comboboxes that each default to their "Alle" (value 0) entry.
+    const filters = page.locator('form.filter-bar .searchable-select');
+    expect(await filters.count()).toBeGreaterThanOrEqual(5);
+    await expect(filters.first().locator('.searchable-select-value')).toHaveText('Alle');
   });
 
   test('should keep the page functional after changing a filter', async ({ page }) => {
-    const customer = page.locator('form.filter-bar select').first();
-    const options = customer.locator('option');
-    // Only exercise selection when seed data provides at least one real option.
-    if ((await options.count()) > 1) {
-      await customer.selectOption({ index: 1 });
+    // Open the first relation combobox (customer) and pick a real option past the
+    // leading "Alle" entry — only when the seed data provides one.
+    await page.locator('form.filter-bar .searchable-select-trigger').first().click();
+    await expect(page.locator('.combobox-input').first()).toBeVisible();
+    const realOption = page.locator('.combobox-content .combobox-item').nth(1);
+    if (await realOption.isVisible()) {
+      await realOption.click();
+    } else {
+      await page.keyboard.press('Escape');
     }
     await page.locator('form.filter-bar button[type="submit"]').click();
     await expect(page.locator('section.auswertung')).toBeVisible();

--- a/e2e/worklog-sync.spec.ts
+++ b/e2e/worklog-sync.spec.ts
@@ -92,7 +92,8 @@ test.describe('Worklog sync — self-service import', () => {
     // legend, the ticket-system select and the Preview (dry-run) button render.
     const section = page.locator('fieldset.settings-group').filter({ hasText: IMPORT_TITLE });
     await expect(section).toBeVisible();
-    await expect(section.locator('select').first()).toBeVisible();
+    // The ticket-system picker is a searchable combobox now (SearchableSelect).
+    await expect(section.locator('.searchable-select').first()).toBeVisible();
     await expect(section.getByRole('button', { name: PREVIEW })).toBeVisible();
   });
 });

--- a/frontend/src/components/OptionSelect.tsx
+++ b/frontend/src/components/OptionSelect.tsx
@@ -1,10 +1,13 @@
-import { For } from 'solid-js'
+import type { JSX } from 'solid-js'
 
 import type { NamedOption } from '../api/queries'
+import { SearchableSelect } from './SearchableSelect'
 
 /**
- * A labelled relation `<select>` with a leading "all" (value 0) option, shared
- * by the Auswertung filter bar and the Billing form.
+ * A labelled relation picker with a leading "all" (value 0) option, shared by the
+ * Auswertung filter bar and the Billing form. Built on {@link SearchableSelect}
+ * so the (often long) option list is type-to-search; the props stay a plain
+ * single-select contract (value / onInput) for its callers.
  */
 export function OptionSelect(props: {
   label: string
@@ -13,20 +16,16 @@ export function OptionSelect(props: {
   options: NamedOption[] | undefined
   allLabel: string
   disabled?: boolean
-}) {
+}): JSX.Element {
   return (
-    <label class="field">
-      <span>{props.label}</span>
-      <select
-        value={props.value}
-        disabled={props.disabled}
-        onInput={(event) => props.onInput(Number(event.currentTarget.value))}
-      >
-        <option value="0">{props.allLabel}</option>
-        <For each={props.options ?? []}>
-          {(option) => <option value={option.id}>{option.label}</option>}
-        </For>
-      </select>
-    </label>
+    <SearchableSelect
+      label={props.label}
+      value={props.value}
+      // Single-select only ever emits a scalar; guard keeps the numeric contract.
+      onChange={(value) => props.onInput(typeof value === 'number' ? value : (value[0] ?? 0))}
+      options={props.options}
+      allLabel={props.allLabel}
+      disabled={props.disabled}
+    />
   )
 }

--- a/frontend/src/components/SearchableSelect.test.tsx
+++ b/frontend/src/components/SearchableSelect.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { NamedOption } from '../api/queries'
+import { SearchableSelect } from './SearchableSelect'
+
+const customers: NamedOption[] = [
+  { id: 7, label: 'Apollo' },
+  { id: 8, label: 'Zeus' },
+  { id: 9, label: 'Atlas' },
+]
+
+const teams: NamedOption[] = [
+  { id: 1, label: 'Backend' },
+  { id: 2, label: 'Frontend' },
+  { id: 3, label: 'Design' },
+]
+
+afterEach(() => { cleanup(); vi.restoreAllMocks() })
+
+describe('SearchableSelect (jsdom)', () => {
+  it('single: opening the control lists the options plus the "all" entry', async () => {
+    render(() => <SearchableSelect label="Customer" value={0} onChange={vi.fn()} options={customers} allLabel="All" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
+    // 3 real options + the prepended "all" entry.
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+  })
+
+  it('single: typing filters the options', async () => {
+    render(() => <SearchableSelect label="Customer" value={0} onChange={vi.fn()} options={customers} allLabel="All" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+
+    fireEvent.input(screen.getByRole('combobox'), { target: { value: 'Ap' } })
+    await waitFor(() => {
+      const labels = screen.getAllByRole('option').map((o) => o.textContent)
+      expect(labels.some((l) => l?.includes('Apollo'))).toBe(true)
+      expect(labels.some((l) => l?.includes('Zeus'))).toBe(false)
+    })
+  })
+
+  it('single: picking an option commits its numeric id', async () => {
+    const onChange = vi.fn()
+    render(() => <SearchableSelect label="Customer" value={0} onChange={onChange} options={customers} allLabel="All" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+
+    fireEvent.click(screen.getByRole('option', { name: 'Zeus' }))
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(8))
+  })
+
+  it('single: shows the current value and the "all" entry clears it to 0', async () => {
+    const onChange = vi.fn()
+    render(() => <SearchableSelect label="Customer" value={7} onChange={onChange} options={customers} allLabel="All" />)
+
+    // The chosen value is shown in the (compact) control.
+    expect(screen.getByRole('button', { name: 'Customer' })).toHaveTextContent('Apollo')
+    fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+
+    fireEvent.click(screen.getByRole('option', { name: 'All' }))
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(0))
+  })
+
+  it('single: with no selection and no allLabel, shows the "none" placeholder', () => {
+    render(() => <SearchableSelect label="Customer" value={0} onChange={vi.fn()} options={customers} />)
+
+    // No "all" option requested → the compact control falls back to the generic
+    // "none" placeholder rather than a blank control.
+    expect(screen.getByRole('button', { name: 'Customer' })).toBeInTheDocument()
+    expect(screen.queryByText('All')).not.toBeInTheDocument()
+  })
+
+  it('multi: shows the initial selection as chips and adds another on pick', async () => {
+    const onChange = vi.fn()
+    render(() => <SearchableSelect label="Teams" value={[1]} onChange={onChange} options={teams} multiple />)
+
+    expect(screen.getAllByRole('listitem').length).toBe(1) // initial chip (id 1 = Backend)
+    fireEvent.click(screen.getByRole('button', { name: 'Teams' })) // ▾ opens the list
+    fireEvent.input(screen.getByRole('combobox'), { target: { value: 'Des' } })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Design' })).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('option', { name: 'Design' }))
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([1, 3]))
+  })
+
+  it('multi: removing a chip with its × commits the selection without it', async () => {
+    const onChange = vi.fn()
+    render(() => <SearchableSelect label="Teams" value={[1, 2]} onChange={onChange} options={teams} multiple />)
+
+    expect(screen.getAllByRole('listitem').length).toBe(2)
+    fireEvent.click(screen.getByRole('button', { name: /Backend/ })) // the × on the Backend chip
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([2]))
+  })
+
+  it('multi: no "all" pseudo-option is offered', async () => {
+    render(() => <SearchableSelect label="Teams" value={[]} onChange={vi.fn()} options={teams} multiple allLabel="All" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Teams' })) // ▾ opens the list
+    fireEvent.input(screen.getByRole('combobox'), { target: { value: 'e' } }) // matches Backend/Frontend/Design
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+    expect(screen.queryByRole('option', { name: 'All' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/SearchableSelect.test.tsx
+++ b/frontend/src/components/SearchableSelect.test.tsx
@@ -24,13 +24,13 @@ describe('SearchableSelect (jsdom)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
     // 3 real options + the prepended "all" entry.
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(4))
   })
 
   it('single: typing filters the options', async () => {
     render(() => <SearchableSelect label="Customer" value={0} onChange={vi.fn()} options={customers} allLabel="All" />)
     fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(4))
 
     fireEvent.input(screen.getByRole('combobox'), { target: { value: 'Ap' } })
     await waitFor(() => {
@@ -44,7 +44,7 @@ describe('SearchableSelect (jsdom)', () => {
     const onChange = vi.fn()
     render(() => <SearchableSelect label="Customer" value={0} onChange={onChange} options={customers} allLabel="All" />)
     fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(4))
 
     fireEvent.click(screen.getByRole('option', { name: 'Zeus' }))
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(8))
@@ -57,7 +57,7 @@ describe('SearchableSelect (jsdom)', () => {
     // The chosen value is shown in the (compact) control.
     expect(screen.getByRole('button', { name: 'Customer' })).toHaveTextContent('Apollo')
     fireEvent.click(screen.getByRole('button', { name: 'Customer' }))
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(4))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(4))
 
     fireEvent.click(screen.getByRole('option', { name: 'All' }))
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(0))
@@ -76,7 +76,7 @@ describe('SearchableSelect (jsdom)', () => {
     const onChange = vi.fn()
     render(() => <SearchableSelect label="Teams" value={[1]} onChange={onChange} options={teams} multiple />)
 
-    expect(screen.getAllByRole('listitem').length).toBe(1) // initial chip (id 1 = Backend)
+    expect(screen.getAllByRole('listitem')).toHaveLength(1) // initial chip (id 1 = Backend)
     fireEvent.click(screen.getByRole('button', { name: 'Teams' })) // ▾ opens the list
     fireEvent.input(screen.getByRole('combobox'), { target: { value: 'Des' } })
     await waitFor(() => expect(screen.getByRole('option', { name: 'Design' })).toBeInTheDocument())
@@ -89,7 +89,7 @@ describe('SearchableSelect (jsdom)', () => {
     const onChange = vi.fn()
     render(() => <SearchableSelect label="Teams" value={[1, 2]} onChange={onChange} options={teams} multiple />)
 
-    expect(screen.getAllByRole('listitem').length).toBe(2)
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
     fireEvent.click(screen.getByRole('button', { name: /Backend/ })) // the × on the Backend chip
     await waitFor(() => expect(onChange).toHaveBeenCalledWith([2]))
   })
@@ -99,7 +99,7 @@ describe('SearchableSelect (jsdom)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Teams' })) // ▾ opens the list
     fireEvent.input(screen.getByRole('combobox'), { target: { value: 'e' } }) // matches Backend/Frontend/Design
-    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(3))
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3))
     expect(screen.queryByRole('option', { name: 'All' })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/SearchableSelect.tsx
+++ b/frontend/src/components/SearchableSelect.tsx
@@ -1,11 +1,10 @@
-import { Combobox, createListCollection } from '@ark-ui/solid/combobox'
+import { Combobox } from '@ark-ui/solid/combobox'
 import { createMemo, createSignal, For, type JSX, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
 import type { NamedOption } from '../api/queries'
+import { ComboboxContent, ComboSearchIcon, comboCollection, type ComboItem } from '../lib/comboboxParts'
 import { m } from '../paraglide/messages.js'
-
-type Item = { value: string; label: string }
 
 // The "all / none" pseudo-option (value 0) for an optional single select. A
 // sentinel that can't collide with a real relation id (which stringify to
@@ -58,19 +57,19 @@ export function SearchableSelect(props: {
     return raw > 0 ? [String(raw)] : []
   })
 
-  const allItems = createMemo<Item[]>(() => (props.options ?? []).map((option) => ({ value: String(option.id), label: option.label })))
+  const allItems = createMemo<ComboItem[]>(() => (props.options ?? []).map((option) => ({ value: String(option.id), label: option.label })))
   const labelOf = (value: string): string =>
     value === ALL_VALUE ? (props.allLabel ?? '') : (allItems().find((item) => item.value === value)?.label ?? value)
 
   // Offer an explicit "all / none" entry only for an optional single select.
   const showAll = (): boolean => !isMulti() && props.allLabel !== undefined
-  const filteredItems = createMemo<Item[]>(() => {
+  const filteredItems = createMemo<ComboItem[]>(() => {
     const query = inputValue().trim().toLowerCase()
     const base = query === '' ? allItems() : allItems().filter((item) => item.label.toLowerCase().includes(query))
 
     return showAll() && query === '' ? [{ value: ALL_VALUE, label: props.allLabel ?? '' }, ...base] : base
   })
-  const collection = createMemo(() => createListCollection<Item>({ items: filteredItems(), itemToValue: (item) => item.value, itemToString: (item) => item.label }))
+  const collection = createMemo(() => comboCollection(filteredItems()))
 
   // Single-select control display: the chosen label, or the "all" label when
   // nothing is chosen (value 0), falling back to a generic "none" placeholder.
@@ -87,13 +86,6 @@ export function SearchableSelect(props: {
     props.onChange(selectedValues().filter((current) => current !== value).map(Number))
   }
 
-  const magnifier = (): JSX.Element => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true">
-      <circle cx="10.5" cy="10.5" r="6.5" />
-      <line x1="15.6" y1="15.6" x2="21" y2="21" />
-    </svg>
-  )
-
   const searchInput = (): JSX.Element => (
     <Combobox.Input
       ref={(element) => { inputEl = element }}
@@ -109,7 +101,7 @@ export function SearchableSelect(props: {
       <div class={`searchable-select chip-select${isMulti() ? ' inline-tags' : ''}${props.disabled === true ? ' is-disabled' : ''}`}>
         {/* Multi: a leading magnifier in the control. Single's search is in the popup. */}
         <Show when={isMulti()}>
-          <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
+          <ComboSearchIcon />
           <ul class="tag-list">
             <For each={selectedValues()}>
               {(value) => (
@@ -191,24 +183,7 @@ export function SearchableSelect(props: {
           {/* Body-portal so the popup floats above cards/dialogs and is never clipped. */}
           <Portal>
             <Combobox.Positioner class="combobox-positioner">
-              <Combobox.Content class="combobox-content">
-                {/* Single: a roomy, sticky search field at the TOP of the dropdown. */}
-                <Show when={!isMulti()}>
-                  <div class="combobox-search-row">
-                    <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
-                    {searchInput()}
-                  </div>
-                </Show>
-                <For each={filteredItems()}>
-                  {(item) => (
-                    <Combobox.Item item={item} class="combobox-item">
-                      <Combobox.ItemText>{item.label}</Combobox.ItemText>
-                      <Combobox.ItemIndicator class="combobox-indicator">✓</Combobox.ItemIndicator>
-                    </Combobox.Item>
-                  )}
-                </For>
-                <Combobox.Empty class="combobox-empty">{m.app_no_results()}</Combobox.Empty>
-              </Combobox.Content>
+              <ComboboxContent items={filteredItems()} multiple={isMulti()} searchInput={searchInput} />
             </Combobox.Positioner>
           </Portal>
         </Combobox.Root>

--- a/frontend/src/components/SearchableSelect.tsx
+++ b/frontend/src/components/SearchableSelect.tsx
@@ -110,10 +110,10 @@ export function SearchableSelect(props: {
         {/* Multi: a leading magnifier in the control. Single's search is in the popup. */}
         <Show when={isMulti()}>
           <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
-          <span class="tag-list" role="list">
+          <ul class="tag-list">
             <For each={selectedValues()}>
               {(value) => (
-                <span class="tag" role="listitem">
+                <li class="tag">
                   <span class="tag-label">{labelOf(value)}</span>
                   <button
                     type="button"
@@ -124,10 +124,10 @@ export function SearchableSelect(props: {
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={() => { removeValue(value); inputEl?.focus() }}
                   >×</button>
-                </span>
+                </li>
               )}
             </For>
-          </span>
+          </ul>
         </Show>
 
         {/* Announce selection changes — Ark's own live region only narrates the

--- a/frontend/src/components/SearchableSelect.tsx
+++ b/frontend/src/components/SearchableSelect.tsx
@@ -1,0 +1,218 @@
+import { Combobox, createListCollection } from '@ark-ui/solid/combobox'
+import { createMemo, createSignal, For, type JSX, Show } from 'solid-js'
+import { Portal } from 'solid-js/web'
+
+import type { NamedOption } from '../api/queries'
+import { m } from '../paraglide/messages.js'
+
+type Item = { value: string; label: string }
+
+// The "all / none" pseudo-option (value 0) for an optional single select. A
+// sentinel that can't collide with a real relation id (which stringify to
+// digits), so it never enters the committed numeric value.
+const ALL_VALUE = '__all__'
+
+/**
+ * A searchable relation combobox for ordinary FORMS (not the admin grid),
+ * built on the same Ark UI Combobox primitive + combobox CSS as the inline-grid
+ * editor ({@link ChipSelect}), so it looks identical to the worklog table's cell
+ * editor — but with a plain controlled form API (value / onChange) instead of
+ * the grid's field/commit/cancel contract.
+ *
+ * Two layouts share all the logic:
+ * - SINGLE: a compact control showing the chosen label + a ▾; the search field
+ *   lives at the top of the (body-portalled) popup. An optional "all" (value 0)
+ *   entry clears the selection.
+ * - MULTI: removable chips + a leading magnifier + the search input, all in the
+ *   control; the popup lists the options.
+ *
+ * Boundary: Ark deals in string[]; relation ids are carried verbatim as the
+ * option's string value and converted back to numbers only in onChange.
+ */
+export function SearchableSelect(props: {
+  label: string
+  /** Single: the chosen id (0 = none/all). Multi: the chosen ids. */
+  value: number | number[]
+  onChange: (value: number | number[]) => void
+  /** Option source in the {@link NamedOption} shape ({ id, label }). */
+  options: NamedOption[] | undefined
+  multiple?: boolean
+  /** Single-only: label for the "all / none" (value 0) entry. */
+  allLabel?: string
+  disabled?: boolean
+  required?: boolean
+}): JSX.Element {
+  let inputEl: HTMLInputElement | undefined
+  const [inputValue, setInputValue] = createSignal('')
+
+  const isMulti = (): boolean => props.multiple === true
+
+  // Controlled selection, derived from props.value (never carries the ALL
+  // sentinel — value 0 maps to an empty selection).
+  const selectedValues = createMemo<string[]>(() => {
+    const raw = props.value
+    if (Array.isArray(raw)) {
+      return raw.filter((value) => value > 0).map(String)
+    }
+
+    return raw > 0 ? [String(raw)] : []
+  })
+
+  const allItems = createMemo<Item[]>(() => (props.options ?? []).map((option) => ({ value: String(option.id), label: option.label })))
+  const labelOf = (value: string): string =>
+    value === ALL_VALUE ? (props.allLabel ?? '') : (allItems().find((item) => item.value === value)?.label ?? value)
+
+  // Offer an explicit "all / none" entry only for an optional single select.
+  const showAll = (): boolean => !isMulti() && props.allLabel !== undefined
+  const filteredItems = createMemo<Item[]>(() => {
+    const query = inputValue().trim().toLowerCase()
+    const base = query === '' ? allItems() : allItems().filter((item) => item.label.toLowerCase().includes(query))
+
+    return showAll() && query === '' ? [{ value: ALL_VALUE, label: props.allLabel ?? '' }, ...base] : base
+  })
+  const collection = createMemo(() => createListCollection<Item>({ items: filteredItems(), itemToValue: (item) => item.value, itemToString: (item) => item.label }))
+
+  // Single-select control display: the chosen label, or the "all" label when
+  // nothing is chosen (value 0), falling back to a generic "none" placeholder.
+  const singleDisplay = (): string => {
+    const first = selectedValues()[0]
+    if (first !== undefined) {
+      return labelOf(first)
+    }
+
+    return props.allLabel ?? m.app_select_none()
+  }
+
+  const removeValue = (value: string): void => {
+    props.onChange(selectedValues().filter((current) => current !== value).map(Number))
+  }
+
+  const magnifier = (): JSX.Element => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true">
+      <circle cx="10.5" cy="10.5" r="6.5" />
+      <line x1="15.6" y1="15.6" x2="21" y2="21" />
+    </svg>
+  )
+
+  const searchInput = (): JSX.Element => (
+    <Combobox.Input
+      ref={(element) => { inputEl = element }}
+      class="combobox-input"
+      aria-label={props.label}
+      placeholder={isMulti() && selectedValues().length === 0 ? m.app_type_to_add() : m.app_type_to_search()}
+    />
+  )
+
+  return (
+    <div class="field">
+      <span>{props.label}</span>
+      <div class={`searchable-select chip-select${isMulti() ? ' inline-tags' : ''}${props.disabled === true ? ' is-disabled' : ''}`}>
+        {/* Multi: a leading magnifier in the control. Single's search is in the popup. */}
+        <Show when={isMulti()}>
+          <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
+          <span class="tag-list" role="list">
+            <For each={selectedValues()}>
+              {(value) => (
+                <span class="tag" role="listitem">
+                  <span class="tag-label">{labelOf(value)}</span>
+                  <button
+                    type="button"
+                    class="tag-remove"
+                    tabindex="-1"
+                    disabled={props.disabled}
+                    aria-label={`${m.admin_delete()}: ${labelOf(value)}`}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => { removeValue(value); inputEl?.focus() }}
+                  >×</button>
+                </span>
+              )}
+            </For>
+          </span>
+        </Show>
+
+        {/* Announce selection changes — Ark's own live region only narrates the
+            highlighted option during navigation. */}
+        <span class="visually-hidden" role="status" aria-live="polite">
+          {selectedValues().map(labelOf).join(', ')}
+        </span>
+
+        <Combobox.Root
+          class="chip-select-root"
+          collection={collection()}
+          multiple={isMulti()}
+          disabled={props.disabled}
+          value={selectedValues()}
+          onValueChange={(details) => {
+            if (isMulti()) {
+              props.onChange(details.value.map(Number))
+
+              return
+            }
+            const first = details.value[0]
+            props.onChange(first === undefined || first === ALL_VALUE ? 0 : Number(first))
+          }}
+          inputValue={inputValue()}
+          onInputValueChange={(details) => setInputValue(details.inputValue)}
+          onOpenChange={(details) => {
+            // Single's search input lives in the popup — focus it once the popup
+            // mounts so typing starts immediately. Clear a stale filter on close.
+            if (details.open) {
+              requestAnimationFrame(() => { if (inputEl?.isConnected) inputEl.focus() })
+            } else {
+              setInputValue('')
+            }
+          }}
+          openOnClick
+          closeOnSelect={!isMulti()}
+          allowCustomValue={false}
+          inputBehavior="autohighlight"
+          positioning={{ sameWidth: true, gutter: 2, flip: true, fitViewport: true }}
+        >
+          <Combobox.Label class="visually-hidden">{props.label}</Combobox.Label>
+          <Combobox.Control class="combobox-control">
+            {/* Multi: search input next to the chips. Single: a value + ▾ trigger. */}
+            <Show
+              when={isMulti()}
+              fallback={
+                <Combobox.Trigger
+                  class="searchable-select-trigger"
+                  aria-label={props.label}
+                  aria-required={props.required === true ? 'true' : undefined}
+                >
+                  <span class="searchable-select-value">{singleDisplay()}</span>
+                  <span class="combobox-trigger-glyph" aria-hidden="true">▾</span>
+                </Combobox.Trigger>
+              }
+            >
+              {searchInput()}
+              <Combobox.Trigger class="combobox-trigger" tabindex="-1" aria-label={props.label}>▾</Combobox.Trigger>
+            </Show>
+          </Combobox.Control>
+          {/* Body-portal so the popup floats above cards/dialogs and is never clipped. */}
+          <Portal>
+            <Combobox.Positioner class="combobox-positioner">
+              <Combobox.Content class="combobox-content">
+                {/* Single: a roomy, sticky search field at the TOP of the dropdown. */}
+                <Show when={!isMulti()}>
+                  <div class="combobox-search-row">
+                    <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
+                    {searchInput()}
+                  </div>
+                </Show>
+                <For each={filteredItems()}>
+                  {(item) => (
+                    <Combobox.Item item={item} class="combobox-item">
+                      <Combobox.ItemText>{item.label}</Combobox.ItemText>
+                      <Combobox.ItemIndicator class="combobox-indicator">✓</Combobox.ItemIndicator>
+                    </Combobox.Item>
+                  )}
+                </For>
+                <Combobox.Empty class="combobox-empty">{m.app_no_results()}</Combobox.Empty>
+              </Combobox.Content>
+            </Combobox.Positioner>
+          </Portal>
+        </Combobox.Root>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/WorklogImportSection.test.tsx
+++ b/frontend/src/components/WorklogImportSection.test.tsx
@@ -31,6 +31,13 @@ vi.mock('../api/client', () => ({
 
 const { WorklogImportSection } = await import('./WorklogImportSection')
 
+// Pick an option in a SearchableSelect (single) combobox: open its trigger by the
+// field label, then choose the seeded option once the popup mounts it.
+async function pickOption(comboboxLabel: string, optionName: string): Promise<void> {
+  fireEvent.click(screen.getByRole('button', { name: comboboxLabel }))
+  fireEvent.click(await screen.findByRole('option', { name: optionName }))
+}
+
 function makeRun(overrides: Partial<SyncRun> = {}): SyncRun {
   return {
     id: 1,
@@ -78,15 +85,13 @@ describe('WorklogImportSection', () => {
     const { container, queryClient } = renderWithProviders(() => <WorklogImportSection />)
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
 
-    // Reference selects populate from the mocked endpoints.
-    await waitFor(() => expect(screen.getByRole('option', { name: 'Jira Cloud' })).toBeInTheDocument())
-
     // Exact group name: the "Help: …" trigger inside the legend is kept out of
     // the accessible name by the fieldset's aria-labelledby.
     expect(screen.getByRole('group', { name: 'Import Jira worklogs' })).toBeInTheDocument()
 
-    fireEvent.change(screen.getByLabelText('Ticket system'), { target: { value: '1' } })
-    fireEvent.change(screen.getByLabelText('Default activity'), { target: { value: '2' } })
+    // Pick the ticket system and default activity in their searchable comboboxes.
+    await pickOption('Ticket system', 'Jira Cloud')
+    await pickOption('Default activity', 'Development')
 
     // Step 1: preview → dry_run:true, scoped to the current user (unittest).
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
@@ -112,7 +117,9 @@ describe('WorklogImportSection', () => {
     expect(createSyncRun).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: 'import', ticket_system_id: 1, dry_run: false }),
     )
-    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Import complete.'))
+    // Each SearchableSelect carries its own aria-live status region, so scope the
+    // success assertion to the import form's success status paragraph.
+    await waitFor(() => expect(container.querySelector('.form-status.is-ok')).toHaveTextContent('Import complete.'))
     expect(screen.getByText('Created')).toBeInTheDocument()
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['worklog-sync', 'conflicts'] })
     // The real import created entries: the worklog grid and the header
@@ -128,12 +135,13 @@ describe('WorklogImportSection', () => {
     createSyncRun.mockRejectedValue(new Error('Jira unreachable'))
     const { container } = renderWithProviders(() => <WorklogImportSection />)
 
-    await waitFor(() => expect(screen.getByRole('option', { name: 'Jira Cloud' })).toBeInTheDocument())
-    fireEvent.change(screen.getByLabelText('Ticket system'), { target: { value: '1' } })
+    await pickOption('Ticket system', 'Jira Cloud')
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
 
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Jira unreachable'))
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    // No success status paragraph on failure (SearchableSelects keep their own
+    // aria-live status regions, so target the success class rather than role).
+    expect(container.querySelector('.form-status.is-ok')).not.toBeInTheDocument()
 
     expect(await axe(container)).toHaveNoViolations()
   })
@@ -142,10 +150,10 @@ describe('WorklogImportSection', () => {
     mockRefs()
     renderWithProviders(() => <WorklogImportSection />)
 
-    await waitFor(() => expect(screen.getByRole('option', { name: 'Jira Cloud' })).toBeInTheDocument())
+    // Preview stays disabled until a ticket system is chosen.
     expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled()
 
-    fireEvent.change(screen.getByLabelText('Ticket system'), { target: { value: '1' } })
-    expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled()
+    await pickOption('Ticket system', 'Jira Cloud')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled())
   })
 })

--- a/frontend/src/components/WorklogImportSection.tsx
+++ b/frontend/src/components/WorklogImportSection.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/solid-query'
-import { createSignal, For, Show, type JSX } from 'solid-js'
+import { createSignal, Show, type JSX } from 'solid-js'
 
 import { apiErrorMessage } from '../api/client'
 import { activitiesQuery, refreshEntriesAndWorktime, ticketSystemsQuery } from '../api/queries'
@@ -8,6 +8,7 @@ import { appConfig } from '../config'
 import { isoDate } from '../lib/format'
 import { DateField } from './DateField'
 import { HelpPopover } from './HelpPopover'
+import { SearchableSelect } from './SearchableSelect'
 import { SyncRunSummary } from './SyncRunSummary'
 import { m } from '../paraglide/messages.js'
 
@@ -94,19 +95,14 @@ export function WorklogImportSection(): JSX.Element {
         <p class="settings-section-hint">{m.worklogsync_import_intro()}</p>
 
         <div class="security-block">
-          <label class="field">
-            <span>{m.worklogsync_ticket_system()}</span>
-            <select
-              value={ticketSystemId()}
-              disabled={busy()}
-              onChange={(event) => setTicketSystemId(Number(event.currentTarget.value))}
-            >
-              <option value={0}>—</option>
-              <For each={ticketSystems.data ?? []}>
-                {(option) => <option value={option.id}>{option.label}</option>}
-              </For>
-            </select>
-          </label>
+          <SearchableSelect
+            label={m.worklogsync_ticket_system()}
+            value={ticketSystemId()}
+            onChange={(value) => setTicketSystemId(typeof value === 'number' ? value : (value[0] ?? 0))}
+            options={ticketSystems.data}
+            allLabel="—"
+            disabled={busy()}
+          />
 
           <label class="field">
             <span>{m.worklogsync_from()}</span>
@@ -118,19 +114,14 @@ export function WorklogImportSection(): JSX.Element {
             <DateField value={to()} onChange={setTo} disabled={busy()} calendar />
           </label>
 
-          <label class="field">
-            <span>{m.worklogsync_default_activity()}</span>
-            <select
-              value={activityId()}
-              disabled={busy()}
-              onChange={(event) => setActivityId(Number(event.currentTarget.value))}
-            >
-              <option value={0}>—</option>
-              <For each={activities.data ?? []}>
-                {(option) => <option value={option.id}>{option.label}</option>}
-              </For>
-            </select>
-          </label>
+          <SearchableSelect
+            label={m.worklogsync_default_activity()}
+            value={activityId()}
+            onChange={(value) => setActivityId(typeof value === 'number' ? value : (value[0] ?? 0))}
+            options={activities.data}
+            allLabel="—"
+            disabled={busy()}
+          />
 
           <div class="form-actions">
             <button type="button" class="primary-button" disabled={!canRun()} onClick={() => void runImport(true)}>

--- a/frontend/src/lib/chipSelect.tsx
+++ b/frontend/src/lib/chipSelect.tsx
@@ -1,13 +1,12 @@
-import { Combobox, createListCollection } from '@ark-ui/solid/combobox'
+import { Combobox } from '@ark-ui/solid/combobox'
 import { createMemo, createSignal, For, type JSX, onMount, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
 
 import type { FieldDef, FormValues, OptionLookup } from '../admin/types'
+import { ComboboxContent, ComboSearchIcon, comboCollection, type ComboItem } from './comboboxParts'
 import { getEnterBehavior } from './gridEditPref'
 import { fieldSelectOptions } from './inlineGridEdit'
 import { m } from '../paraglide/messages.js'
-
-type Item = { value: string; label: string }
 
 // The "clear to none" pseudo-option for an optional single relation select. A
 // sentinel (never a real option value — relation values stringify to digits) so
@@ -69,17 +68,17 @@ export function ChipSelect(props: {
   // resulting onSelect commits as 'next' (guides to the next required field).
   let committedByEnter = false
 
-  const allItems = createMemo<Item[]>(() => fieldSelectOptions(props.field, props.options).map((option) => ({ value: String(option.value), label: option.label })))
+  const allItems = createMemo<ComboItem[]>(() => fieldSelectOptions(props.field, props.options).map((option) => ({ value: String(option.value), label: option.label })))
   const labelOf = (value: string): string => allItems().find((item) => item.value === value)?.label ?? value
   // Offer an explicit "none" only for an optional, numeric (relation) single select.
   const showClear = (): boolean => !props.multiple && props.field.required !== true && props.field.stringValue !== true
-  const filteredItems = createMemo<Item[]>(() => {
+  const filteredItems = createMemo<ComboItem[]>(() => {
     const query = inputValue().trim().toLowerCase()
     const base = query === '' ? allItems() : allItems().filter((item) => item.label.toLowerCase().includes(query))
 
     return showClear() && query === '' ? [{ value: CLEAR_VALUE, label: m.app_select_none() }, ...base] : base
   })
-  const collection = createMemo(() => createListCollection<Item>({ items: filteredItems(), itemToValue: (item) => item.value, itemToString: (item) => item.label }))
+  const collection = createMemo(() => comboCollection(filteredItems()))
 
   const coerced = (): FormValues[string] => {
     if (props.multiple) {
@@ -189,13 +188,6 @@ export function ChipSelect(props: {
     }
   }
 
-  const magnifier = (): JSX.Element => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true">
-      <circle cx="10.5" cy="10.5" r="6.5" />
-      <line x1="15.6" y1="15.6" x2="21" y2="21" />
-    </svg>
-  )
-
   const searchInput = (): JSX.Element => (
     <Combobox.Input
       ref={(element) => { inputEl = element }}
@@ -226,7 +218,7 @@ export function ChipSelect(props: {
     >
       {/* Multi: a leading magnifier in the cell. Single's search lives in the popup. */}
       <Show when={props.multiple}>
-        <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
+        <ComboSearchIcon />
       </Show>
 
       {/* Selection chips in the cell: multi = removable; single = the current value
@@ -321,25 +313,7 @@ export function ChipSelect(props: {
             focus-out logic so opening it doesn't save/close the row. */}
         <Portal>
           <Combobox.Positioner class="combobox-positioner" data-chipselect-popup>
-            <Combobox.Content class="combobox-content">
-              {/* Single: a roomy, sticky search field at the TOP of the dropdown —
-                  not constrained by the narrow cell. */}
-              <Show when={!props.multiple}>
-                <div class="combobox-search-row">
-                  <span class="combobox-search" aria-hidden="true">{magnifier()}</span>
-                  {searchInput()}
-                </div>
-              </Show>
-              <For each={filteredItems()}>
-                {(item) => (
-                  <Combobox.Item item={item} class="combobox-item">
-                    <Combobox.ItemText>{item.label}</Combobox.ItemText>
-                    <Combobox.ItemIndicator class="combobox-indicator">✓</Combobox.ItemIndicator>
-                  </Combobox.Item>
-                )}
-              </For>
-              <Combobox.Empty class="combobox-empty">{m.app_no_results()}</Combobox.Empty>
-            </Combobox.Content>
+            <ComboboxContent items={filteredItems()} multiple={props.multiple} searchInput={searchInput} />
           </Combobox.Positioner>
         </Portal>
       </Combobox.Root>

--- a/frontend/src/lib/comboboxParts.tsx
+++ b/frontend/src/lib/comboboxParts.tsx
@@ -1,0 +1,57 @@
+import { Combobox, createListCollection } from '@ark-ui/solid/combobox'
+import { For, type JSX, Show } from 'solid-js'
+
+import { m } from '../paraglide/messages.js'
+
+/** An Ark combobox option: the stringified value carried verbatim + its label. */
+export type ComboItem = { value: string; label: string }
+
+/** Build the Ark list collection from already-filtered items (value ↔ label mapping). */
+export const comboCollection = (items: ComboItem[]) =>
+  createListCollection<ComboItem>({ items, itemToValue: (item) => item.value, itemToString: (item) => item.label })
+
+/**
+ * The leading magnifier glyph, wrapped in its `.combobox-search` decoration span.
+ * Shared by the grid editor ({@link ChipSelect}) and the form control
+ * ({@link SearchableSelect}) so both render the identical search affordance.
+ */
+export const ComboSearchIcon = (): JSX.Element => (
+  <span class="combobox-search" aria-hidden="true">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true">
+      <circle cx="10.5" cy="10.5" r="6.5" />
+      <line x1="15.6" y1="15.6" x2="21" y2="21" />
+    </svg>
+  </span>
+)
+
+/**
+ * The dropdown body shared by both comboboxes: an optional sticky search row at the
+ * top (single-select only — multi keeps its search inline in the control), the
+ * option list, and the empty state. Rendered inside the caller's `Combobox.Root` →
+ * `Portal` → `Combobox.Positioner`, so Ark's context resolves normally.
+ */
+export function ComboboxContent(props: {
+  items: ComboItem[]
+  multiple: boolean
+  searchInput: () => JSX.Element
+}): JSX.Element {
+  return (
+    <Combobox.Content class="combobox-content">
+      <Show when={!props.multiple}>
+        <div class="combobox-search-row">
+          <ComboSearchIcon />
+          {props.searchInput()}
+        </div>
+      </Show>
+      <For each={props.items}>
+        {(item) => (
+          <Combobox.Item item={item} class="combobox-item">
+            <Combobox.ItemText>{item.label}</Combobox.ItemText>
+            <Combobox.ItemIndicator class="combobox-indicator">✓</Combobox.ItemIndicator>
+          </Combobox.Item>
+        )}
+      </For>
+      <Combobox.Empty class="combobox-empty">{m.app_no_results()}</Combobox.Empty>
+    </Combobox.Content>
+  )
+}

--- a/frontend/src/pages/Auswertung.test.tsx
+++ b/frontend/src/pages/Auswertung.test.tsx
@@ -64,7 +64,7 @@ describe('Auswertung', () => {
 
     getJson.mockClear()
     // Change a filter so the query key actually changes, then submit.
-    const ticket = container.querySelector('input[type=text]') as HTMLInputElement
+    const ticket = container.querySelector('.filter-grid input[type=text]') as HTMLInputElement
     fireEvent.input(ticket, { target: { value: 'ABC-1' } })
     fireEvent.click(getByRole('button', { name: 'Refresh' }))
 

--- a/frontend/src/pages/Auswertung.tsx
+++ b/frontend/src/pages/Auswertung.tsx
@@ -16,6 +16,7 @@ import {
   timeSeriesQuery,
   usersQuery,
 } from '../api/queries'
+import { DateField } from '../components/DateField'
 import { EffortChart, type EffortRow } from '../components/EffortChart'
 import { EntrySourceBadge } from '../components/EntrySourceBadge'
 import { OptionSelect } from '../components/OptionSelect'
@@ -234,11 +235,11 @@ export default function Auswertung() {
         <div class="field-row">
           <label class="field">
             <span>{m.auswertung_date_start()}</span>
-            <input type="date" value={filters().datestart} onInput={(e) => set('datestart', e.currentTarget.value)} />
+            <DateField value={filters().datestart} onChange={(iso) => set('datestart', iso)} calendar />
           </label>
           <label class="field">
             <span>{m.auswertung_date_end()}</span>
-            <input type="date" value={filters().dateend} onInput={(e) => set('dateend', e.currentTarget.value)} />
+            <DateField value={filters().dateend} onChange={(iso) => set('dateend', iso)} calendar />
           </label>
         </div>
 

--- a/frontend/src/pages/ProjectImport.test.tsx
+++ b/frontend/src/pages/ProjectImport.test.tsx
@@ -80,14 +80,11 @@ afterEach(() => {
   window.APP_CONFIG!.roles = [...FULL_ROLES]
 })
 
-// Select the ticket system so the proposals table loads.
+// Select the ticket system (now a searchable combobox) so the proposals table
+// loads: open its trigger and pick the seeded option.
 async function selectTicketSystem(): Promise<void> {
-  await waitFor(() =>
-    expect(screen.getByRole('option', { name: 'Jira Cloud' })).toBeInTheDocument(),
-  )
-  fireEvent.change(screen.getByLabelText('Ticket system', { selector: '#projectimport-ticket' }), {
-    target: { value: '1' },
-  })
+  fireEvent.click(screen.getByRole('button', { name: 'Ticket system' }))
+  fireEvent.click(await screen.findByRole('option', { name: 'Jira Cloud' }))
   await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument())
 }
 

--- a/frontend/src/pages/ProjectImport.tsx
+++ b/frontend/src/pages/ProjectImport.tsx
@@ -12,6 +12,7 @@ import {
   proposalsQuery,
 } from '../api/projectImport'
 import { customersQuery, ticketSystemsQuery, type NamedOption } from '../api/queries'
+import { SearchableSelect } from '../components/SearchableSelect'
 import { hasRole } from '../config'
 import { m } from '../paraglide/messages.js'
 
@@ -220,24 +221,18 @@ function ProjectImportArea(): JSX.Element {
         <p class="field-hint">{m.projectimport_intro()}</p>
 
         <div class="stack-form">
-          <label class="field">
-            <span>{m.worklogsync_ticket_system()}</span>
-            <select
-              id="projectimport-ticket"
-              value={ticketSystemId()}
-              disabled={busy()}
-              onChange={(event) => {
-                setResults([])
-                setError('')
-                setTicketSystemId(Number(event.currentTarget.value))
-              }}
-            >
-              <option value={0}>—</option>
-              <For each={ticketSystems.data ?? []}>
-                {(option) => <option value={option.id}>{option.label}</option>}
-              </For>
-            </select>
-          </label>
+          <SearchableSelect
+            label={m.worklogsync_ticket_system()}
+            value={ticketSystemId()}
+            onChange={(value) => {
+              setResults([])
+              setError('')
+              setTicketSystemId(typeof value === 'number' ? value : (value[0] ?? 0))
+            }}
+            options={ticketSystems.data}
+            allLabel="—"
+            disabled={busy()}
+          />
         </div>
 
         <Show when={ticketSystemId() > 0}>

--- a/frontend/src/pages/WorklogSync.test.tsx
+++ b/frontend/src/pages/WorklogSync.test.tsx
@@ -112,6 +112,14 @@ function mockRefs(): void {
   })
 }
 
+// Pick a ticket system in the trigger form's searchable combobox: the two
+// 'Ticket system' comboboxes (trigger + history filter) share a label, so the
+// first (region 1 — trigger) is opened, then the seeded option is chosen.
+async function pickTriggerTicketSystem(): Promise<void> {
+  fireEvent.click(screen.getAllByRole('button', { name: 'Ticket system' })[0]!)
+  fireEvent.click(await screen.findByRole('option', { name: 'Jira Cloud' }))
+}
+
 const FULL_ROLES = ['ROLE_USER', 'ROLE_PL', 'ROLE_ADMIN']
 
 afterEach(() => {
@@ -134,13 +142,8 @@ describe('WorklogSync', () => {
     expect(screen.getByText('Completed')).toBeInTheDocument()
     expect(screen.getByText('Failed')).toBeInTheDocument()
 
-    // Pick a ticket system, then trigger a run.
-    // Both selects (trigger + history filter) carry the ticket system, so the
-    // option appears twice — wait for the trigger select to be populated.
-    await waitFor(() => expect(screen.getAllByRole('option', { name: 'Jira Cloud' }).length).toBeGreaterThanOrEqual(2))
-    fireEvent.change(screen.getByLabelText('Ticket system', { selector: '#worklogsync-trigger-ticket' }), {
-      target: { value: '1' },
-    })
+    // Pick a ticket system in the trigger combobox, then trigger a run.
+    await pickTriggerTicketSystem()
     fireEvent.click(screen.getByRole('button', { name: 'Trigger a run' }))
 
     await waitFor(() => expect(createSyncRun).toHaveBeenCalledTimes(1))
@@ -148,8 +151,10 @@ describe('WorklogSync', () => {
       expect.objectContaining({ type: 'verify', ticket_system_id: 1, dry_run: true }),
     )
     // The returned run's summary + a success status appear; runs are invalidated.
+    // (Each SearchableSelect carries its own aria-live status region, so scope to
+    // the trigger form's success status paragraph rather than role='status'.)
     await waitFor(() => expect(screen.getByText('Created')).toBeInTheDocument())
-    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(container.querySelector('.form-status.is-ok')).toBeInTheDocument()
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['worklog-sync', 'runs'] })
     // The default trigger is a dry run — it writes nothing, so the worklog grid
     // and the header totals must not refresh (#620).
@@ -165,10 +170,7 @@ describe('WorklogSync', () => {
     const { queryClient } = renderWithProviders(() => <WorklogSync />)
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
 
-    await waitFor(() => expect(screen.getAllByRole('option', { name: 'Jira Cloud' }).length).toBeGreaterThanOrEqual(2))
-    fireEvent.change(screen.getByLabelText('Ticket system', { selector: '#worklogsync-trigger-ticket' }), {
-      target: { value: '1' },
-    })
+    await pickTriggerTicketSystem()
     fireEvent.click(screen.getByLabelText('Dry run')) // uncheck → a real run
     fireEvent.click(screen.getByRole('button', { name: 'Trigger a run' }))
 
@@ -178,6 +180,35 @@ describe('WorklogSync', () => {
     // day/week/month totals refresh (#620).
     await waitFor(() => expect(updateWorktime).toHaveBeenCalledTimes(1))
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['tracking-entries'] })
+  })
+
+  it('maps a picked user id back to its username in the trigger payload', async () => {
+    // The users picker is a relation combobox over ids, but the API targets users
+    // by username — the payload must still carry the name the old <select> sent.
+    getJson.mockImplementation((path: string) => {
+      if (path === '/getTicketSystems') {
+        return Promise.resolve([{ ticketSystem: { id: 1, name: 'Jira Cloud', active: true } }])
+      }
+      if (path === '/getAllUsers') {
+        return Promise.resolve([{ user: { id: 7, username: 'alice' } }])
+      }
+
+      return Promise.resolve([])
+    })
+    createSyncRun.mockResolvedValue(makeRun())
+    renderWithProviders(() => <WorklogSync />)
+
+    await pickTriggerTicketSystem()
+    // Open the users multi-combobox (▾), filter, pick alice. Ark applies the
+    // selection asynchronously, so wait for its chip before triggering.
+    fireEvent.click(screen.getByRole('button', { name: 'Users' }))
+    fireEvent.input(screen.getByRole('combobox', { name: 'Users' }), { target: { value: 'ali' } })
+    fireEvent.click(await screen.findByRole('option', { name: 'alice' }))
+    await waitFor(() => expect(screen.getByRole('listitem')).toHaveTextContent('alice'))
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger a run' }))
+
+    await waitFor(() => expect(createSyncRun).toHaveBeenCalledTimes(1))
+    expect(createSyncRun).toHaveBeenLastCalledWith(expect.objectContaining({ users: ['alice'] }))
   })
 
   it('loads a run detail (with items) when a run is opened', async () => {
@@ -194,16 +225,15 @@ describe('WorklogSync', () => {
   it('surfaces a trigger failure as an alert', async () => {
     mockRefs()
     createSyncRun.mockRejectedValue(new Error('Jira unreachable'))
-    renderWithProviders(() => <WorklogSync />)
+    const { container } = renderWithProviders(() => <WorklogSync />)
 
-    await waitFor(() => expect(screen.getAllByRole('option', { name: 'Jira Cloud' }).length).toBeGreaterThanOrEqual(2))
-    fireEvent.change(screen.getByLabelText('Ticket system', { selector: '#worklogsync-trigger-ticket' }), {
-      target: { value: '1' },
-    })
+    await pickTriggerTicketSystem()
     fireEvent.click(screen.getByRole('button', { name: 'Trigger a run' }))
 
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Jira unreachable'))
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    // No success status paragraph on failure (SearchableSelects keep their own
+    // aria-live status regions, so target the trigger form's success class).
+    expect(container.querySelector('.form-status.is-ok')).not.toBeInTheDocument()
   })
 
   it('does not expose the sync area to a non-admin', () => {

--- a/frontend/src/pages/WorklogSync.tsx
+++ b/frontend/src/pages/WorklogSync.tsx
@@ -13,6 +13,7 @@ import {
 } from '../api/worklogSync'
 import { ConflictList } from '../components/ConflictList'
 import { DateField } from '../components/DateField'
+import { SearchableSelect } from '../components/SearchableSelect'
 import { SyncRunSummary } from '../components/SyncRunSummary'
 import { hasRole } from '../config'
 import { isoDate } from '../lib/format'
@@ -88,7 +89,9 @@ function WorklogSyncArea(): JSX.Element {
   const [ticketSystemId, setTicketSystemId] = createSignal(0)
   const [from, setFrom] = createSignal(firstOfMonth())
   const [to, setTo] = createSignal(isoDate(new Date()))
-  const [selectedUsers, setSelectedUsers] = createSignal<string[]>([])
+  // Selected TT users, held as ids; mapped back to usernames for the payload
+  // (the API targets users by name — see buildPayload).
+  const [selectedUserIds, setSelectedUserIds] = createSignal<number[]>([])
   const [dryRun, setDryRun] = createSignal(true)
   const [busy, setBusy] = createSignal(false)
   const [error, setError] = createSignal('')
@@ -111,7 +114,12 @@ function WorklogSyncArea(): JSX.Element {
 
   function buildPayload(): CreateRunPayload {
     // A sync run targets at most one user; verify/import accept several.
-    const users = type() === 'sync' ? selectedUsers().slice(0, 1) : selectedUsers()
+    const ids = type() === 'sync' ? selectedUserIds().slice(0, 1) : selectedUserIds()
+    // The API identifies target users by username, so map the picked ids back to
+    // their names (the same payload the native <select> of usernames produced).
+    const users = ids
+      .map((id) => userOptions.data?.find((option) => option.id === id)?.label)
+      .filter((name): name is string => name !== undefined)
 
     return {
       type: type(),
@@ -162,18 +170,14 @@ function WorklogSyncArea(): JSX.Element {
               </select>
             </label>
 
-            <label class="field">
-              <span>{m.worklogsync_ticket_system()}</span>
-              <select
-                id="worklogsync-trigger-ticket"
-                value={ticketSystemId()}
-                disabled={busy()}
-                onChange={(event) => setTicketSystemId(Number(event.currentTarget.value))}
-              >
-                <option value={0}>—</option>
-                <For each={ticketSystems.data ?? []}>{(option) => <option value={option.id}>{option.label}</option>}</For>
-              </select>
-            </label>
+            <SearchableSelect
+              label={m.worklogsync_ticket_system()}
+              value={ticketSystemId()}
+              onChange={(value) => setTicketSystemId(typeof value === 'number' ? value : (value[0] ?? 0))}
+              options={ticketSystems.data}
+              allLabel="—"
+              disabled={busy()}
+            />
 
             <label class="field">
               <span>{m.worklogsync_from()}</span>
@@ -185,34 +189,34 @@ function WorklogSyncArea(): JSX.Element {
               <DateField value={to()} onChange={setTo} disabled={busy()} calendar />
             </label>
 
-            <label class="field">
-              <span>{m.worklogsync_users()}</span>
-              <select
-                multiple={type() !== 'sync'}
-                disabled={busy()}
-                onChange={(event) => {
-                  // A sync run targets a single user (the backend rejects >1 with 422);
-                  // verify/import accept a multi-selection.
-                  if (type() === 'sync') {
-                    setSelectedUsers(event.currentTarget.value ? [event.currentTarget.value] : [])
-                  } else {
-                    setSelectedUsers(Array.from(event.currentTarget.selectedOptions, (option) => option.value))
-                  }
-                }}
+            {/* A sync run targets a single user (the backend rejects >1 with 422);
+                verify/import accept several. Remount across the mode switch so
+                Ark's combobox re-inits single vs multiple cleanly. */}
+            <div class="field">
+              <Show
+                when={type() === 'sync'}
+                fallback={
+                  <SearchableSelect
+                    label={m.worklogsync_users()}
+                    multiple
+                    value={selectedUserIds()}
+                    onChange={(value) => setSelectedUserIds(Array.isArray(value) ? value : value > 0 ? [value] : [])}
+                    options={userOptions.data}
+                    disabled={busy()}
+                  />
+                }
               >
-                <Show when={type() === 'sync'}>
-                  <option value="" selected={selectedUsers().length === 0}>—</option>
-                </Show>
-                <For each={userOptions.data ?? []}>
-                  {(option) => (
-                    <option value={String(option.label)} selected={selectedUsers().includes(String(option.label))}>
-                      {option.label}
-                    </option>
-                  )}
-                </For>
-              </select>
+                <SearchableSelect
+                  label={m.worklogsync_users()}
+                  value={selectedUserIds()[0] ?? 0}
+                  onChange={(value) => setSelectedUserIds(Array.isArray(value) ? value : value > 0 ? [value] : [])}
+                  options={userOptions.data}
+                  allLabel="—"
+                  disabled={busy()}
+                />
+              </Show>
               <small class="field-hint">{m.worklogsync_users_hint()}</small>
-            </label>
+            </div>
 
             <label class="field-check">
               <input
@@ -250,17 +254,13 @@ function WorklogSyncArea(): JSX.Element {
       <section class="status-group">
         <h2 class="status-group-title">{m.worklogsync_run_history()}</h2>
         <div class="stack-form">
-          <label class="field">
-            <span>{m.worklogsync_ticket_system()}</span>
-            <select
-              id="worklogsync-history-ticket"
-              value={historyFilter()}
-              onChange={(event) => setHistoryFilter(Number(event.currentTarget.value))}
-            >
-              <option value={0}>—</option>
-              <For each={ticketSystems.data ?? []}>{(option) => <option value={option.id}>{option.label}</option>}</For>
-            </select>
-          </label>
+          <SearchableSelect
+            label={m.worklogsync_ticket_system()}
+            value={historyFilter()}
+            onChange={(value) => setHistoryFilter(typeof value === 'number' ? value : (value[0] ?? 0))}
+            options={ticketSystems.data}
+            allLabel="—"
+          />
         </div>
 
         <Show

--- a/frontend/src/pages/WorklogSync.tsx
+++ b/frontend/src/pages/WorklogSync.tsx
@@ -191,32 +191,33 @@ function WorklogSyncArea(): JSX.Element {
 
             {/* A sync run targets a single user (the backend rejects >1 with 422);
                 verify/import accept several. Remount across the mode switch so
-                Ark's combobox re-inits single vs multiple cleanly. */}
-            <div class="field">
-              <Show
-                when={type() === 'sync'}
-                fallback={
-                  <SearchableSelect
-                    label={m.worklogsync_users()}
-                    multiple
-                    value={selectedUserIds()}
-                    onChange={(value) => setSelectedUserIds(Array.isArray(value) ? value : value > 0 ? [value] : [])}
-                    options={userOptions.data}
-                    disabled={busy()}
-                  />
-                }
-              >
+                Ark's combobox re-inits single vs multiple cleanly. Each
+                SearchableSelect is its own .field (label + control); the hint is a
+                sibling — a wrapping .field would nest a grid inside the
+                .stack-form label/control grid and squeeze the control. */}
+            <Show
+              when={type() === 'sync'}
+              fallback={
                 <SearchableSelect
                   label={m.worklogsync_users()}
-                  value={selectedUserIds()[0] ?? 0}
+                  multiple
+                  value={selectedUserIds()}
                   onChange={(value) => setSelectedUserIds(Array.isArray(value) ? value : value > 0 ? [value] : [])}
                   options={userOptions.data}
-                  allLabel="—"
                   disabled={busy()}
                 />
-              </Show>
-              <small class="field-hint">{m.worklogsync_users_hint()}</small>
-            </div>
+              }
+            >
+              <SearchableSelect
+                label={m.worklogsync_users()}
+                value={selectedUserIds()[0] ?? 0}
+                onChange={(value) => setSelectedUserIds(Array.isArray(value) ? value : value > 0 ? [value] : [])}
+                options={userOptions.data}
+                allLabel="—"
+                disabled={busy()}
+              />
+            </Show>
+            <small class="field-hint">{m.worklogsync_users_hint()}</small>
 
             <label class="field-check">
               <input

--- a/frontend/src/pages/WorklogSync.tsx
+++ b/frontend/src/pages/WorklogSync.tsx
@@ -22,6 +22,16 @@ import { m } from '../paraglide/messages.js'
 const RUN_TYPES = ['verify', 'import', 'sync'] as const
 type RunType = (typeof RUN_TYPES)[number]
 
+/** Normalize a SearchableSelect value (single id or id array) to an id list,
+ *  dropping the 0 = "none" sentinel. */
+function toIdArray(value: number | number[]): number[] {
+  if (Array.isArray(value)) {
+    return value
+  }
+
+  return value > 0 ? [value] : []
+}
+
 const typeLabels: Record<RunType, () => string> = {
   verify: m.worklogsync_type_verify,
   import: m.worklogsync_type_import,
@@ -202,7 +212,7 @@ function WorklogSyncArea(): JSX.Element {
                   label={m.worklogsync_users()}
                   multiple
                   value={selectedUserIds()}
-                  onChange={(value) => setSelectedUserIds(Array.isArray(value) ? value : value > 0 ? [value] : [])}
+                  onChange={(value) => setSelectedUserIds(toIdArray(value))}
                   options={userOptions.data}
                   disabled={busy()}
                 />
@@ -211,7 +221,7 @@ function WorklogSyncArea(): JSX.Element {
               <SearchableSelect
                 label={m.worklogsync_users()}
                 value={selectedUserIds()[0] ?? 0}
-                onChange={(value) => setSelectedUserIds(Array.isArray(value) ? value : value > 0 ? [value] : [])}
+                onChange={(value) => setSelectedUserIds(toIdArray(value))}
                 options={userOptions.data}
                 allLabel="—"
                 disabled={busy()}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -3592,6 +3592,7 @@ th[aria-sort='descending'] .th-sort-glyph {
    nav. Textarea keeps its multi-line height. */
 :root[data-density='compact'] .field input:not([type='checkbox']):not([type='radio']),
 :root[data-density='compact'] .field select,
+:root[data-density='compact'] .searchable-select-trigger,
 :root[data-density='compact'] .range-preset,
 :root[data-density='compact'] .admin-filter,
 :root[data-density='compact'] .today-button,
@@ -3659,6 +3660,7 @@ th[aria-sort='descending'] .th-sort-glyph {
 :root[data-density='ultra-compact'] .tracking-days-input,
 :root[data-density='ultra-compact'] .field input:not([type='checkbox']):not([type='radio']),
 :root[data-density='ultra-compact'] .field select,
+:root[data-density='ultra-compact'] .searchable-select-trigger,
 :root[data-density='ultra-compact'] .range-preset,
 :root[data-density='ultra-compact'] .admin-filter,
 :root[data-density='ultra-compact'] .today-button,
@@ -3708,6 +3710,7 @@ th[aria-sort='descending'] .th-sort-glyph {
    controls and their help text at every density. */
 :root[data-density] :is(.settings-page,.modal) .field input:not([type='checkbox']):not([type='radio']),
 :root[data-density] :is(.settings-page,.modal) .field select,
+:root[data-density] :is(.settings-page,.modal) .searchable-select-trigger,
 :root[data-density] :is(.settings-page,.modal) :is(.link-button,.action-button,.primary-button,.days-combo-toggle){ min-height:44px; }
 :root[data-density] :is(.settings-page,.modal) .primary-button{ padding:0 1.2rem; }
 :root[data-density] :is(.settings-page,.modal) .days-combo-toggle{ width:auto; }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2546,6 +2546,69 @@ kbd {
   display: contents;
 }
 
+/* ---- SearchableSelect: the same Ark Combobox + chip styling as a standalone
+   FORM control (not a grid cell). The inline editor borrows the cell's box; a
+   form field needs its own, so .searchable-select carries the border, the 44px
+   height and the focus ring, while the popup and chips reuse the combobox/tag
+   classes above. */
+.searchable-select {
+  align-items: center;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  column-gap: 0.3rem;
+  display: flex;
+  flex-wrap: wrap;
+  min-height: 44px;
+  padding: 0.15rem 0.5rem;
+  row-gap: 0.2rem;
+}
+
+.searchable-select:focus-within {
+  border-color: var(--color-accent);
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+.searchable-select.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* SINGLE: the current value fills the row, a trailing ▾ opens the popup; the
+   whole control is the click target. */
+.searchable-select-trigger {
+  align-items: center;
+  background: none;
+  border: 0;
+  color: var(--color-text);
+  cursor: pointer;
+  display: flex;
+  flex: 1;
+  font: inherit;
+  gap: 0.3rem;
+  justify-content: space-between;
+  min-height: 40px;
+  padding: 0;
+  text-align: start;
+}
+
+.searchable-select.is-disabled .searchable-select-trigger {
+  cursor: not-allowed;
+}
+
+.searchable-select-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.combobox-trigger-glyph {
+  color: var(--color-accent);
+  flex: none;
+  font-size: 0.8rem;
+}
+
 /* MULTI: the cell IS the search field — surface fill + accent border + focus ring,
    with the magnifier, chips and input on one (wrapping) row. */
 .data-table td[data-inline-editing] .chip-select.inline-tags {


### PR DESCRIPTION
## Description

Uniform date and select behavior across the app: the last native date inputs become the enhanced date field, and the data-heavy relation selects become type-to-search comboboxes like the worklog grid.

## Type of Change

- [x] New feature (non-breaking)
- [x] Bug fix (consistency)

## Changes Made

- **Auswertung date fields** — the last native `<input type="date">` in the app (datestart/dateend) now use `DateField` (calendar + the user's date format).
- **New `SearchableSelect` component** — a reusable form combobox on the same Ark UI primitive as the worklog grid's editor (type-to-filter, body-portalled popup, keyboard accessible), with a `value/onChange/options` API for single and multi.
- **Shared combobox parts** — `SearchableSelect` and the grid's `ChipSelect` consume `frontend/src/lib/comboboxParts.tsx` (the `ComboItem` type, the `createListCollection` builder, the search-icon glyph, and the `Combobox.Content` dropdown body). ChipSelect's grid behavior is unchanged.
- **Migrated the data-heavy relation selects**:
  - `OptionSelect` reimplemented on `SearchableSelect` → Auswertung (customer/project/team/user/activity) and Billing (user/project/customer), no page changes.
  - Worklog-sync admin: ticket-system + the **user multi-select** → searchable; the user picker maps ids back to usernames so the API payload is unchanged (characterization test added).
  - Worklog-import (settings) and project-import: ticket-system / activity selects → searchable.
- **Left native** (a 2–5-option enum doesn't benefit from type-to-search): language, date format, font size, nav layout, run-type, year/month, and the project-import *create-new-customer* override (its `new` sentinel can't be a numeric-id combobox).
- Density: the searchable trigger shrinks at compact/ultra like the native fields, and keeps full height in settings/dialogs (per the #626 opt-out).
- **E2E specs** updated to the new markup: the Auswertung/Billing/import specs assert on `.searchable-select` / `.date-field` and drive the combobox (open + pick) instead of native `<select>` / `<input type=date>`.

## Testing

- [x] `bun run lint` / `typecheck` / `test` (576) green
- [x] E2E: interpretation/export/worklog-sync specs 21/21 against the running stack; full suite green in CI (4/4 shards)
- [x] SonarCloud gate green (new-code duplication 2%)

## Checklist

- [x] CONTRIBUTING read
- [x] Code of Conduct
