### PR TITLE
ci: coverage off the PR path → nightly + branch coverage (#624 S9, drops S5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: ["main", "v4"]
   pull_request:
     branches: ["**"]
+  # Nightly full run WITH code coverage (#624 S9). PR/push runs skip xdebug
+  # coverage instrumentation so they don't pay its overhead on the critical path;
+  # the schedule (and on-demand workflow_dispatch) re-collect it — with branch
+  # coverage (phpunit.xml.dist branchCoverage=true → Cobertura) — off that path.
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
 
 # Supersede an in-flight run when new commits land on the same ref. Scoped to
 # non-default refs so every main commit still gets a complete run (bisect
@@ -184,14 +191,24 @@ jobs:
         run: |
           docker compose run --rm -e APP_ENV=test app-e2e php bin/console cache:warmup --env=test
 
-      - name: Run unit tests with coverage
+      - name: Run unit tests
         env:
           COMPOSE_PROFILES: e2e
+          # Coverage only on the nightly schedule / manual dispatch (#624 S9);
+          # PR & push run without xdebug instrumentation. Cobertura carries the
+          # branch coverage (phpunit.xml.dist branchCoverage=true) for Codecov.
+          COVERAGE: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
         run: |
-          docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=coverage app-e2e \
-            php -d memory_limit=1G bin/phpunit --testsuite unit --coverage-clover var/coverage/unit.xml
+          if [ "$COVERAGE" = "1" ]; then
+            docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=coverage app-e2e \
+              php -d memory_limit=1G bin/phpunit --testsuite unit --coverage-cobertura var/coverage/unit.xml
+          else
+            docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=off app-e2e \
+              php -d memory_limit=1G bin/phpunit --testsuite unit
+          fi
 
       - name: Upload unit coverage to Codecov
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -243,14 +260,22 @@ jobs:
           docker compose up -d db_unittest
           docker compose exec -T db_unittest mariadb-admin ping -h 127.0.0.1 -uroot -pglobal123 --wait --connect-timeout=60
 
-      - name: Run integration tests with coverage
+      - name: Run integration tests
         env:
           COMPOSE_PROFILES: e2e
+          # Coverage only on the nightly schedule / manual dispatch (#624 S9).
+          COVERAGE: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
         run: |
-          docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=coverage app-e2e \
-            php -d memory_limit=2G bin/phpunit --testsuite integration,controller,api-functional,mcp --coverage-clover var/coverage/integration.xml
+          if [ "$COVERAGE" = "1" ]; then
+            docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=coverage app-e2e \
+              php -d memory_limit=2G bin/phpunit --testsuite integration,controller,api-functional,mcp --coverage-cobertura var/coverage/integration.xml
+          else
+            docker compose run --rm -e APP_ENV=test -e XDEBUG_MODE=off app-e2e \
+              php -d memory_limit=2G bin/phpunit --testsuite integration,controller,api-functional,mcp
+          fi
 
       - name: Upload integration coverage to Codecov
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -310,11 +335,13 @@ jobs:
           # Artifact download doesn't preserve npm binary symlinks, reinstall to fix
           docker compose run --rm app-e2e npm install --legacy-peer-deps
 
-      - name: Start E2E stack with coverage
+      - name: Start E2E stack
         env:
           COMPOSE_PROFILES: e2e
-          COVERAGE_ENABLED: '1'
-          XDEBUG_MODE: coverage
+          # Coverage only on the nightly schedule / manual dispatch (#624 S9);
+          # PR & push start the stack without xdebug coverage instrumentation.
+          COVERAGE_ENABLED: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
+          XDEBUG_MODE: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'coverage' || 'off' }}
         run: |
           docker compose up -d
 
@@ -363,7 +390,7 @@ jobs:
             app-e2e bash -c "npx playwright install chromium && npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }} -x"
 
       - name: Collect E2E coverage
-        if: always()
+        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
         run: |
           curl -s "http://localhost:8766/coverage.php?action=report&format=clover" > var/coverage/e2e-clover-${{ matrix.shard }}.xml || true
           if [ -s var/coverage/e2e-clover-${{ matrix.shard }}.xml ]; then
@@ -373,7 +400,7 @@ jobs:
           fi
 
       - name: Upload E2E coverage to Codecov
-        if: always()
+        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
     displayDetailsOnTestsThatTriggerWarnings="false"
     displayDetailsOnTestsThatTriggerDeprecations="false"
 >
-    <coverage/>
+    <coverage branchCoverage="true"/>
     <source>
         <include>
             <directory suffix=".php">src</directory>


### PR DESCRIPTION
## Summary

Two related changes, replacing the dismissed S5 (xdebug→pcov):
1. **S9** — move code coverage off the PR critical path to a nightly run.
2. **Enable branch coverage** — the thing pcov *couldn't* do.

## Why not pcov (S5, dismissed)

pcov is **line-coverage only** — it's fast precisely because it does less. Switching to it would have permanently foreclosed branch/path coverage for a marginal ~18s. We already run on xdebug (branch/path-capable); the better move is to keep xdebug, get coverage *off* the PR path (S9), and actually enable branch coverage.

## Changes

- **`ci.yml`**: `unit` / `integration` / `e2e` run **coverage-free** on `pull_request` and `push` (no xdebug instrumentation). A `schedule` (03:00 UTC nightly) + `workflow_dispatch` re-collect coverage and upload to Codecov; the Codecov upload steps are gated to those events.
- **`phpunit.xml.dist`**: `<coverage branchCoverage="true"/>` — covered runs now collect branch coverage.
- Covered unit/integration runs emit **Cobertura** (`--coverage-cobertura`) instead of Clover, since Cobertura carries branch data for Codecov.

## Safety

- **Only `CI Success` is a required status check** — `codecov/patch` and `codecov/project` are informational, so dropping per-PR coverage uploads does not affect the merge gate.
- PR-path tests verified passing without coverage (`XDEBUG_MODE=off`, 1939 unit tests OK).
- Branch coverage verified locally: `--coverage-cobertura` with `branchCoverage=true` emits `branch-rate` / `branches-covered` (127/158) — real branch data (pcov cannot produce this).

## Verification note

This PR's own CI run exercises the **coverage-off** (PR) path. The **coverage-on** (nightly) path runs on the schedule, or via `workflow_dispatch` once the file is on the default branch — I'll trigger a dispatch to confirm the Cobertura upload + branch data after merge.

Refs #624. Dismisses S5.
