### PR TITLE
chore(deps): stop dependabot proposing typescript >= 6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
       frontend:
         patterns:
           - "*"
+    ignore:
+      # typescript-eslint declares `typescript: ">=4.8.4 <6.1.0"` and hard-fails
+      # at load ("typescript-eslint does not support TS 7.0"), so anything from
+      # 6.1 up breaks `eslint .`. 8.65.0 is latest and no release supports it.
+      # Drop this entry once typescript-eslint widens the peer range; the pin in
+      # frontend/package.json goes with it.
+      - dependency-name: typescript
+        versions:
+          - ">= 6.1"
   # Root npm lockfile (Playwright e2e tooling). Was unmonitored, so dev-tooling
   # advisories (http-proxy-middleware, uuid) never produced a bump PR.
   - package-ecosystem: npm


### PR DESCRIPTION
Follow-up to #654.

#654 held `typescript` at `^6.0.3` by hand because `typescript-eslint` refuses to load against TS 7 (`typescript-eslint does not support TS 7.0`), which fails `eslint .` in the frontend job. Without an ignore entry the weekly `frontend` group (`patterns: ["*"]`) re-proposes the same upgrade and the PR goes red again on every run — the pin alone is repeat work, not a fix.

The boundary is **6.1, not 7**: `typescript-eslint@8.65.0` declares `peerDependencies.typescript: ">=4.8.4 <6.1.0"`, so a 6.1 bump breaks it exactly the same way. The ignore encodes that range rather than only the version we happened to hit.

Removal condition is in the comment: drop the entry once typescript-eslint widens its peer range, and remove the `package.json` pin with it.