### PR TITLE
fix(deps): bump phpspreadsheet to 5.9.0 (CVE-2026-59931/2/3), monitor composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,14 @@ updates:
       npm:
         patterns:
           - "*"
+  # Composer (PHP backend). Was unmonitored — this is why the phpoffice/
+  # phpspreadsheet CVE-2026-59931/2/3 advisory produced no bump PR and only
+  # surfaced as a red composer-audit gate. Now covered.
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      composer:
+        patterns:
+          - "*"

--- a/composer.lock
+++ b/composer.lock
@@ -2759,16 +2759,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.8.0",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb"
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/01964d92536edf1a3a874b9580a52824bebf6fbb",
-                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339",
                 "shasum": ""
             },
             "require": {
@@ -2790,7 +2790,7 @@
                 "maennchen/zipstream-php": "^2.1 || ^3.0",
                 "markbaker/complex": "^3.0",
                 "markbaker/matrix": "^3.0",
-                "php": "^8.1",
+                "php": "^8.2",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
@@ -2804,7 +2804,7 @@
                 "phpstan/phpstan": "^1.1 || ^2.0",
                 "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^10.5 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.7",
                 "tecnickcom/tcpdf": "^6.5"
             },
@@ -2862,9 +2862,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.8.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.9.0"
             },
-            "time": "2026-06-07T03:51:10+00:00"
+            "time": "2026-07-12T19:17:39+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",


### PR DESCRIPTION
`composer audit` turned main red (the `CI Success` gate fails on it).

### The vulnerability

`phpoffice/phpspreadsheet` **5.8.0** is affected by three **HIGH** advisories disclosed **2026-07-23**:

| CVE | GHSA | issue |
|---|---|---|
| CVE-2026-59933 | [GHSA-xh5m-36r6-47m3](https://github.com/advisories/GHSA-xh5m-36r6-47m3) | XLS/OLE sector-chain self-loop → memory exhaustion |
| CVE-2026-59932 | [GHSA-2mrg-gjxq-2gvr](https://github.com/advisories/GHSA-2mrg-gjxq-2gvr) | Gnumeric reader unbounded gzip expansion → memory exhaustion |
| CVE-2026-59931 | [GHSA-6hq5-7373-42rg](https://github.com/advisories/GHSA-6hq5-7373-42rg) | WEBSERVICE() SSRF whitelist bypass via HTTP redirect |

All fixed in **5.8.1**; the `^5.0` constraint resolves to **5.9.0**, so only `composer.lock` changes — one package, no code, no `composer.json` change.

### Why no bump PR appeared

`dependabot.yml` monitored `github-actions`, `bun`, `npm` — but **not `composer`**. So the PHP backend's advisories never produced a bump PR and only surfaced as a red audit gate — the same gap the file already documents for npm. This PR adds the `composer` ecosystem, so future PHP security updates are auto-bumped (and auto-merged via the deps workflow).

### Verification

```
composer audit --locked   -> No security vulnerability advisories found.
composer validate         -> ./composer.json is valid
```

Diff: `composer.lock` (phpspreadsheet 5.8.0 → 5.9.0) + `.github/dependabot.yml` (+composer ecosystem).