### PR TITLE
ci: flatten the job graph — drop setup, per-job self-install (#624 S1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,65 +15,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  setup:
-    name: Setup Dependencies
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Pull or build E2E image
-        run: |
-          # Try to pull pre-built image, fall back to building
-          docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
-
-      - name: Prepare directories
-        run: |
-          mkdir -p vendor var/cache var/log bin node_modules
-          chmod -R 777 vendor var bin node_modules public
-
-      - name: Install PHP dependencies
-        env:
-          COMPOSE_PROFILES: e2e
-        run: |
-          # --ignore-platform-req=php needed until laminas-ldap adds PHP 8.5 support
-          docker compose run --rm app-e2e composer install --no-interaction --prefer-dist --ignore-platform-req=php
-
-      - name: Install Node dependencies
-        env:
-          COMPOSE_PROFILES: e2e
-        run: |
-          docker compose run --rm app-e2e npm install --legacy-peer-deps
-
-      - name: Build SolidJS UI assets (Vite)
-        env:
-          COMPOSE_PROFILES: e2e
-        run: |
-          # The compose mount masks the image's frontend build, so build the
-          # Vite app into the host-mounted public/build-ui that the E2E app serves.
-          docker compose run --rm app-e2e sh -c 'cd frontend && bun install --frozen-lockfile && bun run build'
-
-      - name: Upload dependencies artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dependencies
-          # Vite writes its manifest to public/build-ui/.vite/ — a hidden dir
-          # that upload-artifact drops by default, which left the SPA without
-          # its entrypoints on the E2E runner.
-          include-hidden-files: true
-          path: |
-            vendor/
-            bin/
-            node_modules/
-            public/build-ui/
-          retention-days: 1
-
   frontend:
     name: Frontend (SolidJS)
     runs-on: ubuntu-latest
@@ -113,7 +54,6 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
-    needs: setup
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -124,16 +64,18 @@ jobs:
       - name: Pull E2E image
         run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
-      - name: Download dependencies
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dependencies
-
       - name: Prepare directories
         run: |
-          mkdir -p var/cache var/log
+          mkdir -p var/cache var/log vendor bin
           chmod -R 777 var bin vendor
           if [ ! -f phpstan.neon ] && [ -f phpstan.dist.neon ]; then cp phpstan.dist.neon phpstan.neon; fi
+
+      - name: Install PHP dependencies
+        env:
+          COMPOSE_PROFILES: e2e
+        run: |
+          # --ignore-platform-req=php needed until laminas-ldap adds PHP 8.5 support
+          docker compose run --rm app-e2e composer install --no-interaction --prefer-dist --ignore-platform-req=php
 
       - name: Warmup Symfony cache
         env:
@@ -189,7 +131,6 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
-    needs: setup
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -200,16 +141,18 @@ jobs:
       - name: Pull E2E image
         run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
-      - name: Download dependencies
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dependencies
-
       - name: Prepare directories
         run: |
-          mkdir -p var/cache var/log var/coverage
+          mkdir -p var/cache var/log var/coverage vendor bin
           chmod -R 777 var bin vendor
           if [ ! -f phpunit.xml ] && [ -f phpunit.xml.dist ]; then cp phpunit.xml.dist phpunit.xml; fi
+
+      - name: Install PHP dependencies
+        env:
+          COMPOSE_PROFILES: e2e
+        run: |
+          # --ignore-platform-req=php needed until laminas-ldap adds PHP 8.5 support
+          docker compose run --rm app-e2e composer install --no-interaction --prefer-dist --ignore-platform-req=php
 
       - name: Warmup Symfony cache
         env:
@@ -239,7 +182,6 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 15
-    needs: setup
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -250,17 +192,19 @@ jobs:
       - name: Pull E2E image
         run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
-      - name: Download dependencies
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dependencies
-
       - name: Prepare config files and SQL
         run: |
-          mkdir -p var/cache var/log var/coverage
+          mkdir -p var/cache var/log var/coverage vendor bin
           chmod -R 777 var bin vendor
           if [ ! -f phpunit.xml ] && [ -f phpunit.xml.dist ]; then cp phpunit.xml.dist phpunit.xml; fi
           sed '1s/^/USE unittest;\\n/' sql/full.sql > sql/unittest/001_testtables.sql
+
+      - name: Install PHP dependencies
+        env:
+          COMPOSE_PROFILES: e2e
+        run: |
+          # --ignore-platform-req=php needed until laminas-ldap adds PHP 8.5 support
+          docker compose run --rm app-e2e composer install --no-interaction --prefer-dist --ignore-platform-req=php
 
       - name: Warmup Symfony cache
         env:
@@ -301,7 +245,6 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 15
-    needs: setup
     strategy:
       fail-fast: false
       matrix:
@@ -316,15 +259,25 @@ jobs:
       - name: Pull E2E image
         run: docker pull ghcr.io/netresearch/timetracker:e2e-${{ github.sha }} || docker pull ghcr.io/netresearch/timetracker:e2e || docker buildx bake app-e2e --load
 
-      - name: Download dependencies
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dependencies
-
       - name: Prepare directories
         run: |
-          mkdir -p var/cache var/log var/coverage/e2e playwright-report test-results
+          mkdir -p var/cache var/log var/coverage/e2e playwright-report test-results vendor bin node_modules
           chmod -R 777 var bin vendor node_modules public playwright-report test-results
+
+      - name: Install PHP dependencies
+        env:
+          COMPOSE_PROFILES: e2e
+        run: |
+          # --ignore-platform-req=php needed until laminas-ldap adds PHP 8.5 support
+          docker compose run --rm app-e2e composer install --no-interaction --prefer-dist --ignore-platform-req=php
+
+      - name: Build SolidJS UI assets (Vite)
+        env:
+          COMPOSE_PROFILES: e2e
+        run: |
+          # The compose mount masks the image's frontend build, so build the
+          # Vite app into the host-mounted public/build-ui that the E2E app serves.
+          docker compose run --rm app-e2e sh -c 'cd frontend && bun install --frozen-lockfile && bun run build'
 
       - name: Reinstall npm binaries
         env:
@@ -431,7 +384,7 @@ jobs:
     permissions:
       contents: read
     if: always()
-    needs: [setup, frontend, lint, test-unit, test-integration, e2e]
+    needs: [frontend, lint, test-unit, test-integration, e2e]
     steps:
       - name: Verify all jobs succeeded
         # Pass the results through env (never interpolate ${{ }} into the shell —


### PR DESCRIPTION
## Summary

Measure **S1** from #624 — the biggest uncontended-wall lever. Removes the `setup` job and has each downstream job install its own dependencies in-container, instead of `setup` building a ~872 MB deps artifact that every job downloads.

## Why

`setup` (~78s) built vendor + node_modules + the SolidJS SPA and uploaded them as one artifact; `lint`, `test-unit`, `test-integration`, and the 4 `e2e` shards each downloaded it. The download plus the `setup` barrier cost more than each job running `composer install` in-container (~13s, measured). Removing the barrier shortens the uncontended critical path: **~258s → ~188s** per the #624 measurements. Pairs with QW2 (landed in #625): the 4-shard matrix keeps the runner-time cost of self-installing bounded.

## Changes (`.github/workflows/ci.yml`)

- Delete the `setup` job (and its `dependencies` artifact upload).
- `lint` / `test-unit` / `test-integration`: drop `needs: setup` and the artifact download; `mkdir` now includes `vendor bin`; add a `composer install` step before the cache warmup.
- `e2e`: same, plus a `bun run build` step so `public/build-ui` exists before the stack starts; keeps the existing `npm install`.
- `ci-success`: `needs` drops `setup`.
- Unchanged: the `frontend` job, the e2e stack-start script, coverage/codecov steps, all SHA-pinned actions, concurrency/triggers.

## Verification

CI is the verifier for a workflow change. Local pre-checks: the file was diffed hunk-by-hunk against the original (exactly S1, nothing else), actionlint-clean (the one `SC2086` info is pre-existing in the e2e stack-start script), YAML valid, no residual `setup` / `dependencies`-artifact references.

Refs #624.
