### PR TITLE
docs(agents): consolidate durable engineering notes into scoped AGENTS.md

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -17,15 +17,47 @@ Node 26 (`.nvmrc`); the Playwright tooling is the only npm usage at the repo roo
 - Stop stack: `make e2e-down`
 - Install browsers once: `make e2e-install`
 - Base URL override: `E2E_BASE_URL` (defaults to http://localhost:8766)
+- `db-e2e` is a PERSISTENT volume seeded only once (first start) from
+  `sql/full.sql` + `sql/testdata.sql` — after any entity gains a column,
+  re-seed manually: `DROP DATABASE`+`CREATE` the `timetracker` DB first (must
+  drop+create before reloading — loading over an existing schema with FKs
+  loads only partially and silently), reload BOTH SQL files, then
+  `cache:clear`. Query/administer via
+  `docker compose exec -T db-e2e mariadb -uroot -pglobal123 timetracker`
+
+## Rebuilding after code changes
+
+- `app-e2e` (and `app`) bind-mounts the host `./public` AND the whole repo over
+  the container, so rebuilding the image changes nothing the browser sees.
+  After editing `frontend/src/*` run `cd frontend && bun run build` (the
+  `build` script lives ONLY in `frontend/package.json` — from repo root it
+  fails `Script not found`) to refresh host `public/build-ui`; for PHP/Twig
+  edits just `docker exec … php bin/console cache:clear`. Verify with
+  `grep -roh '<string>' public/build-ui/assets/*.js` before screenshotting. Do
+  NOT `make e2e-up`/`docker bake --no-cache` for a code change. Review/production
+  images copy assets in (no bind mount) and DO need a rebuild
+- Local `/ui` e2e diverges from CI: worklog-grid/admin relation comboboxes
+  render empty locally even after rebuild+reseed, so
+  `worklog-crud`/`worklog-grid-editing`/`session-expiry`/`admin-inline-edit`
+  must be validated in CI — CI is authoritative for those
 
 ## Test data & clock
 
 - Server time is FROZEN via `APP_FROZEN_TIME="2024-01-15 12:00:00"`
   (compose.yml, app-e2e) to match the seed data in `sql/testdata.sql`
 - Browser-side clock freezing: use the helpers in `e2e/helpers/clock.ts`
-- Test users (`e2e/helpers/auth.ts`): `developer`/`dev123`,
-  `unittest`/`test123`, `i.myself`/`myself123` (PL — sees Billing/Administration);
-  passwords can be overridden via `E2E_*_PASSWORD` env vars
+- Test users (`e2e/helpers/auth.ts`): only `developer`/`dev123` (DEV) and
+  `i.myself`/`myself123` (PL — sees Billing/Administration) actually work
+  end-to-end — both exist in db-e2e AND LDAP and can book the one bookable
+  customer (`Freizeit`, id 2). `unittest`/`test123` is in LDAP but ABSENT from
+  db-e2e, so its login 302s back to `/login` — don't rely on it. Passwords can
+  be overridden via `E2E_*_PASSWORD` env vars
+- Backend PHP integration tests use a DIFFERENT clock:
+  `Tests\Service\TestClock` (hard-coded 2023-10-24) IGNORES `APP_FROZEN_TIME`;
+  its fixtures (`sql/full.sql`, user `unittest`) are aligned to that date
+  instead. Don't "fix" `TestClock` to honor `APP_FROZEN_TIME` — it reds
+  `test-integration` (e.g. `BulkEntryVisibilityTest`); aligning clock+seed is a
+  deferred multi-surface change
 
 ## Build & tests (prefer file-scoped)
 
@@ -37,6 +69,13 @@ Node 26 (`.nvmrc`); the Playwright tooling is the only npm usage at the repo roo
 - Shared logic goes into `e2e/helpers/` (auth, navigation, grid, worklog, api)
 - Use role/label-based locators; the app is built to be accessible — prefer
   `getByRole`/`getByLabel` over CSS selectors
+- A web-first assertion gating on a save→refetch→SolidJS-reconcile→render
+  round-trip needs `{ timeout: 15000 }`, not the Playwright default 5s, under
+  CI contention
+- Local full-suite runs can flake on keyboard-interaction specs on a loaded
+  box, while CI shards stay green (~16 tests/runner, `retries: 2`) — re-run the
+  single spec with `--workers=2 --retries=2` rather than treating a
+  full-suite-on-one-machine failure as a CI blocker
 
 ## Security & safety
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -21,6 +21,7 @@ See [`README.md`](README.md) for the full stack description.
 - Typecheck: `bun run typecheck` (paraglide compile + `tsc --noEmit`)
 - Tests: `bun run test` (Vitest, jsdom) / `bun run test:watch`
 - Single test file: `bun run test src/components/LoginForm.test.tsx`
+- a11y assertions use `vitest-axe` — it requires jsdom (incompatible with happy-dom)
 
 ## Code style & conventions
 
@@ -37,6 +38,13 @@ See [`README.md`](README.md) for the full stack description.
 - Compiled to `src/paraglide/` (via `bun run typecheck` or `i18n:compile`);
   never edit `src/paraglide/` by hand
 - Use `import { m } from '../paraglide/messages.js'` and `m.key()` in components
+
+### Stack decisions
+
+- Ark UI (`@ark-ui/solid`), not Kobalte, for headless components; Tailwind 4
+  (`tailwindcss` + `@tailwindcss/vite`) plus the app's own semantic design tokens
+- Don't re-propose Vue or Svelte — an earlier Vue-3 `timetracker-ui` plan is
+  superseded by the SolidJS decision
 
 ## Security & safety
 
@@ -65,3 +73,26 @@ See [`README.md`](README.md) for the full stack description.
   the SPA only syncs its active state (`src/nav.ts`) — don't duplicate the nav
 - Keyboard shortcuts are defined centrally in `src/lib/shortcuts.ts` and shown
   in the Help page and ShortcutsDialog — register new ones there
+- `@ark-ui/solid` ships no Calendar/DatePicker (only Dialog/Combobox/Popover
+  shells) — hand-roll date UI with `<For>` (role=grid, roving tabindex) and
+  reuse `parseUserDate`/`formatWith` (`src/lib/dateFormat.ts`) so the app stays
+  authoritative over the user's date-format setting. Wiring an Ark Popover into
+  an on-blur-commit inline editor needs cooperating focus guards:
+  `autoFocus={false}`, mousedown-preventDefault on trigger+content,
+  `closeOnEscape={false}` + `restoreFocus={false}` (let the input own Escape,
+  not zag), an `onBlur` guard that ignores focus into `[data-date-popup]`, and
+  extending the row-leave save-whitelist. Portal to `<body>` to escape the
+  table's overflow scroll container — verify in a real browser (invisible to
+  jsdom)
+- Admin + Worklog inline grid editing follows "Philosophy A": `gridNavigation.ts`
+  (gridNav) stays a pure navigation/ARIA controller and the SINGLE owner of the
+  roving-tabindex invariant; edit state lives in the consumer (AdminCrudShell /
+  Tracking) via the shared `createInlineGridEdit` controller
+  (`src/lib/inlineGridEdit.tsx`), cooperating through thin gridNav hooks
+  (`onActivate`, `moveRef`, `data-inline-editing`, `onRowSelectToggle`,
+  `onPageEdge`) — never make the consumer a second writer of the roving
+  invariant. Save is auto-save-on-completeness (`config.invalidFields`
+  auto-flushes a valid draft; a quiet auto-fail sets hints not a rowError; the
+  disk icon forces a save and row-leave shows the full error). Relation cells
+  use `ChipSelect` (`src/lib/chipSelect.tsx`, an Ark Combobox) body-portalled
+  (whitelist `data-chipselect-popup`) to escape the table scroll container

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -122,3 +122,59 @@ public function list(EntityManagerInterface $em): JsonResponse
 - Services go in `Service/` with clear single responsibilities
 - Entities are read-only where possible; mutations via services
 - Use `final` classes unless inheritance is explicitly needed
+- On any "validation blocks deactivate/re-save" report, grandfather the ENTIRE
+  `*SaveDto` constraint family in one pass (uniqueness + length + format), not
+  just the constraint that was hit: when editing an existing entity (`id > 0`)
+  whose persisted value is unchanged, skip the check (fetch current by id,
+  compare `(string) $current->getX() === $value` so a NULL persisted value
+  equals `''`). Declarative `#[Assert\NotBlank/Length]` can't see the DB —
+  convert to a custom validator (e.g. `ValidUserAbbr`) to grandfather. Narrow
+  nullable DTO ids before `> 0`
+- `App\Entity\Holiday` has a `DateTime` primary key the ORM can't manage
+  (persist/hydrate blow up stringifying the identifier) — do ALL holiday read
+  AND write via DBAL (`$connection->fetchAllAssociative`/`insert`/`delete`),
+  never the ORM; reference `GetHolidaysAction`. Holidays are create+delete only
+  (immutable). Validate dates with `#[Assert\Date]`, never `new DateTime()`
+  (it rolls impossible dates over instead of throwing). The list exposes a
+  synthetic `Ymd` int `id` for the grid; delete keys on `{ day }`
+- The production image self-migrates on container start
+  (`docker/php/docker-entrypoint.sh`, opt out `AUTO_MIGRATE=0`): waits for the
+  DB, runs pending Doctrine migrations, then execs php-fpm. `sql/full.sql`
+  seeds `doctrine_migration_versions` so a fresh install reads as
+  up-to-date; an un-versioned legacy DB (schema present, 0 version rows) is
+  baselined from live schema — but a PARTIALLY-versioned DB is NOT
+  auto-baselined, so pre-flight `doctrine:migrations:version '<FQCN>' --add`
+  any present-but-unrecorded migration before deploying. Use `dbal:run-sql`
+  (DoctrineBundle 3.2.4 dropped `doctrine:query:sql`)
+
+## Deployment, CI & merge (operational)
+
+- Merge gate for `netresearch/timetracker` (PRs to `main`) has two required
+  parts: the `Copilot review for default branch` ruleset (a Copilot review on
+  the HEAD commit — feature PRs open as DRAFTS, `gh pr ready` un-drafts and
+  triggers Copilot) AND the required status check `CI Success`
+  (`.github/workflows/ci.yml` `ci-success` job — a single aggregate over
+  `[setup, frontend, lint, test-unit, test-integration, e2e]`, added so branch
+  protection needs one check instead of enumerating all jobs + the e2e
+  shards). Codecov/SonarCloud are NOT part of that aggregate — they stay
+  reporting-only and a red result there does not block merge. Rector is a
+  CI-only lint gate, NOT in CaptainHook — run `composer rector`/`--dry-run` on
+  changed PHP before pushing. Local PHPStan gives false negatives from a stale
+  shared `var/cache` container XML — warm the cache before trusting it (never
+  `cache:clear --no-warmup`). codecov's e2e coverage upload is flaky —
+  `gh run rerun` heals it, keeping the head SHA
+- Prod = `tt.netresearch.de`, container `timetracker` (php-fpm) fronted by
+  `timetracker_httpd` (nginx) on `utility3.nr` (SSH `root@utility3.nr`, default
+  ssh-agent) — `tt.netresearch.de` IS PRODUCTION, there is NO separate "review
+  environment" despite the domain name; never offer a "review deploy" there.
+  "Hot-deploy the last main merge" = pull the floating
+  `ghcr.io/netresearch/timetracker:production` tag (verify
+  `org.opencontainers.image.revision` == the merge commit and its
+  `docker-publish.yml` run is success). Frontend assets live in the persisted
+  volume `timetracker_pub_v5`, so `docker cp build-ui` out of the new image
+  into the volume AFTER the container is healthy (rollback-safe). Attach BOTH
+  `timetracker` + `mariadb` nets before start (`docker create → network
+  connect → start`). Park the old container as `timetracker_prod_rollback`.
+  Migrating deploys: back up first (`mariadb-dump` via the URL user — root has
+  no pw) and pre-flight each pending migration's columns. For local testing use
+  the dev compose stack (`COMPOSE_PROFILES=dev`, port 8765, `APP_ENV=dev`)

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -132,3 +132,12 @@ public function testSyncWithJiraHandlesApiError(): void
 - Use `#[Group('...')]` for test categorization
 - Performance tests go in `Performance/` with `#[Group('performance')]`
 - Prefer `assertSame()` over `assertEquals()` for strict comparison
+- Write portable `LIKE` queries: escape `%`/`_` and spell out `ESCAPE`
+  explicitly (`LIKE :p ESCAPE '|'`, not a default backslash) — SQLite (used by
+  some query-builder tests) has no default LIKE escape char, unlike
+  MySQL/MariaDB (see `EntryRepository::applyInterpretationExtraFilters`)
+- A functional test can't change the logged-in user via raw SQL and have a
+  validator see it: `logInSession()` loads the user into the EM identity map,
+  so a validator's `find($loggedInUserId)` returns the CACHED entity — a raw
+  `UPDATE users …` is invisible to it. Unit-test such validators (mock `find`)
+  or operate on a non-logged-in entity


### PR DESCRIPTION
Consolidates durable, verified engineering notes into the four scoped `AGENTS.md` files. Docs-only, no code changes.

Each fact was checked against the codebase before writing; several stale or incorrect drafts were dropped or corrected — e.g. the API is `/api/v2/*` with a `{error, message}` shape (not Nelmio / `/api/v1` / RFC 9457), the ExtJS→SolidJS migration is already complete (so no "ongoing" note), and the merge gate does include the required `CI Success` aggregate check.

- **`frontend/AGENTS.md`** — Ark UI date-picker / inline-editor focus pattern, "Philosophy A" grid-editing architecture, stack decisions (Ark UI vs Kobalte, Tailwind 4, no Vue/Svelte), vitest-axe/jsdom note.
- **`e2e/AGENTS.md`** — `db-e2e` reseed procedure, image bind-mount rebuild flow, `TestClock` vs `APP_FROZEN_TIME`, usable test users, save-round-trip timeout guidance.
- **`tests/AGENTS.md`** — portable `LIKE … ESCAPE`, `logInSession()` EM identity-map validator gotcha.
- **`src/AGENTS.md`** — `SaveDto` grandfathering pattern, `Holiday` DBAL-only entity, self-migrating prod entrypoint, and a new "Deployment, CI & merge (operational)" section.
