### PR TITLE
ci: persist PHP static-analysis tool caches across runs (#624 S2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,30 @@ jobs:
           chmod -R 777 var bin vendor
           if [ ! -f phpstan.neon ] && [ -f phpstan.dist.neon ]; then cp phpstan.dist.neon phpstan.neon; fi
 
+      # Persist the PHP static-analysis tool caches across runs so PHPStan runs
+      # incrementally (cold ~148s -> warm ~87s). The app-e2e container runs as
+      # root with umask 022, so the cache files it writes are 0644/0755
+      # (world-readable) and the post-job save (running as the runner user) can
+      # read them without a chmod. Restore before the tool steps; the dirs are
+      # created on demand by each tool on a cold run.
+      - name: Cache PHP static-analysis caches
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            var/cache/phpstan
+            var/cache/rector
+            var/phpstan-phpat
+            var/.php-cs-fixer.cache
+          # github.run_id is unique per run, so the primary key never hits and the
+          # job always SAVES a fresh cache at the end (newest incremental state).
+          # restore-keys prefix-matches and restores the most recent prior cache.
+          # PHPStan (config+composer-salted result cache), Rector (config-salted
+          # ChangedFilesDetector) and PHP-CS-Fixer all re-validate internally, so a
+          # stale restore is safe — worst case they recompute the changed files.
+          key: php-static-analysis-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            php-static-analysis-${{ runner.os }}-
+
       - name: Install PHP dependencies
         env:
           COMPOSE_PROFILES: e2e

--- a/config/quality/rector.php
+++ b/config/quality/rector.php
@@ -26,4 +26,9 @@ return RectorConfig::configure()
     ])
     ->withComposerBased(symfony: true)
     ->withAttributesSets(symfony: true)
+    // Host-mounted cache (resolves to repo-root var/cache/rector) so the
+    // ChangedFilesDetector cache persists across CI runs via actions/cache.
+    // Rector salts this cache with the config-file hash, so a rule-set change
+    // invalidates it — a stale restore only recomputes changed files.
+    ->withCache(__DIR__ . '/../../var/cache/rector')
     ->withImportNames(importShortClasses: false);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,7 +30,10 @@ parameters:
 
     # PHPUnit specific configuration handled by extension
 
-    tmpDir: /tmp/phpstan-timetracker
+    # Host-mounted path (compose bind-mounts ./var/cache) so the result cache
+    # survives the ephemeral `docker compose run --rm` container and persists
+    # across CI runs via actions/cache. /tmp/... lived only inside the container.
+    tmpDir: var/cache/phpstan
 
     # These might need to be addressed gradually
     ignoreErrors:


### PR DESCRIPTION
## Summary

Measure **S2** from #624: persist the PHP static-analysis tool caches across CI runs so the Lint job runs incrementally (cold ~148s → ~87s warm, projected).

## Change

- **PHPStan** `tmpDir: /tmp/phpstan-timetracker` → `var/cache/phpstan`. The old path was inside the ephemeral `docker compose run --rm` container, so the result cache was discarded every run and never cacheable.
- **Rector** — add `->withCache('var/cache/rector')` (its cache defaulted to `/tmp`, ephemeral).
- **PHPat** (`var/phpstan-phpat`) and **CS-Fixer** (`var/.php-cs-fixer.cache`) already write host paths — cached as-is.
- **`actions/cache`** step in the `lint` job caching all four. Key `php-static-analysis-<os>-<run_id>` saves a fresh cache every run; `restore-keys` restores the latest prior one → incremental.

## Safety

All four tools re-validate their caches internally (PHPStan salts on config + composer + PHP; Rector's `ChangedFilesDetector` salts on the config-file hash; CS-Fixer keys on PHP + rules), so a stale restore only recomputes changed files — it can never mask a finding. The tools run as root in-container (umask 022 → world-readable cache files), so the post-job save (runner user) reads them without a chmod.

## Verification

- Local (app-e2e container): PHPStan runs with the new `tmpDir` (`var/cache/phpstan` created on host); Rector runs with `withCache`; both `[OK]`.
- CI: the **first** run is a cold-cache miss — it populates the cache, no speedup yet. The warm-cache Lint speedup shows on the **second** run; I'll re-run and compare the Lint job duration and post the numbers.

Refs #624.
