### PR TITLE
ci: #624 step-2 quick wins (LDAP timeout, cheap test hashing, e2e video, PR profiling skip)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -93,6 +93,9 @@ jobs:
       # Prod-like image with the Symfony profiler (admin-gated). Published for
       # operators to switch to on demand — never the default deployment.
       - name: Build and push profiling image
+        # Skip on PRs entirely (#624 QW10): the profiling image is never deployed
+        # from a PR, so its breakage can surface on the main-push build instead.
+        if: github.event_name != 'pull_request'
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         env:
           GIT_SHA: ${{ github.sha }}
@@ -100,7 +103,8 @@ jobs:
           source: .
           targets: app-profiling
           files: docker-bake.hcl
-          push: ${{ github.event_name != 'pull_request' }}
+          # The step's `if:` already excludes PRs, so this only ever runs on a push.
+          push: true
           set: |
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max,ignore-error=true

--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -1,4 +1,12 @@
 security:
+    # Cheap password hashing in tests (#624 QW4): bcrypt cost 4 keeps the $2y$
+    # format the fixtures rely on (password_hash(..., PASSWORD_DEFAULT)) while
+    # cutting per-hash cost — the default 'auto' (Argon2id) dominated the run.
+    password_hashers:
+        App\Entity\User:
+            algorithm: bcrypt
+            cost: 4
+
     firewalls:
         main:
             # Complete override for test environment

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,9 @@ export default defineConfig({
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:8766',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // Record only during a retry (#624 QW9): the happy path captures no video,
+    // while a flaky test still yields one from its first retry.
+    video: 'on-first-retry',
   },
   projects: [
     {

--- a/src/Service/Ldap/LdapClientService.php
+++ b/src/Service/Ldap/LdapClientService.php
@@ -72,7 +72,7 @@ class LdapClientService
     /**
      * @return (bool|int|string)[] LDAP options
      *
-     * @psalm-return array{useSsl: bool, host: string, username: string, password: string, baseDn: string, port: int}
+     * @psalm-return array{useSsl: bool, host: string, username: string, password: string, baseDn: string, port: int, networkTimeout: int}
      */
     protected function getLdapOptions(): array
     {
@@ -83,6 +83,9 @@ class LdapClientService
             'password' => $this->readPass,
             'baseDn' => $this->baseDn,
             'port' => $this->port,
+            // Bound the connect attempt (#624 QW3): an unreachable directory fails
+            // fast (5s) instead of hanging on the default LDAP network timeout.
+            'networkTimeout' => 5,
         ];
     }
 

--- a/src/Service/Ldap/ModernLdapService.php
+++ b/src/Service/Ldap/ModernLdapService.php
@@ -293,8 +293,9 @@ class ModernLdapService
             'baseDn' => $this->config['baseDn'],
             'useSsl' => $this->config['useSsl'],
             // Bound the connect attempt (#624 QW3): an unreachable directory fails
-            // fast (5s) instead of hanging on the default LDAP network timeout.
-            'networkTimeout' => 5,
+            // fast instead of hanging on the default LDAP network timeout. Read
+            // from config so a slow directory can raise it; 5s fail-fast default.
+            'networkTimeout' => $this->config['networkTimeout'] ?? 5,
         ];
 
         if (true === $this->config['useSsl']) {

--- a/src/Service/Ldap/ModernLdapService.php
+++ b/src/Service/Ldap/ModernLdapService.php
@@ -292,6 +292,9 @@ class ModernLdapService
             'port' => $this->config['port'],
             'baseDn' => $this->config['baseDn'],
             'useSsl' => $this->config['useSsl'],
+            // Bound the connect attempt (#624 QW3): an unreachable directory fails
+            // fast (5s) instead of hanging on the default LDAP network timeout.
+            'networkTimeout' => 5,
         ];
 
         if (true === $this->config['useSsl']) {


### PR DESCRIPTION
## Summary

Step 2 of the #624 CI-speed plan — the mechanical, independently-mergeable quick wins. Step 1 (QW1 concurrency + QW2 4-shard E2E) landed in #625.

## Measures

- **QW3 — LDAP network timeout** (`perf`): `networkTimeout=5` on the Laminas LDAP options in both `LdapClientService` and `ModernLdapService`. Bounds the one slow LDAP test (~11s) and the prod login-hang path the same way.
- **QW4 — cheap test password hashing** (`test`): the test env now uses bcrypt cost 4 for `App\Entity\User` instead of the inherited `auto` (Argon2id), whose per-hash cost dominated the unit run. Keeps the `$2y$` format the fixtures rely on (`password_hash(..., PASSWORD_DEFAULT)`).
- **QW9 — Playwright video** (`ci`): `retain-on-failure` → `on-first-retry`, matching `trace`. CI runs with `retries=2`, so a failing test still yields a video from its retry; the happy path records none.
- **QW10 — skip PR profiling build** (`ci`): the profiling image is neither built nor pushed on PRs (it was already not pushed).

## QW7 (vitest `isolate: false`) — investigated and dropped

QW7 turned out unsafe. `isolate: false` leaks the vi.mock / ESM module registry — no `afterEach` resets it, only per-file isolation does. The default `vitest run` (forks pool) masks this by resetting the registry per fork, but under `--no-file-parallelism` (and some coverage / single-fork CI modes) the suite fails. Reproduced with a controlled before/after: **68 failed** with `isolate:false` vs **576 passed** with the same command after reverting — identical ordering, only the flag flipped. The measured wall-clock gain was ~0.3s (within noise). Not worth the fragility, so it is excluded from this batch.

## Verification

- Frontend: 576/576 (including under `--no-file-parallelism`).
- PHP unit suite: 1939/1939.
- PHPStan level 10 clean on the LDAP files; phpat clean; LDAP unit tests 124/124.
- Configs validated: test `security.yaml`, `playwright.config.ts`, `docker-publish.yml`.

Refs #624.
