### PR TITLE
fix(ui): correct stack-form field-hint and checkbox layout on settings pages

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -869,8 +869,10 @@ main:has(.tracking) {
     grid-column: 2;
   }
 
+  /* A field's hint sits under its control (column 2), not full-width under the
+     label — so a date field's "YYYY-MM-DD" hint lines up beneath the input. */
   .stack-form .field > .field-hint {
-    grid-column: 1 / -1;
+    grid-column: 2;
     margin: 0.15em 0 0;
   }
 
@@ -889,16 +891,18 @@ main:has(.tracking) {
     grid-column: auto;
   }
 
-  /* Right-align labels in the beside layout so the label's edge sits at the
-     control's left edge (tight label↔field coupling) — except the full-width
-     exceptions above, whose label sits on top and stays left-aligned. */
-  .stack-form .field > span {
+  /* Right-align only the LABEL (the first span) in the beside layout, so its edge
+     sits at the control's left edge (tight label↔field coupling). Scoped to
+     :first-child so it never catches a field's other spans — e.g. the DateField's
+     .date-field-wrap or its .field-hint, which must not be pushed to the right. */
+  .stack-form .field > span:first-child {
     text-align: right;
   }
 
-  .stack-form .field.multiselect > span,
-  .stack-form .field:has(textarea) > span,
-  .stack-form .field-row .field > span {
+  /* The full-width exceptions keep their label on top, left-aligned. */
+  .stack-form .field.multiselect > span:first-child,
+  .stack-form .field:has(textarea) > span:first-child,
+  .stack-form .field-row .field > span:first-child {
     text-align: left;
   }
 
@@ -913,14 +917,28 @@ main:has(.tracking) {
     grid-template-columns: 18em minmax(0, 22em);
   }
 
-  .stack-form .field-check > span {
+  /* Pin the rows explicitly: label + box share row 1, an optional hint sits under
+     the box on row 2. Without pinned rows, sparse auto-placement (the box has an
+     explicit col 2 and comes first in the DOM) pushes the label onto row 2, leaving
+     the box stranded above it — visible only once a label wraps or a hint is present. */
+  .stack-form .field-check > span:not(.field-hint) {
     grid-column: 1;
+    grid-row: 1;
     text-align: right;
   }
 
   .stack-form .field-check > input {
     grid-column: 2;
+    grid-row: 1;
     justify-self: start;
+  }
+
+  /* A checkbox's own hint (e.g. Personio's "available once configured" note) sits
+     under the box in column 2. */
+  .stack-form .field-check > .field-hint {
+    grid-column: 2;
+    grid-row: 2;
+    margin: 0.15em 0 0;
   }
 
   /* Help-icon rows keep the compact inline pattern (checkbox + its ⓘ side by side),


### PR DESCRIPTION
## Summary

Fixes two form-layout regressions from #635 (shipped in v6.3.1) that landed on the settings pages. #635's `.stack-form` rules were verified against Billing/Auswertung but not the settings, where the field and checkbox structures differ (a `.field` can hold a `.field-hint`; a `.field-check` can hold three children).

## Fixes

- **Date-field hint floated to the far right** (`/ui/settings/sync`): the label right-align (`.stack-form .field > span`) also caught the DateField's `.field-hint` span, which spans the full width — pushing "YYYY-MM-DD" to the right edge. Scoped the right-align to the label (`:first-child`); a field's hint now sits under its control (column 2).
- **A checkbox with its own hint stranded the box above its label** (Personio opt-in): sparse grid auto-placement — the checkbox has an explicit column 2 and precedes the label in the DOM — pushed the label onto row 2, leaving the box alone above it. Pinned the rows explicitly: label + box on row 1, the hint under the box on row 2.

## Verification

Visual check at 1440px on `/ui/settings/sync` and `/ui/settings/account`: date hints sit under the date fields, checkboxes align with their labels on one row, and a per-checkbox hint sits below the box. CSS-only — CI re-verifies tests/typecheck/lint.
