### PR TITLE
chore(renovate): restore the Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>netresearch/renovate-config"
+  ]
+}


### PR DESCRIPTION
Renovate is not running on this repository, and the reason is a file that went missing rather than a decision.

This repository was onboarded in February 2025: [#100](https://github.com/netresearch/timetracker/pull/100) "Configure Renovate" merged `renovate.json` into `main` on 2025-02-19, and roughly a hundred Renovate pull requests followed over the next month. They stop in March 2025.

The file is not in the tree today, and no commit touching `renovate.json` exists anywhere in the current history — not on `main`, not on `v4`, not on any ref; the merge commit for #100 is gone as well. So `main` was rewritten after that merge and the configuration went with it, silently. Renovate then treats the repository as not onboarded and skips it, which is exactly when the pull requests stopped.

The content is the canonical form used by the other 127 repositories in the organization — a single `extends` of `github>netresearch/renovate-config`, which is where the policy lives (stability days, the automerge rules, the `deps-no-automerge` label). The 2025 onboarding config predates that preset, so this is not a byte-for-byte restore.

Dependabot stays for now. Removing it is a separate step per repository, taken once Renovate is demonstrably running here, not on the strength of this file existing.

Verified with Renovate's own validator, not just JSON syntax: `INFO: Config validated successfully`.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01AXRGd6GWAC7TLK3wuiYeGg)_
