### PR TITLE
chore(ci): route OpenSSF Scorecard through shared reusable

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,26 +11,12 @@ permissions:
   contents: read
 
 jobs:
+  # Scorecard via the org's shared reusable, so the pinned scorecard /
+  # codeql-action versions are maintained centrally instead of per-repo.
   analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
     permissions:
+      contents: read
       security-events: write
       id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          sarif_file: results.sarif
+      actions: read


### PR DESCRIPTION
Routes the inline ossf/scorecard-action + codeql-action/upload-sarif through the org scorecard.yml reusable. Centralizes the pinned actions.