### PR TITLE
ci(codeql): use shared netresearch/.github codeql reusable

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,8 +1,0 @@
-name: "CodeQL config"
-
-# Only analyze our code, not external libraries
-paths-ignore:
-  # Node modules
-  - node_modules
-  # Vendor dependencies
-  - vendor

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,37 +12,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-permissions:
-  contents: read
+# Least privilege by default; the reusable's jobs request their own subset.
+permissions: {}
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+  codeql:
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
-      security-events: write
-      contents: read
       actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        # CodeQL supported languages: javascript-typescript, python, ruby, go, java, c-cpp, csharp, swift
-        # PHP is NOT supported by CodeQL
-        language: [javascript-typescript]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          languages: ${{ matrix.language }}
-          config-file: .github/codeql/codeql-config.yml
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          category: "/language:${{ matrix.language }}"
+      contents: read
+      security-events: write
+    with:
+      languages: javascript-typescript


### PR DESCRIPTION
Closes #650.

## What
`codeql.yml` becomes a thin caller of the shared [`netresearch/.github` `codeql.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/codeql.yml) reusable — same pattern as `t3x-nr-llm`. Removes 4 direct action references (`checkout` + `codeql-action` init/autobuild/analyze).

## Behavior notes
- **Language scope unchanged:** `javascript-typescript` only (PHP is unsupported by CodeQL). SARIF category stays `/language:javascript-typescript`.
- **Custom config removed:** `.github/codeql/codeql-config.yml` only set `paths-ignore: [node_modules, vendor]`, which is a no-op for JS/TS (`node_modules` is auto-ignored; `vendor` is PHP). The reusable doesn't accept a config-file, so it's deleted rather than left orphaned.
- **Query suite:** the reusable runs `security-and-quality` (broader than the previous default) — expect it may surface additional quality alerts. This is the fleet-standard posture.
- CodeQL is **not** a required check here (only `CI Success` is) and there's no merge queue, so the job-name change doesn't affect branch protection.

## Validation
- `actionlint` clean

> Want `actions` added to the analyzed languages too (workflow SAST)? It's a one-line change (`languages: actions,javascript-typescript`) — left out to keep this a faithful migration.
