### PR TITLE
fix(ci): bake build provenance into the profiling image (status page version)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,6 +99,8 @@ jobs:
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         env:
           GIT_SHA: ${{ github.sha }}
+          GIT_REF: ${{ github.ref_name }}
+          BUILD_DATE: ${{ env.BUILD_DATE }}
         with:
           source: .
           targets: app-profiling

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -155,6 +155,14 @@ target "app-e2e" {
 target "app-profiling" {
   inherits = ["_common"]
   target   = "profiling"
+  # Bake the build provenance into the profiling image too (like the `app` target),
+  # so /ui/admin/status shows the deployed commit/ref/date — the prod hot-deploy runs
+  # :profiling-<sha>, not the release image, so without this the page reads "unknown".
+  args = {
+    APP_BUILD_REVISION = GIT_SHA
+    APP_BUILD_REF      = GIT_REF
+    APP_BUILD_DATE     = BUILD_DATE
+  }
   tags = compact([
     "${REGISTRY}/${IMAGE_NAME}:profiling",
     GIT_SHA != "" ? "${REGISTRY}/${IMAGE_NAME}:profiling-${GIT_SHA}" : "",


### PR DESCRIPTION
The prod hot-deploy runs the `:profiling-<sha>` image, but only the `app` (release) bake target baked `APP_BUILD_REVISION/REF/DATE`. `app-profiling` inherited only `_common` and passed no build args, so the deployed image had them empty and **/ui/admin/status showed "unknown"** for the version.

## Fix
- `docker-bake.hcl`: add the `args = { APP_BUILD_REVISION = GIT_SHA, APP_BUILD_REF = GIT_REF, APP_BUILD_DATE = BUILD_DATE }` block to the `app-profiling` target (mirroring `app`).
- `docker-publish.yml`: pass `GIT_REF` + `BUILD_DATE` to the profiling build step (it only passed `GIT_SHA`).

## Verification
`docker buildx bake app-profiling --print` resolves the target with the three `APP_BUILD_*` args populated. Dockerfile (profiling stage) + the frontend BuildSection already consume them — after this builds + deploys, the status page shows the deployed commit / ref / date and the up-to-date check.

Note: modifies a `.github/workflows/` file, so it needs a manual merge (the default token lacks the `workflows` scope).