### PR TITLE
fix(ui): drop the double border on searchable-select form inputs

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -751,8 +751,10 @@ main:has(.tracking) {
 }
 
 /* All text-like inputs, selects and textareas in a field share the same
-   recognisable box (checkboxes/radios keep their native look in .field-check). */
-.field input:not([type='checkbox']):not([type='radio']):not(.date-field),
+   recognisable box (checkboxes/radios keep their native look in .field-check).
+   .combobox-input is excluded: its wrapper .searchable-select carries the box,
+   so bordering the inner input too would draw a double frame. */
+.field input:not([type='checkbox']):not([type='radio']):not(.date-field):not(.combobox-input),
 .field select,
 .field textarea {
   background: var(--color-bg);
@@ -770,7 +772,7 @@ main:has(.tracking) {
   resize: vertical;
 }
 
-.field input:not([type='checkbox']):not([type='radio']):not(.date-field):focus-visible,
+.field input:not([type='checkbox']):not([type='radio']):not(.date-field):not(.combobox-input):focus-visible,
 .field select:focus-visible,
 .field textarea:focus-visible {
   border-color: var(--color-accent);


### PR DESCRIPTION
Searchable-select fields on the settings/sync page (and every other form combobox) drew a **double border**: the outer `.searchable-select` wrapper carries the field box by design, but the shared `.field input { border: 1px }` rule also matched the inner `.combobox-input`, adding a second inner frame.

## Fix

Exclude `.combobox-input` from the `.field input` box rule (base + `:focus-visible`), mirroring the existing `:not(.date-field)` exclusion. The input keeps its own `border: 0`; only the wrapper borders the control.

## Verification

Computed styles on `/ui/settings/sync` (dark theme) after the change:
- `.searchable-select` → `border: 1px solid rgb(60,67,75)` (single frame)
- `.combobox-input` → `border: 0px none` (no inner frame)

Pre-existing since the combobox landed in v6.3.0; the same class of rule needed `:not(.date-field)` earlier.
