### PR TITLE
ci: track netresearch/.github reusables on @main again

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@53469ad0d1024265804184e214318b9895559cc9 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
   node-audit:
     permissions:
       contents: read
-    uses: netresearch/.github/.github/workflows/node-audit.yml@53469ad0d1024265804184e214318b9895559cc9 # main
+    uses: netresearch/.github/.github/workflows/node-audit.yml@main
     with:
       package-manager: npm
       audit-level: high


### PR DESCRIPTION
`security.yml` and `auto-merge-deps.yml` referenced `netresearch/.github` reusables by full SHA with a trailing `# main` comment — they were already meant to follow main and merely could not. They now do.

## Why

Org-owned reusables are referenced by `@main` so an upstream fix reaches every consumer at once. SHA-pinning is for **third-party** actions; applied to `netresearch/*` it freezes the consumer and defeats the propagation model. Here it also left the repo inconsistent with itself: the sibling callers in `docker-publish.yml`, `scorecard.yml` and `codeql.yml` all track `@main`, so only the audit and auto-merge jobs sat on an old copy.

The `githubactions:S7637` hotspot this leaves in SonarCloud is accepted house practice. If a quality gate blocks on it, mark the hotspot Safe rather than re-pinning.

## Scope

A sweep over all 191 non-archived `netresearch` repos with a default branch found 1178 `uses: netresearch/…` references across 126 repos, of which 4 were pinned. Two of them are here; the others are being fixed in `t3x-nr-llm` and `retro-skill`.
