### PR TITLE
fix(deps): unpin rector, apply what the newer version finds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "phpstan/phpstan-strict-rules": "*",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^13.0",
-        "rector/rector": "2.5.8",
+        "rector/rector": "^2.0",
         "struggle-for-php/sfp-phpstan-psr-log": "*",
         "symfony/browser-kit": "^8.1",
         "symfony/debug-bundle": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd6312d48c592ffd6300295476dc06e8",
+    "content-hash": "c6b56c13d86288093f2068cee65e45f7",
     "packages": [
         {
             "name": "brick/math",
@@ -11918,16 +11918,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.5.8",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "861c77fd2a6d45317a401f4e0b617f947e8b6f96"
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/861c77fd2a6d45317a401f4e0b617f947e8b6f96",
-                "reference": "861c77fd2a6d45317a401f4e0b617f947e8b6f96",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
                 "shasum": ""
             },
             "require": {
@@ -11966,7 +11966,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.5.8"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
             },
             "funding": [
                 {
@@ -11974,7 +11974,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-27T06:19:16+00:00"
+            "time": "2026-08-03T17:30:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/src/EventSubscriber/RequireTwoFactorSubscriber.php
+++ b/src/EventSubscriber/RequireTwoFactorSubscriber.php
@@ -72,7 +72,7 @@ final readonly class RequireTwoFactorSubscriber implements EventSubscriberInterf
         private Security $security,
         private TwoFactorStatusService $status,
         private RouterInterface $router,
-        #[Autowire('%app_require_two_factor%')]
+        #[Autowire(param: 'app_require_two_factor')]
         private bool $required,
     ) {
     }

--- a/src/Service/Security/TwoFactorEnrollmentService.php
+++ b/src/Service/Security/TwoFactorEnrollmentService.php
@@ -44,7 +44,7 @@ final readonly class TwoFactorEnrollmentService
     public function __construct(
         private TokenEncryptionService $tokenEncryptionService,
         private ClockInterface $clock,
-        #[Autowire('%app_title%')]
+        #[Autowire(param: 'app_title')]
         private string $issuer,
     ) {
     }


### PR DESCRIPTION
Part of removing exact pins on the analysis toolchain org-wide, so that new rules take effect immediately rather than waiting for a bump PR. Companion to [netresearch/typo3-ci-workflows#158](https://github.com/netresearch/typo3-ci-workflows/pull/158).

## Where the pin came from

`rector/rector: 2.5.8` traces back to `chore(deps): hold rector at 2.4.5 during lockfile maintenance` (2026-07-05). The maintenance it was holding for is long finished; dependency bumps have simply carried the exact constraint forward since.

## This one is not a no-op

Unlike the same change in the shared workflows package, where both packages already resolved to the pinned versions, here the constraint actually moves: **2.5.8 → 2.6.1**. Two things follow, both checked rather than assumed:

- **The 2.6.0 breakage does not apply.** Rector 2.6.0 removed `SetList::STRICT_BOOLEANS` and took the TYPO3 fleet down with it. `config/quality/rector.php` never referenced that set, so nothing fatals here.
- **2.6.x finds two things, and they are applied.** `ParamAndEnvAttributeRector` rewrites `#[Autowire('%app_require_two_factor%')]` to `#[Autowire(param: 'app_require_two_factor')]` in `RequireTwoFactorSubscriber` and the same for `app_title` in `TwoFactorEnrollmentService`. Same container wiring, in the form Symfony documents. Applying them here is the point of dropping the pin — deferring them would recreate the pin by other means.

## Verification

```
$ php bin/rector --version
Rector 2.6.1
$ php bin/rector process src --config=config/quality/rector.php --dry-run
 [OK] 2 files would have been changed (dry-run) by Rector
$ php bin/rector process src --config=config/quality/rector.php
 [OK] 2 files have been changed by Rector
$ php bin/rector process src --config=config/quality/rector.php --dry-run   # after
 [OK] Rector is done!
```

The `composer.lock` diff is rector and nothing else — 7 lines, no transitive movement.

The test suite was not run locally: this host lacks `ext-ldap` and the other extensions the app requires, so composer had to resolve with `--ignore-platform-reqs`. CI runs it properly.