### PR TITLE
perf(ci): cache dev/e2e Docker tooling below the code copy (#624 S4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,11 +137,44 @@ RUN composer install --ignore-platform-req=php
 USER app
 
 # =============================================================================
-# DEV - Development image with debugging tools
+# DEVTOOLS - Code-INDEPENDENT dev/e2e tooling, cached across code-only commits.
+#
+# Built FROM base (NOT deps), so none of these installs — git/curl, Xdebug,
+# Symfony CLI, Node, Bun, composer, the root Playwright npm deps, and the
+# Chromium browser — sit above the application code copy. A src-only change
+# invalidates `deps` (its trailing `COPY . .`) but leaves this whole stage
+# cached, so the ~68s of apt/pecl/chromium/composer no longer re-runs per commit.
+#
+# Xdebug and Chromium live ONLY here (→ dev → e2e); production (FROM base),
+# profiling and tools (FROM deps) never inherit from this stage, so they stay
+# free of Xdebug (would skew profiling timings) and Chromium (bloat).
 # =============================================================================
-FROM deps AS dev
+FROM base AS devtools
 
+ARG NODE_VERSION
 ARG XDEBUG_VERSION
+
+# Reproduce the env `dev`'s composer install ran under when it was FROM deps:
+# CAPTAINHOOK_DISABLE skips the captainhook git-hook install (no .git in image),
+# APP_ENV=prod keeps the post-install cache:clear identical to before. `dev`
+# overrides APP_ENV back to `dev` at the end of its stage (as it always did).
+ENV CAPTAINHOOK_DISABLE=true
+ENV APP_ENV=prod
+
+# Get composer from official image
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# Install Node.js (Playwright/chromium need it; also handy in the dev shell)
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bun is the package manager of the new SolidJS frontend (frontend/)
+COPY --from=oven/bun:1.3.14 /usr/local/bin/bun /usr/local/bin/bun
 
 # Install dev tools
 RUN set -ex \
@@ -166,6 +199,26 @@ RUN curl -sS https://get.symfony.com/cli/installer | bash \
     && symfony completion bash > /etc/bash_completion.d/symfony \
     && echo 'source /etc/bash_completion.d/symfony' >> /etc/bash.bashrc
 
+# Root npm deps (Playwright + axe) — needed so `npx playwright install` below can
+# resolve the browser version. Kept LAST of the manifest-independent installs so
+# a package.json bump doesn't invalidate the apt/pecl layers above.
+COPY --chown=app:app package.json package-lock.json ./
+RUN npm ci
+
+# Install Playwright + chromium including its canonical system dependencies.
+# Cached here (below the app code), so a src change never re-downloads chromium.
+RUN npx playwright install chromium --with-deps
+
+# =============================================================================
+# DEV - Development image with debugging tools
+# =============================================================================
+FROM devtools AS dev
+
+# Bring in the built application tree (vendor, built SolidJS UI, app code) from
+# deps. This is the ONLY code-dependent layer of the dev image — it invalidates
+# on any src change, but that is unavoidable and cheap (a plain copy).
+COPY --from=deps --chown=app:app /var/www/html /var/www/html
+
 # Install dev dependencies
 RUN composer install --ignore-platform-req=php
 
@@ -180,9 +233,7 @@ ENV APP_DEBUG=1
 # =============================================================================
 FROM dev AS e2e
 
-# Install Playwright + chromium including its canonical system dependencies
-RUN npx playwright install chromium --with-deps
-
+# Chromium + Playwright are already installed in the cached `devtools` stage.
 ENV APP_ENV=test
 
 # =============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,15 +199,16 @@ RUN curl -sS https://get.symfony.com/cli/installer | bash \
     && symfony completion bash > /etc/bash_completion.d/symfony \
     && echo 'source /etc/bash_completion.d/symfony' >> /etc/bash.bashrc
 
-# Root npm deps (Playwright + axe) — needed so `npx playwright install` below can
-# resolve the browser version. Kept LAST of the manifest-independent installs so
-# a package.json bump doesn't invalidate the apt/pecl layers above.
+# Root npm deps (Playwright + axe), the chromium install, and cleanup in ONE
+# layer: dev/e2e receive node_modules + manifests from deps' `COPY --from=deps`,
+# so devtools' copy is transient and must not be committed (image bloat). The
+# chromium browser installs to ~/.cache/ms-playwright (outside node_modules), so
+# it survives the cleanup. Kept LAST of the manifest-independent installs so a
+# package.json bump doesn't invalidate the apt/pecl layers above.
 COPY --chown=app:app package.json package-lock.json ./
-RUN npm ci
-
-# Install Playwright + chromium including its canonical system dependencies.
-# Cached here (below the app code), so a src change never re-downloads chromium.
-RUN npx playwright install chromium --with-deps
+RUN npm ci \
+    && npx playwright install chromium --with-deps \
+    && rm -rf node_modules package.json package-lock.json
 
 # =============================================================================
 # DEV - Development image with debugging tools


### PR DESCRIPTION
## Summary

Measure **S4** from #624: reorder the multi-stage Dockerfile so the code-independent dev/e2e tooling caches across code-only commits, instead of re-running ~68s of apt/pecl/chromium/composer on every commit.

## Problem

The dev+e2e tooling (git/curl, Xdebug, Symfony CLI, Node, Bun, the Playwright npm deps, and the Chromium browser) was installed in `dev`/`e2e`, which were `FROM deps`. `deps` ends with `COPY . .`, so **any** src change invalidated `deps` and forced all that tooling to re-install on top.

## Change

- New `devtools` stage `FROM base` (not `deps`) holds all the code-independent tooling — below any code copy, so a src change never invalidates it.
- `dev` is now `FROM devtools` and brings in the built tree via one `COPY --from=deps --chown=app:app /var/www/html /var/www/html` (the only code-dependent layer of the dev image).
- `e2e` is `FROM dev` and just sets `APP_ENV=test` (Chromium already present from `devtools`).
- **Isolation preserved:** Xdebug and Chromium live only in `devtools → dev → e2e`. `production` (`FROM base`), `tools` and `profiling` (`FROM deps`) never inherit `devtools` — they stay Xdebug-free (profiling timings) and Chromium-free. Those four stages are byte-identical to before.

Note: `app-dev` now also carries Chromium (shared with e2e via `devtools`), so the dev image is larger — acceptable for a non-deployed dev image, and required for the caching win.

## Verification (local)

- `docker build --check` clean on all five bake targets (app, app-dev, app-tools, app-e2e, app-profiling).
- `docker buildx bake app-e2e` builds successfully (base → deps → devtools → dev → e2e, Chromium included), 3m9s cold.
- After a src content change, the rebuild leaves the whole `devtools` stage **CACHED** — `pecl install xdebug`, `npm ci`, `npx playwright install chromium --with-deps` all CACHED — and only `dev`'s `COPY --from=deps` re-runs. That is the ~68s no longer paid per commit.

Scope note: this is "0 PR wall-clock" (the `docker` job doesn't gate `CI Success`). The gain is faster image builds (Docker Publish ~226→120s on main) and faster local / CI cache-miss rebuilds.

Refs #624.
