### PR TITLE
fix: drop rector-generated serialize() stub on User

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -691,9 +691,4 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TotpTwo
             $this->{$property} = $value;
         }
     }
-
-    public function serialize(): void
-    {
-        // If you store any temporary, sensitive data on the user, clear it here
-    }
 }


### PR DESCRIPTION
Follow-up to #656.

`RemoveEraseCredentialsRector` (rector 2.5.7) does not only delete `User::eraseCredentials()` — it appends a `serialize(): void` method carrying the old body to the end of the class. That landed on `main` via #656:

```php
    public function serialize(): void
    {
        // If you store any temporary, sensitive data on the user, clear it here
    }
```

Why it should not stay:

- Nothing calls it — `grep -rn '->serialize(\|::serialize(' src tests e2e config` returns nothing.
- `User` does not implement `Serializable` (`UserInterface, PasswordAuthenticatedUserInterface, TotpTwoFactorInterface, BackupCodeInterface`).
- The entity already has hand-written `__serialize()` / `__unserialize()` (`src/Entity/User.php:671`, `:685`) that deliberately exclude the transient plaintext fields. The stub's comment contradicts them.
- `void` does not match `Serializable::serialize(): ?string`, so adding that interface later would fatal.

Rector does not re-add the stub once `eraseCredentials()` is gone, so no rule skip is needed.

## Verification

On this branch: `rector --dry-run` over `src/` clean, PHPStan clean, PHPat clean, php-cs-fixer 0 of 683, and `phpunit --testsuite unit` in the `app-e2e` container — **1938 tests, 4501 assertions, OK**.
